### PR TITLE
sql: almost remove context.Context from eval.Context

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -727,7 +727,16 @@
             "cockroach/pkg/.*\\.eg\\.go$": "generated code",
             ".*\\.pb\\.go$": "generated code",
             ".*\\.pb\\.gw\\.go$": "generated code",
-            "cockroach/pkg/.*_generated\\.go$": "generated code"
+            "cockroach/pkg/.*_generated\\.go$": "generated code",
+            "pkg/sql/conn_executor.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/instrumentation.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/planner.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/schema_changer.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/distsql/server.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/execinfra/processorsbase.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/importer/import_table_creation.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/row/expr_walker_test.go$": "temporary exclusion until deprecatedContext is removed from eval.Context",
+            "pkg/sql/schemachanger/scbuild/tree_context_builder.go$": "temporary exclusion until deprecatedContext is removed from eval.Context"
         },
         "only_files": {
             "cockroach/pkg/.*$": "first-party code"

--- a/docs/codelabs/00-sql-function.md
+++ b/docs/codelabs/00-sql-function.md
@@ -77,7 +77,7 @@ var builtins = map[string]builtinDefinition{
     tree.Overload{
       Types:      tree.VariadicType{VarType: types.String},
       ReturnType: tree.FixedReturnType(types.String),
-      Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+      Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
         return tree.DNull, fmt.Errorf("nothing to see here")
       },
     },
@@ -349,7 +349,7 @@ check your solution against ours.
       tree.Overload{
         Types:      tree.VariadicType{VarType: types.String},
         ReturnType: tree.FixedReturnType(types.String),
-        Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+        Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
           users := map[string]string{
             "bdarnell": "Ben Darnell",
             "pmattis":  "Peter Mattis",

--- a/pkg/ccl/changefeedccl/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro_test.go
@@ -119,7 +119,7 @@ func parseValues(tableDesc catalog.TableDescriptor, values string) ([]rowenc.Enc
 			if err != nil {
 				return nil, err
 			}
-			datum, err := eval.Expr(evalCtx, typedExpr)
+			datum, err := eval.Expr(ctx, evalCtx, typedExpr)
 			if err != nil {
 				return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 			}

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -448,7 +448,7 @@ func (e *exprEval) typeCheck(
 	if err != nil {
 		return nil, err
 	}
-	return normalize.Expr(e.evalCtx, typedExpr)
+	return normalize.Expr(ctx, e.evalCtx, typedExpr)
 }
 
 // evalExpr evaluates typed expression and returns resulting datum.

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -293,7 +293,7 @@ func (e *exprEval) evalProjection(
 		if err != nil {
 			return cdcevent.Row{}, err
 		}
-		if err := e.projection.SetValueDatumAt(e.evalCtx, i, d); err != nil {
+		if err := e.projection.SetValueDatumAt(ctx, e.evalCtx, i, d); err != nil {
 			return cdcevent.Row{}, err
 		}
 	}

--- a/pkg/ccl/changefeedccl/cdceval/expr_eval.go
+++ b/pkg/ccl/changefeedccl/cdceval/expr_eval.go
@@ -425,7 +425,7 @@ func (e *exprEval) typeCheck(
 		ctx, expr, targetType, "cdc", e.semaCtx,
 		volatility.Immutable, true)
 	if err == nil {
-		d, err := eval.Expr(e.evalCtx, typedExpr)
+		d, err := eval.Expr(ctx, e.evalCtx, typedExpr)
 		if err != nil {
 			return nil, err
 		}
@@ -476,7 +476,7 @@ func (e *exprEval) evalExpr(
 		if err != nil {
 			return nil, err
 		}
-		d, err := eval.Expr(e.evalCtx, typedExpr)
+		d, err := eval.Expr(ctx, e.evalCtx, typedExpr)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -9,6 +9,7 @@
 package cdceval
 
 import (
+	"context"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
@@ -61,7 +62,7 @@ var cdcFunctions = map[string]*tree.ResolvedFunctionDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, datums tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, datums tree.Datums) (tree.Datum, error) {
 				rowEvalCtx := rowEvalContextFromEvalContext(evalCtx)
 				if rowEvalCtx.updatedRow.IsDeleted() {
 					return tree.DBoolTrue, nil
@@ -130,7 +131,7 @@ func cdcTimestampBuiltin(
 			{
 				Types:      tree.ArgTypes{},
 				ReturnType: tree.FixedReturnType(types.Decimal),
-				Fn: func(evalCtx *eval.Context, datums tree.Datums) (tree.Datum, error) {
+				Fn: func(ctx context.Context, evalCtx *eval.Context, datums tree.Datums) (tree.Datum, error) {
 					rowEvalCtx := rowEvalContextFromEvalContext(evalCtx)
 					return eval.TimestampToDecimalDatum(tsFn(rowEvalCtx)), nil
 				},
@@ -145,7 +146,7 @@ func cdcTimestampBuiltin(
 	return tree.QualifyBuiltinFunctionDefinition(def, catconstants.PublicSchemaName)
 }
 
-func prevRowAsJSON(evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+func prevRowAsJSON(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
 	rec := rowEvalContextFromEvalContext(evalCtx)
 	if rec.memo.prevJSON != nil {
 		return rec.memo.prevJSON, nil

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -557,7 +557,7 @@ func TestingGetFamilyIDFromKey(
 // MakeRowFromTuple converts a SQL datum produced by, for example, SELECT ROW(foo.*),
 // into the same kind of cdcevent.Row you'd get as a result of an insert, but without
 // the primary key.
-func MakeRowFromTuple(evalCtx *eval.Context, t *tree.DTuple) Row {
+func MakeRowFromTuple(ctx context.Context, evalCtx *eval.Context, t *tree.DTuple) Row {
 	r := Projection{EventDescriptor: &EventDescriptor{}}
 	names := t.ResolvedType().TupleLabels()
 	for i, d := range t.D {
@@ -568,10 +568,10 @@ func MakeRowFromTuple(evalCtx *eval.Context, t *tree.DTuple) Row {
 			name = names[i]
 		}
 		r.AddValueColumn(name, d.ResolvedType())
-		if err := r.SetValueDatumAt(evalCtx, i, d); err != nil {
+		if err := r.SetValueDatumAt(ctx, evalCtx, i, d); err != nil {
 			if build.IsRelease() {
-				log.Warningf(context.Background(), "failed to set row value from tuple due to error %v", err)
-				_ = r.SetValueDatumAt(evalCtx, i, tree.DNull)
+				log.Warningf(ctx, "failed to set row value from tuple due to error %v", err)
+				_ = r.SetValueDatumAt(ctx, evalCtx, i, tree.DNull)
 			} else {
 				panic(err)
 			}

--- a/pkg/ccl/changefeedccl/cdcevent/event_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event_test.go
@@ -413,7 +413,7 @@ func TestMakeRowFromTuple(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.MakeTestingEvalContext(st)
 
-	rowFromUnlabeledTuple := MakeRowFromTuple(&evalCtx, unlabeledTuple)
+	rowFromUnlabeledTuple := MakeRowFromTuple(context.Background(), &evalCtx, unlabeledTuple)
 	expectedCols := []struct {
 		name        string
 		typ         *types.T
@@ -446,7 +446,7 @@ func TestMakeRowFromTuple(t *testing.T) {
 
 	remainingCols = expectedCols
 
-	rowFromLabeledTuple := MakeRowFromTuple(&evalCtx, labeledTuple)
+	rowFromLabeledTuple := MakeRowFromTuple(context.Background(), &evalCtx, labeledTuple)
 
 	require.NoError(t, rowFromLabeledTuple.ForEachColumn().Datum(func(d tree.Datum, col ResultColumn) error {
 		current := remainingCols[0]

--- a/pkg/ccl/changefeedccl/cdcevent/projection.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection.go
@@ -9,6 +9,8 @@
 package cdcevent
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -66,7 +68,9 @@ func (p *Projection) AddValueColumn(name string, typ *types.T) {
 }
 
 // SetValueDatumAt sets value datum at specified position.
-func (p *Projection) SetValueDatumAt(evalCtx *eval.Context, pos int, d tree.Datum) error {
+func (p *Projection) SetValueDatumAt(
+	ctx context.Context, evalCtx *eval.Context, pos int, d tree.Datum,
+) error {
 	pos += len(p.keyCols)
 	if pos >= len(p.datums) {
 		return errors.AssertionFailedf("%d out of bounds", pos)
@@ -78,7 +82,7 @@ func (p *Projection) SetValueDatumAt(evalCtx *eval.Context, pos int, d tree.Datu
 			return pgerror.Newf(pgcode.DatatypeMismatch,
 				"expected type %s for column %s@%d, found %s", col.Typ, col.Name, pos, d.ResolvedType())
 		}
-		cd, err := eval.PerformCast(evalCtx, d, col.Typ)
+		cd, err := eval.PerformCast(ctx, evalCtx, d, col.Typ)
 		if err != nil {
 			return errors.Wrapf(err, "expected type %s for column %s@%d, found %s",
 				col.Typ, col.Name, pos, d.ResolvedType())

--- a/pkg/ccl/changefeedccl/cdcevent/projection_test.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection_test.go
@@ -29,8 +29,9 @@ func TestProjection(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	ctx := context.Background()
 	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(db)
 	sqlDB.Exec(t, `CREATE TYPE status AS ENUM ('open', 'closed', 'inactive')`)
@@ -61,7 +62,7 @@ CREATE TABLE foo (
 		idx := 0
 		require.NoError(t, input.ForEachColumn().Datum(func(d tree.Datum, col ResultColumn) error {
 			p.AddValueColumn(col.Name, col.Typ)
-			err := p.SetValueDatumAt(&evalCtx, idx, d)
+			err := p.SetValueDatumAt(ctx, &evalCtx, idx, d)
 			idx++
 			return err
 		}))
@@ -76,9 +77,9 @@ CREATE TABLE foo (
 		input := TestingMakeEventRow(desc, 0, encDatums, false)
 		p := MakeProjection(input.EventDescriptor)
 		p.AddValueColumn("wrong_type", types.Int)
-		require.Regexp(t, "expected type int", p.SetValueDatumAt(&evalCtx, 0, tree.NewDString("fail")))
+		require.Regexp(t, "expected type int", p.SetValueDatumAt(ctx, &evalCtx, 0, tree.NewDString("fail")))
 		// But we allow NULL.
-		require.NoError(t, p.SetValueDatumAt(&evalCtx, 0, tree.DNull))
+		require.NoError(t, p.SetValueDatumAt(ctx, &evalCtx, 0, tree.DNull))
 	})
 
 	t.Run("project_extra_column", func(t *testing.T) {
@@ -87,12 +88,12 @@ CREATE TABLE foo (
 		idx := 0
 		require.NoError(t, input.ForEachColumn().Datum(func(d tree.Datum, col ResultColumn) error {
 			p.AddValueColumn(col.Name, col.Typ)
-			err := p.SetValueDatumAt(&evalCtx, idx, d)
+			err := p.SetValueDatumAt(ctx, &evalCtx, idx, d)
 			idx++
 			return err
 		}))
 		p.AddValueColumn("test", types.Int)
-		require.NoError(t, p.SetValueDatumAt(&evalCtx, idx, tree.NewDInt(5)))
+		require.NoError(t, p.SetValueDatumAt(ctx, &evalCtx, idx, tree.NewDInt(5)))
 
 		pr, err := p.Project(input)
 		require.NoError(t, err)

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -414,7 +414,7 @@ func init() {
 	overload := tree.Overload{
 		Types:      tree.VariadicType{FixedTypes: []*types.T{types.AnyTuple}, VarType: types.String},
 		ReturnType: tree.FixedReturnType(types.Bytes),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			row := cdcevent.MakeRowFromTuple(evalCtx, tree.MustBeDTuple(args[0]))
 			flags := make([]string, len(args)-1)
 			for i, d := range args[1:] {

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -415,7 +415,7 @@ func init() {
 		Types:      tree.VariadicType{FixedTypes: []*types.T{types.AnyTuple}, VarType: types.String},
 		ReturnType: tree.FixedReturnType(types.Bytes),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			row := cdcevent.MakeRowFromTuple(evalCtx, tree.MustBeDTuple(args[0]))
+			row := cdcevent.MakeRowFromTuple(ctx, evalCtx, tree.MustBeDTuple(args[0]))
 			flags := make([]string, len(args)-1)
 			for i, d := range args[1:] {
 				flags[i] = string(tree.MustBeDString(d))

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1379,7 +1379,7 @@ func exprAsString(expr tree.Expr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	datum, err := eval.Expr(evalCtx.Context, evalCtx, te)
+	datum, err := eval.Expr(context.Background(), evalCtx, te)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1379,7 +1379,7 @@ func exprAsString(expr tree.Expr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	datum, err := eval.Expr(evalCtx, te)
+	datum, err := eval.Expr(evalCtx.Context, evalCtx, te)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness.go
@@ -9,6 +9,7 @@
 package kvfollowerreadsccl
 
 import (
+	"context"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
@@ -22,18 +23,20 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-func checkBoundedStalenessEnabled(ctx *eval.Context) error {
-	st := ctx.Settings
+func checkBoundedStalenessEnabled(evalCtx *eval.Context) error {
+	st := evalCtx.Settings
 	return utilccl.CheckEnterpriseEnabled(
 		st,
-		ctx.ClusterID,
+		evalCtx.ClusterID,
 		sql.ClusterOrganization.Get(&st.SV),
 		"bounded staleness",
 	)
 }
 
-func evalMaxStaleness(ctx *eval.Context, d duration.Duration) (time.Time, error) {
-	if err := checkBoundedStalenessEnabled(ctx); err != nil {
+func evalMaxStaleness(
+	ctx context.Context, evalCtx *eval.Context, d duration.Duration,
+) (time.Time, error) {
+	if err := checkBoundedStalenessEnabled(evalCtx); err != nil {
 		return time.Time{}, err
 	}
 	if d.Compare(duration.FromInt64(0)) < 0 {
@@ -43,15 +46,15 @@ func evalMaxStaleness(ctx *eval.Context, d duration.Duration) (time.Time, error)
 			asof.WithMaxStalenessFunctionName,
 		)
 	}
-	return duration.Add(ctx.GetStmtTimestamp(), d.Mul(-1)), nil
+	return duration.Add(evalCtx.GetStmtTimestamp(), d.Mul(-1)), nil
 }
 
-func evalMinTimestamp(ctx *eval.Context, t time.Time) (time.Time, error) {
-	if err := checkBoundedStalenessEnabled(ctx); err != nil {
+func evalMinTimestamp(ctx context.Context, evalCtx *eval.Context, t time.Time) (time.Time, error) {
+	if err := checkBoundedStalenessEnabled(evalCtx); err != nil {
 		return time.Time{}, err
 	}
 	t = t.Round(time.Microsecond)
-	if stmtTimestamp := ctx.GetStmtTimestamp().Round(time.Microsecond); t.After(stmtTimestamp) {
+	if stmtTimestamp := evalCtx.GetStmtTimestamp().Round(time.Microsecond); t.After(stmtTimestamp) {
 		return time.Time{}, errors.WithDetailf(
 			pgerror.Newf(
 				pgcode.InvalidParameterValue,

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -112,7 +112,7 @@ func valueEncodePartitionTuple(
 			return nil, pgerror.Newf(pgcode.Syntax,
 				"%s: partition values must be constant", typedExpr)
 		}
-		datum, err := eval.Expr(evalCtx, typedExpr)
+		datum, err := eval.Expr(ctx, evalCtx, typedExpr)
 		if err != nil {
 			return nil, errors.Wrapf(err, "evaluating %s", typedExpr)
 		}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -27,16 +27,20 @@ type streamIngestManagerImpl struct{}
 
 // CompleteStreamIngestion implements streaming.StreamIngestManager interface.
 func (r *streamIngestManagerImpl) CompleteStreamIngestion(
-	evalCtx *eval.Context, txn *kv.Txn, ingestionJobID jobspb.JobID, cutoverTimestamp hlc.Timestamp,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	txn *kv.Txn,
+	ingestionJobID jobspb.JobID,
+	cutoverTimestamp hlc.Timestamp,
 ) error {
-	return completeStreamIngestion(evalCtx, txn, ingestionJobID, cutoverTimestamp)
+	return completeStreamIngestion(ctx, evalCtx, txn, ingestionJobID, cutoverTimestamp)
 }
 
 // GetStreamIngestionStats implements streaming.StreamIngestManager interface.
 func (r *streamIngestManagerImpl) GetStreamIngestionStats(
-	evalCtx *eval.Context, txn *kv.Txn, ingestionJobID jobspb.JobID,
+	ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, ingestionJobID jobspb.JobID,
 ) (*streampb.StreamIngestionStats, error) {
-	return getStreamIngestionStats(evalCtx, txn, ingestionJobID)
+	return getStreamIngestionStats(ctx, evalCtx, txn, ingestionJobID)
 }
 
 func newStreamIngestManagerWithPrivilegesCheck(

--- a/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingest_manager.go
@@ -9,6 +9,8 @@
 package streamingest
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -38,9 +40,9 @@ func (r *streamIngestManagerImpl) GetStreamIngestionStats(
 }
 
 func newStreamIngestManagerWithPrivilegesCheck(
-	evalCtx *eval.Context,
+	ctx context.Context, evalCtx *eval.Context,
 ) (streaming.StreamIngestManager, error) {
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -9,6 +9,8 @@
 package streamproducer
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -58,9 +60,9 @@ func (r *replicationStreamManagerImpl) CompleteReplicationStream(
 }
 
 func newReplicationStreamManagerWithPrivilegesCheck(
-	evalCtx *eval.Context,
+	ctx context.Context, evalCtx *eval.Context,
 ) (streaming.ReplicationStreamManager, error) {
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager.go
@@ -26,16 +26,20 @@ type replicationStreamManagerImpl struct{}
 
 // StartReplicationStream implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) StartReplicationStream(
-	evalCtx *eval.Context, txn *kv.Txn, tenantID uint64,
+	ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, tenantID uint64,
 ) (streaming.StreamID, error) {
-	return startReplicationStreamJob(evalCtx, txn, tenantID)
+	return startReplicationStreamJob(ctx, evalCtx, txn, tenantID)
 }
 
 // HeartbeatReplicationStream implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) HeartbeatReplicationStream(
-	evalCtx *eval.Context, streamID streaming.StreamID, frontier hlc.Timestamp, txn *kv.Txn,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	streamID streaming.StreamID,
+	frontier hlc.Timestamp,
+	txn *kv.Txn,
 ) (streampb.StreamReplicationStatus, error) {
-	return heartbeatReplicationStream(evalCtx, streamID, frontier, txn)
+	return heartbeatReplicationStream(ctx, evalCtx, streamID, frontier, txn)
 }
 
 // StreamPartition implements streaming.ReplicationStreamManager interface.
@@ -45,18 +49,22 @@ func (r *replicationStreamManagerImpl) StreamPartition(
 	return streamPartition(evalCtx, streamID, opaqueSpec)
 }
 
-// GetReplicationStreamSpec implements ReplicationStreamManager interface.
+// GetReplicationStreamSpec implements streaming.ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) GetReplicationStreamSpec(
-	evalCtx *eval.Context, txn *kv.Txn, streamID streaming.StreamID,
+	ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, streamID streaming.StreamID,
 ) (*streampb.ReplicationStreamSpec, error) {
-	return getReplicationStreamSpec(evalCtx, txn, streamID)
+	return getReplicationStreamSpec(ctx, evalCtx, txn, streamID)
 }
 
 // CompleteReplicationStream implements ReplicationStreamManager interface.
 func (r *replicationStreamManagerImpl) CompleteReplicationStream(
-	evalCtx *eval.Context, txn *kv.Txn, streamID streaming.StreamID, successfulIngestion bool,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	txn *kv.Txn,
+	streamID streaming.StreamID,
+	successfulIngestion bool,
 ) error {
-	return completeReplicationStream(evalCtx, txn, streamID, successfulIngestion)
+	return completeReplicationStream(ctx, evalCtx, txn, streamID, successfulIngestion)
 }
 
 func newReplicationStreamManagerWithPrivilegesCheck(

--- a/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
+++ b/pkg/ccl/streamingccl/streamproducer/replication_manager_test.go
@@ -52,7 +52,7 @@ func TestReplicationManagerRequiresAdminRole(t *testing.T) {
 		p, cleanup := sql.NewInternalPlanner("test", txn, sqlUser, &sql.MemoryMetrics{}, &execCfg, sessionData)
 		defer cleanup()
 		ec := p.(interface{ EvalContext() *eval.Context }).EvalContext()
-		return newReplicationStreamManagerWithPrivilegesCheck(ec)
+		return newReplicationStreamManagerWithPrivilegesCheck(ctx, ec)
 	}
 
 	for _, tc := range []struct {

--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -160,7 +160,7 @@ func runBundleRecreate(cmd *cobra.Command, args []string) (resErr error) {
 				}
 				placeholderToColMap[n] = pair[1]
 			}
-			inputs, outputs, err := getExplainCombinations(conn, explainPrefix, placeholderToColMap, bundle)
+			inputs, outputs, err := getExplainCombinations(ctx, conn, explainPrefix, placeholderToColMap, bundle)
 			if err != nil {
 				return err
 			}
@@ -205,6 +205,7 @@ type bucketKey struct {
 // Columns are linked to placeholders by the --placeholder=n=schema.table.col
 // commandline flags.
 func getExplainCombinations(
+	ctx context.Context,
 	conn clisqlclient.Conn,
 	explainPrefix string,
 	placeholderToColMap map[int]string,
@@ -310,7 +311,7 @@ func getExplainCombinations(
 				}
 				upperBound := bucket["upper_bound"].(string)
 				bucketMap[key] = []string{upperBound}
-				datum, err := rowenc.ParseDatumStringAs(colType, upperBound, &evalCtx)
+				datum, err := rowenc.ParseDatumStringAs(ctx, colType, upperBound, &evalCtx)
 				if err != nil {
 					panic("failed parsing datum string as " + datum.String() + " " + err.Error())
 				}

--- a/pkg/cli/statement_bundle_test.go
+++ b/pkg/cli/statement_bundle_test.go
@@ -82,7 +82,7 @@ func TestRunExplainCombinations(t *testing.T) {
 			}
 		}
 
-		inputs, outputs, err := getExplainCombinations(conn, "EXPLAIN(OPT)", test.placeholderToColMap, bundle)
+		inputs, outputs, err := getExplainCombinations(ctx, conn, "EXPLAIN(OPT)", test.placeholderToColMap, bundle)
 		assert.NoError(t, err)
 		assert.Equal(t, test.expectedInputs, inputs)
 		assert.Equal(t, test.expectedOutputs, outputs)

--- a/pkg/security/password.go
+++ b/pkg/security/password.go
@@ -135,9 +135,7 @@ func GetConfiguredPasswordCost(
 
 // GetConfiguredPasswordHashMethod returns the configured hash method
 // to use before storing passwords provided in cleartext from clients.
-func GetConfiguredPasswordHashMethod(
-	ctx context.Context, sv *settings.Values,
-) (method password.HashMethod) {
+func GetConfiguredPasswordHashMethod(sv *settings.Values) (method password.HashMethod) {
 	return password.HashMethod(PasswordHashMethod.Get(sv))
 }
 

--- a/pkg/security/password/password.go
+++ b/pkg/security/password/password.go
@@ -568,7 +568,7 @@ func isMD5Hash(hashedPassword []byte) bool {
 //   - hashedPassword is a translated version from the input,
 //     suitable for storage in the password database.
 func CheckPasswordHashValidity(
-	ctx context.Context, inputPassword []byte,
+	inputPassword []byte,
 ) (
 	isPreHashed, supportedScheme bool,
 	issueNum int,

--- a/pkg/security/password/password_test.go
+++ b/pkg/security/password/password_test.go
@@ -57,7 +57,7 @@ func TestBCryptToSCRAMConversion(t *testing.T) {
 
 			// Check conversion succeeds.
 			autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&s.SV)
-			method := security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
+			method := security.GetConfiguredPasswordHashMethod(&s.SV)
 			converted, prevHash, newHashBytes, hashMethod, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, bh, nil, log.Infof)
 			require.NoError(t, err)
 			require.True(t, converted)
@@ -72,7 +72,7 @@ func TestBCryptToSCRAMConversion(t *testing.T) {
 
 			// Check that converted hash can't be converted further.
 			autoUpgradePasswordHashesBool = security.AutoUpgradePasswordHashes.Get(&s.SV)
-			method = security.GetConfiguredPasswordHashMethod(ctx, &s.SV)
+			method = security.GetConfiguredPasswordHashMethod(&s.SV)
 
 			ec, _, _, _, err := password.MaybeUpgradePasswordHash(ctx, autoUpgradePasswordHashesBool, method, cleartext, newHash, nil, log.Infof)
 			require.NoError(t, err)

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -618,7 +618,7 @@ func (n *alterRoleSetNode) getSessionVarVal(params runParams) (string, error) {
 		strVal, err = n.sVar.GetStringVal(params.ctx, params.extendedEvalCtx, n.typedValues, params.p.Txn())
 	} else {
 		// No string converter defined, use the default one.
-		strVal, err = getStringVal(params.EvalContext(), n.varName, n.typedValues)
+		strVal, err = getStringVal(params.ctx, params.EvalContext(), n.varName, n.typedValues)
 	}
 	if err != nil {
 		return "", err

--- a/pkg/sql/alter_role.go
+++ b/pkg/sql/alter_role.go
@@ -606,7 +606,7 @@ func (n *alterRoleSetNode) getSessionVarVal(params runParams) (string, error) {
 		return "", nil
 	}
 	for i, v := range n.typedValues {
-		d, err := eval.Expr(params.EvalContext(), v)
+		d, err := eval.Expr(params.ctx, params.EvalContext(), v)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -760,6 +760,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 		case *tree.AlterTableResetStorageParams:
 			setter := tablestorageparam.NewSetter(n.tableDesc)
 			if err := storageparam.Reset(
+				params.ctx,
 				params.EvalContext(),
 				t.Params,
 				setter,

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1248,7 +1248,7 @@ func updateSequenceDependencies(
 func injectTableStats(
 	params runParams, desc catalog.TableDescriptor, statsExpr tree.TypedExpr,
 ) error {
-	val, err := eval.Expr(params.EvalContext(), statsExpr)
+	val, err := eval.Expr(params.ctx, params.EvalContext(), statsExpr)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/analyze_expr.go
+++ b/pkg/sql/analyze_expr.go
@@ -60,5 +60,5 @@ func (p *planner) analyzeExpr(
 	}
 
 	// Normalize.
-	return p.txCtx.NormalizeExpr(p.EvalContext(), typedExpr)
+	return p.txCtx.NormalizeExpr(ctx, p.EvalContext(), typedExpr)
 }

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -138,7 +138,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 					break
 				}
 				// Compute join.
-				predMatched, err := a.pred.eval(params.EvalContext(), a.run.leftRow, rrow)
+				predMatched, err := a.pred.eval(params.ctx, params.EvalContext(), a.run.leftRow, rrow)
 				if err != nil {
 					return false, err
 				}
@@ -247,7 +247,7 @@ func (a *applyJoinNode) runNextRightSideIteration(params runParams, leftRow tree
 	opName := "apply-join-iteration-" + strconv.Itoa(a.iterationCount)
 	ctx, sp := tracing.ChildSpan(params.ctx, opName)
 	defer sp.Finish()
-	p, err := a.planRightSideFn(ctx, newExecFactory(params.p), leftRow)
+	p, err := a.planRightSideFn(ctx, newExecFactory(ctx, params.p), leftRow)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -368,7 +368,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		// Evaluate the new values. This must be done separately for
 		// each row so as to handle impure functions correctly.
 		for j, e := range cb.updateExprs {
-			val, err := eval.Expr(cb.evalCtx, e)
+			val, err := eval.Expr(ctx, cb.evalCtx, e)
 			if err != nil {
 				return roachpb.Key{}, sqlerrors.NewInvalidSchemaDefinitionError(err)
 			}
@@ -874,7 +874,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 			if !ok {
 				continue
 			}
-			val, err := eval.Expr(ib.evalCtx, texpr)
+			val, err := eval.Expr(ctx, ib.evalCtx, texpr)
 			if err != nil {
 				return err
 			}
@@ -931,7 +931,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 				// predicate expression evaluates to true.
 				texpr := ib.predicates[idx.GetID()]
 
-				val, err := eval.Expr(ib.evalCtx, texpr)
+				val, err := eval.Expr(ctx, ib.evalCtx, texpr)
 				if err != nil {
 					return nil, nil, 0, err
 				}

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -248,7 +248,7 @@ func (d *dummyColumn) TypeCheck(
 	return d, nil
 }
 
-func (*dummyColumn) Eval(v tree.ExprEvaluator) (tree.Datum, error) {
+func (*dummyColumn) Eval(ctx context.Context, v tree.ExprEvaluator) (tree.Datum, error) {
 	panic("dummyColumnItem.EvalVisit() is undefined")
 }
 

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -254,7 +254,7 @@ func MakeComputedExprs(
 		if err != nil {
 			return nil, catalog.TableColSet{}, err
 		}
-		if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
+		if typedExpr, err = txCtx.NormalizeExpr(ctx, evalCtx, typedExpr); err != nil {
 			return nil, catalog.TableColSet{}, err
 		}
 		computedExprs = append(computedExprs, typedExpr)

--- a/pkg/sql/catalog/schemaexpr/computed_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/computed_exprs.go
@@ -11,9 +11,12 @@
 package schemaexpr
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -29,10 +32,12 @@ type RowIndexedVarContainer struct {
 	Mapping catalog.TableColMap
 }
 
-var _ tree.IndexedVarContainer = &RowIndexedVarContainer{}
+var _ eval.IndexedVarContainer = &RowIndexedVarContainer{}
 
-// IndexedVarEval implements tree.IndexedVarContainer.
-func (r *RowIndexedVarContainer) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
+// IndexedVarEval implements eval.IndexedVarContainer.
+func (r *RowIndexedVarContainer) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
 	rowIdx, ok := r.Mapping.Get(r.Cols[idx].GetID())
 	if !ok {
 		return tree.DNull, nil

--- a/pkg/sql/catalog/schemaexpr/default_exprs.go
+++ b/pkg/sql/catalog/schemaexpr/default_exprs.go
@@ -71,7 +71,7 @@ func MakeDefaultExprs(
 		if err != nil {
 			return nil, err
 		}
-		if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
+		if typedExpr, err = txCtx.NormalizeExpr(ctx, evalCtx, typedExpr); err != nil {
 			return nil, err
 		}
 		defaultExprs = append(defaultExprs, typedExpr)

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -309,7 +309,7 @@ func deserializeExprForFormatting(
 		if err == nil {
 			// An empty EvalContext is fine here since the expression has
 			// Immutable.
-			d, err := eval.Expr(&eval.Context{}, sanitizedExpr)
+			d, err := eval.Expr(ctx, &eval.Context{}, sanitizedExpr)
 			if err == nil {
 				return d, nil
 			}
@@ -378,10 +378,12 @@ type nameResolverIVarContainer struct {
 	cols []catalog.Column
 }
 
-// IndexedVarEval implements the tree.IndexedVarContainer interface.
-// Evaluation is not support, so this function panics.
+var _ eval.IndexedVarContainer = &nameResolverIVarContainer{}
+
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
+// Evaluation is not supported, so this function panics.
 func (nrc *nameResolverIVarContainer) IndexedVarEval(
-	idx int, e tree.ExprEvaluator,
+	ctx context.Context, idx int, e tree.ExprEvaluator,
 ) (tree.Datum, error) {
 	panic("unsupported")
 }
@@ -391,7 +393,7 @@ func (nrc *nameResolverIVarContainer) IndexedVarResolvedType(idx int) *types.T {
 	return nrc.cols[idx].GetType()
 }
 
-// IndexVarNodeFormatter implements the tree.IndexedVarContainer interface.
+// IndexedVarNodeFormatter implements the tree.IndexedVarContainer interface.
 func (nrc *nameResolverIVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 	return nil
 }

--- a/pkg/sql/catalog/schemaexpr/partial_index.go
+++ b/pkg/sql/catalog/schemaexpr/partial_index.go
@@ -150,7 +150,7 @@ func MakePartialIndexExprs(
 				return nil, refColIDs, err
 			}
 
-			if typedExpr, err = txCtx.NormalizeExpr(evalCtx, typedExpr); err != nil {
+			if typedExpr, err = txCtx.NormalizeExpr(ctx, evalCtx, typedExpr); err != nil {
 				return nil, refColIDs, err
 			}
 

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -277,7 +277,7 @@ func EvalShardBucketCount(
 		if err != nil {
 			return 0, err
 		}
-		d, err := eval.Expr(evalCtx, typedExpr)
+		d, err := eval.Expr(ctx, evalCtx, typedExpr)
 		if err != nil {
 			return 0, pgerror.Wrapf(err, pgcode.InvalidParameterValue, invalidBucketCountMsg, typedExpr)
 		}

--- a/pkg/sql/colexec/builtin_funcs.go
+++ b/pkg/sql/colexec/builtin_funcs.go
@@ -74,7 +74,7 @@ func (b *defaultBuiltinFuncOperator) Next() coldata.Batch {
 					res = tree.DNull
 				} else {
 					res, err = b.funcExpr.ResolvedOverload().
-						Fn.(eval.FnOverload)(b.evalCtx, b.row)
+						Fn.(eval.FnOverload)(b.Ctx, b.evalCtx, b.row)
 					if err != nil {
 						colexecerror.ExpectedError(b.funcExpr.MaybeWrapError(err))
 					}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2699,7 +2699,7 @@ func evalTupleIfConst(evalCtx *eval.Context, t *tree.Tuple) (_ tree.Datum, ok bo
 			return nil, false
 		}
 	}
-	tuple, err := eval.Expr(evalCtx, t)
+	tuple, err := eval.Expr(evalCtx.Context, evalCtx, t)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -869,7 +869,7 @@ func NewColOperator(
 					// The second argument is nil because we disable the
 					// tracking of the input tuples.
 					result.Root = colexec.NewHashAggregator(
-						newAggArgs, nil, /* newSpillingQueueArgs */
+						ctx, newAggArgs, nil, /* newSpillingQueueArgs */
 						hashTableAllocator, outputUnlimitedAllocator, maxOutputBatchMemSize,
 					)
 				} else {
@@ -911,6 +911,7 @@ func NewColOperator(
 					newAggArgs.MemAccount = hashAggregatorMemAccount
 					hashTableAllocator := colmem.NewLimitedAllocator(ctx, hashTableMemAccount, accounts[1], factory)
 					inMemoryHashAggregator := colexec.NewHashAggregator(
+						ctx,
 						newAggArgs,
 						&colexecutils.NewSpillingQueueArgs{
 							UnlimitedAllocator: colmem.NewAllocator(ctx, accounts[2], factory),
@@ -952,6 +953,7 @@ func NewColOperator(
 							newAggArgs.Input = input
 							ehaHashTableAllocator := colmem.NewAllocator(ctx, ehaAccounts[1], factory)
 							eha, toClose := colexecdisk.NewExternalHashAggregator(
+								ctx,
 								flowCtx,
 								args,
 								&newAggArgs,
@@ -971,7 +973,7 @@ func NewColOperator(
 				evalCtx.SingleDatumAggMemAccount = args.StreamingMemAccount
 				newAggArgs.Allocator = getStreamingAllocator(ctx, args)
 				newAggArgs.MemAccount = args.StreamingMemAccount
-				result.Root = colexec.NewOrderedAggregator(newAggArgs)
+				result.Root = colexec.NewOrderedAggregator(ctx, newAggArgs)
 			}
 			result.ToClose = append(result.ToClose, result.Root.(colexecop.Closer))
 
@@ -1428,7 +1430,7 @@ func NewColOperator(
 							// Min and max window functions have specialized implementations
 							// when the frame can shrink and has a default exclusion clause.
 							aggFnsAlloc, _, toClose, err = colexecagg.NewAggregateFuncsAlloc(
-								&aggArgs, aggregations, 1 /* allocSize */, colexecagg.WindowAggKind,
+								ctx, &aggArgs, aggregations, 1 /* allocSize */, colexecagg.WindowAggKind,
 							)
 							if err != nil {
 								colexecerror.InternalError(err)
@@ -2343,7 +2345,7 @@ func planProjectionOperators(
 	case *tree.OrExpr:
 		return planLogicalProjectionOp(ctx, evalCtx, expr, columnTypes, input, acc, factory, releasables)
 	case *tree.Tuple:
-		tuple, isConstTuple := evalTupleIfConst(evalCtx, t)
+		tuple, isConstTuple := evalTupleIfConst(ctx, evalCtx, t)
 		if isConstTuple {
 			// Tuple expression is a constant, so we can just project the
 			// resulting datum.
@@ -2474,7 +2476,7 @@ func planProjectionExpr(
 		if tuple, ok := right.(*tree.Tuple); ok {
 			// If we have a tuple on the right, try to pre-evaluate it in case
 			// it consists only of constant expressions.
-			tupleDatum, ok := evalTupleIfConst(evalCtx, tuple)
+			tupleDatum, ok := evalTupleIfConst(ctx, evalCtx, tuple)
 			if ok {
 				right = tupleDatum
 			}
@@ -2692,14 +2694,16 @@ func useDefaultCmpOpForIn(tuple *tree.DTuple) bool {
 
 // evalTupleIfConst checks whether t contains only constant (i.e. tree.Datum)
 // expressions and evaluates the tuple if so.
-func evalTupleIfConst(evalCtx *eval.Context, t *tree.Tuple) (_ tree.Datum, ok bool) {
+func evalTupleIfConst(
+	ctx context.Context, evalCtx *eval.Context, t *tree.Tuple,
+) (_ tree.Datum, ok bool) {
 	for _, expr := range t.Exprs {
 		if _, isDatum := expr.(tree.Datum); !isDatum {
 			// Not a constant expression.
 			return nil, false
 		}
 	}
-	tuple, err := eval.Expr(evalCtx.Context, evalCtx, t)
+	tuple, err := eval.Expr(ctx, evalCtx, t)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -220,6 +220,7 @@ const (
 
 // NewAggregateFuncsAlloc returns a new AggregateFuncsAlloc.
 func NewAggregateFuncsAlloc(
+	ctx context.Context,
 	args *NewAggregatorArgs,
 	aggregations []execinfrapb.AggregatorSpec_Aggregation,
 	allocSize int64,
@@ -381,12 +382,12 @@ func NewAggregateFuncsAlloc(
 			switch aggKind {
 			case HashAggKind:
 				funcAllocs[i] = newDefaultHashAggAlloc(
-					args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
+					ctx, args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
 					len(aggFn.ColIdx), args.ConstArguments[i], args.OutputTypes[i], allocSize,
 				)
 			case OrderedAggKind:
 				funcAllocs[i] = newDefaultOrderedAggAlloc(
-					args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
+					ctx, args.Allocator, args.Constructors[i], args.EvalCtx, inputArgsConverter,
 					len(aggFn.ColIdx), args.ConstArguments[i], args.OutputTypes[i], allocSize,
 				)
 			case WindowAggKind:

--- a/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecagg/default_agg_tmpl.go
@@ -117,6 +117,7 @@ func (a *default_AGGKINDAgg) Reset() {
 }
 
 func newDefault_AGGKINDAggAlloc(
+	ctx context.Context,
 	allocator *colmem.Allocator,
 	constructor execagg.AggregateConstructor,
 	evalCtx *eval.Context,
@@ -136,6 +137,7 @@ func newDefault_AGGKINDAggAlloc(
 			allocSize: allocSize,
 		},
 		constructor:        constructor,
+		ctx:                ctx,
 		evalCtx:            evalCtx,
 		inputArgsConverter: inputArgsConverter,
 		resultConverter:    colconv.GetDatumToPhysicalFn(outputType),
@@ -149,6 +151,7 @@ type default_AGGKINDAggAlloc struct {
 	aggFuncs []default_AGGKINDAgg
 
 	constructor execagg.AggregateConstructor
+	ctx         context.Context
 	evalCtx     *eval.Context
 	// inputArgsConverter is a converter from coldata.Vecs to tree.Datums that
 	// is shared among all aggregate functions and is managed by the aggregator
@@ -190,7 +193,7 @@ func (a *default_AGGKINDAggAlloc) newAggFunc() AggregateFunc {
 	f := &a.aggFuncs[0]
 	*f = default_AGGKINDAgg{
 		fn:                 a.constructor(a.evalCtx, a.arguments),
-		ctx:                a.evalCtx.Context,
+		ctx:                a.ctx,
 		inputArgsConverter: a.inputArgsConverter,
 		resultConverter:    a.resultConverter,
 	}

--- a/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_default_agg.eg.go
@@ -90,6 +90,7 @@ func (a *defaultHashAgg) Reset() {
 }
 
 func newDefaultHashAggAlloc(
+	ctx context.Context,
 	allocator *colmem.Allocator,
 	constructor execagg.AggregateConstructor,
 	evalCtx *eval.Context,
@@ -109,6 +110,7 @@ func newDefaultHashAggAlloc(
 			allocSize: allocSize,
 		},
 		constructor:        constructor,
+		ctx:                ctx,
 		evalCtx:            evalCtx,
 		inputArgsConverter: inputArgsConverter,
 		resultConverter:    colconv.GetDatumToPhysicalFn(outputType),
@@ -122,6 +124,7 @@ type defaultHashAggAlloc struct {
 	aggFuncs []defaultHashAgg
 
 	constructor execagg.AggregateConstructor
+	ctx         context.Context
 	evalCtx     *eval.Context
 	// inputArgsConverter is a converter from coldata.Vecs to tree.Datums that
 	// is shared among all aggregate functions and is managed by the aggregator
@@ -163,7 +166,7 @@ func (a *defaultHashAggAlloc) newAggFunc() AggregateFunc {
 	f := &a.aggFuncs[0]
 	*f = defaultHashAgg{
 		fn:                 a.constructor(a.evalCtx, a.arguments),
-		ctx:                a.evalCtx.Context,
+		ctx:                a.ctx,
 		inputArgsConverter: a.inputArgsConverter,
 		resultConverter:    a.resultConverter,
 	}

--- a/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_default_agg.eg.go
@@ -155,6 +155,7 @@ func (a *defaultOrderedAgg) Reset() {
 }
 
 func newDefaultOrderedAggAlloc(
+	ctx context.Context,
 	allocator *colmem.Allocator,
 	constructor execagg.AggregateConstructor,
 	evalCtx *eval.Context,
@@ -174,6 +175,7 @@ func newDefaultOrderedAggAlloc(
 			allocSize: allocSize,
 		},
 		constructor:        constructor,
+		ctx:                ctx,
 		evalCtx:            evalCtx,
 		inputArgsConverter: inputArgsConverter,
 		resultConverter:    colconv.GetDatumToPhysicalFn(outputType),
@@ -187,6 +189,7 @@ type defaultOrderedAggAlloc struct {
 	aggFuncs []defaultOrderedAgg
 
 	constructor execagg.AggregateConstructor
+	ctx         context.Context
 	evalCtx     *eval.Context
 	// inputArgsConverter is a converter from coldata.Vecs to tree.Datums that
 	// is shared among all aggregate functions and is managed by the aggregator
@@ -228,7 +231,7 @@ func (a *defaultOrderedAggAlloc) newAggFunc() AggregateFunc {
 	f := &a.aggFuncs[0]
 	*f = defaultOrderedAgg{
 		fn:                 a.constructor(a.evalCtx, a.arguments),
-		ctx:                a.evalCtx.Context,
+		ctx:                a.ctx,
 		inputArgsConverter: a.inputArgsConverter,
 		resultConverter:    a.resultConverter,
 	}

--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -1306,13 +1306,16 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 			if inputVec.Nulls().MaybeHasNulls() {
 				for scratchIdx, outputIdx := range sel[:n] {
 					{
-						var evalCtx *eval.Context = c.evalCtx
+						var (
+							ctx     context.Context = c.Ctx
+							evalCtx *eval.Context   = c.evalCtx
+						)
 						converted := scratch[scratchIdx]
 						if true && converted == tree.DNull {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := eval.PerformCast(evalCtx, converted, toType)
+						res, err := eval.PerformCast(ctx, evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1322,13 +1325,16 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 			} else {
 				for scratchIdx, outputIdx := range sel[:n] {
 					{
-						var evalCtx *eval.Context = c.evalCtx
+						var (
+							ctx     context.Context = c.Ctx
+							evalCtx *eval.Context   = c.evalCtx
+						)
 						converted := scratch[scratchIdx]
 						if false && converted == tree.DNull {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := eval.PerformCast(evalCtx, converted, toType)
+						res, err := eval.PerformCast(ctx, evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1342,9 +1348,10 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 				for idx := 0; idx < n; idx++ {
 					{
 						var (
-							scratchIdx int           = idx
-							outputIdx  int           = idx
-							evalCtx    *eval.Context = c.evalCtx
+							ctx        context.Context = c.Ctx
+							scratchIdx int             = idx
+							outputIdx  int             = idx
+							evalCtx    *eval.Context   = c.evalCtx
 						)
 						//gcassert:bce
 						converted := scratch[scratchIdx]
@@ -1352,7 +1359,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := eval.PerformCast(evalCtx, converted, toType)
+						res, err := eval.PerformCast(ctx, evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1363,9 +1370,10 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 				for idx := 0; idx < n; idx++ {
 					{
 						var (
-							scratchIdx int           = idx
-							outputIdx  int           = idx
-							evalCtx    *eval.Context = c.evalCtx
+							ctx        context.Context = c.Ctx
+							scratchIdx int             = idx
+							outputIdx  int             = idx
+							evalCtx    *eval.Context   = c.evalCtx
 						)
 						//gcassert:bce
 						converted := scratch[scratchIdx]
@@ -1373,7 +1381,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 							outputNulls.SetNull(outputIdx)
 							continue
 						}
-						res, err := eval.PerformCast(evalCtx, converted, toType)
+						res, err := eval.PerformCast(ctx, evalCtx, converted, toType)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -12187,7 +12195,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12217,7 +12225,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12249,7 +12257,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12279,7 +12287,7 @@ func (c *castDatumBoolOp) Next() coldata.Batch {
 							var r bool
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12344,7 +12352,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12374,7 +12382,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12406,7 +12414,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12436,7 +12444,7 @@ func (c *castDatumInt2Op) Next() coldata.Batch {
 							var r int16
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12501,7 +12509,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12531,7 +12539,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12563,7 +12571,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12593,7 +12601,7 @@ func (c *castDatumInt4Op) Next() coldata.Batch {
 							var r int32
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12658,7 +12666,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12688,7 +12696,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12720,7 +12728,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12750,7 +12758,7 @@ func (c *castDatumIntOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12815,7 +12823,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12845,7 +12853,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12877,7 +12885,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12907,7 +12915,7 @@ func (c *castDatumFloatOp) Next() coldata.Batch {
 							var r float64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -12972,7 +12980,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13002,7 +13010,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13034,7 +13042,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13064,7 +13072,7 @@ func (c *castDatumDecimalOp) Next() coldata.Batch {
 							var r apd.Decimal
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13129,7 +13137,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13159,7 +13167,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13191,7 +13199,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13221,7 +13229,7 @@ func (c *castDatumDateOp) Next() coldata.Batch {
 							var r int64
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13286,7 +13294,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13316,7 +13324,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13348,7 +13356,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13378,7 +13386,7 @@ func (c *castDatumTimestampOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13443,7 +13451,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13473,7 +13481,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13505,7 +13513,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13535,7 +13543,7 @@ func (c *castDatumIntervalOp) Next() coldata.Batch {
 							var r duration.Duration
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13600,7 +13608,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13629,7 +13637,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13660,7 +13668,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13689,7 +13697,7 @@ func (c *castDatumStringOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13753,7 +13761,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13782,7 +13790,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13813,7 +13821,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13842,7 +13850,7 @@ func (c *castDatumBytesOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13906,7 +13914,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13936,7 +13944,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13968,7 +13976,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -13998,7 +14006,7 @@ func (c *castDatumTimestamptzOp) Next() coldata.Batch {
 							var r time.Time
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14063,7 +14071,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14092,7 +14100,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14123,7 +14131,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14152,7 +14160,7 @@ func (c *castDatumUuidOp) Next() coldata.Batch {
 							var r []byte
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14216,7 +14224,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14245,7 +14253,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14276,7 +14284,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14305,7 +14313,7 @@ func (c *castDatumJsonbOp) Next() coldata.Batch {
 							var r json.JSON
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14368,7 +14376,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14403,7 +14411,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14440,7 +14448,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}
@@ -14475,7 +14483,7 @@ func (c *castDatumDatumOp) Next() coldata.Batch {
 							var r interface{}
 
 							{
-								_castedDatum, err := eval.PerformCast(evalCtx, v.(tree.Datum), toType)
+								_castedDatum, err := eval.PerformCast(c.Ctx, evalCtx, v.(tree.Datum), toType)
 								if err != nil {
 									colexecerror.ExpectedError(err)
 								}

--- a/pkg/sql/colexec/colexecbase/cast_test.go
+++ b/pkg/sql/colexec/colexecbase/cast_test.go
@@ -68,7 +68,7 @@ func TestRandomizedCast(t *testing.T) {
 			// We don't allow any NULL datums to be generated, so disable this
 			// ability in the RandDatum function.
 			fromDatum := randgen.RandDatum(rng, from, false)
-			toDatum, err := eval.PerformCast(&evalCtx, fromDatum, to)
+			toDatum, err := eval.PerformCast(ctx, &evalCtx, fromDatum, to)
 			var toPhys interface{}
 			if err != nil {
 				errorExpected = true

--- a/pkg/sql/colexec/colexecbase/cast_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/cast_tmpl.go
@@ -411,22 +411,22 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 		if sel != nil {
 			if inputVec.Nulls().MaybeHasNulls() {
 				for scratchIdx, outputIdx := range sel[:n] {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, true, false)
+					setNativeToDatumCast(c.Ctx, outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, true, false)
 				}
 			} else {
 				for scratchIdx, outputIdx := range sel[:n] {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, false, false)
+					setNativeToDatumCast(c.Ctx, outputCol, outputNulls, scratch, scratchIdx, outputIdx, toType, c.evalCtx, false, false)
 				}
 			}
 		} else {
 			_ = scratch[n-1]
 			if inputVec.Nulls().MaybeHasNulls() {
 				for idx := 0; idx < n; idx++ {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, true, true)
+					setNativeToDatumCast(c.Ctx, outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, true, true)
 				}
 			} else {
 				for idx := 0; idx < n; idx++ {
-					setNativeToDatumCast(outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, false, true)
+					setNativeToDatumCast(c.Ctx, outputCol, outputNulls, scratch, idx, idx, toType, c.evalCtx, false, true)
 				}
 			}
 		}
@@ -440,6 +440,7 @@ func (c *castNativeToDatumOp) Next() coldata.Batch {
 // execgen:inline
 // execgen:template<hasNulls,scratchBCE>
 func setNativeToDatumCast(
+	ctx context.Context,
 	outputCol coldata.DatumVec,
 	outputNulls *coldata.Nulls,
 	scratch []tree.Datum,
@@ -458,7 +459,7 @@ func setNativeToDatumCast(
 		outputNulls.SetNull(outputIdx)
 		continue
 	}
-	res, err := eval.PerformCast(evalCtx, converted, toType)
+	res, err := eval.PerformCast(ctx, evalCtx, converted, toType)
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr.eg.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr.eg.go
@@ -12,6 +12,8 @@
 package colexeccmp
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -28,11 +30,11 @@ type cmpExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpExprAdapter{}
 
-func (c *cmpExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
 	}
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -50,11 +52,11 @@ type cmpNegateExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpNegateExprAdapter{}
 
-func (c *cmpNegateExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpNegateExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
 	}
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -72,12 +74,12 @@ type cmpFlippedExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpFlippedExprAdapter{}
 
-func (c *cmpFlippedExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpFlippedExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
 	}
 	left, right = right, left
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -95,12 +97,12 @@ type cmpFlippedNegateExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpFlippedNegateExprAdapter{}
 
-func (c *cmpFlippedNegateExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpFlippedNegateExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
 	}
 	left, right = right, left
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -118,8 +120,8 @@ type cmpNullableExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpNullableExprAdapter{}
 
-func (c *cmpNullableExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+func (c *cmpNullableExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -137,8 +139,8 @@ type cmpNullableNegateExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpNullableNegateExprAdapter{}
 
-func (c *cmpNullableNegateExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+func (c *cmpNullableNegateExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -156,9 +158,9 @@ type cmpNullableFlippedExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpNullableFlippedExprAdapter{}
 
-func (c *cmpNullableFlippedExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpNullableFlippedExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	left, right = right, left
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -176,9 +178,9 @@ type cmpNullableFlippedNegateExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpNullableFlippedNegateExprAdapter{}
 
-func (c *cmpNullableFlippedNegateExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *cmpNullableFlippedNegateExprAdapter) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	left, right = right, left
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -197,6 +199,8 @@ type cmpWithSubOperatorExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpWithSubOperatorExprAdapter{}
 
-func (c *cmpWithSubOperatorExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
-	return eval.ComparisonExprWithSubOperator(c.evalCtx, c.expr, left, right)
+func (c *cmpWithSubOperatorExprAdapter) Eval(
+	ctx context.Context, left, right tree.Datum,
+) (tree.Datum, error) {
+	return eval.ComparisonExprWithSubOperator(ctx, c.evalCtx, c.expr, left, right)
 }

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr.go
@@ -11,6 +11,8 @@
 package colexeccmp
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -19,7 +21,7 @@ import (
 // structs that behave as an adapter from tree.ComparisonExpr to a vectorized
 // friendly model.
 type ComparisonExprAdapter interface {
-	Eval(left, right tree.Datum) (tree.Datum, error)
+	Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error)
 }
 
 // NewComparisonExprAdapter returns a new ComparisonExprAdapter for the provided

--- a/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
+++ b/pkg/sql/colexec/colexeccmp/default_cmp_expr_tmpl.go
@@ -22,6 +22,8 @@
 package colexeccmp
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/errors"
@@ -40,7 +42,7 @@ type _EXPR_NAME struct {
 
 var _ ComparisonExprAdapter = &_EXPR_NAME{}
 
-func (c *_EXPR_NAME) Eval(left, right tree.Datum) (tree.Datum, error) {
+func (c *_EXPR_NAME) Eval(ctx context.Context, left, right tree.Datum) (tree.Datum, error) {
 	// {{if not .CalledOnNullInput}}
 	if left == tree.DNull || right == tree.DNull {
 		return tree.DNull, nil
@@ -49,7 +51,7 @@ func (c *_EXPR_NAME) Eval(left, right tree.Datum) (tree.Datum, error) {
 	// {{if .FlippedArgs}}
 	left, right = right, left
 	// {{end}}
-	d, err := eval.BinaryOp(c.evalCtx, c.op, left, right)
+	d, err := eval.BinaryOp(ctx, c.evalCtx, c.op, left, right)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -74,6 +76,8 @@ type cmpWithSubOperatorExprAdapter struct {
 
 var _ ComparisonExprAdapter = &cmpWithSubOperatorExprAdapter{}
 
-func (c *cmpWithSubOperatorExprAdapter) Eval(left, right tree.Datum) (tree.Datum, error) {
-	return eval.ComparisonExprWithSubOperator(c.evalCtx, c.expr, left, right)
+func (c *cmpWithSubOperatorExprAdapter) Eval(
+	ctx context.Context, left, right tree.Datum,
+) (tree.Datum, error) {
+	return eval.ComparisonExprWithSubOperator(ctx, c.evalCtx, c.expr, left, right)
 }

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_op.eg.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_op.eg.go
@@ -54,7 +54,7 @@ func (d *defaultCmpProjOp) Next() coldata.Batch {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether sel is non-nil.
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], rightColumn[i])
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], rightColumn[i])
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/default_cmp_proj_ops_tmpl.go
@@ -77,10 +77,10 @@ func (d *defaultCmp_KINDProjOp) Next() coldata.Batch {
 			// is no need to check whether sel is non-nil.
 			// {{if .IsRightConst}}
 			//gcassert:bce
-			res, err := d.adapter.Eval(nonConstColumn[i], d.constArg)
+			res, err := d.adapter.Eval(d.Ctx, nonConstColumn[i], d.constArg)
 			// {{else}}
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], rightColumn[i])
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], rightColumn[i])
 			// {{end}}
 			if err != nil {
 				colexecerror.ExpectedError(err)

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -803,6 +803,7 @@ type projBitandDatumDatumOp struct {
 
 func (p projBitandDatumDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -834,7 +835,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -862,7 +863,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -884,7 +885,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -902,7 +903,7 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1663,6 +1664,7 @@ type projBitorDatumDatumOp struct {
 
 func (p projBitorDatumDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -1694,7 +1696,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1722,7 +1724,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1744,7 +1746,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1762,7 +1764,7 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2523,6 +2525,7 @@ type projBitxorDatumDatumOp struct {
 
 func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -2554,7 +2557,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2582,7 +2585,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2604,7 +2607,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2622,7 +2625,7 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3513,6 +3516,7 @@ type projPlusInt16DatumOp struct {
 
 func (p projPlusInt16DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -3542,7 +3546,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3569,7 +3573,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3593,7 +3597,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3616,7 +3620,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4071,6 +4075,7 @@ type projPlusInt32DatumOp struct {
 
 func (p projPlusInt32DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4100,7 +4105,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4127,7 +4132,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4151,7 +4156,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4174,7 +4179,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4629,6 +4634,7 @@ type projPlusInt64DatumOp struct {
 
 func (p projPlusInt64DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4658,7 +4664,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4685,7 +4691,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4709,7 +4715,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4732,7 +4738,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5111,6 +5117,7 @@ type projPlusIntervalDatumOp struct {
 
 func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5140,7 +5147,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5167,7 +5174,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5191,7 +5198,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5214,7 +5221,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5237,6 +5244,7 @@ type projPlusDatumIntervalOp struct {
 
 func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5266,7 +5274,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5293,7 +5301,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5317,7 +5325,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5340,7 +5348,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5363,6 +5371,7 @@ type projPlusDatumInt16Op struct {
 
 func (p projPlusDatumInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5392,7 +5401,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5419,7 +5428,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5443,7 +5452,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5466,7 +5475,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5489,6 +5498,7 @@ type projPlusDatumInt32Op struct {
 
 func (p projPlusDatumInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5518,7 +5528,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5545,7 +5555,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5569,7 +5579,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5592,7 +5602,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5615,6 +5625,7 @@ type projPlusDatumInt64Op struct {
 
 func (p projPlusDatumInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5644,7 +5655,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5671,7 +5682,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5695,7 +5706,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5718,7 +5729,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6609,6 +6620,7 @@ type projMinusInt16DatumOp struct {
 
 func (p projMinusInt16DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -6638,7 +6650,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6665,7 +6677,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6689,7 +6701,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6712,7 +6724,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7167,6 +7179,7 @@ type projMinusInt32DatumOp struct {
 
 func (p projMinusInt32DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7196,7 +7209,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7223,7 +7236,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7247,7 +7260,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7270,7 +7283,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7725,6 +7738,7 @@ type projMinusInt64DatumOp struct {
 
 func (p projMinusInt64DatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7754,7 +7768,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7781,7 +7795,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7805,7 +7819,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7828,7 +7842,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8199,6 +8213,7 @@ type projMinusIntervalDatumOp struct {
 
 func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8228,7 +8243,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8255,7 +8270,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8279,7 +8294,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8302,7 +8317,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8707,6 +8722,7 @@ type projMinusDatumDatumOp struct {
 
 func (p projMinusDatumDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8738,7 +8754,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8766,7 +8782,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8788,7 +8804,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8806,7 +8822,7 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8829,6 +8845,7 @@ type projMinusDatumIntervalOp struct {
 
 func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8858,7 +8875,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8885,7 +8902,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8909,7 +8926,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8932,7 +8949,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8955,6 +8972,7 @@ type projMinusDatumBytesOp struct {
 
 func (p projMinusDatumBytesOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8984,7 +9002,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9010,7 +9028,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9034,7 +9052,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9056,7 +9074,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9079,6 +9097,7 @@ type projMinusDatumInt16Op struct {
 
 func (p projMinusDatumInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -9108,7 +9127,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9135,7 +9154,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9159,7 +9178,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9182,7 +9201,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9205,6 +9224,7 @@ type projMinusDatumInt32Op struct {
 
 func (p projMinusDatumInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -9234,7 +9254,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9261,7 +9281,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9285,7 +9305,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9308,7 +9328,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9331,6 +9351,7 @@ type projMinusDatumInt64Op struct {
 
 func (p projMinusDatumInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -9360,7 +9381,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9387,7 +9408,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -9411,7 +9432,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -9434,7 +9455,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20879,6 +20900,7 @@ type projConcatDatumDatumOp struct {
 
 func (p projConcatDatumDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20910,7 +20932,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20938,7 +20960,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 							arg2 = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20960,7 +20982,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20978,7 +21000,7 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					arg1 := col1.Get(i)
 					arg2 := col2.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21955,6 +21977,7 @@ type projLShiftDatumInt16Op struct {
 
 func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21984,7 +22007,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22011,7 +22034,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22035,7 +22058,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -22058,7 +22081,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -22081,6 +22104,7 @@ type projLShiftDatumInt32Op struct {
 
 func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -22110,7 +22134,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22137,7 +22161,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22161,7 +22185,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -22184,7 +22208,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -22207,6 +22231,7 @@ type projLShiftDatumInt64Op struct {
 
 func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -22236,7 +22261,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22263,7 +22288,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -22287,7 +22312,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -22310,7 +22335,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23287,6 +23312,7 @@ type projRShiftDatumInt16Op struct {
 
 func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -23316,7 +23342,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23343,7 +23369,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23367,7 +23393,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23390,7 +23416,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23413,6 +23439,7 @@ type projRShiftDatumInt32Op struct {
 
 func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -23442,7 +23469,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23469,7 +23496,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23493,7 +23520,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23516,7 +23543,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23539,6 +23566,7 @@ type projRShiftDatumInt64Op struct {
 
 func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -23568,7 +23596,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23595,7 +23623,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -23619,7 +23647,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -23642,7 +23670,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -103,6 +103,7 @@ func (p _OP_NAME) Next() coldata.Batch {
 	//     variable of type `colexecutils.BinaryOverloadHelper`.
 	// */}}
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	// {{end}}
 	batch := p.Input.Next()
 	n := batch.Length()

--- a/pkg/sql/colexec/colexecprojconst/default_cmp_proj_const_op.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/default_cmp_proj_const_op.eg.go
@@ -53,7 +53,7 @@ func (d *defaultCmpRConstProjOp) Next() coldata.Batch {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether sel is non-nil.
 			//gcassert:bce
-			res, err := d.adapter.Eval(nonConstColumn[i], d.constArg)
+			res, err := d.adapter.Eval(d.Ctx, nonConstColumn[i], d.constArg)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/colexecprojconst/like_ops.go
+++ b/pkg/sql/colexec/colexecprojconst/like_ops.go
@@ -25,7 +25,7 @@ import (
 // true. The implementation varies depending on the complexity of the pattern.
 func GetLikeProjectionOperator(
 	allocator *colmem.Allocator,
-	ctx *eval.Context,
+	evalCtx *eval.Context,
 	input colexecop.Operator,
 	colIdx int,
 	resultIdx int,
@@ -87,7 +87,7 @@ func GetLikeProjectionOperator(
 			caseInsensitive: caseInsensitive,
 		}, nil
 	case colexeccmp.LikeRegexp:
-		re, err := eval.ConvertLikeToRegexp(ctx, string(patterns[0]), caseInsensitive, '\\')
+		re, err := eval.ConvertLikeToRegexp(evalCtx, string(patterns[0]), caseInsensitive, '\\')
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -721,6 +721,7 @@ type projBitandDatumConstDatumOp struct {
 
 func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -748,7 +749,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -770,7 +771,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -791,7 +792,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -807,7 +808,7 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1497,6 +1498,7 @@ type projBitorDatumConstDatumOp struct {
 
 func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -1524,7 +1526,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1546,7 +1548,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1567,7 +1569,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1583,7 +1585,7 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2273,6 +2275,7 @@ type projBitxorDatumConstDatumOp struct {
 
 func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -2300,7 +2303,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2322,7 +2325,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2343,7 +2346,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2359,7 +2362,7 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3187,6 +3190,7 @@ type projPlusInt16ConstDatumOp struct {
 
 func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -3215,7 +3219,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3239,7 +3243,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3262,7 +3266,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3283,7 +3287,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3707,6 +3711,7 @@ type projPlusInt32ConstDatumOp struct {
 
 func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -3735,7 +3740,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3759,7 +3764,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3782,7 +3787,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3803,7 +3808,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4227,6 +4232,7 @@ type projPlusInt64ConstDatumOp struct {
 
 func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4255,7 +4261,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4279,7 +4285,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4302,7 +4308,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4323,7 +4329,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4671,6 +4677,7 @@ type projPlusIntervalConstDatumOp struct {
 
 func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4699,7 +4706,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4723,7 +4730,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4746,7 +4753,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4767,7 +4774,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4791,6 +4798,7 @@ type projPlusDatumConstIntervalOp struct {
 
 func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4819,7 +4827,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4842,7 +4850,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4865,7 +4873,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4885,7 +4893,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4909,6 +4917,7 @@ type projPlusDatumConstInt16Op struct {
 
 func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4937,7 +4946,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4960,7 +4969,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4983,7 +4992,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5003,7 +5012,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5027,6 +5036,7 @@ type projPlusDatumConstInt32Op struct {
 
 func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5055,7 +5065,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5078,7 +5088,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5101,7 +5111,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5121,7 +5131,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5145,6 +5155,7 @@ type projPlusDatumConstInt64Op struct {
 
 func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5173,7 +5184,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5196,7 +5207,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5219,7 +5230,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5239,7 +5250,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6067,6 +6078,7 @@ type projMinusInt16ConstDatumOp struct {
 
 func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -6095,7 +6107,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6119,7 +6131,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6142,7 +6154,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6163,7 +6175,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6587,6 +6599,7 @@ type projMinusInt32ConstDatumOp struct {
 
 func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -6615,7 +6628,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6639,7 +6652,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6662,7 +6675,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6683,7 +6696,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7107,6 +7120,7 @@ type projMinusInt64ConstDatumOp struct {
 
 func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7135,7 +7149,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7159,7 +7173,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7182,7 +7196,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7203,7 +7217,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7543,6 +7557,7 @@ type projMinusIntervalConstDatumOp struct {
 
 func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7571,7 +7586,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7595,7 +7610,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7618,7 +7633,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7639,7 +7654,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8015,6 +8030,7 @@ type projMinusDatumConstDatumOp struct {
 
 func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8042,7 +8058,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8064,7 +8080,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8085,7 +8101,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8101,7 +8117,7 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8125,6 +8141,7 @@ type projMinusDatumConstIntervalOp struct {
 
 func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8153,7 +8170,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8176,7 +8193,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8199,7 +8216,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8219,7 +8236,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8243,6 +8260,7 @@ type projMinusDatumConstBytesOp struct {
 
 func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8271,7 +8289,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8294,7 +8312,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8317,7 +8335,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8337,7 +8355,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8361,6 +8379,7 @@ type projMinusDatumConstInt16Op struct {
 
 func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8389,7 +8408,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8412,7 +8431,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8435,7 +8454,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8455,7 +8474,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8479,6 +8498,7 @@ type projMinusDatumConstInt32Op struct {
 
 func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8507,7 +8527,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8530,7 +8550,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8553,7 +8573,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8573,7 +8593,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8597,6 +8617,7 @@ type projMinusDatumConstInt64Op struct {
 
 func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8625,7 +8646,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8648,7 +8669,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8671,7 +8692,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8691,7 +8712,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -19333,6 +19354,7 @@ type projConcatDatumConstDatumOp struct {
 
 func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -19360,7 +19382,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19382,7 +19404,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19403,7 +19425,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -19419,7 +19441,7 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20325,6 +20347,7 @@ type projLShiftDatumConstInt16Op struct {
 
 func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20353,7 +20376,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20376,7 +20399,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20399,7 +20422,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20419,7 +20442,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20443,6 +20466,7 @@ type projLShiftDatumConstInt32Op struct {
 
 func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20471,7 +20495,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20494,7 +20518,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20517,7 +20541,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20537,7 +20561,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20561,6 +20585,7 @@ type projLShiftDatumConstInt64Op struct {
 
 func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20589,7 +20614,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20612,7 +20637,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20635,7 +20660,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20655,7 +20680,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21561,6 +21586,7 @@ type projRShiftDatumConstInt16Op struct {
 
 func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21589,7 +21615,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21612,7 +21638,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21635,7 +21661,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21655,7 +21681,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21679,6 +21705,7 @@ type projRShiftDatumConstInt32Op struct {
 
 func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21707,7 +21734,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21730,7 +21757,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21753,7 +21780,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21773,7 +21800,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21797,6 +21824,7 @@ type projRShiftDatumConstInt64Op struct {
 
 func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21825,7 +21853,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21848,7 +21876,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21871,7 +21899,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21891,7 +21919,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_ops_tmpl.go
@@ -109,6 +109,7 @@ func (p _OP_CONST_NAME) Next() coldata.Batch {
 	//     variable of type `colexecutils.BinaryOverloadHelper`.
 	// */}}
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	// {{end}}
 	// {{if .Negatable}}
 	// {{/*

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -724,6 +724,7 @@ type projBitandDatumDatumConstOp struct {
 
 func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -751,7 +752,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -773,7 +774,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -794,7 +795,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -810,7 +811,7 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1500,6 +1501,7 @@ type projBitorDatumDatumConstOp struct {
 
 func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -1527,7 +1529,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1549,7 +1551,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -1570,7 +1572,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -1586,7 +1588,7 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2276,6 +2278,7 @@ type projBitxorDatumDatumConstOp struct {
 
 func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -2303,7 +2306,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2325,7 +2328,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -2346,7 +2349,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -2362,7 +2365,7 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3190,6 +3193,7 @@ type projPlusInt16DatumConstOp struct {
 
 func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -3218,7 +3222,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3241,7 +3245,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3264,7 +3268,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3284,7 +3288,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3708,6 +3712,7 @@ type projPlusInt32DatumConstOp struct {
 
 func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -3736,7 +3741,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3759,7 +3764,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -3782,7 +3787,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -3802,7 +3807,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4226,6 +4231,7 @@ type projPlusInt64DatumConstOp struct {
 
 func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4254,7 +4260,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4277,7 +4283,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4300,7 +4306,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4320,7 +4326,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4668,6 +4674,7 @@ type projPlusIntervalDatumConstOp struct {
 
 func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4696,7 +4703,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4719,7 +4726,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4742,7 +4749,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4762,7 +4769,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4786,6 +4793,7 @@ type projPlusDatumIntervalConstOp struct {
 
 func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4814,7 +4822,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4838,7 +4846,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4861,7 +4869,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4882,7 +4890,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -4906,6 +4914,7 @@ type projPlusDatumInt16ConstOp struct {
 
 func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -4934,7 +4943,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4958,7 +4967,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -4981,7 +4990,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5002,7 +5011,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5026,6 +5035,7 @@ type projPlusDatumInt32ConstOp struct {
 
 func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5054,7 +5064,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5078,7 +5088,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5101,7 +5111,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5122,7 +5132,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5146,6 +5156,7 @@ type projPlusDatumInt64ConstOp struct {
 
 func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -5174,7 +5185,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5198,7 +5209,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -5221,7 +5232,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -5242,7 +5253,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6070,6 +6081,7 @@ type projMinusInt16DatumConstOp struct {
 
 func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -6098,7 +6110,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6121,7 +6133,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6144,7 +6156,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6164,7 +6176,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6588,6 +6600,7 @@ type projMinusInt32DatumConstOp struct {
 
 func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -6616,7 +6629,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6639,7 +6652,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -6662,7 +6675,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -6682,7 +6695,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7106,6 +7119,7 @@ type projMinusInt64DatumConstOp struct {
 
 func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7134,7 +7148,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7157,7 +7171,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7180,7 +7194,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7200,7 +7214,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7540,6 +7554,7 @@ type projMinusIntervalDatumConstOp struct {
 
 func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -7568,7 +7583,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7591,7 +7606,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -7614,7 +7629,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -7634,7 +7649,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, _nonDatumArgAsDatum.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8016,6 +8031,7 @@ type projMinusDatumDatumConstOp struct {
 
 func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8043,7 +8059,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8065,7 +8081,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8086,7 +8102,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8102,7 +8118,7 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8126,6 +8142,7 @@ type projMinusDatumIntervalConstOp struct {
 
 func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8154,7 +8171,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8178,7 +8195,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8201,7 +8218,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8222,7 +8239,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8246,6 +8263,7 @@ type projMinusDatumBytesConstOp struct {
 
 func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8274,7 +8292,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8297,7 +8315,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8320,7 +8338,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8340,7 +8358,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8364,6 +8382,7 @@ type projMinusDatumInt16ConstOp struct {
 
 func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8392,7 +8411,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8416,7 +8435,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8439,7 +8458,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8460,7 +8479,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8484,6 +8503,7 @@ type projMinusDatumInt32ConstOp struct {
 
 func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8512,7 +8532,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8536,7 +8556,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8559,7 +8579,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8580,7 +8600,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8604,6 +8624,7 @@ type projMinusDatumInt64ConstOp struct {
 
 func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -8632,7 +8653,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8656,7 +8677,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -8679,7 +8700,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -8700,7 +8721,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -19342,6 +19363,7 @@ type projConcatDatumDatumConstOp struct {
 
 func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -19369,7 +19391,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19391,7 +19413,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 							arg = tree.DNull
 						}
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19412,7 +19434,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				for _, i := range sel {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -19428,7 +19450,7 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				for i := 0; i < n; i++ {
 					arg := col.Get(i)
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20334,6 +20356,7 @@ type projLShiftDatumInt16ConstOp struct {
 
 func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20362,7 +20385,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20386,7 +20409,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20409,7 +20432,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20430,7 +20453,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20454,6 +20477,7 @@ type projLShiftDatumInt32ConstOp struct {
 
 func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20482,7 +20506,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20506,7 +20530,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20529,7 +20553,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20550,7 +20574,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20574,6 +20598,7 @@ type projLShiftDatumInt64ConstOp struct {
 
 func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -20602,7 +20627,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20626,7 +20651,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20649,7 +20674,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -20670,7 +20695,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21576,6 +21601,7 @@ type projRShiftDatumInt16ConstOp struct {
 
 func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21604,7 +21630,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21628,7 +21654,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21651,7 +21677,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21672,7 +21698,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21696,6 +21722,7 @@ type projRShiftDatumInt32ConstOp struct {
 
 func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21724,7 +21751,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21748,7 +21775,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21771,7 +21798,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21792,7 +21819,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21816,6 +21843,7 @@ type projRShiftDatumInt64ConstOp struct {
 
 func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 	_overloadHelper := p.BinaryOverloadHelper
+	_ctx := p.Ctx
 	batch := p.Input.Next()
 	n := batch.Length()
 	if n == 0 {
@@ -21844,7 +21872,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21868,7 +21896,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 						var _nonDatumArgAsDatum tree.Datum
 						_nonDatumArgAsDatum = &_convertedNativeElem
 
-						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+						_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -21891,7 +21919,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}
@@ -21912,7 +21940,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 					var _nonDatumArgAsDatum tree.Datum
 					_nonDatumArgAsDatum = &_convertedNativeElem
 
-					_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
+					_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), _nonDatumArgAsDatum.(tree.Datum))
 					if err != nil {
 						colexecerror.ExpectedError(err)
 					}

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops.eg.go
@@ -52,7 +52,7 @@ func (d *defaultCmpSelOp) Next() coldata.Batch {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether hasSel is true.
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], rightColumn[i])
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], rightColumn[i])
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
@@ -107,7 +107,7 @@ func (d *defaultCmpConstSelOp) Next() coldata.Batch {
 			// Note that we performed a conversion with deselection, so there
 			// is no need to check whether hasSel is true.
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], d.constArg)
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], d.constArg)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecsel/default_cmp_sel_ops_tmpl.go
@@ -75,10 +75,10 @@ func (d *defaultCmp_KINDSelOp) Next() coldata.Batch {
 			// is no need to check whether hasSel is true.
 			// {{if .HasConst}}
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], d.constArg)
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], d.constArg)
 			// {{else}}
 			//gcassert:bce
-			res, err := d.adapter.Eval(leftColumn[i], rightColumn[i])
+			res, err := d.adapter.Eval(d.Ctx, leftColumn[i], rightColumn[i])
 			// {{end}}
 			if err != nil {
 				colexecerror.ExpectedError(err)

--- a/pkg/sql/colexec/colexecsel/like_ops.go
+++ b/pkg/sql/colexec/colexecsel/like_ops.go
@@ -21,7 +21,7 @@ import (
 // pattern, or NOT LIKE if the negate argument is true. The implementation
 // varies depending on the complexity of the pattern.
 func GetLikeOperator(
-	ctx *eval.Context,
+	evalCtx *eval.Context,
 	input colexecop.Operator,
 	colIdx int,
 	pattern string,
@@ -79,7 +79,7 @@ func GetLikeOperator(
 			caseInsensitive: caseInsensitive,
 		}, nil
 	case colexeccmp.LikeRegexp:
-		re, err := eval.ConvertLikeToRegexp(ctx, string(patterns[0]), caseInsensitive, '\\')
+		re, err := eval.ConvertLikeToRegexp(evalCtx, string(patterns[0]), caseInsensitive, '\\')
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/colexec/colexectestutils/proj_utils.go
+++ b/pkg/sql/colexec/colexectestutils/proj_utils.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -29,11 +30,13 @@ type MockTypeContext struct {
 	Typs []*types.T
 }
 
-var _ tree.IndexedVarContainer = &MockTypeContext{}
+var _ eval.IndexedVarContainer = &MockTypeContext{}
 
-// IndexedVarEval implements the tree.IndexedVarContainer interface.
-func (p *MockTypeContext) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
-	return tree.DNull.Eval(e)
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
+func (p *MockTypeContext) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
+	return tree.DNull.Eval(ctx, e)
 }
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -745,7 +745,7 @@ func stringToDatum(val string, typ *types.T, evalCtx *eval.Context) tree.Datum {
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
-	d, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
+	d, err := eval.Expr(context.Background(), evalCtx, typedExpr)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -745,7 +745,7 @@ func stringToDatum(val string, typ *types.T, evalCtx *eval.Context) tree.Datum {
 	if err != nil {
 		colexecerror.InternalError(err)
 	}
-	d, err := eval.Expr(evalCtx, typedExpr)
+	d, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
 	if err != nil {
 		colexecerror.InternalError(err)
 	}

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
@@ -1920,6 +1920,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetPrecedingStartAscDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -1948,7 +1949,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -3000,6 +3001,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetPrecedingStartDescDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -3028,7 +3030,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -4405,6 +4407,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetPrecedingEndAscDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -4450,7 +4453,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -5638,6 +5641,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetPrecedingEndDescDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -5683,7 +5687,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -6924,6 +6928,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetFollowingStartAscDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -6952,7 +6957,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -8004,6 +8009,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetFollowingStartDescDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -8032,7 +8038,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -9409,6 +9415,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetFollowingEndAscDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -9454,7 +9461,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}
@@ -10642,6 +10649,7 @@ var _ rangeOffsetHandler = &rangeHandlerOffsetFollowingEndDescDatum{}
 // be '4' to indicate that the end index is the end of the partition.
 func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, currRow, lastIdx int) (idx int) {
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 
 	if lastIdx >= h.storedCols.Length() {
 		return lastIdx
@@ -10687,7 +10695,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 	col := vec.Datum()
 	currRowVal := col.Get(vecIdx)
 
-	_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
+	_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, currRowVal.(tree.Datum), h.offset.(tree.Datum))
 	if err != nil {
 		colexecerror.ExpectedError(err)
 	}

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
@@ -200,6 +200,7 @@ func (h *_OP_STRING) getIdx(ctx context.Context, currRow, lastIdx int) (idx int)
 	//     yet handled natively.
 	// */}}
 	_overloadHelper := h.overloadHelper
+	_ctx := ctx
 	// {{end}}
 
 	if lastIdx >= h.storedCols.Length() {

--- a/pkg/sql/colexec/colexecwindow/window_functions_test.go
+++ b/pkg/sql/colexec/colexecwindow/window_functions_test.go
@@ -1222,7 +1222,7 @@ func BenchmarkWindowFunctions(b *testing.B) {
 				colexecagg.ProcessAggregations(ctx, &evalCtx, &semaCtx, aggregations, sourceTypes)
 			require.NoError(b, err)
 			aggFnsAlloc, _, toClose, err := colexecagg.NewAggregateFuncsAlloc(
-				&aggArgs, aggregations, 1 /* allocSize */, colexecagg.WindowAggKind,
+				ctx, &aggArgs, aggregations, 1 /* allocSize */, colexecagg.WindowAggKind,
 			)
 			require.NoError(b, err)
 			op = NewWindowAggregatorOperator(

--- a/pkg/sql/colexec/default_agg_test.go
+++ b/pkg/sql/colexec/default_agg_test.go
@@ -148,7 +148,7 @@ func TestDefaultAggregateFunc(t *testing.T) {
 				)
 				require.NoError(t, err)
 				colexectestutils.RunTestsWithTyps(t, testAllocator, []colexectestutils.Tuples{tc.input}, [][]*types.T{tc.typs}, tc.expected, colexectestutils.UnorderedVerifier, func(input []colexecop.Operator) (colexecop.Operator, error) {
-					return agg.new(&colexecagg.NewAggregatorArgs{
+					return agg.new(context.Background(), &colexecagg.NewAggregatorArgs{
 						Allocator:      testAllocator,
 						MemAccount:     testMemAcc,
 						Input:          input[0],

--- a/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/cast_gen_util.go
@@ -619,7 +619,7 @@ func getDatumToNativeCastFunc(nonDatumPhysicalRepresentation string) castFunc {
 	return func(to, from, evalCtx, toType, _ string) string {
 		convStr := `
 		{
-			_castedDatum, err := eval.PerformCast(%[3]s, %[2]s.(tree.Datum), %[4]s)
+			_castedDatum, err := eval.PerformCast(c.Ctx, %[3]s, %[2]s.(tree.Datum), %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}
@@ -633,7 +633,7 @@ func getDatumToNativeCastFunc(nonDatumPhysicalRepresentation string) castFunc {
 func datumToDatum(to, from, evalCtx, toType, _ string) string {
 	convStr := `
 		{
-			_castedDatum, err := eval.PerformCast(%[3]s, %[2]s.(tree.Datum), %[4]s)
+			_castedDatum, err := eval.PerformCast(c.Ctx, %[3]s, %[2]s.(tree.Datum), %[4]s)
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -952,7 +952,7 @@ func (c decimalIntervalCustomizer) getBinOpAssignFunc() assignFunc {
 func executeBinOpOnDatums(prelude, targetElem, leftDatumElem, rightDatumElem string) string {
 	codeBlock := fmt.Sprintf(`
 			%s
-			_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, %s.(tree.Datum), %s.(tree.Datum))
+			_res, err := eval.BinaryOp(_ctx, _overloadHelper.EvalCtx, _overloadHelper.BinOp, %s.(tree.Datum), %s.(tree.Datum))
 			if err != nil {
 				colexecerror.ExpectedError(err)
 			}`, prelude, leftDatumElem, rightDatumElem,

--- a/pkg/sql/colexec/external_hash_aggregator_test.go
+++ b/pkg/sql/colexec/external_hash_aggregator_test.go
@@ -200,7 +200,7 @@ func BenchmarkExternalHashAggregator(b *testing.B) {
 			for _, groupSize := range groupSizes {
 				benchmarkAggregateFunction(
 					b, aggType{
-						new: func(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
+						new: func(ctx context.Context, args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
 							op, _, err := createExternalHashAggregator(
 								ctx, flowCtx, args, queueCfg, &colexecop.TestingSemaphore{},
 								0 /* numForcedRepartitions */, &monitorRegistry,

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -194,6 +194,7 @@ func randomizeHashAggregatorMaxBuffered() {
 // the disk-backed operator. Pass in nil in order to not track all input
 // tuples.
 func NewHashAggregator(
+	ctx context.Context,
 	args *colexecagg.NewAggregatorArgs,
 	newSpillingQueueArgs *colexecutils.NewSpillingQueueArgs,
 	hashTableAllocator *colmem.Allocator,
@@ -201,7 +202,7 @@ func NewHashAggregator(
 	maxOutputBatchMemSize int64,
 ) colexecop.ResettableOperator {
 	aggFnsAlloc, inputArgsConverter, toClose, err := colexecagg.NewAggregateFuncsAlloc(
-		args, args.Spec.Aggregations, hashAggregatorAllocSize, colexecagg.HashAggKind,
+		ctx, args, args.Spec.Aggregations, hashAggregatorAllocSize, colexecagg.HashAggKind,
 	)
 	if err != nil {
 		colexecerror.InternalError(err)

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -141,7 +141,9 @@ var _ colexecop.ResettableOperator = &orderedAggregator{}
 var _ colexecop.ClosableOperator = &orderedAggregator{}
 
 // NewOrderedAggregator creates an ordered aggregator.
-func NewOrderedAggregator(args *colexecagg.NewAggregatorArgs) colexecop.ResettableOperator {
+func NewOrderedAggregator(
+	ctx context.Context, args *colexecagg.NewAggregatorArgs,
+) colexecop.ResettableOperator {
 	for _, aggFn := range args.Spec.Aggregations {
 		if aggFn.FilterColIdx != nil {
 			colexecerror.InternalError(errors.AssertionFailedf("filtering ordered aggregation is not supported"))
@@ -154,7 +156,7 @@ func NewOrderedAggregator(args *colexecagg.NewAggregatorArgs) colexecop.Resettab
 	// We will be reusing the same aggregate functions, so we use 1 as the
 	// allocation size.
 	funcsAlloc, inputArgsConverter, toClose, err := colexecagg.NewAggregateFuncsAlloc(
-		args, args.Spec.Aggregations, 1 /* allocSize */, colexecagg.OrderedAggKind,
+		ctx, args, args.Spec.Aggregations, 1 /* allocSize */, colexecagg.OrderedAggKind,
 	)
 	if err != nil {
 		colexecerror.InternalError(err)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2815,7 +2815,7 @@ func (ex *connExecutor) resetEvalCtx(evalCtx *extendedEvalContext, txn *kv.Txn, 
 	evalCtx.Placeholders = nil
 	evalCtx.Annotations = nil
 	evalCtx.IVarContainer = nil
-	evalCtx.Context.Context = ex.Ctx()
+	evalCtx.SetDeprecatedContext(ex.Ctx())
 	evalCtx.Txn = txn
 	evalCtx.PrepareOnly = false
 	evalCtx.SkipNormalize = false

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -315,7 +315,7 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	var cancelQuery context.CancelFunc
 	ctx, cancelQuery = contextutil.WithCancel(ctx)
-	ex.addActiveQuery(ast, formatWithPlaceholders(ast, ex.planner.EvalContext()), queryID, cancelQuery)
+	ex.addActiveQuery(ast, formatWithPlaceholders(ctx, ast, ex.planner.EvalContext()), queryID, cancelQuery)
 
 	// Make sure that we always unregister the query. It also deals with
 	// overwriting res.Error to a more user-friendly message in case of query
@@ -844,21 +844,21 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 	return nil
 }
 
-func formatWithPlaceholders(ast tree.Statement, evalCtx *eval.Context) string {
+func formatWithPlaceholders(ctx context.Context, ast tree.Statement, evalCtx *eval.Context) string {
 	var fmtCtx *tree.FmtCtx
 	fmtFlags := tree.FmtSimple
 
 	if evalCtx.HasPlaceholders() {
 		fmtCtx = evalCtx.FmtCtx(
 			fmtFlags,
-			tree.FmtPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
-				d, err := eval.Expr(evalCtx.Context, evalCtx, placeholder)
+			tree.FmtPlaceholderFormat(func(fmtCtx *tree.FmtCtx, placeholder *tree.Placeholder) {
+				d, err := eval.Expr(ctx, evalCtx, placeholder)
 				if err != nil || d == nil {
 					// Fall back to the default behavior if something goes wrong.
-					ctx.Printf("$%d", placeholder.Idx+1)
+					fmtCtx.Printf("$%d", placeholder.Idx+1)
 					return
 				}
-				d.Format(ctx)
+				d.Format(fmtCtx)
 			}),
 		)
 	} else {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -852,7 +852,7 @@ func formatWithPlaceholders(ast tree.Statement, evalCtx *eval.Context) string {
 		fmtCtx = evalCtx.FmtCtx(
 			fmtFlags,
 			tree.FmtPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
-				d, err := eval.Expr(evalCtx, placeholder)
+				d, err := eval.Expr(evalCtx.Context, evalCtx, placeholder)
 				if err != nil || d == nil {
 					// Fall back to the default behavior if something goes wrong.
 					ctx.Printf("$%d", placeholder.Idx+1)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -420,6 +420,7 @@ func (ex *connExecutor) execBind(
 						}
 					}
 					d, err := pgwirebase.DecodeDatum(
+						ctx,
 						ex.planner.EvalContext(),
 						typ,
 						qArgFormatCodes[i],

--- a/pkg/sql/constraint.go
+++ b/pkg/sql/constraint.go
@@ -83,7 +83,7 @@ func (p *planner) ConstrainPrimaryIndexSpanByExpr(
 	}
 
 	var nf norm.Factory
-	nf.Init(evalCtx, &oc)
+	nf.Init(ctx, evalCtx, &oc)
 	nf.Metadata().AddTable(tbl, tn)
 
 	b := optbuilder.NewScalar(ctx, semaCtx, evalCtx, &nf)
@@ -154,7 +154,7 @@ func (p *planner) ConstrainPrimaryIndexSpanByExpr(
 	if remaining.IsTrue() {
 		remainingFilter = tree.DBoolTrue
 	} else {
-		eb := execbuilder.New(newExecFactory(p), &p.optPlanningCtx.optimizer,
+		eb := execbuilder.New(ctx, newExecFactory(ctx, p), &p.optPlanningCtx.optimizer,
 			nf.Memo(), &oc, &remaining, evalCtx, false)
 		eb.SetBuiltinFuncWrapper(semaCtx.FunctionResolver)
 		expr, err := eb.BuildScalar()

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -705,6 +705,7 @@ func (c *copyMachine) readBinaryTuple(ctx context.Context) (readSoFar []byte, er
 			return readSoFar, err
 		}
 		d, err := pgwirebase.DecodeDatum(
+			ctx,
 			c.parsingEvalCtx,
 			c.resultColumns[i].Typ,
 			pgwirebase.FormatBinary,

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -315,7 +315,7 @@ func (p *planner) checkPasswordAndGetHash(
 		var isPreHashed, schemeSupported bool
 		var schemeName string
 		var issueNum int
-		isPreHashed, schemeSupported, issueNum, schemeName, hashedPassword, err = password.CheckPasswordHashValidity(ctx, []byte(passwordStr))
+		isPreHashed, schemeSupported, issueNum, schemeName, hashedPassword, err = password.CheckPasswordHashValidity([]byte(passwordStr))
 		if err != nil {
 			return hashedPassword, pgerror.WithCandidateCode(err, pgcode.Syntax)
 		}

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -332,7 +332,7 @@ func (p *planner) checkPasswordAndGetHash(
 			"Passwords must be %d characters or longer.", minLength)
 	}
 
-	method := security.GetConfiguredPasswordHashMethod(ctx, &st.SV)
+	method := security.GetConfiguredPasswordHashMethod(&st.SV)
 	cost, err := security.GetConfiguredPasswordCost(ctx, &st.SV, method)
 	if err != nil {
 		return hashedPassword, errors.HandleAsAssertionFailure(err)

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1158,7 +1158,7 @@ func getFinalSourceQuery(
 	ctx := evalCtx.FmtCtx(
 		tree.FmtSerializable,
 		tree.FmtPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
-			d, err := eval.Expr(evalCtx, placeholder)
+			d, err := eval.Expr(params.ctx, evalCtx, placeholder)
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "failed to serialize placeholder"))
 			}

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -360,18 +360,15 @@ func (ds *ServerImpl) setupFlow(
 			return nil, nil, nil, err
 		}
 		evalCtx = &eval.Context{
-			Settings:         ds.ServerConfig.Settings,
-			SessionDataStack: sessiondata.NewStack(sd),
-			ClusterID:        ds.ServerConfig.LogicalClusterID.Get(),
-			ClusterName:      ds.ServerConfig.ClusterName,
-			NodeID:           ds.ServerConfig.NodeID,
-			Codec:            ds.ServerConfig.Codec,
-			ReCache:          ds.regexpCache,
-			Locality:         ds.ServerConfig.Locality,
-			Tracer:           ds.ServerConfig.Tracer,
-			// Most processors will override this Context with their own context in
-			// ProcessorBase. StartInternal().
-			Context:                   ctx,
+			Settings:                  ds.ServerConfig.Settings,
+			SessionDataStack:          sessiondata.NewStack(sd),
+			ClusterID:                 ds.ServerConfig.LogicalClusterID.Get(),
+			ClusterName:               ds.ServerConfig.ClusterName,
+			NodeID:                    ds.ServerConfig.NodeID,
+			Codec:                     ds.ServerConfig.Codec,
+			ReCache:                   ds.regexpCache,
+			Locality:                  ds.ServerConfig.Locality,
+			Tracer:                    ds.ServerConfig.Tracer,
 			Planner:                   &faketreeeval.DummyEvalPlanner{Monitor: monitor},
 			PrivilegedAccessor:        &faketreeeval.DummyPrivilegedAccessor{},
 			SessionAccessor:           &faketreeeval.DummySessionAccessor{},
@@ -386,6 +383,9 @@ func (ds *ServerImpl) setupFlow(
 			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,
 			RangeStatsFetcher:         ds.ServerConfig.RangeStatsFetcher,
 		}
+		// Most processors will override this Context with their own context in
+		// ProcessorBase. StartInternal().
+		evalCtx.SetDeprecatedContext(ctx)
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
 	}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3454,7 +3454,7 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 	for rowIdx, tuple := range tuples {
 		var buf []byte
 		for colIdx, typedExpr := range tuple {
-			datum, err := eval.Expr(evalCtx, typedExpr)
+			datum, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1776,7 +1776,7 @@ func (dsp *DistSQLPlanner) planTableReaders(
 // corresponding to the render node. An evaluator stage is added if the render
 // node has any expressions which are not just simple column references.
 func (dsp *DistSQLPlanner) createPlanForRender(
-	p *PhysicalPlan, n *renderNode, planCtx *PlanningCtx,
+	ctx context.Context, p *PhysicalPlan, n *renderNode, planCtx *PlanningCtx,
 ) error {
 	typs, err := getTypesForPlanResult(n, nil /* planToStreamColMap */)
 	if err != nil {
@@ -1799,7 +1799,7 @@ func (dsp *DistSQLPlanner) createPlanForRender(
 	newColMap := identityMap(p.PlanToStreamColMap, len(n.render))
 	newMergeOrdering := dsp.convertOrdering(n.reqOrdering, newColMap)
 	err = p.AddRendering(
-		n.render, planCtx, p.PlanToStreamColMap, typs, newMergeOrdering,
+		ctx, n.render, planCtx, p.PlanToStreamColMap, typs, newMergeOrdering,
 	)
 	if err != nil {
 		return err
@@ -1862,7 +1862,7 @@ type aggregatorPlanningInfo struct {
 // addAggregators adds aggregators corresponding to a groupNode and updates the plan to
 // reflect the groupNode.
 func (dsp *DistSQLPlanner) addAggregators(
-	planCtx *PlanningCtx, p *PhysicalPlan, n *groupNode,
+	ctx context.Context, planCtx *PlanningCtx, p *PhysicalPlan, n *groupNode,
 ) error {
 	aggregations := make([]execinfrapb.AggregatorSpec_Aggregation, len(n.funcs))
 	argumentsColumnTypes := make([][]*types.T, len(n.funcs))
@@ -1884,7 +1884,7 @@ func (dsp *DistSQLPlanner) addAggregators(
 		argumentsColumnTypes[i] = make([]*types.T, len(fholder.arguments))
 		for j, argument := range fholder.arguments {
 			var err error
-			aggregations[i].Arguments[j], err = physicalplan.MakeExpression(argument, planCtx, nil)
+			aggregations[i].Arguments[j], err = physicalplan.MakeExpression(ctx, argument, planCtx, nil)
 			if err != nil {
 				return err
 			}
@@ -1892,7 +1892,7 @@ func (dsp *DistSQLPlanner) addAggregators(
 		}
 	}
 
-	return dsp.planAggregators(planCtx, p, &aggregatorPlanningInfo{
+	return dsp.planAggregators(ctx, planCtx, p, &aggregatorPlanningInfo{
 		aggregations:         aggregations,
 		argumentsColumnTypes: argumentsColumnTypes,
 		isScalar:             n.isScalar,
@@ -1921,7 +1921,7 @@ func (dsp *DistSQLPlanner) addAggregators(
 //     All other expressions simply pass through unchanged, for e.g. '1' in
 //     'SELECT 1 GROUP BY k'.
 func (dsp *DistSQLPlanner) planAggregators(
-	planCtx *PlanningCtx, p *PhysicalPlan, info *aggregatorPlanningInfo,
+	ctx context.Context, planCtx *PlanningCtx, p *PhysicalPlan, info *aggregatorPlanningInfo,
 ) error {
 	aggType := execinfrapb.AggregatorSpec_NON_SCALAR
 	if info.isScalar {
@@ -2294,7 +2294,8 @@ func (dsp *DistSQLPlanner) planAggregators(
 					mappedIdx := int(finalIdxMap[finalIdx])
 					var err error
 					renderExprs[i], err = physicalplan.MakeExpression(
-						h.IndexedVar(mappedIdx), planCtx, nil /* indexVarMap */)
+						ctx, h.IndexedVar(mappedIdx), planCtx, nil, /* indexVarMap */
+					)
 					if err != nil {
 						return err
 					}
@@ -2314,8 +2315,8 @@ func (dsp *DistSQLPlanner) planAggregators(
 						return err
 					}
 					renderExprs[i], err = physicalplan.MakeExpression(
-						expr, planCtx,
-						nil /* indexVarMap */)
+						ctx, expr, planCtx, nil, /* indexVarMap */
+					)
 					if err != nil {
 						return err
 					}
@@ -2607,7 +2608,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	if n.lookupExpr != nil {
 		var err error
 		joinReaderSpec.LookupExpr, err = physicalplan.MakeExpression(
-			n.lookupExpr, planCtx, nil, /* indexVarMap */
+			ctx, n.lookupExpr, planCtx, nil, /* indexVarMap */
 		)
 		if err != nil {
 			return nil, err
@@ -2619,7 +2620,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 		}
 		var err error
 		joinReaderSpec.RemoteLookupExpr, err = physicalplan.MakeExpression(
-			n.remoteLookupExpr, planCtx, nil, /* indexVarMap */
+			ctx, n.remoteLookupExpr, planCtx, nil, /* indexVarMap */
 		)
 		if err != nil {
 			return nil, err
@@ -2630,7 +2631,7 @@ func (dsp *DistSQLPlanner) createPlanForLookupJoin(
 	if n.onCond != nil {
 		var err error
 		joinReaderSpec.OnExpr, err = physicalplan.MakeExpression(
-			n.onCond, planCtx, nil, /* indexVarMap */
+			ctx, n.onCond, planCtx, nil, /* indexVarMap */
 		)
 		if err != nil {
 			return nil, err
@@ -2696,14 +2697,14 @@ func (dsp *DistSQLPlanner) createPlanForInvertedJoin(
 	}
 
 	if invertedJoinerSpec.InvertedExpr, err = physicalplan.MakeExpression(
-		n.invertedExpr, planCtx, nil, /* indexVarMap */
+		ctx, n.invertedExpr, planCtx, nil, /* indexVarMap */
 	); err != nil {
 		return nil, err
 	}
 	// Set the ON condition.
 	if n.onExpr != nil {
 		if invertedJoinerSpec.OnExpr, err = physicalplan.MakeExpression(
-			n.onExpr, planCtx, nil, /* indexVarMap */
+			ctx, n.onExpr, planCtx, nil, /* indexVarMap */
 		); err != nil {
 			return nil, err
 		}
@@ -2740,7 +2741,7 @@ func (dsp *DistSQLPlanner) createPlanForInvertedJoin(
 
 // createPlanForZigzagJoin creates a distributed plan for a zigzagJoinNode.
 func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
-	planCtx *PlanningCtx, n *zigzagJoinNode,
+	ctx context.Context, planCtx *PlanningCtx, n *zigzagJoinNode,
 ) (plan *PhysicalPlan, err error) {
 
 	sides := make([]zigzagPlanningSide, len(n.sides))
@@ -2748,7 +2749,7 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 	for i, side := range n.sides {
 		// The fixed values are represented as a Values node with one tuple.
 		typs := getTypesFromResultColumns(side.fixedVals.columns)
-		valuesSpec, err := dsp.createValuesSpecFromTuples(planCtx, side.fixedVals.tuples, typs)
+		valuesSpec, err := dsp.createValuesSpecFromTuples(ctx, planCtx, side.fixedVals.tuples, typs)
 		if err != nil {
 			return nil, err
 		}
@@ -2764,7 +2765,7 @@ func (dsp *DistSQLPlanner) createPlanForZigzagJoin(
 		}
 	}
 
-	return dsp.planZigzagJoin(planCtx, zigzagPlanningInfo{
+	return dsp.planZigzagJoin(ctx, planCtx, zigzagPlanningInfo{
 		sides:       sides,
 		columns:     n.columns,
 		onCond:      n.onCond,
@@ -2790,7 +2791,7 @@ type zigzagPlanningInfo struct {
 }
 
 func (dsp *DistSQLPlanner) planZigzagJoin(
-	planCtx *PlanningCtx, pi zigzagPlanningInfo,
+	ctx context.Context, planCtx *PlanningCtx, pi zigzagPlanningInfo,
 ) (plan *PhysicalPlan, err error) {
 
 	plan = planCtx.NewPhysicalPlan()
@@ -2829,7 +2830,7 @@ func (dsp *DistSQLPlanner) planZigzagJoin(
 	// Set the ON condition.
 	if pi.onCond != nil {
 		zigzagJoinerSpec.OnExpr, err = physicalplan.MakeExpression(
-			pi.onCond, planCtx, nil, /* indexVarMap */
+			ctx, pi.onCond, planCtx, nil, /* indexVarMap */
 		)
 		if err != nil {
 			return nil, err
@@ -2875,7 +2876,8 @@ func (dsp *DistSQLPlanner) createPlanForInvertedFilter(
 			Type: n.preFiltererType,
 		}
 		if invertedFiltererSpec.PreFiltererSpec.Expression, err = physicalplan.MakeExpression(
-			n.preFiltererExpr, planCtx, nil); err != nil {
+			ctx, n.preFiltererExpr, planCtx, nil,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -2990,7 +2992,7 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 		rightPlanToStreamColMap: rightMap,
 	}
 	post, joinToStreamColMap := helper.joinOutColumns(n.pred.joinType, n.columns)
-	onExpr, err := helper.remapOnExpr(planCtx, n.pred.onCond)
+	onExpr, err := helper.remapOnExpr(ctx, planCtx, n.pred.onCond)
 	if err != nil {
 		return nil, err
 	}
@@ -3141,7 +3143,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			return nil, err
 		}
 
-		if err := plan.AddFilter(n.filter, planCtx, plan.PlanToStreamColMap); err != nil {
+		if err := plan.AddFilter(ctx, n.filter, planCtx, plan.PlanToStreamColMap); err != nil {
 			return nil, err
 		}
 
@@ -3151,7 +3153,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			return nil, err
 		}
 
-		if err := dsp.addAggregators(planCtx, plan, n); err != nil {
+		if err := dsp.addAggregators(ctx, planCtx, plan, n); err != nil {
 			return nil, err
 		}
 
@@ -3173,10 +3175,10 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 			return nil, err
 		}
 		var count, offset int64
-		if count, offset, err = evalLimit(planCtx.EvalContext(), n.countExpr, n.offsetExpr); err != nil {
+		if count, offset, err = evalLimit(ctx, planCtx.EvalContext(), n.countExpr, n.offsetExpr); err != nil {
 			return nil, err
 		}
-		if err := plan.AddLimit(count, offset, planCtx); err != nil {
+		if err := plan.AddLimit(ctx, count, offset, planCtx); err != nil {
 			return nil, err
 		}
 
@@ -3194,7 +3196,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		if err != nil {
 			return nil, err
 		}
-		err = dsp.createPlanForRender(plan, n, planCtx)
+		err = dsp.createPlanForRender(ctx, plan, n, planCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -3233,7 +3235,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		} else {
 			colTypes := getTypesFromResultColumns(n.columns)
 			var spec *execinfrapb.ValuesCoreSpec
-			spec, err = dsp.createValuesSpecFromTuples(planCtx, n.tuples, colTypes)
+			spec, err = dsp.createValuesSpecFromTuples(ctx, planCtx, n.tuples, colTypes)
 			if err != nil {
 				return nil, err
 			}
@@ -3247,7 +3249,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		plan, err = dsp.createPlanForZero(planCtx, n)
 
 	case *zigzagJoinNode:
-		plan, err = dsp.createPlanForZigzagJoin(planCtx, n)
+		plan, err = dsp.createPlanForZigzagJoin(ctx, planCtx, n)
 
 	default:
 		// Can't handle a node? We wrap it and continue on our way.
@@ -3440,7 +3442,7 @@ func (dsp *DistSQLPlanner) createValuesPlan(
 // createValuesSpecFromTuples creates a ValuesCoreSpec from the results of
 // evaluating the given tuples.
 func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
-	planCtx *PlanningCtx, tuples [][]tree.TypedExpr, resultTypes []*types.T,
+	ctx context.Context, planCtx *PlanningCtx, tuples [][]tree.TypedExpr, resultTypes []*types.T,
 ) (*execinfrapb.ValuesCoreSpec, error) {
 	var a tree.DatumAlloc
 	evalCtx := &planCtx.ExtendedEvalCtx.Context
@@ -3454,7 +3456,7 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 	for rowIdx, tuple := range tuples {
 		var buf []byte
 		for colIdx, typedExpr := range tuple {
-			datum, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
+			datum, err := eval.Expr(ctx, evalCtx, typedExpr)
 			if err != nil {
 				return nil, err
 			}
@@ -3573,7 +3575,7 @@ func (dsp *DistSQLPlanner) createPlanForOrdinality(
 }
 
 func createProjectSetSpec(
-	planCtx *PlanningCtx, n *projectSetPlanningInfo, indexVarMap []int,
+	ctx context.Context, planCtx *PlanningCtx, n *projectSetPlanningInfo, indexVarMap []int,
 ) (*execinfrapb.ProjectSetSpec, error) {
 	spec := execinfrapb.ProjectSetSpec{
 		Exprs:                 make([]execinfrapb.Expression, len(n.exprs)),
@@ -3583,7 +3585,7 @@ func createProjectSetSpec(
 	}
 	for i, expr := range n.exprs {
 		var err error
-		spec.Exprs[i], err = physicalplan.MakeExpression(expr, planCtx, indexVarMap)
+		spec.Exprs[i], err = physicalplan.MakeExpression(ctx, expr, planCtx, indexVarMap)
 		if err != nil {
 			return nil, err
 		}
@@ -3605,19 +3607,19 @@ func (dsp *DistSQLPlanner) createPlanForProjectSet(
 	if err != nil {
 		return nil, err
 	}
-	err = dsp.addProjectSet(plan, planCtx, &n.projectSetPlanningInfo)
+	err = dsp.addProjectSet(ctx, plan, planCtx, &n.projectSetPlanningInfo)
 	return plan, err
 }
 
 // addProjectSet adds a grouping stage consisting of a single
 // projectSetProcessor that is planned on the gateway.
 func (dsp *DistSQLPlanner) addProjectSet(
-	plan *PhysicalPlan, planCtx *PlanningCtx, info *projectSetPlanningInfo,
+	ctx context.Context, plan *PhysicalPlan, planCtx *PlanningCtx, info *projectSetPlanningInfo,
 ) error {
 	numResults := len(plan.GetResultTypes())
 
 	// Create the project set processor spec.
-	projectSetSpec, err := createProjectSetSpec(planCtx, info, plan.PlanToStreamColMap)
+	projectSetSpec, err := createProjectSetSpec(ctx, planCtx, info, plan.PlanToStreamColMap)
 	if err != nil {
 		return err
 	}
@@ -3981,7 +3983,7 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 	newResultTypes := make([]*types.T, len(plan.GetResultTypes())+len(n.funcs))
 	copy(newResultTypes, plan.GetResultTypes())
 	for windowFnSpecIdx, windowFn := range n.funcs {
-		windowFnSpec, outputType, err := createWindowFnSpec(planCtx, plan, windowFn)
+		windowFnSpec, outputType, err := createWindowFnSpec(ctx, planCtx, plan, windowFn)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -11,6 +11,8 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -134,7 +136,7 @@ func (h *joinPlanningHelper) joinOutColumns(
 // join columns as described above) to values that make sense in the joiner (0
 // to N-1 for the left input columns, N to N+M-1 for the right input columns).
 func (h *joinPlanningHelper) remapOnExpr(
-	planCtx *PlanningCtx, onCond tree.TypedExpr,
+	ctx context.Context, planCtx *PlanningCtx, onCond tree.TypedExpr,
 ) (execinfrapb.Expression, error) {
 	if onCond == nil {
 		return execinfrapb.Expression{}, nil
@@ -155,7 +157,7 @@ func (h *joinPlanningHelper) remapOnExpr(
 		idx++
 	}
 
-	return physicalplan.MakeExpression(onCond, planCtx, joinColMap)
+	return physicalplan.MakeExpression(ctx, onCond, planCtx, joinColMap)
 }
 
 // eqCols produces a slice of ordinal references for the plan columns specified

--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -11,6 +11,8 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
@@ -19,7 +21,7 @@ import (
 )
 
 func createWindowFnSpec(
-	planCtx *PlanningCtx, plan *PhysicalPlan, funcInProgress *windowFuncHolder,
+	ctx context.Context, planCtx *PlanningCtx, plan *PhysicalPlan, funcInProgress *windowFuncHolder,
 ) (execinfrapb.WindowerSpec_WindowFn, *types.T, error) {
 	for _, argIdx := range funcInProgress.argsIdxs {
 		if argIdx >= uint32(len(plan.GetResultTypes())) {
@@ -59,7 +61,7 @@ func createWindowFnSpec(
 	if funcInProgress.frame != nil {
 		// funcInProgress has a custom window frame.
 		frameSpec := execinfrapb.WindowerSpec_Frame{}
-		if err := frameSpec.InitFromAST(funcInProgress.frame, planCtx.EvalContext()); err != nil {
+		if err := frameSpec.InitFromAST(ctx, funcInProgress.frame, planCtx.EvalContext()); err != nil {
 			return execinfrapb.WindowerSpec_WindowFn{}, outputType, err
 		}
 		funcInProgressSpec.Frame = &frameSpec

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1610,7 +1610,7 @@ func (dsp *DistSQLPlanner) PlanAndRunCascadesAndChecks(
 		}
 
 		evalCtx := evalCtxFactory()
-		execFactory := newExecFactory(planner)
+		execFactory := newExecFactory(ctx, planner)
 		// The cascading query is allowed to autocommit only if it is the last
 		// cascade and there are no check queries to run.
 		allowAutoCommit := planner.autoCommit

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -98,7 +98,7 @@ func GetAggregateConstructor(
 			err = errors.Wrapf(err, "%s", argument)
 			return
 		}
-		d, err = h.Eval(nil /* row */)
+		d, err = h.Eval(ctx, nil /* row */)
 		if err != nil {
 			err = errors.Wrapf(err, "%s", argument)
 			return

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -868,8 +868,7 @@ func (pb *ProcessorBaseNoHelper) StartInternal(ctx context.Context, name string)
 			pb.span.SetTag(execinfrapb.ProcessorIDTagKey, attribute.IntValue(int(pb.ProcessorID)))
 		}
 	}
-	pb.evalOrigCtx = pb.EvalCtx.Context
-	pb.EvalCtx.Context = pb.Ctx
+	pb.evalOrigCtx = pb.EvalCtx.SetDeprecatedContext(pb.Ctx)
 	return pb.Ctx
 }
 
@@ -900,7 +899,7 @@ func (pb *ProcessorBaseNoHelper) InternalClose() bool {
 	// Reset the context so that any incidental uses after this point do not
 	// access the finished span.
 	pb.Ctx = pb.origCtx
-	pb.EvalCtx.Context = pb.evalOrigCtx
+	pb.EvalCtx.SetDeprecatedContext(pb.evalOrigCtx)
 	return true
 }
 

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -270,7 +270,7 @@ func (h *ProcOutputHelper) ProcessRow(
 	if len(h.renderExprs) > 0 {
 		// Rendering.
 		for i := range h.renderExprs {
-			datum, err := h.renderExprs[i].Eval(row)
+			datum, err := h.renderExprs[i].Eval(ctx, row)
 			if err != nil {
 				return nil, false, err
 			}

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -81,7 +81,7 @@ func ExprFmtCtxBase(evalCtx *eval.Context) *tree.FmtCtx {
 		tree.FmtCheckEquivalence,
 		tree.FmtPlaceholderFormat(
 			func(fmtCtx *tree.FmtCtx, p *tree.Placeholder) {
-				d, err := eval.Expr(evalCtx, p)
+				d, err := eval.Expr(evalCtx.Context, evalCtx, p)
 				if err != nil {
 					panic(errors.NewAssertionErrorWithWrappedErrf(err, "failed to serialize placeholder"))
 				}

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -76,12 +76,12 @@ func ConvertToMappedSpecOrdering(
 // ExprFmtCtxBase produces a FmtCtx used for serializing expressions; a proper
 // IndexedVar formatting function needs to be added on. It replaces placeholders
 // with their values.
-func ExprFmtCtxBase(evalCtx *eval.Context) *tree.FmtCtx {
+func ExprFmtCtxBase(ctx context.Context, evalCtx *eval.Context) *tree.FmtCtx {
 	fmtCtx := evalCtx.FmtCtx(
 		tree.FmtCheckEquivalence,
 		tree.FmtPlaceholderFormat(
 			func(fmtCtx *tree.FmtCtx, p *tree.Placeholder) {
-				d, err := eval.Expr(evalCtx.Context, evalCtx, p)
+				d, err := eval.Expr(ctx, evalCtx, p)
 				if err != nil {
 					panic(errors.NewAssertionErrorWithWrappedErrf(err, "failed to serialize placeholder"))
 				}

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -93,7 +93,7 @@ func processExpression(
 	//
 	// TODO(solon): It would be preferable to enhance our expression serialization
 	// format so this wouldn't be necessary.
-	c := normalize.MakeConstantEvalVisitor(evalCtx)
+	c := normalize.MakeConstantEvalVisitor(ctx, evalCtx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {
 		return nil, err
@@ -212,21 +212,21 @@ func (eh *ExprHelper) Init(
 
 // EvalFilter is used for filter expressions; it evaluates the expression and
 // returns whether the filter passes.
-func (eh *ExprHelper) EvalFilter(row rowenc.EncDatumRow) (bool, error) {
+func (eh *ExprHelper) EvalFilter(ctx context.Context, row rowenc.EncDatumRow) (bool, error) {
 	eh.Row = row
 	eh.evalCtx.PushIVarContainer(eh)
-	pass, err := RunFilter(eh.Expr, eh.evalCtx)
+	pass, err := RunFilter(ctx, eh.Expr, eh.evalCtx)
 	eh.evalCtx.PopIVarContainer()
 	return pass, err
 }
 
 // RunFilter runs a filter expression and returns whether the filter passes.
-func RunFilter(filter tree.TypedExpr, evalCtx *eval.Context) (bool, error) {
+func RunFilter(ctx context.Context, filter tree.TypedExpr, evalCtx *eval.Context) (bool, error) {
 	if filter == nil {
 		return true, nil
 	}
 
-	d, err := eval.Expr(evalCtx.Context, evalCtx, filter)
+	d, err := eval.Expr(ctx, evalCtx, filter)
 	if err != nil {
 		return false, err
 	}
@@ -241,11 +241,11 @@ func RunFilter(filter tree.TypedExpr, evalCtx *eval.Context) (bool, error) {
 //	'@2 + @5' would return '7'
 //	'@1' would return '1'
 //	'@2 + 10' would return '12'
-func (eh *ExprHelper) Eval(row rowenc.EncDatumRow) (tree.Datum, error) {
+func (eh *ExprHelper) Eval(ctx context.Context, row rowenc.EncDatumRow) (tree.Datum, error) {
 	eh.Row = row
 
 	eh.evalCtx.PushIVarContainer(eh)
-	d, err := eval.Expr(eh.evalCtx.Context, eh.evalCtx, eh.Expr)
+	d, err := eval.Expr(ctx, eh.evalCtx, eh.Expr)
 	eh.evalCtx.PopIVarContainer()
 	return d, err
 }

--- a/pkg/sql/execinfrapb/expr_test.go
+++ b/pkg/sql/execinfrapb/expr_test.go
@@ -25,12 +25,10 @@ import (
 
 type testVarContainer struct{}
 
+var _ tree.IndexedVarContainer = testVarContainer{}
+
 func (d testVarContainer) IndexedVarResolvedType(idx int) *types.T {
 	return types.Int
-}
-
-func (d testVarContainer) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
-	return nil, nil
 }
 
 func (d testVarContainer) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -11,6 +11,7 @@
 package execinfrapb
 
 import (
+	context "context"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -146,7 +147,10 @@ func (spec *WindowerSpec_Frame_Exclusion) initFromAST(e treewindow.WindowFrameEx
 // If offset exprs are present, we evaluate them and save the encoded results
 // in the spec.
 func (spec *WindowerSpec_Frame_Bounds) initFromAST(
-	b tree.WindowFrameBounds, m treewindow.WindowFrameMode, evalCtx *eval.Context,
+	ctx context.Context,
+	b tree.WindowFrameBounds,
+	m treewindow.WindowFrameMode,
+	evalCtx *eval.Context,
 ) error {
 	if b.StartBound == nil {
 		return errors.Errorf("unexpected: Start Bound is nil")
@@ -157,7 +161,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 	}
 	if b.StartBound.HasOffset() {
 		typedStartOffset := b.StartBound.OffsetExpr.(tree.TypedExpr)
-		dStartOffset, err := eval.Expr(evalCtx.Context, evalCtx, typedStartOffset)
+		dStartOffset, err := eval.Expr(ctx, evalCtx, typedStartOffset)
 		if err != nil {
 			return err
 		}
@@ -201,7 +205,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 		}
 		if b.EndBound.HasOffset() {
 			typedEndOffset := b.EndBound.OffsetExpr.(tree.TypedExpr)
-			dEndOffset, err := eval.Expr(evalCtx.Context, evalCtx, typedEndOffset)
+			dEndOffset, err := eval.Expr(ctx, evalCtx, typedEndOffset)
 			if err != nil {
 				return err
 			}
@@ -260,14 +264,16 @@ func isNegative(evalCtx *eval.Context, offset tree.Datum) bool {
 
 // InitFromAST initializes the spec based on tree.WindowFrame. It will evaluate
 // offset expressions if present in the frame.
-func (spec *WindowerSpec_Frame) InitFromAST(f *tree.WindowFrame, evalCtx *eval.Context) error {
+func (spec *WindowerSpec_Frame) InitFromAST(
+	ctx context.Context, f *tree.WindowFrame, evalCtx *eval.Context,
+) error {
 	if err := spec.Mode.initFromAST(f.Mode); err != nil {
 		return err
 	}
 	if err := spec.Exclusion.initFromAST(f.Exclusion); err != nil {
 		return err
 	}
-	return spec.Bounds.initFromAST(f.Bounds, f.Mode, evalCtx)
+	return spec.Bounds.initFromAST(ctx, f.Bounds, f.Mode, evalCtx)
 }
 
 func (spec WindowerSpec_Frame_Mode) convertToAST() (treewindow.WindowFrameMode, error) {

--- a/pkg/sql/execinfrapb/processors.go
+++ b/pkg/sql/execinfrapb/processors.go
@@ -157,7 +157,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 	}
 	if b.StartBound.HasOffset() {
 		typedStartOffset := b.StartBound.OffsetExpr.(tree.TypedExpr)
-		dStartOffset, err := eval.Expr(evalCtx, typedStartOffset)
+		dStartOffset, err := eval.Expr(evalCtx.Context, evalCtx, typedStartOffset)
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func (spec *WindowerSpec_Frame_Bounds) initFromAST(
 		}
 		if b.EndBound.HasOffset() {
 			typedEndOffset := b.EndBound.OffsetExpr.(tree.TypedExpr)
-			dEndOffset, err := eval.Expr(evalCtx, typedEndOffset)
+			dEndOffset, err := eval.Expr(evalCtx.Context, evalCtx, typedEndOffset)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -134,7 +134,7 @@ func buildStatementBundle(
 	b := makeStmtBundleBuilder(db, ie, plan, trace, placeholders)
 
 	b.addStatement()
-	b.addOptPlans()
+	b.addOptPlans(ctx)
 	b.addExecPlan(planString)
 	b.addDistSQLDiagrams()
 	b.addExplainVec()
@@ -238,7 +238,7 @@ func (b *stmtBundleBuilder) addStatement() {
 
 // addOptPlans adds the EXPLAIN (OPT) variants as files opt.txt, opt-v.txt,
 // opt-vv.txt.
-func (b *stmtBundleBuilder) addOptPlans() {
+func (b *stmtBundleBuilder) addOptPlans(ctx context.Context) {
 	if b.plan.mem == nil || b.plan.mem.RootExpr() == nil {
 		// No optimizer plans; an error must have occurred during planning.
 		b.z.AddFile("opt.txt", "no plan")
@@ -248,7 +248,7 @@ func (b *stmtBundleBuilder) addOptPlans() {
 	}
 
 	formatOptPlan := func(flags memo.ExprFmtFlags) string {
-		f := memo.MakeExprFmtCtx(flags, b.plan.mem, b.plan.catalog)
+		f := memo.MakeExprFmtCtx(ctx, flags, b.plan.mem, b.plan.catalog)
 		f.FormatExpr(b.plan.mem.RootExpr())
 		return f.Buffer.String()
 	}

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -134,7 +134,7 @@ func (ef *execFactory) ConstructExport(
 		return nil, errors.Errorf("unsupported export format: %q", fileSuffix)
 	}
 
-	destinationDatum, err := eval.Expr(ef.planner.EvalContext(), fileName)
+	destinationDatum, err := eval.Expr(ef.planner.EvalContext().Context, ef.planner.EvalContext(), fileName)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/export.go
+++ b/pkg/sql/export.go
@@ -118,7 +118,7 @@ func (ef *execFactory) ConstructExport(
 	}
 
 	if err := featureflag.CheckEnabled(
-		ef.planner.EvalContext().Context,
+		ef.ctx,
 		ef.planner.execCfg,
 		featureExportEnabled,
 		"EXPORT",
@@ -134,7 +134,7 @@ func (ef *execFactory) ConstructExport(
 		return nil, errors.Errorf("unsupported export format: %q", fileSuffix)
 	}
 
-	destinationDatum, err := eval.Expr(ef.planner.EvalContext().Context, ef.planner.EvalContext(), fileName)
+	destinationDatum, err := eval.Expr(ef.ctx, ef.planner.EvalContext(), fileName)
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +143,7 @@ func (ef *execFactory) ConstructExport(
 	if !ok {
 		return nil, errors.Errorf("expected string value for the file location")
 	}
-	admin, err := ef.planner.HasAdminRole(ef.planner.EvalContext().Context)
+	admin, err := ef.planner.HasAdminRole(ef.ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -151,8 +151,9 @@ func (ef *execFactory) ConstructExport(
 	// `cloudprivilege.CheckDestinationPrivileges privileges here, but because of
 	// a ciruclar dependancy with `pkg/sql` this is not possible. Consider moving
 	// this file into `pkg/sql/importer` to get around this.
-	hasExternalIOImplicitAccess := ef.planner.CheckPrivilege(ef.planner.EvalContext().Context,
-		syntheticprivilege.GlobalPrivilegeObject, privilege.EXTERNALIOIMPLICITACCESS) == nil
+	hasExternalIOImplicitAccess := ef.planner.CheckPrivilege(
+		ef.ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.EXTERNALIOIMPLICITACCESS,
+	) == nil
 	if !admin &&
 		!ef.planner.ExecCfg().ExternalIODirConfig.EnableNonAdminImplicitAndArbitraryOutbound &&
 		!hasExternalIOImplicitAccess {
@@ -167,7 +168,7 @@ func (ef *execFactory) ConstructExport(
 					"are allowed to access the specified %s URI", conf.Provider.String()))
 		}
 	}
-	optVals, err := evalStringOptions(ef.planner.EvalContext(), options, exportOptionExpectValues)
+	optVals, err := evalStringOptions(ef.ctx, ef.planner.EvalContext(), options, exportOptionExpectValues)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/filter.go
+++ b/pkg/sql/filter.go
@@ -13,6 +13,7 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -27,12 +28,14 @@ type filterNode struct {
 	reqOrdering ReqOrdering
 }
 
-// filterNode implements tree.IndexedVarContainer
-var _ tree.IndexedVarContainer = &filterNode{}
+// filterNode implements eval.IndexedVarContainer
+var _ eval.IndexedVarContainer = &filterNode{}
 
-// IndexedVarEval implements the tree.IndexedVarContainer interface.
-func (f *filterNode) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
-	return f.source.plan.Values()[idx].Eval(e)
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
+func (f *filterNode) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
+	return f.source.plan.Values()[idx].Eval(ctx, e)
 }
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -1378,7 +1378,7 @@ func writeNonDropDatabaseChange(
 ) ([]jobspb.JobID, error) {
 	var job *jobs.Job
 	var err error
-	if job, err = createNonDropDatabaseChangeJob(p.User(), desc.ID, jobDesc, p, txn); err != nil {
+	if job, err = createNonDropDatabaseChangeJob(ctx, p.User(), desc.ID, jobDesc, p, txn); err != nil {
 		return nil, err
 	}
 
@@ -1397,6 +1397,7 @@ func writeNonDropDatabaseChange(
 }
 
 func createNonDropDatabaseChangeJob(
+	ctx context.Context,
 	user username.SQLUsername,
 	databaseID descpb.ID,
 	jobDesc string,
@@ -1416,7 +1417,7 @@ func createNonDropDatabaseChangeJob(
 
 	jobID := p.ExecCfg().JobRegistry.MakeJobID()
 	return p.ExecCfg().JobRegistry.CreateJobWithTxn(
-		p.ExtendedEvalContext().Ctx(),
+		ctx,
 		jobRecord,
 		jobID,
 		txn,

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -221,12 +221,12 @@ func (idp *readImportDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pro
 	}, nil
 }
 
-func injectTimeIntoEvalCtx(ctx *eval.Context, walltime int64) {
+func injectTimeIntoEvalCtx(evalCtx *eval.Context, walltime int64) {
 	sec := walltime / int64(time.Second)
 	nsec := walltime % int64(time.Second)
 	unixtime := timeutil.Unix(sec, nsec)
-	ctx.StmtTimestamp = unixtime
-	ctx.TxnTimestamp = unixtime
+	evalCtx.StmtTimestamp = unixtime
+	evalCtx.TxnTimestamp = unixtime
 }
 
 func makeInputConverter(

--- a/pkg/sql/importer/import_table_creation.go
+++ b/pkg/sql/importer/import_table_creation.go
@@ -156,7 +156,6 @@ func MakeSimpleTableDescriptor(
 	create.Defs = filteredDefs
 
 	evalCtx := eval.Context{
-		Context:            ctx,
 		Sequence:           &importSequenceOperators{},
 		Regions:            makeImportRegionOperator(""),
 		SessionDataStack:   sessiondata.NewStack(&sessiondata.SessionData{}),
@@ -164,6 +163,7 @@ func MakeSimpleTableDescriptor(
 		TxnTimestamp:       timeutil.Unix(0, walltime),
 		Settings:           st,
 	}
+	evalCtx.SetDeprecatedContext(ctx)
 	affected := make(map[descpb.ID]*tabledesc.Mutable)
 
 	tableDesc, err := sql.NewTableDesc(

--- a/pkg/sql/importer/read_import_avro_test.go
+++ b/pkg/sql/importer/read_import_avro_test.go
@@ -226,7 +226,7 @@ func (t *testRecordStream) Row() error {
 	r, err := t.producer.Row()
 	if err == nil {
 		t.rowNum++
-		err = t.consumer.FillDatums(r, t.rowNum, t.conv)
+		err = t.consumer.FillDatums(context.Background(), r, t.rowNum, t.conv)
 	}
 	return err
 }

--- a/pkg/sql/importer/read_import_base.go
+++ b/pkg/sql/importer/read_import_base.go
@@ -527,7 +527,7 @@ type importRowProducer interface {
 // Implementations of this interface do not need to be thread safe.
 type importRowConsumer interface {
 	// FillDatums sends row data to the provide datum converter.
-	FillDatums(row interface{}, rowNum int64, conv *row.DatumRowConverter) error
+	FillDatums(ctx context.Context, row interface{}, rowNum int64, conv *row.DatumRowConverter) error
 }
 
 // batch represents batch of data to convert.
@@ -715,7 +715,7 @@ func (p *parallelImporter) importWorker(
 		conv.KvBatch.Progress = batch.progress
 		for batchIdx, record := range batch.data {
 			rowNum = batch.startPos + int64(batchIdx)
-			if err := consumer.FillDatums(record, rowNum, conv); err != nil {
+			if err := consumer.FillDatums(ctx, record, rowNum, conv); err != nil {
 				if err = handleCorruptRow(ctx, fileCtx, err); err != nil {
 					return err
 				}

--- a/pkg/sql/importer/read_import_base_test.go
+++ b/pkg/sql/importer/read_import_base_test.go
@@ -91,7 +91,7 @@ type errorReturningConsumer struct {
 }
 
 func (d *errorReturningConsumer) FillDatums(
-	_ interface{}, _ int64, c *row.DatumRowConverter,
+	_ context.Context, _ interface{}, _ int64, c *row.DatumRowConverter,
 ) error {
 	return d.err
 }
@@ -102,7 +102,9 @@ var _ importRowConsumer = &errorReturningConsumer{}
 // it implements importRowConsumer.
 type nilDataConsumer struct{}
 
-func (n *nilDataConsumer) FillDatums(_ interface{}, _ int64, c *row.DatumRowConverter) error {
+func (n *nilDataConsumer) FillDatums(
+	_ context.Context, _ interface{}, _ int64, c *row.DatumRowConverter,
+) error {
 	c.Datums[0] = tree.DNull
 	return nil
 }

--- a/pkg/sql/importer/read_import_csv.go
+++ b/pkg/sql/importer/read_import_csv.go
@@ -192,7 +192,7 @@ var _ importRowConsumer = &csvRowConsumer{}
 
 // FillDatums() implements importRowConsumer interface
 func (c *csvRowConsumer) FillDatums(
-	row interface{}, rowNum int64, conv *row.DatumRowConverter,
+	ctx context.Context, row interface{}, rowNum int64, conv *row.DatumRowConverter,
 ) error {
 	record := row.([]csv.Record)
 	datumIdx := 0
@@ -219,7 +219,7 @@ func (c *csvRowConsumer) FillDatums(
 			conv.Datums[datumIdx] = tree.DNull
 		} else {
 			var err error
-			conv.Datums[datumIdx], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[i], field.Val, conv.EvalCtx)
+			conv.Datums[datumIdx], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], field.Val, conv.EvalCtx)
 			if err != nil {
 				// Fallback to parsing as a string literal. This allows us to support
 				// both array expressions (like `ARRAY[1, 2, 3]`) and literals (like

--- a/pkg/sql/importer/read_import_mysql_test.go
+++ b/pkg/sql/importer/read_import_mysql_test.go
@@ -370,7 +370,7 @@ func TestMysqlValueToDatum(t *testing.T) {
 	evalContext := eval.NewTestingEvalContext(st)
 	for _, tc := range tests {
 		t.Run(fmt.Sprintf("%v", tc.raw), func(t *testing.T) {
-			got, err := mysqlValueToDatum(tc.raw, tc.typ, evalContext)
+			got, err := mysqlValueToDatum(context.Background(), tc.raw, tc.typ, evalContext)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/importer/read_import_mysqlout.go
+++ b/pkg/sql/importer/read_import_mysqlout.go
@@ -178,7 +178,7 @@ var _ importRowConsumer = &delimitedConsumer{}
 
 // FillDatums implements importRowConsumer
 func (d *delimitedConsumer) FillDatums(
-	input interface{}, rowNum int64, conv *row.DatumRowConverter,
+	ctx context.Context, input interface{}, rowNum int64, conv *row.DatumRowConverter,
 ) error {
 	data := input.([]rune)
 
@@ -256,7 +256,7 @@ func (d *delimitedConsumer) FillDatums(
 			// function expects, and the difference between ParseStringAs and
 			// ParseDatumStringAs is whether or not it attempts to parse bytes.
 			var err error
-			datum, err = rowenc.ParseDatumStringAsWithRawBytes(conv.VisibleColTypes[datumIdx], field, conv.EvalCtx)
+			datum, err = rowenc.ParseDatumStringAsWithRawBytes(ctx, conv.VisibleColTypes[datumIdx], field, conv.EvalCtx)
 			if err != nil {
 				col := conv.VisibleCols[datumIdx]
 				return newImportRowError(

--- a/pkg/sql/importer/read_import_pgcopy.go
+++ b/pkg/sql/importer/read_import_pgcopy.go
@@ -321,7 +321,7 @@ var _ importRowConsumer = &pgCopyConsumer{}
 
 // FillDatums implements importRowConsumer
 func (p *pgCopyConsumer) FillDatums(
-	row interface{}, rowNum int64, conv *row.DatumRowConverter,
+	ctx context.Context, row interface{}, rowNum int64, conv *row.DatumRowConverter,
 ) error {
 	data := row.(copyData)
 	var err error
@@ -336,7 +336,7 @@ func (p *pgCopyConsumer) FillDatums(
 		if s == nil {
 			conv.Datums[i] = tree.DNull
 		} else {
-			conv.Datums[i], err = rowenc.ParseDatumStringAs(conv.VisibleColTypes[i], *s, conv.EvalCtx)
+			conv.Datums[i], err = rowenc.ParseDatumStringAs(ctx, conv.VisibleColTypes[i], *s, conv.EvalCtx)
 			if err != nil {
 				col := conv.VisibleCols[i]
 				return newImportRowError(errors.Wrapf(

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -819,7 +819,7 @@ func readPostgresStmt(
 						datums[i] = d
 					}
 					// Now that we have all of the datums, we can execute the overload.
-					fnSQL, err := fn(evalCtx, datums)
+					fnSQL, err := fn(ctx, evalCtx, datums)
 					if err != nil {
 						return err
 					}
@@ -1161,7 +1161,7 @@ func (m *pgDumpReader) readFile(
 						return errors.Wrapf(err, "reading row %d (%d in insert statement %d)",
 							count, count-startingCount, inserts)
 					}
-					converted, err := eval.Expr(conv.EvalCtx, typed)
+					converted, err := eval.Expr(ctx, conv.EvalCtx, typed)
 					if err != nil {
 						return errors.Wrapf(err, "reading row %d (%d in insert statement %d)",
 							count, count-startingCount, inserts)

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -363,6 +363,7 @@ func getSchemaByNameFromMap(
 }
 
 func createPostgresTables(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	p sql.JobExecContext,
 	createTbl map[schemaAndTableName]*tree.CreateTable,
@@ -377,7 +378,7 @@ func createPostgresTables(
 		if create == nil {
 			continue
 		}
-		schema, err := getSchemaByNameFromMap(evalCtx.Ctx(), schemaAndTableName, schemaNameToDesc, evalCtx.Settings.Version)
+		schema, err := getSchemaByNameFromMap(ctx, schemaAndTableName, schemaNameToDesc, evalCtx.Settings.Version)
 		if err != nil {
 			return nil, err
 		}
@@ -385,11 +386,11 @@ func createPostgresTables(
 		// Bundle imports do not support user defined types, and so we nil out the
 		// type resolver to protect against unexpected behavior on UDT resolution.
 		semaCtxPtr := makeSemaCtxWithoutTypeResolver(p.SemaCtx())
-		id, err := getNextPlaceholderDescID(evalCtx.Ctx(), p.ExecCfg())
+		id, err := getNextPlaceholderDescID(ctx, p.ExecCfg())
 		if err != nil {
 			return nil, err
 		}
-		desc, err := MakeSimpleTableDescriptor(evalCtx.Ctx(), semaCtxPtr, p.ExecCfg().Settings,
+		desc, err := MakeSimpleTableDescriptor(ctx, semaCtxPtr, p.ExecCfg().Settings,
 			create, parentDB, schema, id, fks, walltime)
 		if err != nil {
 			return nil, err
@@ -403,6 +404,7 @@ func createPostgresTables(
 }
 
 func resolvePostgresFKs(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	parentDB catalog.DatabaseDescriptor,
 	tableFKs map[schemaAndTableName][]*tree.ForeignKeyConstraintTableDef,
@@ -415,7 +417,7 @@ func resolvePostgresFKs(
 		if desc == nil {
 			continue
 		}
-		schema, err := getSchemaByNameFromMap(evalCtx.Ctx(), schemaAndTableName, schemaNameToDesc, evalCtx.Settings.Version)
+		schema, err := getSchemaByNameFromMap(ctx, schemaAndTableName, schemaNameToDesc, evalCtx.Settings.Version)
 		if err != nil {
 			return err
 		}
@@ -431,7 +433,7 @@ func resolvePostgresFKs(
 				constraint.Table.CatalogName = "defaultdb"
 			}
 			if err := sql.ResolveFK(
-				evalCtx.Ctx(), nil /* txn */, &fks.resolver,
+				ctx, nil /* txn */, &fks.resolver,
 				parentDB, schema, desc,
 				constraint, backrefs, sql.NewTable,
 				tree.ValidationDefault, evalCtx,
@@ -553,8 +555,9 @@ func readPostgresCreateTable(
 
 	// Construct table descriptors.
 	backrefs := make(map[descpb.ID]*tabledesc.Mutable)
-	tableDescs, err := createPostgresTables(evalCtx, p, schemaObjects.createTbl, fks, backrefs,
-		parentDB, walltime, schemaNameToDesc)
+	tableDescs, err := createPostgresTables(
+		ctx, evalCtx, p, schemaObjects.createTbl, fks, backrefs, parentDB, walltime, schemaNameToDesc,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -562,7 +565,7 @@ func readPostgresCreateTable(
 
 	// Resolve FKs.
 	err = resolvePostgresFKs(
-		evalCtx, parentDB, schemaObjects.tableFKs, fks, backrefs, schemaNameToDesc,
+		ctx, evalCtx, parentDB, schemaObjects.tableFKs, fks, backrefs, schemaNameToDesc,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -281,7 +281,7 @@ func (n *insertFastPathNode) BatchedNext(params runParams) (bool, error) {
 		inputRow := n.run.inputRow(rowIdx)
 		for col, typedExpr := range tupleRow {
 			var err error
-			inputRow[col], err = eval.Expr(params.EvalContext(), typedExpr)
+			inputRow[col], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr)
 			if err != nil {
 				err = interceptAlterColumnTypeParseError(n.run.insertCols, col, err)
 				return false, err

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -712,7 +712,7 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 	) {
 		f := opc.optimizer.Factory()
 		evalCtx := opc.p.EvalContext()
-		f.Init(evalCtx, &opc.catalog)
+		f.Init(ctx, evalCtx, &opc.catalog)
 		f.FoldingControl().AllowStableFolds()
 		bld := optbuilder.New(ctx, &opc.p.semaCtx, evalCtx, &opc.catalog, f, opc.p.stmt.AST)
 		err := bld.Build()

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -265,7 +265,7 @@ func (ih *instrumentationHelper) Setup(
 			ih.traceMetadata = make(execNodeTraceMetadata)
 		}
 		// Make sure that the builtins use the correct context.
-		ih.evalCtx.Context = newCtx
+		ih.evalCtx.SetDeprecatedContext(newCtx)
 	}()
 
 	if sp := tracing.SpanFromContext(ctx); sp != nil {

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -137,12 +137,14 @@ func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // in the join algorithm already).
 // Returns true if there is no on condition or the on condition accepts the
 // row.
-func (p *joinPredicate) eval(evalCtx *eval.Context, leftRow, rightRow tree.Datums) (bool, error) {
+func (p *joinPredicate) eval(
+	ctx context.Context, evalCtx *eval.Context, leftRow, rightRow tree.Datums,
+) (bool, error) {
 	if p.onCond != nil {
 		copy(p.curRow[:len(leftRow)], leftRow)
 		copy(p.curRow[len(leftRow):], rightRow)
 		evalCtx.PushIVarContainer(p.iVarHelper.Container())
-		pred, err := execinfrapb.RunFilter(p.onCond, evalCtx)
+		pred, err := execinfrapb.RunFilter(ctx, p.onCond, evalCtx)
 		evalCtx.PopIVarContainer()
 		return pred, err
 	}

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -11,6 +11,8 @@
 package sql
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -71,6 +73,8 @@ type joinPredicate struct {
 	rightEqKey bool
 }
 
+var _ eval.IndexedVarContainer = &joinPredicate{}
+
 // getJoinResultColumns returns the result columns of a join.
 func getJoinResultColumns(
 	joinType descpb.JoinType, left, right colinfo.ResultColumns,
@@ -105,9 +109,11 @@ func makePredicate(joinType descpb.JoinType, left, right colinfo.ResultColumns) 
 	return pred
 }
 
-// IndexedVarEval implements the tree.IndexedVarContainer interface.
-func (p *joinPredicate) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
-	return p.curRow[idx].Eval(e)
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
+func (p *joinPredicate) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
+	return p.curRow[idx].Eval(ctx, e)
 }
 
 // IndexedVarResolvedType implements the tree.IndexedVarContainer interface.
@@ -131,13 +137,13 @@ func (p *joinPredicate) IndexedVarNodeFormatter(idx int) tree.NodeFormatter {
 // in the join algorithm already).
 // Returns true if there is no on condition or the on condition accepts the
 // row.
-func (p *joinPredicate) eval(ctx *eval.Context, leftRow, rightRow tree.Datums) (bool, error) {
+func (p *joinPredicate) eval(evalCtx *eval.Context, leftRow, rightRow tree.Datums) (bool, error) {
 	if p.onCond != nil {
 		copy(p.curRow[:len(leftRow)], leftRow)
 		copy(p.curRow[len(leftRow):], rightRow)
-		ctx.PushIVarContainer(p.iVarHelper.Container())
-		pred, err := execinfrapb.RunFilter(p.onCond, ctx)
-		ctx.PopIVarContainer()
+		evalCtx.PushIVarContainer(p.iVarHelper.Container())
+		pred, err := execinfrapb.RunFilter(p.onCond, evalCtx)
+		evalCtx.PopIVarContainer()
 		return pred, err
 	}
 	return true, nil

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -62,7 +62,7 @@ func evalLimit(
 
 	for _, datum := range data {
 		if datum.src != nil {
-			dstDatum, err := eval.Expr(evalCtx, datum.src)
+			dstDatum, err := eval.Expr(evalCtx.Context, evalCtx, datum.src)
 			if err != nil {
 				return count, offset, err
 			}

--- a/pkg/sql/limit.go
+++ b/pkg/sql/limit.go
@@ -46,7 +46,7 @@ func (n *limitNode) Close(ctx context.Context) {
 // evalLimit evaluates the Count and Offset fields. If Count is missing, the
 // value is MaxInt64. If Offset is missing, the value is 0
 func evalLimit(
-	evalCtx *eval.Context, countExpr, offsetExpr tree.TypedExpr,
+	ctx context.Context, evalCtx *eval.Context, countExpr, offsetExpr tree.TypedExpr,
 ) (count, offset int64, err error) {
 	count = math.MaxInt64
 	offset = 0
@@ -62,7 +62,7 @@ func evalLimit(
 
 	for _, datum := range data {
 		if datum.src != nil {
-			dstDatum, err := eval.Expr(evalCtx.Context, evalCtx, datum.src)
+			dstDatum, err := eval.Expr(ctx, evalCtx, datum.src)
 			if err != nil {
 				return count, offset, err
 			}

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -705,6 +705,7 @@ func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
 
 	root := execMemo.RootExpr()
 	eb := execbuilder.New(
+		context.Background(),
 		explain.NewPlanGistFactory(exec.StubFactory{}),
 		&h.optimizer,
 		execMemo,
@@ -758,6 +759,7 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 
 	root := execMemo.RootExpr()
 	eb := execbuilder.New(
+		context.Background(),
 		explain.NewPlanGistFactory(exec.StubFactory{}),
 		&h.optimizer,
 		execMemo,

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -30,7 +30,7 @@ func TestBuildProvided(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 
 	testCases := []struct {
 		leftDist  []string

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -11,6 +11,7 @@
 package execbuilder
 
 import (
+	"context"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -340,16 +341,18 @@ func (b *Builder) boundedStaleness() bool {
 	return b.evalCtx != nil && b.evalCtx.BoundedStaleness()
 }
 
-// mdVarContainer is an IndexedVarContainer implementation used by BuildScalar -
-// it maps indexed vars to columns in the metadata.
+// mdVarContainer is an eval.IndexedVarContainer implementation used by
+// BuildScalar - it maps indexed vars to columns in the metadata.
 type mdVarContainer struct {
 	md *opt.Metadata
 }
 
-var _ tree.IndexedVarContainer = &mdVarContainer{}
+var _ eval.IndexedVarContainer = &mdVarContainer{}
 
-// IndexedVarEval is part of the IndexedVarContainer interface.
-func (c *mdVarContainer) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
+// IndexedVarEval is part of the eval.IndexedVarContainer interface.
+func (c *mdVarContainer) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("no eval allowed in mdVarContainer")
 }
 

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -52,6 +52,7 @@ func getParallelScanResultThreshold(forceProductionValue bool) uint64 {
 // Builder constructs a tree of execution nodes (exec.Node) from an optimized
 // expression tree (opt.Expr).
 type Builder struct {
+	ctx              context.Context
 	factory          exec.Factory
 	optimizer        *xform.Optimizer
 	mem              *memo.Memo
@@ -179,6 +180,7 @@ type Builder struct {
 // `transaction_rows_read_err` guardrail is disabled.). It should be false if
 // the statement is executed as part of an explicit transaction.
 func New(
+	ctx context.Context,
 	factory exec.Factory,
 	optimizer *xform.Optimizer,
 	mem *memo.Memo,
@@ -193,6 +195,7 @@ func New(
 		mem:                    mem,
 		catalog:                catalog,
 		e:                      e,
+		ctx:                    ctx,
 		evalCtx:                evalCtx,
 		allowAutoCommit:        allowAutoCommit,
 		initialAllowAutoCommit: allowAutoCommit,

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -293,7 +293,7 @@ func (cb *cascadeBuilder) planCascade(
 	}
 
 	// 5. Execbuild the optimized expression.
-	eb := New(execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
+	eb := New(ctx, execFactory, &o, factory.Memo(), cb.b.catalog, optimizedExpr, evalCtx, allowAutoCommit)
 	if bufferRef != nil {
 		// Set up the With binding.
 		eb.addBuiltWithExpr(cascadeInputWithID, bufferColMap, bufferRef)

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -41,6 +41,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 
 	// Build the scalar expression and format it as a single string.
 	bld := New(
+		f.Ctx,
 		nil, /* factory */
 		nil, /* optimizer */
 		f.Memo,

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -812,7 +812,7 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 	for i, expr := range scan.Span {
 		// The expression is either a placeholder or a constant.
 		if p, ok := expr.(*memo.PlaceholderExpr); ok {
-			val, err := eval.Expr(b.evalCtx, p.Value)
+			val, err := eval.Expr(b.evalCtx.Context, b.evalCtx, p.Value)
 			if err != nil {
 				return execPlan{}, err
 			}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -812,7 +812,7 @@ func (b *Builder) buildPlaceholderScan(scan *memo.PlaceholderScanExpr) (execPlan
 	for i, expr := range scan.Span {
 		// The expression is either a placeholder or a constant.
 		if p, ok := expr.(*memo.PlaceholderExpr); ok {
-			val, err := eval.Expr(b.evalCtx.Context, b.evalCtx, p.Value)
+			val, err := eval.Expr(b.ctx, b.evalCtx, p.Value)
 			if err != nil {
 				return execPlan{}, err
 			}
@@ -1102,7 +1102,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 			return nil, err
 		}
 
-		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
+		eb := New(ctx, ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
 		eb.disableTelemetry = true
 		eb.withExprs = withExprs
 		plan, err := eb.Build()
@@ -2659,6 +2659,7 @@ func (b *Builder) buildRecursiveCTE(rec *memo.RecursiveCTEExpr) (execPlan, error
 	// To implement exec.RecursiveCTEIterationFn, we create a special Builder.
 
 	innerBldTemplate := &Builder{
+		ctx:     b.ctx,
 		mem:     b.mem,
 		catalog: b.catalog,
 		evalCtx: b.evalCtx,

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -721,7 +721,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		// TODO(mgartner): Add support for WITH expressions inside UDF bodies.
 		// TODO(mgartner): Add support for subqueries inside UDF bodies.
 		ef := ref.(exec.Factory)
-		eb := New(ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
+		eb := New(ctx, ef, &o, f.Memo(), b.catalog, newRightSide, b.evalCtx, false /* allowAutoCommit */)
 		eb.disableTelemetry = true
 		plan, err := eb.Build()
 		if err != nil {

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -115,7 +115,7 @@ func (b *Builder) buildExplainOpt(explain *memo.ExplainExpr) (execPlan, error) {
 		planText.WriteString(b.optimizer.FormatMemo(xform.FmtPretty))
 	}
 
-	f := memo.MakeExprFmtCtx(fmtFlags, b.mem, b.catalog)
+	f := memo.MakeExprFmtCtx(b.ctx, fmtFlags, b.mem, b.catalog)
 	f.FormatExpr(explain.Input)
 	planText.WriteString(f.Buffer.String())
 
@@ -151,7 +151,7 @@ func (b *Builder) buildExplain(explainExpr *memo.ExplainExpr) (execPlan, error) 
 			ef := explain.NewFactory(gf)
 
 			explainBld := New(
-				ef, b.optimizer, b.mem, b.catalog, explainExpr.Input, b.evalCtx, b.initialAllowAutoCommit,
+				b.ctx, ef, b.optimizer, b.mem, b.catalog, explainExpr.Input, b.evalCtx, b.initialAllowAutoCommit,
 			)
 			explainBld.disableTelemetry = true
 			plan, err := explainBld.Build()

--- a/pkg/sql/opt/idxconstraint/index_constraints_test.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints_test.go
@@ -69,7 +69,7 @@ func TestIndexConstraints(t *testing.T) {
 			var err error
 
 			var f norm.Factory
-			f.Init(&evalCtx, nil /* catalog */)
+			f.Init(context.Background(), &evalCtx, nil /* catalog */)
 			md := f.Metadata()
 
 			for _, arg := range d.CmdArgs {
@@ -136,7 +136,7 @@ func TestIndexConstraints(t *testing.T) {
 				remainingFilter := ic.RemainingFilters()
 				if !remainingFilter.IsTrue() {
 					execBld := execbuilder.New(
-						nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
+						context.Background(), nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 						&remainingFilter, &evalCtx, false, /* allowAutoCommit */
 					)
 					expr, err := execBld.BuildScalar()
@@ -222,7 +222,7 @@ func BenchmarkIndexConstraints(b *testing.B) {
 	for _, tc := range testCases {
 		b.Run(tc.name, func(b *testing.B) {
 			var f norm.Factory
-			f.Init(&evalCtx, nil /* catalog */)
+			f.Init(context.Background(), &evalCtx, nil /* catalog */)
 			md := f.Metadata()
 			var sv testutils.ScalarVars
 			err := sv.Init(md, strings.Split(tc.vars, ", "))

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -749,7 +749,11 @@ func (g *geoDatumsToInvertedExpr) IndexedVarNodeFormatter(idx int) tree.NodeForm
 
 // NewGeoDatumsToInvertedExpr returns a new geoDatumsToInvertedExpr.
 func NewGeoDatumsToInvertedExpr(
-	evalCtx *eval.Context, colTypes []*types.T, expr tree.TypedExpr, config geoindex.Config,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	colTypes []*types.T,
+	expr tree.TypedExpr,
+	config geoindex.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if config.IsEmpty() {
 		return nil, fmt.Errorf("inverted joins are currently only supported for geospatial indexes")
@@ -813,7 +817,7 @@ func NewGeoDatumsToInvertedExpr(
 			// it for every row.
 			var invertedExpr inverted.Expression
 			if d, ok := nonIndexParam.(tree.Datum); ok {
-				invertedExpr = g.getSpanExpr(evalCtx.Ctx(), d, additionalParams, relationship, g.indexConfig)
+				invertedExpr = g.getSpanExpr(ctx, d, additionalParams, relationship, g.indexConfig)
 			} else if funcExprCount == 1 {
 				// Currently pre-filtering is limited to a single FuncExpr.
 				preFilterRelationship = relationship

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -723,17 +723,17 @@ type geoDatumsToInvertedExpr struct {
 }
 
 var _ invertedexpr.DatumsToInvertedExpr = &geoDatumsToInvertedExpr{}
-var _ tree.IndexedVarContainer = &geoDatumsToInvertedExpr{}
+var _ eval.IndexedVarContainer = &geoDatumsToInvertedExpr{}
 
-// IndexedVarEval is part of the IndexedVarContainer interface.
+// IndexedVarEval is part of the eval.IndexedVarContainer interface.
 func (g *geoDatumsToInvertedExpr) IndexedVarEval(
-	idx int, e tree.ExprEvaluator,
+	ctx context.Context, idx int, e tree.ExprEvaluator,
 ) (tree.Datum, error) {
 	err := g.row[idx].EnsureDecoded(g.colTypes[idx], &g.alloc)
 	if err != nil {
 		return nil, err
 	}
-	return g.row[idx].Datum.Eval(e)
+	return g.row[idx].Datum.Eval(ctx, e)
 }
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
@@ -860,7 +860,7 @@ func (g *geoDatumsToInvertedExpr) Convert(
 				// We call Copy so the caller can modify the returned expression.
 				return t.invertedExpr.Copy(), nil
 			}
-			d, err := eval.Expr(g.evalCtx, t.nonIndexParam)
+			d, err := eval.Expr(ctx, g.evalCtx, t.nonIndexParam)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/opt/invertedidx/geo.go
+++ b/pkg/sql/opt/invertedidx/geo.go
@@ -337,7 +337,7 @@ var _ invertedFilterPlanner = &geoFilterPlanner{}
 // extractInvertedFilterConditionFromLeaf is part of the invertedFilterPlanner
 // interface.
 func (g *geoFilterPlanner) extractInvertedFilterConditionFromLeaf(
-	evalCtx *eval.Context, expr opt.ScalarExpr,
+	ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr,
 ) (
 	invertedExpr inverted.Expression,
 	remainingFilters opt.ScalarExpr,
@@ -375,11 +375,11 @@ func (g *geoFilterPlanner) extractInvertedFilterConditionFromLeaf(
 	//
 	// See geoindex.CommuteRelationshipMap for the full list of mappings.
 	invertedExpr, pfState := extractGeoFilterCondition(
-		evalCtx.Context, g.factory, expr, args, false /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
+		ctx, g.factory, expr, args, false /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
 	)
 	if _, ok := invertedExpr.(inverted.NonInvertedColExpression); ok {
 		invertedExpr, pfState = extractGeoFilterCondition(
-			evalCtx.Context, g.factory, expr, args, true /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
+			ctx, g.factory, expr, args, true /* commuteArgs */, g.tabID, g.index, g.getSpanExpr,
 		)
 	}
 	if !invertedExpr.IsTight() {

--- a/pkg/sql/opt/invertedidx/geo_test.go
+++ b/pkg/sql/opt/invertedidx/geo_test.go
@@ -57,7 +57,7 @@ func TestTryJoinGeoIndex(t *testing.T) {
 	}
 
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn1 := tree.NewUnqualifiedTableName("t1")
 	tn2 := tree.NewUnqualifiedTableName("t2")
@@ -326,7 +326,7 @@ func TestTryFilterGeoIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -496,6 +496,7 @@ func TestTryFilterGeoIndex(t *testing.T) {
 		// that is tested elsewhere. This is just testing that we are constraining
 		// the index when we expect to.
 		spanExpr, _, remainingFilters, pfState, ok := invertedidx.TryFilterInvertedIndex(
+			context.Background(),
 			evalCtx,
 			&f,
 			filters,

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -31,10 +31,14 @@ import (
 
 // NewDatumsToInvertedExpr returns a new DatumsToInvertedExpr.
 func NewDatumsToInvertedExpr(
-	evalCtx *eval.Context, colTypes []*types.T, expr tree.TypedExpr, geoConfig geoindex.Config,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	colTypes []*types.T,
+	expr tree.TypedExpr,
+	geoConfig geoindex.Config,
 ) (invertedexpr.DatumsToInvertedExpr, error) {
 	if !geoConfig.IsEmpty() {
-		return NewGeoDatumsToInvertedExpr(evalCtx, colTypes, expr, geoConfig)
+		return NewGeoDatumsToInvertedExpr(ctx, evalCtx, colTypes, expr, geoConfig)
 	}
 
 	return NewJSONOrArrayDatumsToInvertedExpr(evalCtx, colTypes, expr)

--- a/pkg/sql/opt/invertedidx/inverted_index_expr.go
+++ b/pkg/sql/opt/invertedidx/inverted_index_expr.go
@@ -66,6 +66,7 @@ func NewBoundPreFilterer(typ *types.T, expr tree.TypedExpr) (*PreFilterer, inter
 //   - pre-filterer state that can be used by the invertedFilterer operator to
 //     reduce the number of false positives returned by the span expression.
 func TryFilterInvertedIndex(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	factory *norm.Factory,
 	filters memo.FiltersExpr,
@@ -130,7 +131,7 @@ func TryFilterInvertedIndex(
 	var pfState *invertedexpr.PreFiltererStateForInvertedFilterer
 	for i := range filters {
 		invertedExprLocal, remFiltersLocal, pfStateLocal := extractInvertedFilterCondition(
-			evalCtx, factory, filters[i].Condition, filterPlanner,
+			ctx, evalCtx, factory, filters[i].Condition, filterPlanner,
 		)
 		if invertedExpr == nil {
 			invertedExpr = invertedExprLocal
@@ -447,7 +448,7 @@ type invertedFilterPlanner interface {
 	// - remaining filters that must be applied if the inverted expression is not
 	//   tight, and
 	// - pre-filterer state that can be used to reduce false positives.
-	extractInvertedFilterConditionFromLeaf(evalCtx *eval.Context, expr opt.ScalarExpr) (
+	extractInvertedFilterConditionFromLeaf(ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr) (
 		invertedExpr inverted.Expression,
 		remainingFilters opt.ScalarExpr,
 		_ *invertedexpr.PreFiltererStateForInvertedFilterer,
@@ -469,6 +470,7 @@ type invertedFilterPlanner interface {
 //   - pre-filterer state that can be used to reduce false positives. This is
 //     only non-nil if filterCond is a leaf condition (i.e., has no ANDs or ORs).
 func extractInvertedFilterCondition(
+	ctx context.Context,
 	evalCtx *eval.Context,
 	factory *norm.Factory,
 	filterCond opt.ScalarExpr,
@@ -480,8 +482,8 @@ func extractInvertedFilterCondition(
 ) {
 	switch t := filterCond.(type) {
 	case *memo.AndExpr:
-		l, remLeft, _ := extractInvertedFilterCondition(evalCtx, factory, t.Left, filterPlanner)
-		r, remRight, _ := extractInvertedFilterCondition(evalCtx, factory, t.Right, filterPlanner)
+		l, remLeft, _ := extractInvertedFilterCondition(ctx, evalCtx, factory, t.Left, filterPlanner)
+		r, remRight, _ := extractInvertedFilterCondition(ctx, evalCtx, factory, t.Right, filterPlanner)
 		if remLeft == nil {
 			remainingFilters = remRight
 		} else if remRight == nil {
@@ -492,8 +494,8 @@ func extractInvertedFilterCondition(
 		return inverted.And(l, r), remainingFilters, nil
 
 	case *memo.OrExpr:
-		l, remLeft, _ := extractInvertedFilterCondition(evalCtx, factory, t.Left, filterPlanner)
-		r, remRight, _ := extractInvertedFilterCondition(evalCtx, factory, t.Right, filterPlanner)
+		l, remLeft, _ := extractInvertedFilterCondition(ctx, evalCtx, factory, t.Left, filterPlanner)
+		r, remRight, _ := extractInvertedFilterCondition(ctx, evalCtx, factory, t.Right, filterPlanner)
 		if remLeft != nil || remRight != nil {
 			// If either child has remaining filters, we must return the original
 			// condition as the remaining filter. It would be incorrect to return
@@ -503,7 +505,7 @@ func extractInvertedFilterCondition(
 		return inverted.Or(l, r), remainingFilters, nil
 
 	default:
-		return filterPlanner.extractInvertedFilterConditionFromLeaf(evalCtx, filterCond)
+		return filterPlanner.extractInvertedFilterConditionFromLeaf(ctx, evalCtx, filterCond)
 	}
 }
 

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -205,17 +205,17 @@ type jsonOrArrayDatumsToInvertedExpr struct {
 }
 
 var _ invertedexpr.DatumsToInvertedExpr = &jsonOrArrayDatumsToInvertedExpr{}
-var _ tree.IndexedVarContainer = &jsonOrArrayDatumsToInvertedExpr{}
+var _ eval.IndexedVarContainer = &jsonOrArrayDatumsToInvertedExpr{}
 
-// IndexedVarEval is part of the IndexedVarContainer interface.
+// IndexedVarEval is part of the eval.IndexedVarContainer interface.
 func (g *jsonOrArrayDatumsToInvertedExpr) IndexedVarEval(
-	idx int, e tree.ExprEvaluator,
+	ctx context.Context, idx int, e tree.ExprEvaluator,
 ) (tree.Datum, error) {
 	err := g.row[idx].EnsureDecoded(g.colTypes[idx], &g.alloc)
 	if err != nil {
 		return nil, err
 	}
-	return g.row[idx].Datum.Eval(e)
+	return g.row[idx].Datum.Eval(ctx, e)
 }
 
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
@@ -310,7 +310,7 @@ func (g *jsonOrArrayDatumsToInvertedExpr) Convert(
 				// We call Copy so the caller can modify the returned expression.
 				return t.spanExpr.Copy(), nil
 			}
-			d, err := eval.Expr(g.evalCtx, t.nonIndexParam)
+			d, err := eval.Expr(ctx, g.evalCtx, t.nonIndexParam)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -371,7 +371,7 @@ var _ invertedFilterPlanner = &jsonOrArrayFilterPlanner{}
 // extractInvertedFilterConditionFromLeaf is part of the invertedFilterPlanner
 // interface.
 func (j *jsonOrArrayFilterPlanner) extractInvertedFilterConditionFromLeaf(
-	evalCtx *eval.Context, expr opt.ScalarExpr,
+	ctx context.Context, evalCtx *eval.Context, expr opt.ScalarExpr,
 ) (
 	invertedExpr inverted.Expression,
 	remainingFilters opt.ScalarExpr,

--- a/pkg/sql/opt/invertedidx/json_array_test.go
+++ b/pkg/sql/opt/invertedidx/json_array_test.go
@@ -48,7 +48,7 @@ func TestTryJoinJsonOrArrayIndex(t *testing.T) {
 	}
 
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn1 := tree.NewUnqualifiedTableName("t1")
 	tn2 := tree.NewUnqualifiedTableName("t2")
@@ -230,7 +230,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -860,6 +860,7 @@ func TestTryFilterJsonOrArrayIndex(t *testing.T) {
 		// the index when we expect to and we have the correct values for tight,
 		// unique, and remainingFilters.
 		spanExpr, _, remainingFilters, _, ok := invertedidx.TryFilterInvertedIndex(
+			context.Background(),
 			evalCtx,
 			&f,
 			filters,

--- a/pkg/sql/opt/invertedidx/trigram.go
+++ b/pkg/sql/opt/invertedidx/trigram.go
@@ -11,6 +11,8 @@
 package invertedidx
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -34,7 +36,7 @@ var _ invertedFilterPlanner = &trigramFilterPlanner{}
 // extractInvertedFilterConditionFromLeaf implements the invertedFilterPlanner
 // interface.
 func (t *trigramFilterPlanner) extractInvertedFilterConditionFromLeaf(
-	_ *eval.Context, expr opt.ScalarExpr,
+	_ context.Context, _ *eval.Context, expr opt.ScalarExpr,
 ) (
 	invertedExpr inverted.Expression,
 	remainingFilters opt.ScalarExpr,

--- a/pkg/sql/opt/invertedidx/trigram_test.go
+++ b/pkg/sql/opt/invertedidx/trigram_test.go
@@ -11,6 +11,7 @@
 package invertedidx_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -35,7 +36,7 @@ func TestTryFilterTrigram(t *testing.T) {
 		t.Fatal(err)
 	}
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -101,6 +102,7 @@ func TestTryFilterTrigram(t *testing.T) {
 		// the index when we expect to and we have the correct values for tight,
 		// unique, and remainingFilters.
 		spanExpr, _, remainingFilters, _, ok := invertedidx.TryFilterInvertedIndex(
+			context.Background(),
 			evalCtx,
 			&f,
 			filters,

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -63,7 +63,7 @@ func TestLookupConstraints(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			testCatalog := testcat.New()
 			var f norm.Factory
-			f.Init(&evalCtx, testCatalog)
+			f.Init(context.Background(), &evalCtx, testCatalog)
 			md := f.Metadata()
 
 			for _, arg := range d.CmdArgs {
@@ -319,7 +319,7 @@ func makeFiltersExpr(
 
 func formatScalar(e opt.Expr, f *norm.Factory, evalCtx *eval.Context) string {
 	execBld := execbuilder.New(
-		nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
+		context.Background(), nil /* execFactory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 		e, evalCtx, false, /* allowAutoCommit */
 	)
 	expr, err := execBld.BuildScalar()
@@ -347,7 +347,7 @@ type testFilterBuilder struct {
 func makeFilterBuilder(t *testing.T) testFilterBuilder {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	var f norm.Factory
-	f.Init(&evalCtx, nil)
+	f.Init(context.Background(), &evalCtx, nil)
 	cat := testcat.New()
 	if _, err := cat.ExecuteDDL("CREATE TABLE a (i INT PRIMARY KEY, b BOOL)"); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -11,6 +11,7 @@
 package memo
 
 import (
+	"context"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -55,14 +56,14 @@ type logicalPropsBuilder struct {
 	disableStats bool
 }
 
-func (b *logicalPropsBuilder) init(evalCtx *eval.Context, mem *Memo) {
+func (b *logicalPropsBuilder) init(ctx context.Context, evalCtx *eval.Context, mem *Memo) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*b = logicalPropsBuilder{
 		evalCtx: evalCtx,
 		mem:     mem,
 	}
-	b.sb.init(evalCtx, mem.Metadata())
+	b.sb.init(ctx, evalCtx, mem.Metadata())
 }
 
 func (b *logicalPropsBuilder) clear() {

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -183,7 +183,7 @@ type Memo struct {
 // information about the context in which it is compiled from the evalContext
 // argument. If any of that changes, then the memo must be invalidated (see the
 // IsStale method for more details).
-func (m *Memo) Init(evalCtx *eval.Context) {
+func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*m = Memo{
@@ -213,7 +213,7 @@ func (m *Memo) Init(evalCtx *eval.Context) {
 		variableInequalityLookupJoinEnabled:    evalCtx.SessionData().VariableInequalityLookupJoinEnabled,
 	}
 	m.metadata.Init()
-	m.logPropsBuilder.init(evalCtx, m)
+	m.logPropsBuilder.init(ctx, evalCtx, m)
 }
 
 // AllowUnconstrainedNonCoveringIndexScan indicates whether unconstrained
@@ -226,8 +226,8 @@ func (m *Memo) AllowUnconstrainedNonCoveringIndexScan() bool {
 // with the perturb-cost OptTester flag in order to update the query plan tree
 // after optimization is complete with the real computed cost, not the perturbed
 // cost.
-func (m *Memo) ResetLogProps(evalCtx *eval.Context) {
-	m.logPropsBuilder.init(evalCtx, m)
+func (m *Memo) ResetLogProps(ctx context.Context, evalCtx *eval.Context) {
+	m.logPropsBuilder.init(ctx, evalCtx, m)
 }
 
 // NotifyOnNewGroup sets a callback function which is invoked each time we

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -66,7 +66,7 @@ func TestCompositeSensitive(t *testing.T) {
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 
 		var f norm.Factory
-		f.Init(&evalCtx, nil /* catalog */)
+		f.Init(context.Background(), &evalCtx, nil /* catalog */)
 		md := f.Metadata()
 
 		if d.Cmd != "composite-sensitive" {

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -11,6 +11,7 @@
 package memo
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -469,12 +470,12 @@ type testOpBuilder struct {
 }
 
 func makeOpBuilder(t *testing.T) testOpBuilder {
-	ctx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	var mem Memo
-	mem.Init(&ctx)
+	mem.Init(context.Background(), &evalCtx)
 	ob := testOpBuilder{
 		t:       t,
-		evalCtx: &ctx,
+		evalCtx: &evalCtx,
 		mem:     &mem,
 		cat:     testcat.New(),
 	}

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -462,10 +462,10 @@ func TestGetJoinMultiplicity(t *testing.T) {
 }
 
 type testOpBuilder struct {
-	t   *testing.T
-	ctx *eval.Context
-	mem *Memo
-	cat *testcat.Catalog
+	t       *testing.T
+	evalCtx *eval.Context
+	mem     *Memo
+	cat     *testcat.Catalog
 }
 
 func makeOpBuilder(t *testing.T) testOpBuilder {
@@ -473,10 +473,10 @@ func makeOpBuilder(t *testing.T) testOpBuilder {
 	var mem Memo
 	mem.Init(&ctx)
 	ob := testOpBuilder{
-		t:   t,
-		ctx: &ctx,
-		mem: &mem,
-		cat: testcat.New(),
+		t:       t,
+		evalCtx: &ctx,
+		mem:     &mem,
+		cat:     testcat.New(),
 	}
 	return ob
 }

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -11,6 +11,7 @@
 package memo
 
 import (
+	"context"
 	"math"
 	"reflect"
 
@@ -228,14 +229,16 @@ const (
 //
 // See props/statistics.go for more details.
 type statisticsBuilder struct {
+	ctx     context.Context
 	evalCtx *eval.Context
 	md      *opt.Metadata
 }
 
-func (sb *statisticsBuilder) init(evalCtx *eval.Context, md *opt.Metadata) {
+func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, md *opt.Metadata) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*sb = statisticsBuilder{
+		ctx:     ctx,
 		evalCtx: evalCtx,
 		md:      md,
 	}
@@ -4594,9 +4597,9 @@ func (sb *statisticsBuilder) numConjunctsInConstraint(
 
 // RequestColStat causes a column statistic to be calculated on the relational
 // expression. This is used for testing.
-func RequestColStat(evalCtx *eval.Context, e RelExpr, cols opt.ColSet) {
+func RequestColStat(ctx context.Context, evalCtx *eval.Context, e RelExpr, cols opt.ColSet) {
 	var sb statisticsBuilder
-	sb.init(evalCtx, e.Memo().Metadata())
+	sb.init(ctx, evalCtx, e.Memo().Metadata())
 	sb.colStat(cols, e)
 }
 
@@ -4688,7 +4691,7 @@ func (sb *statisticsBuilder) buildStatsFromCheckConstraints(
 					values, hasNullValue, _ = filterConstraint.CollectFirstColumnValues(sb.evalCtx)
 					if hasNullValue {
 						log.Infof(
-							sb.evalCtx.Ctx(), "null value seen in histogram built from check constraint: %s", filterConstraint.String(),
+							sb.ctx, "null value seen in histogram built from check constraint: %s", filterConstraint.String(),
 						)
 					}
 				}
@@ -4738,7 +4741,7 @@ func (sb *statisticsBuilder) buildStatsFromCheckConstraints(
 				} else {
 					useHistogram = false
 					log.Infof(
-						sb.evalCtx.Ctx(), "histogram could not be generated from check constraint due to error: %v", err,
+						sb.ctx, "histogram could not be generated from check constraint due to error: %v", err,
 					)
 				}
 			}

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -11,6 +11,7 @@
 package memo
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -88,7 +89,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 	}
 
 	var mem Memo
-	mem.Init(&evalCtx)
+	mem.Init(context.Background(), &evalCtx)
 	tn := tree.NewUnqualifiedTableName("sel")
 	tab := catalog.Table(tn)
 	tabID := mem.Metadata().AddTable(tab, tn)
@@ -104,7 +105,7 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		}
 
 		sb := &statisticsBuilder{}
-		sb.init(&evalCtx, mem.Metadata())
+		sb.init(context.Background(), &evalCtx, mem.Metadata())
 
 		// Make the scan.
 		scan := mem.MemoizeScan(&ScanPrivate{Table: tabID, Cols: cols})

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -33,7 +33,7 @@ import (
 func TestMetadata(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
 	var f norm.Factory
-	f.Init(&evalCtx, nil /* catalog */)
+	f.Init(context.Background(), &evalCtx, nil /* catalog */)
 	md := f.Metadata()
 
 	schID := md.AddSchema(&testcat.Schema{})

--- a/pkg/sql/opt/norm/comp_funcs.go
+++ b/pkg/sql/opt/norm/comp_funcs.go
@@ -79,7 +79,7 @@ func (c *CustomFuncs) FoldBinaryCheckOverflow(
 	if lDatum == tree.DNull || rDatum == tree.DNull {
 		return nil, false
 	}
-	result, err := eval.BinaryOp(c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	result, err := eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -317,7 +317,7 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
 	var replaceFn ReplaceFunc
 	replaceFn = func(e opt.Expr) opt.Expr {
 		if placeholder, ok := e.(*memo.PlaceholderExpr); ok {
-			d, err := eval.Expr(f.evalCtx, e.(*memo.PlaceholderExpr).Value)
+			d, err := eval.Expr(f.evalCtx.Context, f.evalCtx, e.(*memo.PlaceholderExpr).Value)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -132,7 +132,7 @@ func (f *Factory) Init(ctx context.Context, evalCtx *eval.Context, catalog cat.C
 	if mem == nil {
 		mem = &memo.Memo{}
 	}
-	mem.Init(evalCtx)
+	mem.Init(ctx, evalCtx)
 
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
@@ -358,7 +358,7 @@ func (f *Factory) onMaxConstructorStackDepthExceeded() {
 	if buildutil.CrdbTestBuild {
 		panic(err)
 	}
-	errorutil.SendReport(f.evalCtx.Ctx(), &f.evalCtx.Settings.SV, err)
+	errorutil.SendReport(f.ctx, &f.evalCtx.Settings.SV, err)
 }
 
 // onConstructRelational is called as a final step by each factory method that

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -38,7 +38,7 @@ func TestSimplifyFilters(t *testing.T) {
 	}
 
 	var f norm.Factory
-	f.Init(&evalCtx, cat)
+	f.Init(context.Background(), &evalCtx, cat)
 
 	tn := tree.NewTableNameWithSchema("t", tree.PublicSchemaName, "a")
 	a := f.Metadata().AddTable(cat.Table(tn), tn)

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -291,7 +291,7 @@ func (c *CustomFuncs) FoldBinary(
 	}
 
 	lDatum, rDatum := memo.ExtractConstDatum(left), memo.ExtractConstDatum(right)
-	result, err := eval.BinaryOp(c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	result, err := eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
 	if err != nil {
 		return nil, false
 	}
@@ -310,7 +310,7 @@ func (c *CustomFuncs) FoldUnary(op opt.Operator, input opt.ScalarExpr) (_ opt.Sc
 		return nil, false
 	}
 
-	result, err := eval.UnaryOp(c.f.evalCtx.Context, c.f.evalCtx, o.EvalOp, datum)
+	result, err := eval.UnaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, datum)
 	if err != nil {
 		return nil, false
 	}
@@ -333,7 +333,7 @@ func (c *CustomFuncs) foldStringToRegclassCast(
 	if err != nil {
 		return nil, err
 	}
-	ds, resName, err := c.f.catalog.ResolveDataSource(c.f.evalCtx.Context, flags, tn)
+	ds, resName, err := c.f.catalog.ResolveDataSource(c.f.ctx, flags, tn)
 	if err != nil {
 		return nil, err
 	}
@@ -368,7 +368,7 @@ func (c *CustomFuncs) FoldCast(input opt.ScalarExpr, typ *types.T) (_ opt.Scalar
 	datum := memo.ExtractConstDatum(input)
 	texpr := tree.NewTypedCastExpr(datum, typ)
 
-	result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
+	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, texpr)
 	if err != nil {
 		// Casts can require KV operations. KV errors are not safe to swallow.
 		// Check if the error is a KV error, and, if so, propagate it rather
@@ -484,7 +484,7 @@ func (c *CustomFuncs) FoldComparison(
 		lDatum, rDatum = rDatum, lDatum
 	}
 
-	result, err := eval.BinaryOp(c.f.evalCtx, o.EvalOp, lDatum, rDatum)
+	result, err := eval.BinaryOp(c.f.ctx, c.f.evalCtx, o.EvalOp, lDatum, rDatum)
 	if err != nil {
 		return nil, false
 	}
@@ -529,7 +529,7 @@ func (c *CustomFuncs) FoldIndirection(input, index opt.ScalarExpr) (_ opt.Scalar
 		}
 		inputD := memo.ExtractConstDatum(input)
 		texpr := tree.NewTypedIndirectionExpr(inputD, indexD, resolvedType)
-		result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
+		result, err := eval.Expr(c.f.ctx, c.f.evalCtx, texpr)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType()), true
 		}
@@ -562,7 +562,7 @@ func (c *CustomFuncs) FoldColumnAccess(
 		datum := memo.ExtractConstDatum(input)
 
 		texpr := tree.NewTypedColumnAccessExpr(datum, "" /* by-index access */, int(idx))
-		result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
+		result, err := eval.Expr(c.f.ctx, c.f.evalCtx, texpr)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType()), true
 		}
@@ -633,7 +633,7 @@ func (c *CustomFuncs) FoldFunction(
 		private.Overload,
 	)
 
-	result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, fn)
+	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, fn)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -310,7 +310,7 @@ func (c *CustomFuncs) FoldUnary(op opt.Operator, input opt.ScalarExpr) (_ opt.Sc
 		return nil, false
 	}
 
-	result, err := eval.UnaryOp(c.f.evalCtx, o.EvalOp, datum)
+	result, err := eval.UnaryOp(c.f.evalCtx.Context, c.f.evalCtx, o.EvalOp, datum)
 	if err != nil {
 		return nil, false
 	}
@@ -368,7 +368,7 @@ func (c *CustomFuncs) FoldCast(input opt.ScalarExpr, typ *types.T) (_ opt.Scalar
 	datum := memo.ExtractConstDatum(input)
 	texpr := tree.NewTypedCastExpr(datum, typ)
 
-	result, err := eval.Expr(c.f.evalCtx, texpr)
+	result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
 	if err != nil {
 		// Casts can require KV operations. KV errors are not safe to swallow.
 		// Check if the error is a KV error, and, if so, propagate it rather
@@ -529,7 +529,7 @@ func (c *CustomFuncs) FoldIndirection(input, index opt.ScalarExpr) (_ opt.Scalar
 		}
 		inputD := memo.ExtractConstDatum(input)
 		texpr := tree.NewTypedIndirectionExpr(inputD, indexD, resolvedType)
-		result, err := eval.Expr(c.f.evalCtx, texpr)
+		result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType()), true
 		}
@@ -562,7 +562,7 @@ func (c *CustomFuncs) FoldColumnAccess(
 		datum := memo.ExtractConstDatum(input)
 
 		texpr := tree.NewTypedColumnAccessExpr(datum, "" /* by-index access */, int(idx))
-		result, err := eval.Expr(c.f.evalCtx, texpr)
+		result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, texpr)
 		if err == nil {
 			return c.f.ConstructConstVal(result, texpr.ResolvedType()), true
 		}
@@ -633,7 +633,7 @@ func (c *CustomFuncs) FoldFunction(
 		private.Overload,
 	)
 
-	result, err := eval.Expr(c.f.evalCtx, fn)
+	result, err := eval.Expr(c.f.evalCtx.Context, c.f.evalCtx, fn)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -403,7 +403,7 @@ func (c *CustomFuncs) FoldAssignmentCast(
 	}
 
 	datum := memo.ExtractConstDatum(input)
-	result, err := eval.PerformAssignmentCast(c.f.evalCtx, datum, typ)
+	result, err := eval.PerformAssignmentCast(c.f.ctx, c.f.evalCtx, datum, typ)
 	if err != nil {
 		// Casts can require KV operations. KV errors are not safe to swallow.
 		// Check if the error is a KV error, and, if so, propagate it rather

--- a/pkg/sql/opt/norm/project_set_funcs.go
+++ b/pkg/sql/opt/norm/project_set_funcs.go
@@ -122,7 +122,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 				panic(errors.AssertionFailedf("unexpected GeneratorWithExprs"))
 			}
 			generator, err := function.Overload.
-				Generator.(eval.GeneratorOverload)(c.f.evalCtx, tree.Datums{t.Value})
+				Generator.(eval.GeneratorOverload)(c.f.evalCtx.Context, c.f.evalCtx, tree.Datums{t.Value})
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator retrieval failed"))
 			}

--- a/pkg/sql/opt/norm/project_set_funcs.go
+++ b/pkg/sql/opt/norm/project_set_funcs.go
@@ -122,16 +122,16 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 				panic(errors.AssertionFailedf("unexpected GeneratorWithExprs"))
 			}
 			generator, err := function.Overload.
-				Generator.(eval.GeneratorOverload)(c.f.evalCtx.Context, c.f.evalCtx, tree.Datums{t.Value})
+				Generator.(eval.GeneratorOverload)(c.f.ctx, c.f.evalCtx, tree.Datums{t.Value})
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator retrieval failed"))
 			}
-			if err = generator.Start(c.f.evalCtx.Context, c.f.evalCtx.Txn); err != nil {
+			if err = generator.Start(c.f.ctx, c.f.evalCtx.Txn); err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator.Start failed"))
 			}
 
 			for j := 0; ; j++ {
-				hasNext, err := generator.Next(c.f.evalCtx.Context)
+				hasNext, err := generator.Next(c.f.ctx)
 				if err != nil {
 					panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator.Next failed"))
 				}
@@ -150,7 +150,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 				val := c.f.ConstructConstVal(vals[0], vals[0].ResolvedType())
 				addValToOutRows(val, j, i)
 			}
-			generator.Close(c.f.evalCtx.Context)
+			generator.Close(c.f.ctx)
 
 		default:
 			panic(errors.AssertionFailedf("invalid parameter type"))

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -139,12 +139,12 @@ func (c *CustomFuncs) UnifyComparison(
 	// means we don't lose any information needed to generate spans, and combined
 	// with monotonicity means that it's safe to convert the RHS to the type of
 	// the LHS.
-	convertedDatum, err := eval.PerformCast(c.f.evalCtx, cnst.Value, desiredType)
+	convertedDatum, err := eval.PerformCast(c.f.ctx, c.f.evalCtx, cnst.Value, desiredType)
 	if err != nil {
 		return nil, false
 	}
 
-	convertedBack, err := eval.PerformCast(c.f.evalCtx, convertedDatum, originalType)
+	convertedBack, err := eval.PerformCast(c.f.ctx, c.f.evalCtx, convertedDatum, originalType)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -445,7 +445,7 @@ func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
 			// we cannot resolve the variables in this context. This matches Postgres
 			// behavior.
 			if !tree.ContainsVars(texpr) {
-				regclass, err := eval.Expr(b.evalCtx, texpr)
+				regclass, err := eval.Expr(b.evalCtx.Context, b.evalCtx, texpr)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -445,7 +445,7 @@ func (b *Builder) maybeTrackRegclassDependenciesForViews(texpr tree.TypedExpr) {
 			// we cannot resolve the variables in this context. This matches Postgres
 			// behavior.
 			if !tree.ContainsVars(texpr) {
-				regclass, err := eval.Expr(b.evalCtx.Context, b.evalCtx, texpr)
+				regclass, err := eval.Expr(b.ctx, b.evalCtx, texpr)
 				if err != nil {
 					panic(err)
 				}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -116,7 +116,7 @@ func TestBuilder(t *testing.T) {
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))
 				}
-				f := memo.MakeExprFmtCtx(tester.Flags.ExprFormat, o.Memo(), catalog)
+				f := memo.MakeExprFmtCtx(ctx, tester.Flags.ExprFormat, o.Memo(), catalog)
 				f.FormatExpr(o.Memo().RootExpr())
 				return f.Buffer.String()
 

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -266,7 +266,7 @@ func (a aggregateInfo) isCommutative() bool {
 }
 
 // Eval is part of the tree.TypedExpr interface.
-func (a *aggregateInfo) Eval(_ tree.ExprEvaluator) (tree.Datum, error) {
+func (a *aggregateInfo) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("aggregateInfo must be replaced before evaluation"))
 }
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -405,7 +405,7 @@ func (b *Builder) buildScalar(
 		if !b.KeepPlaceholders && b.evalCtx.HasPlaceholders() {
 			b.HadPlaceholders = true
 			// Replace placeholders with their value.
-			d, err := eval.Expr(b.evalCtx.Context, b.evalCtx, t)
+			d, err := eval.Expr(b.ctx, b.evalCtx, t)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -405,7 +405,7 @@ func (b *Builder) buildScalar(
 		if !b.KeepPlaceholders && b.evalCtx.HasPlaceholders() {
 			b.HadPlaceholders = true
 			// Replace placeholders with their value.
-			d, err := eval.Expr(b.evalCtx, t)
+			d, err := eval.Expr(b.evalCtx.Context, b.evalCtx, t)
 			if err != nil {
 				panic(err)
 			}

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -1633,10 +1633,12 @@ func (*scope) VisitPost(expr tree.Expr) tree.Expr {
 // scope implements the IndexedVarContainer interface so it can be used as
 // semaCtx.IVarContainer. This allows tree.TypeCheck to determine the correct
 // type for any IndexedVars.
-var _ tree.IndexedVarContainer = &scope{}
+var _ eval.IndexedVarContainer = &scope{}
 
-// IndexedVarEval is part of the IndexedVarContainer interface.
-func (s *scope) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
+// IndexedVarEval is part of the eval.IndexedVarContainer interface.
+func (s *scope) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("unimplemented: scope.IndexedVarEval"))
 }
 

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -176,7 +176,7 @@ func (c *scopeColumn) String() string {
 	return tree.AsString(c)
 }
 
-func (c *scopeColumn) Eval(v tree.ExprEvaluator) (tree.Datum, error) {
+func (c *scopeColumn) Eval(ctx context.Context, v tree.ExprEvaluator) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("scopeColumn must be replaced before evaluation"))
 }
 

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -69,7 +69,7 @@ func (b *Builder) buildSQLFn(
 	}
 
 	// Get the SQL statement and parse it.
-	sql, err := info.def.Overload.SQLFn.(eval.SQLFnOverload)(b.evalCtx.Context, b.evalCtx, exprs)
+	sql, err := info.def.Overload.SQLFn.(eval.SQLFnOverload)(b.ctx, b.evalCtx, exprs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/optbuilder/sql_fn.go
+++ b/pkg/sql/opt/optbuilder/sql_fn.go
@@ -69,7 +69,7 @@ func (b *Builder) buildSQLFn(
 	}
 
 	// Get the SQL statement and parse it.
-	sql, err := info.def.Overload.SQLFn.(eval.SQLFnOverload)(b.evalCtx, exprs)
+	sql, err := info.def.Overload.SQLFn.(eval.SQLFnOverload)(b.evalCtx.Context, b.evalCtx, exprs)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -58,7 +58,7 @@ func (s *srf) TypeCheck(
 }
 
 // Eval is part of the tree.TypedExpr interface.
-func (s *srf) Eval(_ tree.ExprEvaluator) (tree.Datum, error) {
+func (s *srf) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("srf must be replaced before evaluation"))
 }
 

--- a/pkg/sql/opt/optbuilder/subquery.go
+++ b/pkg/sql/opt/optbuilder/subquery.go
@@ -195,7 +195,7 @@ func (s *subquery) ResolvedType() *types.T {
 }
 
 // Eval is part of the tree.TypedExpr interface.
-func (s *subquery) Eval(_ tree.ExprEvaluator) (tree.Datum, error) {
+func (s *subquery) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("subquery must be replaced before evaluation"))
 }
 

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -51,7 +51,7 @@ func (w *windowInfo) TypeCheck(
 }
 
 // Eval is part of the tree.TypedExpr interface.
-func (w *windowInfo) Eval(_ tree.ExprEvaluator) (tree.Datum, error) {
+func (w *windowInfo) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) {
 	panic(errors.AssertionFailedf("windowInfo must be replaced before evaluation"))
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -289,9 +289,9 @@ func (g *exprsGen) genExprFuncs(define *lang.DefineExpr) {
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
 	if define.Tags.Contains("Scalar") {
-		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)\n")
+		fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)\n")
 	} else {
-		fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)\n")
+		fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)\n")
 	}
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
@@ -436,7 +436,7 @@ func (g *exprsGen) genEnforcerFuncs(define *lang.DefineExpr) {
 
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)\n")
+	fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)\n")
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
 	fmt.Fprintf(g.w, "}\n\n")
@@ -545,7 +545,7 @@ func (g *exprsGen) genListExprFuncs(define *lang.DefineExpr) {
 
 	// Generate the String method.
 	fmt.Fprintf(g.w, "func (e *%s) String() string {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)\n")
+	fmt.Fprintf(g.w, "  f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)\n")
 	fmt.Fprintf(g.w, "  f.FormatExpr(e)\n")
 	fmt.Fprintf(g.w, "  return f.Buffer.String()\n")
 	fmt.Fprintf(g.w, "}\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -101,7 +101,7 @@ func (e *ProjectExpr) Private() interface{} {
 }
 
 func (e *ProjectExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -221,7 +221,7 @@ func (e *ProjectionsExpr) Private() interface{} {
 }
 
 func (e *ProjectionsExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -268,7 +268,7 @@ func (e *ProjectionsItem) Private() interface{} {
 }
 
 func (e *ProjectionsItem) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -319,7 +319,7 @@ func (e *SortExpr) Private() interface{} {
 }
 
 func (e *SortExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, e.Memo(), nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, e.Memo(), nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -568,7 +568,7 @@ func (e *VariableExpr) Private() interface{} {
 }
 
 func (e *VariableExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }
@@ -615,7 +615,7 @@ func (e *MaxExpr) Private() interface{} {
 }
 
 func (e *MaxExpr) String() string {
-	f := MakeExprFmtCtx(ExprFmtHideQualifications, nil, nil)
+	f := makeExprFmtCtxForString(ExprFmtHideQualifications, nil, nil)
 	f.FormatExpr(e)
 	return f.Buffer.String()
 }

--- a/pkg/sql/opt/ordering/group_by_test.go
+++ b/pkg/sql/opt/ordering/group_by_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestDistinctOnProvided(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, testcat.New())
+	f.Init(context.Background(), evalCtx, testcat.New())
 	md := f.Metadata()
 	for i := 1; i <= 5; i++ {
 		md.AddColumn(fmt.Sprintf("c%d", i), types.Int)

--- a/pkg/sql/opt/ordering/inverted_join_test.go
+++ b/pkg/sql/opt/ordering/inverted_join_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -33,7 +34,7 @@ func TestInvertedJoinProvided(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 
 	// Add the table with the inverted index.

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestLookupJoinProvided(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -197,7 +198,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -28,7 +29,7 @@ func TestProject(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, testcat.New())
+	f.Init(context.Background(), evalCtx, testcat.New())
 	md := f.Metadata()
 	for i := 1; i <= 4; i++ {
 		md.AddColumn(fmt.Sprintf("col%d", i), types.Int)

--- a/pkg/sql/opt/ordering/row_number_test.go
+++ b/pkg/sql/opt/ordering/row_number_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -76,7 +77,7 @@ func TestOrdinalityProvided(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
 			evalCtx := eval.NewTestingEvalContext(st)
 			var f norm.Factory
-			f.Init(evalCtx, nil /* catalog */)
+			f.Init(context.Background(), evalCtx, nil /* catalog */)
 			input := &testexpr.Instance{
 				Rel: &props.Relational{OutputCols: opt.MakeColSet(1, 2, 3, 4, 5)},
 				Provided: &physical.Provided{

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -11,6 +11,7 @@
 package ordering
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -36,7 +37,7 @@ func TestScan(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
 	var f norm.Factory
-	f.Init(evalCtx, tc)
+	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -60,7 +60,7 @@ func TestImplicator(t *testing.T) {
 			var err error
 
 			var f norm.Factory
-			f.Init(&evalCtx, nil /* catalog */)
+			f.Init(context.Background(), &evalCtx, nil /* catalog */)
 			md := f.Metadata()
 
 			if d.Cmd != "predtest" {
@@ -113,7 +113,7 @@ func TestImplicator(t *testing.T) {
 				buf.WriteString("none")
 			} else {
 				execBld := execbuilder.New(
-					nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
+					context.Background(), nil /* factory */, nil /* optimizer */, f.Memo(), nil, /* catalog */
 					&remainingFilters, &evalCtx, false, /* allowAutoCommit */
 				)
 				expr, err := execBld.BuildScalar()
@@ -267,7 +267,7 @@ func BenchmarkImplicator(b *testing.B) {
 
 	for _, tc := range testCases {
 		var f norm.Factory
-		f.Init(&evalCtx, nil /* catalog */)
+		f.Init(context.Background(), &evalCtx, nil /* catalog */)
 		md := f.Metadata()
 
 		// Parse the variable types.

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -808,7 +808,7 @@ func (ot *OptTester) FormatExpr(e opt.Expr) string {
 	if rel, ok := e.(memo.RelExpr); ok {
 		mem = rel.Memo()
 	}
-	return memo.FormatExpr(e, ot.Flags.ExprFormat, mem, ot.catalog)
+	return memo.FormatExpr(ot.ctx, e, ot.Flags.ExprFormat, mem, ot.catalog)
 }
 
 func formatRuleSet(r RuleSet) string {
@@ -1257,7 +1257,7 @@ func (ot *OptTester) Memo() (string, error) {
 // Expr parses the input directly into an expression; see exprgen.Build.
 func (ot *OptTester) Expr() (opt.Expr, error) {
 	var f norm.Factory
-	f.Init(&ot.evalCtx, ot.catalog)
+	f.Init(ot.ctx, &ot.evalCtx, ot.catalog)
 	f.DisableOptimizations()
 
 	return exprgen.Build(ot.ctx, ot.catalog, &f, ot.sql)
@@ -1267,7 +1267,7 @@ func (ot *OptTester) Expr() (opt.Expr, error) {
 // normalization; see exprgen.Build.
 func (ot *OptTester) ExprNorm() (opt.Expr, error) {
 	var f norm.Factory
-	f.Init(&ot.evalCtx, ot.catalog)
+	f.Init(ot.ctx, &ot.evalCtx, ot.catalog)
 	f.SetDisabledRules(ot.Flags.DisableRules)
 
 	if !ot.Flags.NoStableFolds {
@@ -1581,7 +1581,7 @@ func (ot *OptTester) optStepsExploreDiff() (string, error) {
 
 		for i := range newNodes {
 			name := et.LastRuleName().String()
-			after := memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat, et.fo.o.Memo(), ot.catalog)
+			after := memo.FormatExpr(ot.ctx, newNodes[i], ot.Flags.ExprFormat, et.fo.o.Memo(), ot.catalog)
 
 			diff := difflib.UnifiedDiff{
 				A:        difflib.SplitLines(before),
@@ -1777,7 +1777,7 @@ func (ot *OptTester) ExploreTrace() (string, error) {
 		}
 		for i := range newNodes {
 			ot.output("\nNew expression %d of %d:\n", i+1, len(newNodes))
-			ot.indent(memo.FormatExpr(newNodes[i], ot.Flags.ExprFormat, et.fo.o.Memo(), ot.catalog))
+			ot.indent(memo.FormatExpr(ot.ctx, newNodes[i], ot.Flags.ExprFormat, et.fo.o.Memo(), ot.catalog))
 		}
 	}
 	return ot.builder.String(), nil
@@ -2287,6 +2287,6 @@ func (ot *OptTester) ExecBuild(f exec.Factory, mem *memo.Memo, expr opt.Expr) (e
 		db := kv.NewDB(log.MakeTestingAmbientCtxWithNewTracer(), factory, clock, stopper)
 		ot.evalCtx.Txn = kv.NewTxn(context.Background(), db, 1)
 	}
-	bld := execbuilder.New(f, ot.makeOptimizer(), mem, ot.catalog, expr, &ot.evalCtx, true)
+	bld := execbuilder.New(context.Background(), f, ot.makeOptimizer(), mem, ot.catalog, expr, &ot.evalCtx, true)
 	return bld.Build()
 }

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -842,7 +842,7 @@ func (ot *OptTester) postProcess(tb testing.TB, d *datadriven.TestData, e opt.Ex
 
 	if rel, ok := e.(memo.RelExpr); ok {
 		for _, cols := range ot.Flags.ColStats {
-			memo.RequestColStat(&ot.evalCtx, rel, cols)
+			memo.RequestColStat(ot.ctx, &ot.evalCtx, rel, cols)
 		}
 	}
 	ot.checkExpectedRules(tb, d)
@@ -2015,7 +2015,7 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 
 		// Make sure we have estimated stats for this column.
 		colSet := opt.MakeColSet(col)
-		memo.RequestColStat(&ot.evalCtx, rel, colSet)
+		memo.RequestColStat(ot.ctx, &ot.evalCtx, rel, colSet)
 		stat, ok := relProps.Statistics().ColStats.Lookup(colSet)
 		if !ok {
 			return nil, fmt.Errorf("could not find statistic for column %s", colName)
@@ -2239,7 +2239,7 @@ func (ot *OptTester) optimizeExpr(
 		return nil, err
 	}
 	if ot.Flags.PerturbCost != 0 {
-		o.Memo().ResetLogProps(&ot.evalCtx)
+		o.Memo().ResetLogProps(ot.ctx, &ot.evalCtx)
 		o.RecomputeCost()
 	}
 	return root, nil

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -63,7 +63,7 @@ func injectTableStats(tt *Table, statsExpr tree.Expr) {
 	if err != nil {
 		panic(err)
 	}
-	val, err := eval.Expr(&evalCtx, typedExpr)
+	val, err := eval.Expr(ctx, &evalCtx, typedExpr)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -1171,7 +1171,7 @@ func (ti *Index) partitionByListExprToDatums(
 		if err != nil {
 			panic(err)
 		}
-		d[i], err = eval.Expr(evalCtx, cTyped)
+		d[i], err = eval.Expr(ctx, evalCtx, cTyped)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/testutils/testcat/table_expr.go
+++ b/pkg/sql/opt/testutils/testcat/table_expr.go
@@ -100,8 +100,8 @@ func (c *tableCol) ResolvedType() *types.T {
 	return c.typ
 }
 
-// EvalExpr is part of the tree.TypedExpr interface.
-func (*tableCol) Eval(_ tree.ExprEvaluator) (tree.Datum, error) {
+// Eval is part of the tree.TypedExpr interface.
+func (*tableCol) Eval(_ context.Context, _ tree.ExprEvaluator) (tree.Datum, error) {
 	panic("not implemented")
 }
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -1234,7 +1234,7 @@ func (ts *TableStat) Histogram() []cat.HistogramBucket {
 
 	for i := offset; i < len(histogram); i++ {
 		bucket := &ts.js.HistogramBuckets[i-offset]
-		datum, err := rowenc.ParseDatumStringAs(colType, bucket.UpperBound, &evalCtx)
+		datum, err := rowenc.ParseDatumStringAs(context.Background(), colType, bucket.UpperBound, &evalCtx)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/xform/explorer.go
+++ b/pkg/sql/opt/xform/explorer.go
@@ -11,6 +11,8 @@
 package xform
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -80,6 +82,7 @@ import (
 // themselves match this same rule. However, adding their replace expressions to
 // the memo group will be a no-op, because they're already present.
 type explorer struct {
+	ctx     context.Context
 	evalCtx *eval.Context
 	o       *Optimizer
 	f       *norm.Factory
@@ -97,6 +100,7 @@ func (e *explorer) init(o *Optimizer) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*e = explorer{
+		ctx:     o.ctx,
 		evalCtx: o.evalCtx,
 		o:       o,
 		f:       o.Factory(),

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -864,7 +864,7 @@ func (c *CustomFuncs) GenerateInvertedJoins(
 
 		// Check whether the filter can constrain the inverted column.
 		invertedExpr := invertedidx.TryJoinInvertedIndex(
-			c.e.evalCtx.Context, c.e.f, onFilters, scanPrivate.Table, index, inputCols,
+			c.e.ctx, c.e.f, onFilters, scanPrivate.Table, index, inputCols,
 		)
 		if invertedExpr == nil {
 			return

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -274,7 +274,7 @@ func (mf *memoFormatter) formatPrivate(e opt.Expr, physProps *physical.Required)
 
 	// Start by using private expression formatting.
 	m := mf.o.mem
-	nf := memo.MakeExprFmtCtxBuffer(mf.buf, memo.ExprFmtHideAll, m, nil /* catalog */)
+	nf := memo.MakeExprFmtCtxBuffer(mf.o.ctx, mf.buf, memo.ExprFmtHideAll, m, nil /* catalog */)
 	memo.FormatPrivate(&nf, private, physProps)
 
 	// Now append additional information that's useful in the memo case.

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -132,7 +132,7 @@ func (o *Optimizer) Init(ctx context.Context, evalCtx *eval.Context, catalog cat
 		stateMap: make(map[groupStateKey]*groupState),
 	}
 	o.cancelChecker.Reset(ctx)
-	o.f.Init(evalCtx, catalog)
+	o.f.Init(ctx, evalCtx, catalog)
 	o.mem = o.f.Memo()
 	o.explorer.init(o)
 
@@ -1065,7 +1065,7 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 
 	o.NotifyOnMatchedRule(func(ruleName opt.RuleName) bool {
 		if disabledRules.Contains(int(ruleName)) {
-			log.Infof(o.evalCtx.Context, "disabled rule matched: %s", ruleName.String())
+			log.Infof(o.ctx, "disabled rule matched: %s", ruleName.String())
 			return false
 		}
 		return true
@@ -1121,7 +1121,7 @@ func (o *Optimizer) recomputeCostImpl(
 
 // FormatExpr is a convenience wrapper for memo.FormatExpr.
 func (o *Optimizer) FormatExpr(e opt.Expr, flags memo.ExprFmtFlags) string {
-	return memo.FormatExpr(e, flags, o.mem, o.catalog)
+	return memo.FormatExpr(o.ctx, e, flags, o.mem, o.catalog)
 }
 
 // CustomFuncs exports the xform.CustomFuncs for testing purposes.

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -873,7 +873,7 @@ func (c *CustomFuncs) GenerateInvertedIndexScans(
 	iter.ForEach(func(index cat.Index, filters memo.FiltersExpr, indexCols opt.ColSet, _ bool, _ memo.ProjectionsExpr) {
 		// Check whether the filter can constrain the index.
 		spanExpr, constraint, remainingFilters, pfState, ok := invertedidx.TryFilterInvertedIndex(
-			c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index, tabMeta.ComputedCols,
+			c.e.ctx, c.e.evalCtx, c.e.f, filters, optionalFilters, scanPrivate.Table, index, tabMeta.ComputedCols,
 		)
 		if !ok {
 			// A span expression to constrain the inverted index could not be
@@ -1441,6 +1441,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 		// optional filters generated from CHECK constraints and computed column
 		// expressions to help constrain non-inverted prefix columns.
 		spanExpr, _, _, _, ok := invertedidx.TryFilterInvertedIndex(
+			c.e.ctx,
 			c.e.evalCtx,
 			c.e.f, filters,
 			nil, /* optionalFilters */

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2050,7 +2050,7 @@ func (ef *execFactory) ConstructAlterRangeRelocate(
 func (ef *execFactory) ConstructControlJobs(
 	command tree.JobCommand, input exec.Node, reason tree.TypedExpr,
 ) (exec.Node, error) {
-	reasonDatum, err := eval.Expr(ef.planner.EvalContext(), reason)
+	reasonDatum, err := eval.Expr(ef.planner.EvalContext().Context, ef.planner.EvalContext(), reason)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/paramparse/paramparse.go
+++ b/pkg/sql/paramparse/paramparse.go
@@ -12,6 +12,7 @@
 package paramparse
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"time"
@@ -35,8 +36,10 @@ func UnresolvedNameToStrVal(expr tree.Expr) tree.Expr {
 }
 
 // DatumAsFloat transforms a tree.TypedExpr containing a Datum into a float.
-func DatumAsFloat(evalCtx *eval.Context, name string, value tree.TypedExpr) (float64, error) {
-	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
+func DatumAsFloat(
+	ctx context.Context, evalCtx *eval.Context, name string, value tree.TypedExpr,
+) (float64, error) {
+	val, err := eval.Expr(ctx, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -60,9 +63,9 @@ func DatumAsFloat(evalCtx *eval.Context, name string, value tree.TypedExpr) (flo
 // DatumAsDuration transforms a tree.TypedExpr containing a Datum into a
 // time.Duration.
 func DatumAsDuration(
-	evalCtx *eval.Context, name string, value tree.TypedExpr,
+	ctx context.Context, evalCtx *eval.Context, name string, value tree.TypedExpr,
 ) (time.Duration, error) {
-	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
+	val, err := eval.Expr(ctx, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -95,8 +98,10 @@ func DatumAsDuration(
 }
 
 // DatumAsInt transforms a tree.TypedExpr containing a Datum into an int.
-func DatumAsInt(evalCtx *eval.Context, name string, value tree.TypedExpr) (int64, error) {
-	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
+func DatumAsInt(
+	ctx context.Context, evalCtx *eval.Context, name string, value tree.TypedExpr,
+) (int64, error) {
+	val, err := eval.Expr(ctx, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -112,8 +117,10 @@ func DatumAsInt(evalCtx *eval.Context, name string, value tree.TypedExpr) (int64
 }
 
 // DatumAsString transforms a tree.TypedExpr containing a Datum into a string.
-func DatumAsString(evalCtx *eval.Context, name string, value tree.TypedExpr) (string, error) {
-	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
+func DatumAsString(
+	ctx context.Context, evalCtx *eval.Context, name string, value tree.TypedExpr,
+) (string, error) {
+	val, err := eval.Expr(ctx, evalCtx, value)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/paramparse/paramparse.go
+++ b/pkg/sql/paramparse/paramparse.go
@@ -36,7 +36,7 @@ func UnresolvedNameToStrVal(expr tree.Expr) tree.Expr {
 
 // DatumAsFloat transforms a tree.TypedExpr containing a Datum into a float.
 func DatumAsFloat(evalCtx *eval.Context, name string, value tree.TypedExpr) (float64, error) {
-	val, err := eval.Expr(evalCtx, value)
+	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -62,7 +62,7 @@ func DatumAsFloat(evalCtx *eval.Context, name string, value tree.TypedExpr) (flo
 func DatumAsDuration(
 	evalCtx *eval.Context, name string, value tree.TypedExpr,
 ) (time.Duration, error) {
-	val, err := eval.Expr(evalCtx, value)
+	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -96,7 +96,7 @@ func DatumAsDuration(
 
 // DatumAsInt transforms a tree.TypedExpr containing a Datum into an int.
 func DatumAsInt(evalCtx *eval.Context, name string, value tree.TypedExpr) (int64, error) {
-	val, err := eval.Expr(evalCtx, value)
+	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
 	if err != nil {
 		return 0, err
 	}
@@ -113,7 +113,7 @@ func DatumAsInt(evalCtx *eval.Context, name string, value tree.TypedExpr) (int64
 
 // DatumAsString transforms a tree.TypedExpr containing a Datum into a string.
 func DatumAsString(evalCtx *eval.Context, name string, value tree.TypedExpr) (string, error) {
-	val, err := eval.Expr(evalCtx, value)
+	val, err := eval.Expr(evalCtx.Context, evalCtx, value)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -272,6 +272,7 @@ func TestEncodings(t *testing.T) {
 				}
 
 				d, err := pgwirebase.DecodeDatum(
+					ctx,
 					&evalCtx,
 					types.OidToType[tc.Oid],
 					code,
@@ -335,6 +336,7 @@ func TestExoticNumericEncodings(t *testing.T) {
 	for i, c := range testCases {
 		t.Run(fmt.Sprintf("%d_%s", i, c.Value), func(t *testing.T) {
 			d, err := pgwirebase.DecodeDatum(
+				context.Background(),
 				&evalCtx,
 				types.Decimal,
 				pgwirebase.FormatBinary,

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -83,7 +83,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 		if err != nil {
 			t.Fatal(err)
 		}
-		d, err := eval.Expr(&evalCtx, te)
+		d, err := eval.Expr(ctx, &evalCtx, te)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/pgwire/pgwirebase/fuzz.go
+++ b/pkg/sql/pgwire/pgwirebase/fuzz.go
@@ -44,7 +44,7 @@ func FuzzDecodeDatum(data []byte) int {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 
-	_, err := DecodeDatum(evalCtx, typ, code, b)
+	_, err := DecodeDatum(context.Background(), evalCtx, typ, code, b)
 	if err != nil {
 		return 0
 	}

--- a/pkg/sql/pgwire/types_test.go
+++ b/pkg/sql/pgwire/types_test.go
@@ -143,7 +143,7 @@ func TestIntArrayRoundTrip(t *testing.T) {
 
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	got, err := pgwirebase.DecodeDatum(evalCtx, types.IntArray, pgwirebase.FormatText, b[4:])
+	got, err := pgwirebase.DecodeDatum(context.Background(), evalCtx, types.IntArray, pgwirebase.FormatText, b[4:])
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func TestByteArrayRoundTrip(t *testing.T) {
 
 					evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 					defer evalCtx.Stop(context.Background())
-					got, err := pgwirebase.DecodeDatum(evalCtx, types.Bytes, pgwirebase.FormatText, b[4:])
+					got, err := pgwirebase.DecodeDatum(context.Background(), evalCtx, types.Bytes, pgwirebase.FormatText, b[4:])
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -675,7 +675,7 @@ func BenchmarkDecodeBinaryDecimal(b *testing.B) {
 		evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer evalCtx.Stop(context.Background())
 		b.StartTimer()
-		got, err := pgwirebase.DecodeDatum(evalCtx, types.Decimal, pgwirebase.FormatBinary, bytes)
+		got, err := pgwirebase.DecodeDatum(context.Background(), evalCtx, types.Decimal, pgwirebase.FormatBinary, bytes)
 		b.StopTimer()
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -226,7 +226,7 @@ func checkDistAggregationInfo(
 			t.Fatal(err)
 		}
 		var expr execinfrapb.Expression
-		expr, err = physicalplan.MakeExpression(renderExpr, nil, nil)
+		expr, err = physicalplan.MakeExpression(ctx, renderExpr, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -330,7 +330,7 @@ func checkDistAggregationInfo(
 			t.Fatal(err)
 		}
 		var expr execinfrapb.Expression
-		expr, err = physicalplan.MakeExpression(renderExpr, nil, nil)
+		expr, err = physicalplan.MakeExpression(ctx, renderExpr, nil, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -14,6 +14,8 @@
 package physicalplan
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -56,18 +58,18 @@ func (fakeExprContext) IsLocal() bool {
 //
 // ctx can be nil in which case a fakeExprCtx will be used.
 func MakeExpression(
-	expr tree.TypedExpr, ctx ExprContext, indexVarMap []int,
+	ctx context.Context, expr tree.TypedExpr, exprContext ExprContext, indexVarMap []int,
 ) (execinfrapb.Expression, error) {
 	if expr == nil {
 		return execinfrapb.Expression{}, nil
 	}
-	if ctx == nil {
-		ctx = &fakeExprContext{}
+	if exprContext == nil {
+		exprContext = &fakeExprContext{}
 	}
 
 	// Always replace the subqueries with their results (they must have been
 	// executed before the main query).
-	evalCtx := ctx.EvalContext()
+	evalCtx := exprContext.EvalContext()
 	subqueryVisitor := &evalAndReplaceSubqueryVisitor{
 		evalCtx: evalCtx,
 	}
@@ -82,12 +84,12 @@ func MakeExpression(
 		expr = RemapIVarsInTypedExpr(expr, indexVarMap)
 	}
 	expression := execinfrapb.Expression{LocalExpr: expr}
-	if ctx.IsLocal() {
+	if exprContext.IsLocal() {
 		return expression, nil
 	}
 
 	// Since the plan is not fully local, serialize the expression.
-	fmtCtx := execinfrapb.ExprFmtCtxBase(evalCtx)
+	fmtCtx := execinfrapb.ExprFmtCtxBase(ctx, evalCtx)
 	fmtCtx.FormatNode(expr)
 	if log.V(1) {
 		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(expr))

--- a/pkg/sql/physicalplan/expression.go
+++ b/pkg/sql/physicalplan/expression.go
@@ -92,7 +92,7 @@ func MakeExpression(
 	fmtCtx := execinfrapb.ExprFmtCtxBase(ctx, evalCtx)
 	fmtCtx.FormatNode(expr)
 	if log.V(1) {
-		log.Infof(evalCtx.Ctx(), "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(expr))
+		log.Infof(ctx, "Expr %s:\n%s", fmtCtx.String(), tree.ExprDebugString(expr))
 	}
 	expression.Expr = fmtCtx.CloseAndGetString()
 	return expression, nil

--- a/pkg/sql/physicalplan/physical_plan_test.go
+++ b/pkg/sql/physicalplan/physical_plan_test.go
@@ -11,6 +11,7 @@
 package physicalplan
 
 import (
+	"context"
 	"reflect"
 	"strings"
 	"testing"
@@ -122,6 +123,7 @@ func TestProjectionAndRendering(t *testing.T) {
 
 			action: func(p *PhysicalPlan) {
 				if err := p.AddRendering(
+					context.Background(),
 					[]tree.TypedExpr{
 						&tree.IndexedVar{Idx: 10},
 						&tree.IndexedVar{Idx: 11},
@@ -148,6 +150,7 @@ func TestProjectionAndRendering(t *testing.T) {
 
 			action: func(p *PhysicalPlan) {
 				if err := p.AddRendering(
+					context.Background(),
 					[]tree.TypedExpr{
 						&tree.IndexedVar{Idx: 11},
 						&tree.IndexedVar{Idx: 13},

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -652,7 +652,7 @@ func (p *planner) TypeAsStringOrNull(
 
 func (p *planner) makeStringEvalFn(typedE tree.TypedExpr) func() (bool, string, error) {
 	return func() (bool, string, error) {
-		d, err := eval.Expr(p.EvalContext(), typedE)
+		d, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), typedE)
 		if err != nil {
 			return false, "", err
 		}
@@ -692,7 +692,7 @@ func (p *planner) TypeAsBool(
 
 func (p *planner) makeBoolEvalFn(typedE tree.TypedExpr) func() (bool, bool, error) {
 	return func() (bool, bool, error) {
-		d, err := eval.Expr(p.EvalContext(), typedE)
+		d, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), typedE)
 		if err != nil {
 			return false, false, err
 		}
@@ -730,7 +730,7 @@ func evalStringOptions(
 		if !ok {
 			return nil, errors.Errorf("invalid option %q", k)
 		}
-		val, err := eval.Expr(evalCtx, opt.Value)
+		val, err := eval.Expr(evalCtx.Context, evalCtx, opt.Value)
 		if err != nil {
 			return nil, err
 		}
@@ -790,7 +790,7 @@ func (p *planner) TypeAsStringOpts(
 				res[name] = ""
 				continue
 			}
-			d, err := eval.Expr(p.EvalContext(), e)
+			d, err := eval.Expr(ctx, p.EvalContext(), e)
 			if err != nil {
 				return nil, err
 			}
@@ -822,7 +822,7 @@ func (p *planner) TypeAsStringArray(
 	fn := func() ([]string, error) {
 		strs := make([]string, len(exprs))
 		for i := range exprs {
-			d, err := eval.Expr(p.EvalContext(), typedExprs[i])
+			d, err := eval.Expr(ctx, p.EvalContext(), typedExprs[i])
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -626,7 +626,7 @@ func (p *planner) TypeAsString(
 	if err != nil {
 		return nil, err
 	}
-	evalFn := p.makeStringEvalFn(typedE)
+	evalFn := p.makeStringEvalFn(ctx, typedE)
 	return func() (string, error) {
 		isNull, str, err := evalFn()
 		if err != nil {
@@ -647,12 +647,14 @@ func (p *planner) TypeAsStringOrNull(
 	if err != nil {
 		return nil, err
 	}
-	return p.makeStringEvalFn(typedE), nil
+	return p.makeStringEvalFn(ctx, typedE), nil
 }
 
-func (p *planner) makeStringEvalFn(typedE tree.TypedExpr) func() (bool, string, error) {
+func (p *planner) makeStringEvalFn(
+	ctx context.Context, typedE tree.TypedExpr,
+) func() (bool, string, error) {
 	return func() (bool, string, error) {
-		d, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), typedE)
+		d, err := eval.Expr(ctx, p.EvalContext(), typedE)
 		if err != nil {
 			return false, "", err
 		}
@@ -679,7 +681,7 @@ func (p *planner) TypeAsBool(
 	}
 	evalFn := p.makeBoolEvalFn(typedE)
 	return func() (bool, error) {
-		isNull, b, err := evalFn()
+		isNull, b, err := evalFn(ctx)
 		if err != nil {
 			return false, err
 		}
@@ -690,9 +692,9 @@ func (p *planner) TypeAsBool(
 	}, nil
 }
 
-func (p *planner) makeBoolEvalFn(typedE tree.TypedExpr) func() (bool, bool, error) {
-	return func() (bool, bool, error) {
-		d, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), typedE)
+func (p *planner) makeBoolEvalFn(typedE tree.TypedExpr) func(context.Context) (bool, bool, error) {
+	return func(ctx context.Context) (bool, bool, error) {
+		d, err := eval.Expr(ctx, p.EvalContext(), typedE)
 		if err != nil {
 			return false, false, err
 		}
@@ -721,7 +723,10 @@ const (
 // evalStringOptions evaluates the KVOption values as strings and returns them
 // in a map. Options with no value have an empty string.
 func evalStringOptions(
-	evalCtx *eval.Context, opts []exec.KVOption, optValidate map[string]KVStringOptValidate,
+	ctx context.Context,
+	evalCtx *eval.Context,
+	opts []exec.KVOption,
+	optValidate map[string]KVStringOptValidate,
 ) (map[string]string, error) {
 	res := make(map[string]string, len(opts))
 	for _, opt := range opts {
@@ -730,7 +735,7 @@ func evalStringOptions(
 		if !ok {
 			return nil, errors.Errorf("invalid option %q", k)
 		}
-		val, err := eval.Expr(evalCtx.Context, evalCtx, opt.Value)
+		val, err := eval.Expr(ctx, evalCtx, opt.Value)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -475,7 +475,6 @@ func internalExtendedEvalCtx(
 			TxnReadOnly:                    false,
 			TxnImplicit:                    true,
 			TxnIsSingleStmt:                true,
-			Context:                        ctx,
 			TestingKnobs:                   evalContextTestingKnobs,
 			StmtTimestamp:                  stmtTimestamp,
 			TxnTimestamp:                   txnTimestamp,
@@ -490,6 +489,7 @@ func internalExtendedEvalCtx(
 		Descs:           tables,
 		indexUsageStats: indexUsageStats,
 	}
+	ret.SetDeprecatedContext(ctx)
 	ret.copyFromExecCfg(execCfg)
 	return ret
 }

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -139,7 +139,7 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		rows:  lastWorkingRows,
 		label: n.label,
 	}
-	newPlan, err := n.genIterationFn(newExecFactory(params.p), buf)
+	newPlan, err := n.genIterationFn(newExecFactory(params.ctx, params.p), buf)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/sql/relocate_range.go
+++ b/pkg/sql/relocate_range.go
@@ -55,14 +55,14 @@ type relocateRequest struct {
 }
 
 func (n *relocateRange) startExec(params runParams) error {
-	toStoreID, err := paramparse.DatumAsInt(params.EvalContext(), "TO", n.toStoreID)
+	toStoreID, err := paramparse.DatumAsInt(params.ctx, params.EvalContext(), "TO", n.toStoreID)
 	if err != nil {
 		return err
 	}
 	var fromStoreID int64
 	if n.subjectReplicas != tree.RelocateLease {
 		// The from expression is NULL if the target is LEASE.
-		fromStoreID, err = paramparse.DatumAsInt(params.EvalContext(), "FROM", n.fromStoreID)
+		fromStoreID, err = paramparse.DatumAsInt(params.ctx, params.EvalContext(), "FROM", n.fromStoreID)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/render.go
+++ b/pkg/sql/render.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -57,8 +58,12 @@ type renderNode struct {
 	reqOrdering ReqOrdering
 }
 
-// IndexedVarEval implements the tree.IndexedVarContainer interface.
-func (r *renderNode) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
+var _ eval.IndexedVarContainer = &renderNode{}
+
+// IndexedVarEval implements the eval.IndexedVarContainer interface.
+func (r *renderNode) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
 	panic("renderNode can't be run in local mode")
 }
 

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -66,7 +66,7 @@ func (p *planner) EvalRoutineExpr(
 	}
 
 	// Execute each statement in the routine sequentially.
-	ef := newExecFactory(p)
+	ef := newExecFactory(ctx, p)
 	for i := 0; i < expr.NumStmts; i++ {
 		if err := func() error {
 			opName := "udf-stmt-" + expr.Name + "-" + strconv.Itoa(i)

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -206,7 +206,7 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 					CurChunk:        nil,
 					CurVal:          0,
 				}
-				require.NoError(t, j.RequestChunk(evalCtx, annot, seqMetadata))
+				require.NoError(t, j.RequestChunk(ctx, evalCtx, annot, seqMetadata))
 				getJobProgressQuery := `SELECT progress FROM system.jobs J WHERE J.id = $1`
 
 				var progressBytes []byte

--- a/pkg/sql/row/expr_walker_test.go
+++ b/pkg/sql/row/expr_walker_test.go
@@ -83,9 +83,9 @@ func TestJobBackedSeqChunkProvider(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	evalCtx := &eval.Context{
-		Context: ctx,
-		Codec:   s.ExecutorConfig().(sql.ExecutorConfig).Codec,
+		Codec: s.ExecutorConfig().(sql.ExecutorConfig).Codec,
 	}
+	evalCtx.SetDeprecatedContext(ctx)
 
 	registry := s.JobRegistry().(*jobs.Registry)
 	testCases := []struct {

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -113,7 +113,7 @@ func GenerateInsertRow(
 				rowVals[i] = tree.DNull
 				continue
 			}
-			d, err := eval.Expr(evalCtx, defaultExprs[i])
+			d, err := eval.Expr(evalCtx.Context, evalCtx, defaultExprs[i])
 			if err != nil {
 				return nil, err
 			}
@@ -135,7 +135,7 @@ func GenerateInsertRow(
 			if !col.IsComputed() {
 				continue
 			}
-			d, err := eval.Expr(evalCtx, computeExprs[computeIdx])
+			d, err := eval.Expr(evalCtx.Context, evalCtx, computeExprs[computeIdx])
 			if err != nil {
 				name := col.GetName()
 				return nil, errors.Wrapf(err,
@@ -409,7 +409,7 @@ func NewDatumRowConverter(
 				if volatile == overrideImmutable {
 					// This default expression isn't volatile, so we can evaluate once
 					// here and memoize it.
-					c.defaultCache[i], err = eval.Expr(c.EvalCtx, c.defaultCache[i])
+					c.defaultCache[i], err = eval.Expr(ctx, c.EvalCtx, c.defaultCache[i])
 					if err != nil {
 						return nil, errors.Wrapf(err, "error evaluating default expression")
 					}
@@ -488,7 +488,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 			// number of instances the function random() appears in a row.
 			// TODO (anzoteh96): Optimize this part of code when there's no expression
 			// involving random(), gen_random_uuid(), or anything like that.
-			datum, err := eval.Expr(c.EvalCtx, c.defaultCache[i])
+			datum, err := eval.Expr(ctx, c.EvalCtx, c.defaultCache[i])
 			if !c.TargetColOrds.Contains(i) {
 				if err != nil {
 					return errors.Wrapf(
@@ -521,7 +521,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 		if len(partialIndexPutVals) > 0 {
 			for i, idx := range c.tableDesc.PartialIndexes() {
 				texpr := c.partialIndexExprs[idx.GetID()]
-				val, err := eval.Expr(c.EvalCtx, texpr)
+				val, err := eval.Expr(ctx, c.EvalCtx, texpr)
 				if err != nil {
 					return errors.Wrap(err, "evaluate partial index expression")
 				}

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -88,6 +88,7 @@ func (i KVInserter) InitPut(key, value interface{}, failOnTombstones bool) {
 //     maps the indexes of the comptuedCols/computeExpr slices
 //     back into indexes in the result row tuple.
 func GenerateInsertRow(
+	ctx context.Context,
 	defaultExprs []tree.TypedExpr,
 	computeExprs []tree.TypedExpr,
 	insertCols []catalog.Column,
@@ -113,7 +114,7 @@ func GenerateInsertRow(
 				rowVals[i] = tree.DNull
 				continue
 			}
-			d, err := eval.Expr(evalCtx.Context, evalCtx, defaultExprs[i])
+			d, err := eval.Expr(ctx, evalCtx, defaultExprs[i])
 			if err != nil {
 				return nil, err
 			}
@@ -135,7 +136,7 @@ func GenerateInsertRow(
 			if !col.IsComputed() {
 				continue
 			}
-			d, err := eval.Expr(evalCtx.Context, evalCtx, computeExprs[computeIdx])
+			d, err := eval.Expr(ctx, evalCtx, computeExprs[computeIdx])
 			if err != nil {
 				name := col.GetName()
 				return nil, errors.Wrapf(err,
@@ -505,7 +506,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 	}
 
 	insertRow, err := GenerateInsertRow(
-		c.defaultCache, c.computedExprs, c.cols, computedColsLookup, c.EvalCtx,
+		ctx, c.defaultCache, c.computedExprs, c.cols, computedColsLookup, c.EvalCtx,
 		c.tableDesc, c.Datums, &c.computedIVarContainer)
 	if err != nil {
 		return errors.Wrap(err, "generate insert row")

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -883,11 +883,11 @@ func TestEncodeOverlapsArrayInvertedIndexSpans(t *testing.T) {
 
 // Determines if the input array contains only one or more entries of the
 // same non-null element. NULL entries are not considered.
-func containsNonNullUniqueElement(ctx *eval.Context, valArr *tree.DArray) bool {
+func containsNonNullUniqueElement(evalCtx *eval.Context, valArr *tree.DArray) bool {
 	var lastVal tree.Datum = tree.DNull
 	for _, val := range valArr.Array {
 		if val != tree.DNull {
-			if lastVal != tree.DNull && lastVal.Compare(ctx, val) != 0 {
+			if lastVal != tree.DNull && lastVal.Compare(evalCtx, val) != 0 {
 				return false
 			}
 			lastVal = val
@@ -987,7 +987,7 @@ func TestEncodeTrigramInvertedIndexSpans(t *testing.T) {
 
 		// Since the spans are never tight, apply an additional filter to determine
 		// if the result is contained.
-		datum, err := eval.Expr(&evalCtx, typedExpr)
+		datum, err := eval.Expr(evalCtx.Context, &evalCtx, typedExpr)
 		require.NoError(t, err)
 		actual := bool(*datum.(*tree.DBool))
 		require.Equal(t, expected, actual, "%s, %s: expected evaluation result to match", indexedValue, value)
@@ -1036,7 +1036,7 @@ func TestEncodeTrigramInvertedIndexSpans(t *testing.T) {
 				expectedContainsKeys = all
 			}
 
-			d, err := eval.Expr(&evalCtx, expr)
+			d, err := eval.Expr(evalCtx.Context, &evalCtx, expr)
 			require.NoError(t, err)
 			expected := bool(*d.(*tree.DBool))
 			trigrams := trigram.MakeTrigrams(right, false /* pad */)

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -987,7 +987,7 @@ func TestEncodeTrigramInvertedIndexSpans(t *testing.T) {
 
 		// Since the spans are never tight, apply an additional filter to determine
 		// if the result is contained.
-		datum, err := eval.Expr(evalCtx.Context, &evalCtx, typedExpr)
+		datum, err := eval.Expr(context.Background(), &evalCtx, typedExpr)
 		require.NoError(t, err)
 		actual := bool(*datum.(*tree.DBool))
 		require.Equal(t, expected, actual, "%s, %s: expected evaluation result to match", indexedValue, value)
@@ -1036,7 +1036,7 @@ func TestEncodeTrigramInvertedIndexSpans(t *testing.T) {
 				expectedContainsKeys = all
 			}
 
-			d, err := eval.Expr(evalCtx.Context, &evalCtx, expr)
+			d, err := eval.Expr(context.Background(), &evalCtx, expr)
 			require.NoError(t, err)
 			expected := bool(*d.(*tree.DBool))
 			trigrams := trigram.MakeTrigrams(right, false /* pad */)

--- a/pkg/sql/rowenc/roundtrip_format.go
+++ b/pkg/sql/rowenc/roundtrip_format.go
@@ -57,6 +57,6 @@ func parseAsTyp(evalCtx *eval.Context, typ *types.T, s string) (tree.Datum, erro
 	if err != nil {
 		return nil, err
 	}
-	datum, err := eval.Expr(evalCtx, typedExpr)
+	datum, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
 	return datum, err
 }

--- a/pkg/sql/rowenc/roundtrip_format.go
+++ b/pkg/sql/rowenc/roundtrip_format.go
@@ -11,6 +11,8 @@
 package rowenc
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -19,12 +21,14 @@ import (
 
 // ParseDatumStringAs parses s as type t. This function is guaranteed to
 // round-trip when printing a Datum with FmtExport.
-func ParseDatumStringAs(t *types.T, s string, evalCtx *eval.Context) (tree.Datum, error) {
+func ParseDatumStringAs(
+	ctx context.Context, t *types.T, s string, evalCtx *eval.Context,
+) (tree.Datum, error) {
 	switch t.Family() {
 	// We use a different parser for array types because ParseAndRequireString only parses
 	// the internal postgres string representation of arrays.
 	case types.ArrayFamily, types.CollatedStringFamily:
-		return parseAsTyp(evalCtx, t, s)
+		return parseAsTyp(ctx, evalCtx, t, s)
 	default:
 		res, _, err := tree.ParseAndRequireString(t, s, evalCtx)
 		return res, err
@@ -37,26 +41,28 @@ func ParseDatumStringAs(t *types.T, s string, evalCtx *eval.Context) (tree.Datum
 // than the bytes case, this function does the same as ParseDatumStringAs but is not
 // guaranteed to round-trip.
 func ParseDatumStringAsWithRawBytes(
-	t *types.T, s string, evalCtx *eval.Context,
+	ctx context.Context, t *types.T, s string, evalCtx *eval.Context,
 ) (tree.Datum, error) {
 	switch t.Family() {
 	case types.BytesFamily:
 		return tree.NewDBytes(tree.DBytes(s)), nil
 	default:
-		return ParseDatumStringAs(t, s, evalCtx)
+		return ParseDatumStringAs(ctx, t, s, evalCtx)
 	}
 }
 
-func parseAsTyp(evalCtx *eval.Context, typ *types.T, s string) (tree.Datum, error) {
+func parseAsTyp(
+	ctx context.Context, evalCtx *eval.Context, typ *types.T, s string,
+) (tree.Datum, error) {
 	expr, err := parser.ParseExpr(s)
 	if err != nil {
 		return nil, err
 	}
 	semaCtx := tree.MakeSemaContext()
-	typedExpr, err := tree.TypeCheck(evalCtx.Context, expr, &semaCtx, typ)
+	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, typ)
 	if err != nil {
 		return nil, err
 	}
-	datum, err := eval.Expr(evalCtx.Context, evalCtx, typedExpr)
+	datum, err := eval.Expr(ctx, evalCtx, typedExpr)
 	return datum, err
 }

--- a/pkg/sql/rowenc/roundtrip_format_test.go
+++ b/pkg/sql/rowenc/roundtrip_format_test.go
@@ -11,6 +11,7 @@
 package rowenc_test
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strconv"
@@ -97,7 +98,7 @@ func TestRandParseDatumStringAs(t *testing.T) {
 					t.Fatal(ds, err)
 				}
 
-				parsed, err := rowenc.ParseDatumStringAs(typ, ds, evalCtx)
+				parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx)
 				if err != nil {
 					t.Fatal(ds, err)
 				}
@@ -293,7 +294,7 @@ func TestParseDatumStringAs(t *testing.T) {
 		t.Run(typ.String(), func(t *testing.T) {
 			for _, s := range exprs {
 				t.Run(fmt.Sprintf("%q", s), func(t *testing.T) {
-					d, err := rowenc.ParseDatumStringAs(typ, s, evalCtx)
+					d, err := rowenc.ParseDatumStringAs(context.Background(), typ, s, evalCtx)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -301,7 +302,7 @@ func TestParseDatumStringAs(t *testing.T) {
 						t.Fatalf("unexpected type: %s", d.ResolvedType())
 					}
 					ds := tree.AsStringWithFlags(d, tree.FmtExport)
-					parsed, err := rowenc.ParseDatumStringAs(typ, ds, evalCtx)
+					parsed, err := rowenc.ParseDatumStringAs(context.Background(), typ, ds, evalCtx)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -95,7 +95,7 @@ func (f *filtererProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 		}
 
 		// Perform the actual filtering.
-		passes, err := f.filter.EvalFilter(row)
+		passes, err := f.filter.EvalFilter(f.Ctx, row)
 		if err != nil {
 			f.MoveToDraining(err)
 			break

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -689,7 +689,7 @@ func (ij *invertedJoiner) render(lrow, rrow rowenc.EncDatumRow) (rowenc.EncDatum
 	ij.combinedRow = append(ij.combinedRow[:0], lrow...)
 	ij.combinedRow = append(ij.combinedRow, rrow...)
 	if ij.onExprHelper.Expr != nil {
-		res, err := ij.onExprHelper.EvalFilter(ij.combinedRow)
+		res, err := ij.onExprHelper.EvalFilter(ij.Ctx, ij.combinedRow)
 		if !res || err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -277,7 +277,7 @@ func newInvertedJoiner(
 			return nil, err
 		}
 		ij.datumsToInvertedExpr, err = invertedidx.NewDatumsToInvertedExpr(
-			ij.EvalCtx, onExprColTypes, invertedExprHelper.Expr, ij.fetchSpec.GeoConfig,
+			ctx, ij.EvalCtx, onExprColTypes, invertedExprHelper.Expr, ij.fetchSpec.GeoConfig,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -170,7 +170,7 @@ func (jb *joinerBase) render(lrow, rrow rowenc.EncDatumRow) (rowenc.EncDatumRow,
 		} else {
 			combinedRow = jb.combine(lrow, rrow)
 		}
-		res, err := jb.onCond.EvalFilter(combinedRow)
+		res, err := jb.onCond.EvalFilter(jb.Ctx, combinedRow)
 		if !res || err != nil {
 			return nil, err
 		}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -169,7 +169,7 @@ func (ps *projectSetProcessor) nextInputRow() (
 			ps.exprHelpers[i].Row = row
 
 			ps.EvalCtx.IVarContainer = ps.exprHelpers[i]
-			gen, err := eval.GetGenerator(ps.EvalCtx, fn)
+			gen, err := eval.GetGenerator(ps.Ctx, ps.EvalCtx, fn)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -237,7 +237,7 @@ func (ps *projectSetProcessor) nextGeneratorValues() (newValAvail bool, err erro
 			// Do we still need to produce the scalar value? (first row)
 			if !ps.done[i] {
 				// Yes. Produce it once, then indicate it's "done".
-				value, err := ps.exprHelpers[i].Eval(ps.rowBuffer)
+				value, err := ps.exprHelpers[i].Eval(ps.Ctx, ps.rowBuffer)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -347,7 +347,7 @@ func newZigzagJoiner(
 			z.infos[i].fixedValues = fixedValues[i]
 		} else {
 			fv := &spec.Sides[i].FixedValues
-			if err = execinfra.HydrateTypesInDatumInfo(flowCtx.EvalCtx.Ctx(), &resolver, fv.Columns); err != nil {
+			if err = execinfra.HydrateTypesInDatumInfo(ctx, &resolver, fv.Columns); err != nil {
 				return nil, err
 			}
 			z.infos[i].fixedValues, err = valuesSpecToEncDatum(fv)

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -131,10 +132,12 @@ func (p *planner) Scan() *scanNode {
 	return n
 }
 
-// scanNode implements tree.IndexedVarContainer.
-var _ tree.IndexedVarContainer = &scanNode{}
+// scanNode implements eval.IndexedVarContainer.
+var _ eval.IndexedVarContainer = &scanNode{}
 
-func (n *scanNode) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
+func (n *scanNode) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
 	panic("scanNode can't be run in local mode")
 }
 

--- a/pkg/sql/scatter.go
+++ b/pkg/sql/scatter.go
@@ -80,7 +80,7 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			if err != nil {
 				return nil, err
 			}
-			fromVals[i], err = eval.Expr(p.EvalContext(), typedExpr)
+			fromVals[i], err = eval.Expr(ctx, p.EvalContext(), typedExpr)
 			if err != nil {
 				return nil, err
 			}
@@ -93,7 +93,7 @@ func (p *planner) Scatter(ctx context.Context, n *tree.Scatter) (planNode, error
 			if err != nil {
 				return nil, err
 			}
-			toVals[i], err = eval.Expr(p.EvalContext(), typedExpr)
+			toVals[i], err = eval.Expr(ctx, p.EvalContext(), typedExpr)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -2500,10 +2500,7 @@ func createSchemaChangeEvalCtx(
 		ExecCfg: execCfg,
 		Descs:   descriptors,
 		Context: eval.Context{
-			SessionDataStack: sessiondata.NewStack(sd),
-			// TODO(andrei): This is wrong (just like on the main code path on
-			// setupFlow). Each processor should override Ctx with its own context.
-			Context:            ctx,
+			SessionDataStack:   sessiondata.NewStack(sd),
 			Planner:            &faketreeeval.DummyEvalPlanner{},
 			PrivilegedAccessor: &faketreeeval.DummyPrivilegedAccessor{},
 			SessionAccessor:    &faketreeeval.DummySessionAccessor{},
@@ -2521,6 +2518,9 @@ func createSchemaChangeEvalCtx(
 			Tracer:             execCfg.AmbientCtx.Tracer,
 		},
 	}
+	// TODO(andrei): This is wrong (just like on the main code path on
+	// setupFlow). Each processor should override Ctx with its own context.
+	evalCtx.SetDeprecatedContext(ctx)
 	// The backfill is going to use the current timestamp for the various
 	// functions, like now(), that need it.  It's possible that the backfill has
 	// been partially performed already by another SchemaChangeManager with

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_owned_by.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_owned_by.go
@@ -41,7 +41,7 @@ func DropOwnedBy(b BuildCtx, n *tree.DropOwnedBy) {
 		if role != b.SessionData().User() && !b.CurrentUserHasAdminOrIsMemberOf(role) {
 			panic(pgerror.New(pgcode.InsufficientPrivilege, "permission denied to drop objects"))
 		}
-		ok, err := b.CanPerformDropOwnedBy(b.EvalCtx().Ctx(), role)
+		ok, err := b.CanPerformDropOwnedBy(b, role)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/schemachanger/scbuild/tree_context_builder.go
+++ b/pkg/sql/schemachanger/scbuild/tree_context_builder.go
@@ -45,10 +45,9 @@ func (b buildCtx) EvalCtx() *eval.Context {
 }
 
 func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
-	return &eval.Context{
+	evalCtx := &eval.Context{
 		ClusterID:          d.ClusterID(),
 		SessionDataStack:   sessiondata.NewStack(d.SessionData()),
-		Context:            ctx,
 		Planner:            &faketreeeval.DummyEvalPlanner{},
 		PrivilegedAccessor: &faketreeeval.DummyPrivilegedAccessor{},
 		SessionAccessor:    &faketreeeval.DummySessionAccessor{},
@@ -59,4 +58,6 @@ func newEvalCtx(ctx context.Context, d Dependencies) *eval.Context {
 		Settings:           d.ClusterSettings(),
 		Codec:              d.Codec(),
 	}
+	evalCtx.SetDeprecatedContext(ctx)
+	return evalCtx
 }

--- a/pkg/sql/sem/asof/as_of.go
+++ b/pkg/sql/sem/asof/as_of.go
@@ -160,7 +160,7 @@ func Eval(
 				if err != nil {
 					return eval.AsOfSystemTime{}, err
 				}
-				nearestOnlyEval, err := eval.Expr(evalCtx, nearestOnlyExpr)
+				nearestOnlyEval, err := eval.Expr(ctx, evalCtx, nearestOnlyExpr)
 				if err != nil {
 					return eval.AsOfSystemTime{}, err
 				}
@@ -193,7 +193,7 @@ func Eval(
 		}
 	}
 
-	d, err := eval.Expr(evalCtx, te)
+	d, err := eval.Expr(ctx, evalCtx, te)
 	if err != nil {
 		return eval.AsOfSystemTime{}, err
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -2478,9 +2478,9 @@ type corrAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newCorrAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newCorrAggregate(_ []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &corrAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2494,10 +2494,10 @@ type finalCorrAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalCorrAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalCorrAggregate(_ []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &finalCorrAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2512,9 +2512,9 @@ type covarPopAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newCovarPopAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newCovarPopAggregate(_ []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &covarPopAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2528,10 +2528,12 @@ type finalCovarPopAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalCovarPopAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalCovarPopAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &finalCovarPopAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2560,10 +2562,12 @@ type finalRegrSXXAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalRegrSXXAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalRegrSXXAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &finalRegrSXXAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2579,10 +2583,12 @@ type finalRegrSXYAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalRegrSXYAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalRegrSXYAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &finalRegrSXYAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2597,10 +2603,12 @@ type finalRegrSYYAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalRegrSYYAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalRegrSYYAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &finalRegrSYYAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2615,9 +2623,9 @@ type covarSampAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newCovarSampAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newCovarSampAggregate(_ []*types.T, evalCtx *eval.Context, _ tree.Datums) eval.AggregateFunc {
 	return &covarSampAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2631,10 +2639,12 @@ type finalCovarSampAggregate struct {
 	finalRegressionAccumulatorDecimalBase
 }
 
-func newFinalCovarSampAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newFinalCovarSampAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &finalCovarSampAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2650,9 +2660,11 @@ type regressionAvgXAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionAvgXAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionAvgXAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionAvgXAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2668,11 +2680,11 @@ type finalRegressionAvgXAggregate struct {
 }
 
 func newFinalRegressionAvgXAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &finalRegressionAvgXAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2688,9 +2700,11 @@ type regressionAvgYAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionAvgYAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionAvgYAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionAvgYAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2706,11 +2720,11 @@ type finalRegressionAvgYAggregate struct {
 }
 
 func newFinalRegressionAvgYAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &finalRegressionAvgYAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2726,10 +2740,10 @@ type regressionInterceptAggregate struct {
 }
 
 func newRegressionInterceptAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &regressionInterceptAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2744,11 +2758,11 @@ type finalRegressionInterceptAggregate struct {
 }
 
 func newFinalRegressionInterceptAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &finalRegressionInterceptAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2763,9 +2777,11 @@ type regressionR2Aggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionR2Aggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionR2Aggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionR2Aggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2780,11 +2796,11 @@ type finalRegressionR2Aggregate struct {
 }
 
 func newFinalRegressionR2Aggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &finalRegressionR2Aggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2801,10 +2817,10 @@ type regressionSlopeAggregate struct {
 }
 
 func newRegressionSlopeAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &regressionSlopeAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2820,11 +2836,11 @@ type finalRegressionSlopeAggregate struct {
 }
 
 func newFinalRegressionSlopeAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
 	return &finalRegressionSlopeAggregate{
 		finalRegressionAccumulatorDecimalBase{
-			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(ctx),
+			regressionAccumulatorDecimalBase: makeRegressionAccumulatorDecimalBase(evalCtx),
 		},
 	}
 }
@@ -2839,9 +2855,11 @@ type regressionSXXAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionSXXAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionSXXAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionSXXAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2856,9 +2874,11 @@ type regressionSXYAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionSXYAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionSXYAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionSXYAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -2872,9 +2892,11 @@ type regressionSYYAggregate struct {
 	regressionAccumulatorDecimalBase
 }
 
-func newRegressionSYYAggregate(_ []*types.T, ctx *eval.Context, _ tree.Datums) eval.AggregateFunc {
+func newRegressionSYYAggregate(
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
+) eval.AggregateFunc {
 	return &regressionSYYAggregate{
-		makeRegressionAccumulatorDecimalBase(ctx),
+		makeRegressionAccumulatorDecimalBase(evalCtx),
 	}
 }
 
@@ -3668,9 +3690,9 @@ func newFloatFinalSqrdiffAggregate(
 }
 
 func newDecimalFinalSqrdiffAggregate(
-	_ []*types.T, ctx *eval.Context, _ tree.Datums,
+	_ []*types.T, evalCtx *eval.Context, _ tree.Datums,
 ) eval.AggregateFunc {
-	return newDecimalSumSqrDiffs(ctx)
+	return newDecimalSumSqrDiffs(evalCtx)
 }
 
 type floatSumSqrDiffsAggregate struct {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2357,7 +2357,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.HomogeneousType{},
 			ReturnType: tree.FirstNonNullReturnType(),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return eval.PickFromTuple(evalCtx, true /* greatest */, args)
+				return eval.PickFromTuple(ctx, evalCtx, true /* greatest */, args)
 			},
 			Info:              "Returns the element with the greatest value.",
 			Volatility:        volatility.Immutable,
@@ -2373,7 +2373,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.HomogeneousType{},
 			ReturnType: tree.FirstNonNullReturnType(),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return eval.PickFromTuple(evalCtx, false /* greatest */, args)
+				return eval.PickFromTuple(ctx, evalCtx, false /* greatest */, args)
 			},
 			Info:              "Returns the element with the lowest value.",
 			Volatility:        volatility.Immutable,
@@ -4506,7 +4506,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -4514,7 +4514,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, errInsufficientPriv
 				}
 
-				sp := tracing.SpanFromContext(evalCtx.Context)
+				sp := tracing.SpanFromContext(ctx)
 				if sp == nil {
 					return tree.DNull, nil
 				}
@@ -4542,7 +4542,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -4700,7 +4700,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(evalCtx.Context)
+				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(ctx)
 				jsonStr, err := gojson.Marshal(&activeVersion.Version)
 				if err != nil {
 					return nil, err
@@ -4730,7 +4730,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(evalCtx.Context)
+				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(ctx)
 				if activeVersion == (clusterversion.ClusterVersion{}) {
 					return nil, errors.AssertionFailedf("invalid uninitialized version")
 				}
@@ -4818,7 +4818,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Tenant.CreateTenant(evalCtx.Context, uint64(sTenID)); err != nil {
+				if err := evalCtx.Tenant.CreateTenant(ctx, uint64(sTenID)); err != nil {
 					return nil, err
 				}
 				return args[0], nil
@@ -4835,7 +4835,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				token, err := evalCtx.JoinTokenCreator.CreateJoinToken(evalCtx.Context)
+				token, err := evalCtx.JoinTokenCreator.CreateJoinToken(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -4862,7 +4862,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, err
 				}
 				if err := evalCtx.Tenant.DestroyTenant(
-					evalCtx.Context, uint64(sTenID), false, /* synchronous */
+					ctx, uint64(sTenID), false, /* synchronous */
 				); err != nil {
 					return nil, err
 				}
@@ -4884,7 +4884,7 @@ value if you rely on the HLC for accuracy.`,
 				}
 				synchronous := tree.MustBeDBool(args[1])
 				if err := evalCtx.Tenant.DestroyTenant(
-					evalCtx.Context, uint64(sTenID), bool(synchronous),
+					ctx, uint64(sTenID), bool(synchronous),
 				); err != nil {
 					return nil, err
 				}
@@ -4906,7 +4906,7 @@ value if you rely on the HLC for accuracy.`,
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
-				ok, err := evalCtx.Gossip.TryClearGossipInfo(evalCtx.Context, string(key))
+				ok, err := evalCtx.Gossip.TryClearGossipInfo(ctx, string(key))
 				if err != nil {
 					return nil, err
 				}
@@ -4998,7 +4998,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				msg := string(s)
-				return crdbInternalSendNotice(evalCtx, "NOTICE", msg)
+				return crdbInternalSendNotice(ctx, evalCtx, "NOTICE", msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Volatile,
@@ -5020,7 +5020,7 @@ value if you rely on the HLC for accuracy.`,
 				if _, ok := pgnotice.ParseDisplaySeverity(severityString); !ok {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "severity %s is invalid", severityString)
 				}
-				return crdbInternalSendNotice(evalCtx, severityString, msg)
+				return crdbInternalSendNotice(ctx, evalCtx, severityString, msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Volatile,
@@ -5070,7 +5070,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -5103,7 +5103,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -5438,7 +5438,7 @@ value if you rely on the HLC for accuracy.`,
 				parentID := tree.MustBeDInt(args[0])
 				name := tree.MustBeDString(args[1])
 				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
-					evalCtx.Context,
+					ctx,
 					int64(parentID),
 					0,
 					string(name),
@@ -5464,7 +5464,7 @@ value if you rely on the HLC for accuracy.`,
 				parentSchemaID := tree.MustBeDInt(args[1])
 				name := tree.MustBeDString(args[2])
 				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
-					evalCtx.Context,
+					ctx,
 					int64(parentID),
 					int64(parentSchemaID),
 					string(name),
@@ -5494,7 +5494,7 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
-					evalCtx.Context,
+					ctx,
 					int64(0),
 					int64(0),
 					string(name),
@@ -5522,7 +5522,7 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := tree.MustBeDInt(args[0])
 				bytes, found, err := evalCtx.PrivilegedAccessor.LookupZoneConfigByNamespaceID(
-					evalCtx.Context,
+					ctx,
 					int64(id),
 				)
 				if err != nil {
@@ -5545,7 +5545,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ArgTypes{{"vmodule_string", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -5578,7 +5578,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -5883,7 +5883,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.StringArray),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				prefix := evalCtx.Codec.StartupMigrationKeyPrefix()
-				keyvals, err := evalCtx.Txn.Scan(evalCtx.Context, prefix, prefix.PrefixEnd(), 0 /* maxRows */)
+				keyvals, err := evalCtx.Txn.Scan(ctx, prefix, prefix.PrefixEnd(), 0 /* maxRows */)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to get list of completed migrations")
 				}
@@ -5914,7 +5914,7 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.Planner.UnsafeUpsertDescriptor(evalCtx.Context,
+				if err := evalCtx.Planner.UnsafeUpsertDescriptor(ctx,
 					int64(*args[0].(*tree.DInt)),
 					[]byte(*args[1].(*tree.DBytes)),
 					false /* force */); err != nil {
@@ -5933,7 +5933,7 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.Planner.UnsafeUpsertDescriptor(evalCtx.Context,
+				if err := evalCtx.Planner.UnsafeUpsertDescriptor(ctx,
 					int64(*args[0].(*tree.DInt)),
 					[]byte(*args[1].(*tree.DBytes)),
 					bool(*args[2].(*tree.DBool))); err != nil {
@@ -5957,7 +5957,7 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.Planner.UnsafeDeleteDescriptor(evalCtx.Context,
+				if err := evalCtx.Planner.UnsafeDeleteDescriptor(ctx,
 					int64(*args[0].(*tree.DInt)),
 					false, /* force */
 				); err != nil {
@@ -5975,7 +5975,7 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.Planner.UnsafeDeleteDescriptor(evalCtx.Context,
+				if err := evalCtx.Planner.UnsafeDeleteDescriptor(ctx,
 					int64(*args[0].(*tree.DInt)),
 					bool(*args[1].(*tree.DBool)),
 				); err != nil {
@@ -6004,7 +6004,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Planner.UnsafeUpsertNamespaceEntry(
-					evalCtx.Context,
+					ctx,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6028,7 +6028,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Planner.UnsafeUpsertNamespaceEntry(
-					evalCtx.Context,
+					ctx,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6059,7 +6059,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Planner.UnsafeDeleteNamespaceEntry(
-					evalCtx.Context,
+					ctx,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6084,7 +6084,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Planner.UnsafeDeleteNamespaceEntry(
-					evalCtx.Context,
+					ctx,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6111,7 +6111,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sid := sqlliveness.SessionID(*(args[0].(*tree.DBytes)))
-				live, err := evalCtx.SQLLivenessReader.IsAlive(evalCtx.Context, sid)
+				live, err := evalCtx.SQLLivenessReader.IsAlive(ctx, sid)
 				if err != nil {
 					return tree.MakeDBool(true), err
 				}
@@ -6139,7 +6139,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Tenant.GCTenant(evalCtx.Context, uint64(sTenID)); err != nil {
+				if err := evalCtx.Tenant.GCTenant(ctx, uint64(sTenID)); err != nil {
 					return nil, err
 				}
 				return args[0], nil
@@ -6177,7 +6177,7 @@ value if you rely on the HLC for accuracy.`,
 				asOfConsumed := float64(tree.MustBeDFloat(args[5]))
 
 				if err := evalCtx.Tenant.UpdateTenantResourceLimits(
-					evalCtx.Context,
+					ctx,
 					uint64(sTenID),
 					availableRU,
 					refillRate,
@@ -6209,7 +6209,7 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6221,7 +6221,7 @@ value if you rely on the HLC for accuracy.`,
 				startKey := []byte(tree.MustBeDBytes(args[2]))
 				endKey := []byte(tree.MustBeDBytes(args[3]))
 				if err := evalCtx.CompactEngineSpan(
-					evalCtx.Context, nodeID, storeID, startKey, endKey); err != nil {
+					ctx, nodeID, storeID, startKey, endKey); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -6339,7 +6339,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		},
 		stringOverload1(
 			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
-				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(evalCtx.Context)
+				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6372,7 +6372,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
-				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(evalCtx.Context)
+				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6412,7 +6412,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Regions.ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
-					evalCtx.Context,
+					ctx,
 				); err != nil {
 					return nil, err
 				}
@@ -6437,7 +6437,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 				id := int64(*args[0].(*tree.DInt))
 
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForTable(
-					evalCtx.Context,
+					ctx,
 					id,
 				); err != nil {
 					return nil, err
@@ -6462,7 +6462,7 @@ table.`,
 				id := int64(*args[0].(*tree.DInt))
 
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForDatabase(
-					evalCtx.Context,
+					ctx,
 					id,
 				); err != nil {
 					return nil, err
@@ -6583,7 +6583,7 @@ table's zone configuration this will return NULL.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
-				err := evalCtx.Planner.ForceDeleteTableData(evalCtx.Context, id)
+				err := evalCtx.Planner.ForceDeleteTableData(ctx, id)
 				if err != nil {
 					return tree.DBoolFalse, err
 				}
@@ -6663,14 +6663,14 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
 				if !isAdmin {
 					return nil, errInsufficientPriv
 				}
-				return tree.DVoidDatum, evalCtx.Planner.ValidateTTLScheduledJobsInCurrentDB(evalCtx.Context)
+				return tree.DVoidDatum, evalCtx.Planner.ValidateTTLScheduledJobsInCurrentDB(ctx)
 			},
 			Info:       `Validate all TTL tables have a valid scheduled job attached.`,
 			Volatility: volatility.Volatile,
@@ -6685,7 +6685,7 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6895,7 +6895,7 @@ active for the current transaction.`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6927,7 +6927,7 @@ One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC', 'raftlog',
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6976,7 +6976,7 @@ run from. One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC',
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6991,7 +6991,7 @@ run from. One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC',
 				var foundRepl bool
 				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					var err error
-					_, err = store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
+					_, err = store.Enqueue(ctx, queue, rangeID, skipShouldQueue)
 					if err == nil {
 						foundRepl = true
 						return nil
@@ -7026,7 +7026,7 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 			},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -7043,7 +7043,7 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 				var rec tracingpb.Recording
 				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					var err error
-					rec, err = store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
+					rec, err = store.Enqueue(ctx, queue, rangeID, skipShouldQueue)
 					if err == nil {
 						foundRepl = true
 						return nil
@@ -7082,7 +7082,7 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -7099,7 +7099,7 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					if storeID == store.StoreID() {
 						foundStore = true
-						_, err := store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
+						_, err := store.Enqueue(ctx, queue, rangeID, skipShouldQueue)
 						return err
 					}
 					return nil
@@ -7200,7 +7200,7 @@ expires until the statement bundle is collected`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -7214,7 +7214,7 @@ expires until the statement bundle is collected`,
 					return nil, errors.AssertionFailedf("compaction_concurrency must be > 0")
 				}
 				if err = evalCtx.SetCompactionConcurrency(
-					evalCtx.Context, nodeID, storeID, uint64(compactionConcurrency)); err != nil {
+					ctx, nodeID, storeID, uint64(compactionConcurrency)); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -9765,11 +9765,11 @@ var errInsufficientPriv = pgerror.New(
 // if an enterprise license is not installed.
 var EvalFollowerReadOffset func(logicalClusterID uuid.UUID, _ *cluster.Settings) (time.Duration, error)
 
-func recentTimestamp(evalCtx *eval.Context) (time.Time, error) {
+func recentTimestamp(ctx context.Context, evalCtx *eval.Context) (time.Time, error) {
 	if EvalFollowerReadOffset == nil {
 		telemetry.Inc(sqltelemetry.FollowerReadDisabledCCLCounter)
 		evalCtx.ClientNoticeSender.BufferClientNotice(
-			evalCtx.Context,
+			ctx,
 			pgnotice.Newf("follower reads disabled because you are running a non-CCL distribution"),
 		)
 		return evalCtx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
@@ -9779,7 +9779,7 @@ func recentTimestamp(evalCtx *eval.Context) (time.Time, error) {
 		if code := pgerror.GetPGCode(err); code == pgcode.CCLValidLicenseRequired {
 			telemetry.Inc(sqltelemetry.FollowerReadDisabledNoEnterpriseLicense)
 			evalCtx.ClientNoticeSender.BufferClientNotice(
-				evalCtx.Context, pgnotice.Newf("follower reads disabled: %s", err.Error()),
+				ctx, pgnotice.Newf("follower reads disabled: %s", err.Error()),
 			)
 			return evalCtx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
 		}
@@ -9798,7 +9798,7 @@ func requireNonNull(d tree.Datum) error {
 func followerReadTimestamp(
 	ctx context.Context, evalCtx *eval.Context, _ tree.Datums,
 ) (tree.Datum, error) {
-	ts, err := recentTimestamp(evalCtx)
+	ts, err := recentTimestamp(ctx, evalCtx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -201,7 +201,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"bit_length": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(len(s) * 8)), nil
 			},
 			types.Int,
@@ -209,7 +209,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(len(s) * 8)), nil
 			},
 			types.Int,
@@ -217,7 +217,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		bitsOverload1(
-			func(_ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(s.BitArray.BitLen())), nil
 			},
 			types.Int,
@@ -230,7 +230,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"octet_length": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(len(s))), nil
 			},
 			types.Int,
@@ -238,7 +238,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(len(s))), nil
 			},
 			types.Int,
@@ -246,7 +246,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		bitsOverload1(
-			func(_ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt((s.BitArray.BitLen() + 7) / 8)), nil
 			},
 			types.Int,
@@ -259,7 +259,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"lower": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(strings.ToLower(s)), nil
 			},
 			types.String,
@@ -270,7 +270,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"unaccent": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				var b strings.Builder
 				for _, ch := range s {
 					v, ok := unaccent.Dictionary[ch]
@@ -290,7 +290,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"upper": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(strings.ToUpper(s)), nil
 			},
 			types.String,
@@ -301,7 +301,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"prettify_statement": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				formattedStmt, err := prettyStatement(tree.DefaultPrettyCfg(), s)
 				if err != nil {
 					return nil, err
@@ -320,7 +320,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"case_mode", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				stmt := string(tree.MustBeDString(args[0]))
 				lineWidth := int(tree.MustBeDInt(args[1]))
 				alignMode := int(tree.MustBeDInt(args[2]))
@@ -348,7 +348,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.String},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var buffer bytes.Buffer
 				length := 0
 				for _, d := range args {
@@ -379,7 +379,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.String},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if len(args) == 0 {
 					return nil, pgerror.Newf(pgcode.UndefinedFunction, builtinconstants.ErrInsufficientArgsFmtString, "concat_ws")
 				}
@@ -424,7 +424,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.Bytes}, {"enc", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				str := []byte(tree.MustBeDBytes(args[0]))
 				enc := CleanEncodingName(string(tree.MustBeDString(args[1])))
 				switch enc {
@@ -457,7 +457,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"enc", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				str := string(tree.MustBeDString(args[0]))
 				enc := CleanEncodingName(string(tree.MustBeDString(args[1])))
 				switch enc {
@@ -490,7 +490,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"bit_string", types.VarBit}, {"index", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bitString := tree.MustBeDBitArray(args[0])
 				index := int(tree.MustBeDInt(args[1]))
 				bit, err := bitString.GetBitAtIndex(index)
@@ -505,7 +505,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"byte_string", types.Bytes}, {"index", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := []byte(*args[0].(*tree.DBytes))
 				index := int(tree.MustBeDInt(args[1]))
 				// Check whether index asked is inside ByteArray.
@@ -530,7 +530,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"byte_string", types.Bytes}, {"index", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := []byte(*args[0].(*tree.DBytes))
 				index := int(tree.MustBeDInt(args[1]))
 				// Check whether index asked is inside ByteArray.
@@ -553,7 +553,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"to_set", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bitString := tree.MustBeDBitArray(args[0])
 				index := int(tree.MustBeDInt(args[1]))
 				toSet := int(tree.MustBeDInt(args[2]))
@@ -579,7 +579,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"to_set", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := []byte(*args[0].(*tree.DBytes))
 				index := int(tree.MustBeDInt(args[1]))
 				toSet := int(tree.MustBeDInt(args[2]))
@@ -615,7 +615,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"to_set", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := []byte(*args[0].(*tree.DBytes))
 				index := int(tree.MustBeDInt(args[1]))
 				toSet := int(tree.MustBeDInt(args[2]))
@@ -658,7 +658,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				gen := uuid.NewGenWithHWAF(uuid.RandomHardwareAddrFunc)
 				uv, err := gen.NewV1()
 				if err != nil {
@@ -681,7 +681,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				gen := uuid.NewGenWithHWAF(uuid.RandomHardwareAddrFunc)
 				uv, err := gen.NewV1()
 				if err != nil {
@@ -702,7 +702,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"namespace", types.Uuid}, {"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				namespace := tree.MustBeDUuid(args[0])
 				name := tree.MustBeDString(args[1])
 				uv := uuid.NewV3(namespace.UUID, string(name))
@@ -722,7 +722,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"namespace", types.Uuid}, {"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				namespace := tree.MustBeDUuid(args[0])
 				name := tree.MustBeDString(args[1])
 				uv := uuid.NewV5(namespace.UUID, string(name))
@@ -738,7 +738,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				uv, err := uuid.FromString(s)
 				if err != nil {
@@ -756,7 +756,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				b := []byte(*args[0].(*tree.DBytes))
 				uv, err := uuid.FromBytes(b)
 				if err != nil {
@@ -777,7 +777,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				entropy := ulid.Monotonic(cryptorand.Reader, 0)
 				uv := ulid.MustNew(ulid.Now(), entropy)
 				return tree.NewDUuid(tree.DUuid{UUID: uuid.UUID(uv)}), nil
@@ -791,7 +791,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Uuid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				b := (*args[0].(*tree.DUuid)).GetBytes()
 				var ul ulid.ULID
 				if err := ul.UnmarshalBinary(b); err != nil {
@@ -808,7 +808,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := tree.MustBeDString(args[0])
 				u, err := ulid.Parse(string(s))
 				if err != nil {
@@ -847,7 +847,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				return tree.NewDString(dIPAddr.IPAddr.String()), nil
 			},
@@ -862,7 +862,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				broadcastIPAddr := dIPAddr.IPAddr.Broadcast()
 				return &tree.DIPAddr{IPAddr: broadcastIPAddr}, nil
@@ -877,7 +877,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				if dIPAddr.Family == ipaddr.IPv4family {
 					return tree.NewDInt(tree.DInt(4)), nil
@@ -894,7 +894,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				s := dIPAddr.IPAddr.String()
 				if i := strings.IndexByte(s, '/'); i != -1 {
@@ -912,7 +912,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				ipAddr := dIPAddr.IPAddr.Hostmask()
 				return &tree.DIPAddr{IPAddr: ipAddr}, nil
@@ -927,7 +927,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				return tree.NewDInt(tree.DInt(dIPAddr.Mask)), nil
 			},
@@ -941,7 +941,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				ipAddr := dIPAddr.IPAddr.Netmask()
 				return &tree.DIPAddr{IPAddr: ipAddr}, nil
@@ -959,7 +959,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"prefixlen", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				mask := int(tree.MustBeDInt(args[1]))
 
@@ -979,7 +979,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.INet}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dIPAddr := tree.MustBeDIPAddr(args[0])
 				s := dIPAddr.IPAddr.String()
 				// Ensure the string has a "/mask" suffix.
@@ -1000,7 +1000,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"val", types.INet},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				first := tree.MustBeDIPAddr(args[0])
 				other := tree.MustBeDIPAddr(args[1])
 				return tree.MakeDBool(tree.DBool(first.Family == other.Family)), nil
@@ -1017,7 +1017,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"container", types.INet},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ipAddr := tree.MustBeDIPAddr(args[0]).IPAddr
 				other := tree.MustBeDIPAddr(args[1]).IPAddr
 				return tree.MakeDBool(tree.DBool(ipAddr.ContainedByOrEquals(&other))), nil
@@ -1035,7 +1035,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"val", types.INet},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ipAddr := tree.MustBeDIPAddr(args[0]).IPAddr
 				other := tree.MustBeDIPAddr(args[1]).IPAddr
 				return tree.MakeDBool(tree.DBool(ipAddr.ContainsOrEquals(&other))), nil
@@ -1050,8 +1050,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				inet, err := eval.PerformCast(ctx, args[0], types.INet)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				inet, err := eval.PerformCast(evalCtx, args[0], types.INet)
 				if err != nil {
 					return nil, pgerror.WithCandidateCode(err, pgcode.InvalidTextRepresentation)
 				}
@@ -1066,7 +1066,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ipstr := args[0].(*tree.DBytes)
 				nboip := net.IP(*ipstr)
 				sv := nboip.String()
@@ -1086,7 +1086,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ipdstr := tree.MustBeDString(args[0])
 				ip := net.ParseIP(string(ipdstr))
 				// If ipdstr could not be parsed to a valid IP,
@@ -1111,7 +1111,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"return_index_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				text := string(tree.MustBeDString(args[0]))
 				sep := string(tree.MustBeDString(args[1]))
 				field := int(tree.MustBeDInt(args[2]))
@@ -1138,7 +1138,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}, {"repeat_counter", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
 				s := string(tree.MustBeDString(args[0]))
 				count := int(tree.MustBeDInt(args[1]))
 
@@ -1167,7 +1167,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
 				data, format := *args[0].(*tree.DBytes), string(tree.MustBeDString(args[1]))
 				be, ok := lex.BytesEncodeFormatFromString(format)
 				if !ok {
@@ -1186,7 +1186,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"text", types.String}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
 				data, format := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				be, ok := lex.BytesEncodeFormatFromString(format)
 				if !ok {
@@ -1208,7 +1208,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"codec", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
 				uncompressedData := []byte(tree.MustBeDBytes(args[0]))
 				codec := string(tree.MustBeDString(args[1]))
 				switch strings.ToUpper(codec) {
@@ -1236,7 +1236,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"codec", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (_ tree.Datum, err error) {
 				compressedData := []byte(tree.MustBeDBytes(args[0]))
 				codec := string(tree.MustBeDString(args[1]))
 				switch strings.ToUpper(codec) {
@@ -1263,7 +1263,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"ascii": makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				for _, ch := range s {
 					return tree.NewDInt(tree.DInt(ch)), nil
 				}
@@ -1278,7 +1278,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := tree.MustBeDInt(args[0])
 				var answer string
 				switch {
@@ -1361,7 +1361,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				val := tree.MustBeDInt(args[0])
 				// This should technically match the precision of the types entered
 				// into the function, e.g. `-1 :: int4` should use uint32 for correctness.
@@ -1375,7 +1375,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(fmt.Sprintf("%x", tree.MustBeDBytes(args[0]))), nil
 			},
 			Info:       "Converts `val` to its hexadecimal representation.",
@@ -1384,7 +1384,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(fmt.Sprintf("%x", tree.MustBeDString(args[0]))), nil
 			},
 			Info:       "Converts `val` to its hexadecimal representation.",
@@ -1397,7 +1397,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				val := int(*args[0].(*tree.DInt))
 				var buf bytes.Buffer
 				var digits []string
@@ -1435,7 +1435,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		stringOverload2(
 			"input",
 			"find",
-			func(_ *eval.Context, s, substring string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s, substring string) (tree.Datum, error) {
 				index := strings.Index(s, substring)
 				if index < 0 {
 					return tree.DZero, nil
@@ -1449,7 +1449,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		bitsOverload2("input", "find",
-			func(_ *eval.Context, bitString, bitSubstring *tree.DBitArray) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, bitString, bitSubstring *tree.DBitArray) (tree.Datum, error) {
 				index := strings.Index(bitString.BitArray.String(), bitSubstring.BitArray.String())
 				if index < 0 {
 					return tree.DZero, nil
@@ -1463,7 +1463,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		bytesOverload2(
 			"input",
 			"find",
-			func(_ *eval.Context, byteString, byteSubstring string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, byteString, byteSubstring string) (tree.Datum, error) {
 				index := strings.Index(byteString, byteSubstring)
 				if index < 0 {
 					return tree.DZero, nil
@@ -1483,7 +1483,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"start_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				to := string(tree.MustBeDString(args[1]))
 				pos := int(tree.MustBeDInt(args[2]))
@@ -1503,7 +1503,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"end_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				to := string(tree.MustBeDString(args[1]))
 				pos := int(tree.MustBeDInt(args[2]))
@@ -1521,7 +1521,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				ret, err := lpad(s, length, " ")
@@ -1537,7 +1537,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}, {"fill", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				fill := string(tree.MustBeDString(args[2]))
@@ -1558,7 +1558,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				ret, err := rpad(s, length, " ")
@@ -1574,7 +1574,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"length", types.Int}, {"fill", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				length := int(tree.MustBeDInt(args[1]))
 				fill := string(tree.MustBeDString(args[2]))
@@ -1595,7 +1595,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		stringOverload2(
 			"input",
 			"trim_chars",
-			func(_ *eval.Context, s, chars string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s, chars string) (tree.Datum, error) {
 				return tree.NewDString(strings.Trim(s, chars)), nil
 			},
 			types.String,
@@ -1605,7 +1605,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(strings.TrimSpace(s)), nil
 			},
 			types.String,
@@ -1619,7 +1619,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		stringOverload2(
 			"input",
 			"trim_chars",
-			func(_ *eval.Context, s, chars string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s, chars string) (tree.Datum, error) {
 				return tree.NewDString(strings.TrimLeft(s, chars)), nil
 			},
 			types.String,
@@ -1629,7 +1629,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(strings.TrimLeftFunc(s, unicode.IsSpace)), nil
 			},
 			types.String,
@@ -1643,7 +1643,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		stringOverload2(
 			"input",
 			"trim_chars",
-			func(_ *eval.Context, s, chars string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s, chars string) (tree.Datum, error) {
 				return tree.NewDString(strings.TrimRight(s, chars)), nil
 			},
 			types.String,
@@ -1653,7 +1653,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(strings.TrimRightFunc(s, unicode.IsSpace)), nil
 			},
 			types.String,
@@ -1664,7 +1664,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"reverse": makeBuiltin(defProps(),
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				if len(s) > builtinconstants.MaxAllocatedStringSize {
 					return nil, errStringTooLarge
 				}
@@ -1685,7 +1685,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			"input",
 			"find",
 			"replace",
-			func(evalCtx *eval.Context, input, from, to string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, input, from, to string) (tree.Datum, error) {
 				// Reserve memory for the largest possible result.
 				var maxResultLen int64
 				if len(from) == 0 {
@@ -1712,7 +1712,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"translate": makeBuiltin(defProps(),
 		stringOverload3("input", "find", "replace",
-			func(evalCtx *eval.Context, s, from, to string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s, from, to string) (tree.Datum, error) {
 				const deletionRune = utf8.MaxRune + 1
 				translation := make(map[rune]rune, len(from))
 				for _, fromRune := range from {
@@ -1749,10 +1749,10 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}, {"regex", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
-				return regexpExtract(ctx, s, pattern, `\`)
+				return regexpExtract(evalCtx, s, pattern, `\`)
 			},
 			Info:       "Returns the first match for the Regular Expression `regex` in `input`.",
 			Volatility: volatility.Immutable,
@@ -1767,7 +1767,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"replace", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
 				to := string(tree.MustBeDString(args[2]))
@@ -1789,7 +1789,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"flags", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
 				to := string(tree.MustBeDString(args[2]))
@@ -1814,8 +1814,8 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"pattern", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.MakeArray(types.String)),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return regexpSplitToArray(ctx, args, false /* hasFlags */)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return regexpSplitToArray(evalCtx, args, false /* hasFlags */)
 			},
 			Info:       "Split string using a POSIX regular expression as the delimiter.",
 			Volatility: volatility.Immutable,
@@ -1827,8 +1827,8 @@ var regularBuiltins = map[string]builtinDefinition{
 				{"flags", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.MakeArray(types.String)),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return regexpSplitToArray(ctx, args, true /* hasFlags */)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return regexpSplitToArray(evalCtx, args, true /* hasFlags */)
 			},
 			Info:       "Split string using a POSIX regular expression as the delimiter with flags." + regexpFlagInfo,
 			Volatility: volatility.Immutable,
@@ -1838,7 +1838,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"like_escape": makeBuiltin(defProps(),
 		stringOverload3(
 			"unescaped", "pattern", "escape",
-			func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 				return eval.MatchLikeEscape(evalCtx, unescaped, pattern, escape, false)
 			},
 			types.Bool,
@@ -1850,7 +1850,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"not_like_escape": makeBuiltin(defProps(),
 		stringOverload3(
 			"unescaped", "pattern", "escape",
-			func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 				dmatch, err := eval.MatchLikeEscape(evalCtx, unescaped, pattern, escape, false)
 				if err != nil {
 					return dmatch, err
@@ -1866,7 +1866,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"ilike_escape": makeBuiltin(defProps(),
 		stringOverload3(
 			"unescaped", "pattern", "escape",
-			func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 				return eval.MatchLikeEscape(evalCtx, unescaped, pattern, escape, true)
 			},
 			types.Bool,
@@ -1877,7 +1877,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"not_ilike_escape": makeBuiltin(defProps(),
 		stringOverload3(
 			"unescaped", "pattern", "escape",
-			func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 				dmatch, err := eval.MatchLikeEscape(evalCtx, unescaped, pattern, escape, true)
 				if err != nil {
 					return dmatch, err
@@ -1900,7 +1900,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			similarOverloads(false),
 			stringOverload3(
 				"unescaped", "pattern", "escape",
-				func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+				func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 					return eval.SimilarToEscape(evalCtx, unescaped, pattern, escape)
 				},
 				types.Bool,
@@ -1913,7 +1913,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"not_similar_to_escape": makeBuiltin(defProps(),
 		stringOverload3(
 			"unescaped", "pattern", "escape",
-			func(evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, unescaped, pattern, escape string) (tree.Datum, error) {
 				dmatch, err := eval.SimilarToEscape(evalCtx, unescaped, pattern, escape)
 				if err != nil {
 					return dmatch, err
@@ -1928,7 +1928,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"initcap": makeBuiltin(defProps(),
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDString(cases.Title(language.English, cases.NoLower).String(strings.ToLower(s))), nil
 			},
 			types.String,
@@ -1938,7 +1938,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 	"quote_ident": makeBuiltin(defProps(),
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				var buf bytes.Buffer
 				lexbase.EncodeRestrictedSQLIdent(&buf, s, lexbase.EncNoFlags)
 				return tree.NewDString(buf.String()), nil
@@ -1953,7 +1953,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:             tree.ArgTypes{{"val", types.String}},
 			ReturnType:        tree.FixedReturnType(types.String),
 			PreferredOverload: true,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := tree.MustBeDString(args[0])
 				return tree.NewDString(lexbase.EscapeSQLString(string(s))), nil
 			},
@@ -1963,11 +1963,11 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// PostgreSQL specifies that this variant first casts to the SQL string type,
 				// and only then quotes. We can't use (Datum).String() directly.
-				d := eval.UnwrapDatum(ctx, args[0])
-				strD, err := eval.PerformCast(ctx, d, types.String)
+				d := eval.UnwrapDatum(evalCtx, args[0])
+				strD, err := eval.PerformCast(evalCtx, d, types.String)
 				if err != nil {
 					return nil, err
 				}
@@ -1987,7 +1987,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:             tree.ArgTypes{{"val", types.String}},
 			ReturnType:        tree.FixedReturnType(types.String),
 			PreferredOverload: true,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.NewDString("NULL"), nil
 				}
@@ -2001,14 +2001,14 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.NewDString("NULL"), nil
 				}
 				// PostgreSQL specifies that this variant first casts to the SQL string type,
 				// and only then quotes. We can't use (Datum).String() directly.
-				d := eval.UnwrapDatum(ctx, args[0])
-				strD, err := eval.PerformCast(ctx, d, types.String)
+				d := eval.UnwrapDatum(evalCtx, args[0])
+				strD, err := eval.PerformCast(evalCtx, d, types.String)
 				if err != nil {
 					return nil, err
 				}
@@ -2024,7 +2024,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Bytes}, {"return_set", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bytes := []byte(*args[0].(*tree.DBytes))
 				n := int(tree.MustBeDInt(args[1]))
 
@@ -2043,7 +2043,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}, {"return_set", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				runes := []rune(string(tree.MustBeDString(args[0])))
 				n := int(tree.MustBeDInt(args[1]))
 
@@ -2065,7 +2065,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Bytes}, {"return_set", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bytes := []byte(*args[0].(*tree.DBytes))
 				n := int(tree.MustBeDInt(args[1]))
 
@@ -2084,7 +2084,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}, {"return_set", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				runes := []rune(string(tree.MustBeDString(args[0])))
 				n := int(tree.MustBeDInt(args[1]))
 
@@ -2107,7 +2107,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDFloat(tree.DFloat(rand.Float64())), nil
 			},
 			Info: "Returns a random floating-point number between 0 (inclusive) and 1 (exclusive). " +
@@ -2123,8 +2123,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDInt(GenerateUniqueInt(ctx.NodeID.SQLInstanceID())), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDInt(GenerateUniqueInt(evalCtx.NodeID.SQLInstanceID())), nil
 			},
 			Info: "Returns a unique ID used by CockroachDB to generate unique row IDs if a " +
 				"Primary Key isn't defined for the table. The value is a combination of the " +
@@ -2142,8 +2142,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				v := GenerateUniqueUnorderedID(ctx.NodeID.SQLInstanceID())
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				v := GenerateUniqueUnorderedID(evalCtx.NodeID.SQLInstanceID())
 				return tree.NewDInt(v), nil
 			},
 			Info: "Returns a unique ID. The value is a combination of the " +
@@ -2165,7 +2165,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
 				if err != nil {
@@ -2183,7 +2183,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.RegClass}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
 				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
 				if err != nil {
@@ -2205,7 +2205,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
 				if err != nil {
@@ -2223,7 +2223,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.RegClass}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
 				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
 				if err != nil {
@@ -2243,7 +2243,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				val, err := evalCtx.SessionData().SequenceState.GetLastValue()
 				if err != nil {
 					return nil, err
@@ -2266,7 +2266,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.String}, {"value", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
 				if err != nil {
@@ -2287,7 +2287,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{builtinconstants.SequenceNameArg, types.RegClass}, {"value", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
@@ -2305,7 +2305,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{builtinconstants.SequenceNameArg, types.String}, {"value", types.Int}, {"is_called", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
 				if err != nil {
@@ -2329,7 +2329,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				{builtinconstants.SequenceNameArg, types.RegClass}, {"value", types.Int}, {"is_called", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
 				isCalled := bool(tree.MustBeDBool(args[2]))
 
@@ -2356,8 +2356,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.HomogeneousType{},
 			ReturnType: tree.FirstNonNullReturnType(),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return eval.PickFromTuple(ctx, true /* greatest */, args)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return eval.PickFromTuple(evalCtx, true /* greatest */, args)
 			},
 			Info:              "Returns the element with the greatest value.",
 			Volatility:        volatility.Immutable,
@@ -2372,8 +2372,8 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.HomogeneousType{},
 			ReturnType: tree.FirstNonNullReturnType(),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return eval.PickFromTuple(ctx, false /* greatest */, args)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return eval.PickFromTuple(evalCtx, false /* greatest */, args)
 			},
 			Info:              "Returns the element with the lowest value.",
 			Volatility:        volatility.Immutable,
@@ -2394,7 +2394,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"interval", types.Interval}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				d := tree.MustBeDInterval(args[0]).Duration
 				var buf bytes.Buffer
 				d.FormatWithStyle(&buf, duration.IntervalStyle_POSTGRES)
@@ -2406,7 +2406,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Timestamp}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestamp(args[0])
 				return tree.NewDString(tree.AsStringWithFlags(&ts, tree.FmtBareStrings)), nil
 			},
@@ -2416,7 +2416,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"date", types.Date}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDDate(args[0])
 				return tree.NewDString(tree.AsStringWithFlags(&ts, tree.FmtBareStrings)), nil
 			},
@@ -2430,7 +2430,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"interval", types.Interval}, {"style", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				d := tree.MustBeDInterval(args[0]).Duration
 				styleStr := string(tree.MustBeDString(args[1]))
 				styleVal, ok := duration.IntervalStyle_value[strings.ToUpper(styleStr)]
@@ -2451,7 +2451,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Timestamp}, {"datestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDTimestamp(args[0])
 				dateStyleStr := string(tree.MustBeDString(args[1]))
 				ds, err := pgdate.ParseDateStyle(dateStyleStr, pgdate.DefaultDateStyle())
@@ -2469,7 +2469,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"date", types.Date}, {"datestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := tree.MustBeDDate(args[0])
 				dateStyleStr := string(tree.MustBeDString(args[1]))
 				ds, err := pgdate.ParseDateStyle(dateStyleStr, pgdate.DefaultDateStyle())
@@ -2547,7 +2547,7 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Float}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts := float64(tree.MustBeDFloat(args[0]))
 				if math.IsNaN(ts) {
 					return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "timestamp cannot be NaN")
@@ -2571,10 +2571,10 @@ var regularBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.Interval),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return &tree.DInterval{
 					Duration: duration.Age(
-						ctx.GetTxnTimestamp(time.Microsecond).Time,
+						evalCtx.GetTxnTimestamp(time.Microsecond).Time,
 						args[0].(*tree.DTimestampTZ).Time,
 					),
 				}, nil
@@ -2589,7 +2589,7 @@ months and years, use ` + "`now() - timestamptz`" + `.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"end", types.TimestampTZ}, {"begin", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.Interval),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return &tree.DInterval{
 					Duration: duration.Age(
 						args[0].(*tree.DTimestampTZ).Time,
@@ -2631,8 +2631,8 @@ months and years, use the timestamptz subtraction operator.`,
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
 			PreferredOverload: true,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.MakeDTimestampTZ(ctx.GetStmtTimestamp(), time.Microsecond)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.MakeDTimestampTZ(evalCtx.GetStmtTimestamp(), time.Microsecond)
 			},
 			Info:       "Returns the start time of the current statement.",
 			Volatility: volatility.Stable,
@@ -2640,8 +2640,8 @@ months and years, use the timestamptz subtraction operator.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.MakeDTimestamp(ctx.GetStmtTimestamp(), time.Microsecond)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.MakeDTimestamp(evalCtx.GetStmtTimestamp(), time.Microsecond)
 			},
 			Info:       "Returns the start time of the current statement.",
 			Volatility: volatility.Stable,
@@ -2688,12 +2688,12 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 				{"min_timestamp", types.TimestampTZ},
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts, ok := tree.AsDTimestampTZ(args[0])
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
 				}
-				return withMinTimestamp(ctx, ts.Time)
+				return withMinTimestamp(ctx, evalCtx, ts.Time)
 			},
 			Info:       withMinTimestampInfo(false /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2704,12 +2704,12 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 				{"nearest_only", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ts, ok := tree.AsDTimestampTZ(args[0])
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
 				}
-				return withMinTimestamp(ctx, ts.Time)
+				return withMinTimestamp(ctx, evalCtx, ts.Time)
 			},
 			Info:       withMinTimestampInfo(true /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2723,12 +2723,12 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 				{"max_staleness", types.Interval},
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				interval, ok := tree.AsDInterval(args[0])
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
 				}
-				return withMaxStaleness(ctx, interval.Duration)
+				return withMaxStaleness(ctx, evalCtx, interval.Duration)
 			},
 			Info:       withMaxStalenessInfo(false /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2739,12 +2739,12 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 				{"nearest_only", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				interval, ok := tree.AsDInterval(args[0])
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
 				}
-				return withMaxStaleness(ctx, interval.Duration)
+				return withMaxStaleness(ctx, evalCtx, interval.Duration)
 			},
 			Info:       withMaxStalenessInfo(true /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2758,8 +2758,8 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Decimal),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return ctx.GetClusterTimestamp(), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetClusterTimestamp(), nil
 			},
 			Info: `Returns the logical time of the current transaction as
 a CockroachDB HLC in decimal form.
@@ -2775,7 +2775,7 @@ may increase either contention or retry errors, or both.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"hlc", types.Decimal}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				d := tree.MustBeDDecimal(args[0])
 				return eval.DecimalToInexactDTimestampTZ(&d)
 			},
@@ -2794,7 +2794,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
 			PreferredOverload: true,
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.MakeDTimestampTZ(timeutil.Now(), time.Microsecond)
 			},
 			Info:       "Returns the current system time on one of the cluster nodes.",
@@ -2803,7 +2803,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.MakeDTimestamp(timeutil.Now(), time.Microsecond)
 			},
 			Info:       "Returns the current system time on one of the cluster nodes.",
@@ -2816,8 +2816,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ctxTime := ctx.GetRelativeParseTime()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				ctxTime := evalCtx.GetRelativeParseTime()
 				// From postgres@a166d408eb0b35023c169e765f4664c3b114b52e src/backend/utils/adt/timestamp.c#L1637,
 				// we should support "%a %b %d %H:%M:%S.%%06d %Y %Z".
 				return tree.NewDString(ctxTime.Format("Mon Jan 2 15:04:05.000000 2006 -0700")), nil
@@ -2836,7 +2836,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Interval}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// extract timeSpan fromTime.
 				fromInterval := *args[1].(*tree.DInterval)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
@@ -2909,7 +2909,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Timestamp}},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				fromTS := args[1].(*tree.DTimestamp)
 				tsTZ, err := truncateTimestamp(fromTS.Time, timeSpan)
@@ -2927,11 +2927,11 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Date}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				date := args[1].(*tree.DDate)
 				// Localize the timestamp into the given location.
-				fromTSTZ, err := tree.MakeDTimestampTZFromDate(ctx.GetLocation(), date)
+				fromTSTZ, err := tree.MakeDTimestampTZFromDate(evalCtx.GetLocation(), date)
 				if err != nil {
 					return nil, err
 				}
@@ -2946,7 +2946,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Time}},
 			ReturnType: tree.FixedReturnType(types.Interval),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				fromTime := args[1].(*tree.DTime)
 				time, err := truncateTime(fromTime, timeSpan)
@@ -2963,10 +2963,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTSTZ := args[1].(*tree.DTimestampTZ)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
-				return truncateTimestamp(fromTSTZ.Time.In(ctx.GetLocation()), timeSpan)
+				return truncateTimestamp(fromTSTZ.Time.In(evalCtx.GetLocation()), timeSpan)
 			},
 			Info: "Truncates `input` to precision `element`.  Sets all fields that are less\n" +
 				"significant than `element` to zero (or one, for day and month)\n\n" +
@@ -2977,7 +2977,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Interval}},
 			ReturnType: tree.FixedReturnType(types.Interval),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromInterval := args[1].(*tree.DInterval)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				return truncateInterval(fromInterval, timeSpan)
@@ -2994,7 +2994,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"row", types.AnyTuple}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tuple := args[0].(*tree.DTuple)
 				builder := json.NewObjectBuilder(len(tuple.D))
 				typ := tuple.ResolvedType()
@@ -3009,8 +3009,8 @@ value if you rely on the HLC for accuracy.`,
 					}
 					val, err := tree.AsJSON(
 						d,
-						ctx.SessionData().DataConversionConfig,
-						ctx.GetLocation(),
+						evalCtx.SessionData().DataConversionConfig,
+						evalCtx.GetLocation(),
 					)
 					if err != nil {
 						return nil, err
@@ -3034,10 +3034,10 @@ value if you rely on the HLC for accuracy.`,
 				{"timestamptz_string", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tzArg := string(tree.MustBeDString(args[0]))
 				tsArg := string(tree.MustBeDString(args[1]))
-				ts, _, err := tree.ParseDTimestampTZ(ctx, tsArg, time.Microsecond)
+				ts, _, err := tree.ParseDTimestampTZ(evalCtx, tsArg, time.Microsecond)
 				if err != nil {
 					return nil, err
 				}
@@ -3056,7 +3056,7 @@ value if you rely on the HLC for accuracy.`,
 				{"timestamp", types.Timestamp},
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tzStr := string(tree.MustBeDString(args[0]))
 				ts := tree.MustBeDTimestamp(args[1])
 				loc, err := timeutil.TimeZoneStringToLocation(
@@ -3080,7 +3080,7 @@ value if you rely on the HLC for accuracy.`,
 				{"timestamptz", types.TimestampTZ},
 			},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tzStr := string(tree.MustBeDString(args[0]))
 				ts := tree.MustBeDTimestampTZ(args[1])
 				loc, err := timeutil.TimeZoneStringToLocation(
@@ -3101,7 +3101,7 @@ value if you rely on the HLC for accuracy.`,
 				{"time", types.Time},
 			},
 			ReturnType: tree.FixedReturnType(types.TimeTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tzStr := string(tree.MustBeDString(args[0]))
 				tArg := args[1].(*tree.DTime)
 				loc, err := timeutil.TimeZoneStringToLocation(
@@ -3112,7 +3112,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, err
 				}
 				tTime := timeofday.TimeOfDay(*tArg).ToTime()
-				_, beforeOffsetSecs := tTime.In(ctx.GetLocation()).Zone()
+				_, beforeOffsetSecs := tTime.In(evalCtx.GetLocation()).Zone()
 				durationDelta := time.Duration(-beforeOffsetSecs) * time.Second
 				return tree.NewDTimeTZ(timetz.MakeTimeTZFromTime(tTime.In(loc).Add(durationDelta))), nil
 			},
@@ -3128,7 +3128,7 @@ value if you rely on the HLC for accuracy.`,
 				{"timetz", types.TimeTZ},
 			},
 			ReturnType: tree.FixedReturnType(types.TimeTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// This one should disappear with implicit casts.
 				tzStr := string(tree.MustBeDString(args[0]))
 				tArg := args[1].(*tree.DTimeTZ)
@@ -3158,9 +3158,9 @@ value if you rely on the HLC for accuracy.`,
 	"parse_timestamp": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(ctx *eval.Context, s string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
 				ts, dependsOnContext, err := tree.ParseDTimestamp(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseTimeContext(evalCtx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -3182,10 +3182,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"datestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := string(tree.MustBeDString(args[0]))
 				dateStyle := string(tree.MustBeDString(args[1]))
-				parseCtx, err := parseContextFromDateStyle(ctx, dateStyle)
+				parseCtx, err := parseContextFromDateStyle(evalCtx, dateStyle)
 				if err != nil {
 					return nil, err
 				}
@@ -3213,9 +3213,9 @@ value if you rely on the HLC for accuracy.`,
 	"parse_date": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(ctx *eval.Context, s string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
 				ts, dependsOnContext, err := tree.ParseDDate(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseTimeContext(evalCtx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 				)
 				if err != nil {
@@ -3236,10 +3236,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"datestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.Date),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := string(tree.MustBeDString(args[0]))
 				dateStyle := string(tree.MustBeDString(args[1]))
-				parseCtx, err := parseContextFromDateStyle(ctx, dateStyle)
+				parseCtx, err := parseContextFromDateStyle(evalCtx, dateStyle)
 				if err != nil {
 					return nil, err
 				}
@@ -3263,9 +3263,9 @@ value if you rely on the HLC for accuracy.`,
 	"parse_time": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(ctx *eval.Context, s string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
 				t, dependsOnContext, err := tree.ParseDTime(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseTimeContext(evalCtx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -3287,10 +3287,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"timestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.Time),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := string(tree.MustBeDString(args[0]))
 				dateStyle := string(tree.MustBeDString(args[1]))
-				parseCtx, err := parseContextFromDateStyle(ctx, dateStyle)
+				parseCtx, err := parseContextFromDateStyle(evalCtx, dateStyle)
 				if err != nil {
 					return nil, err
 				}
@@ -3314,7 +3314,7 @@ value if you rely on the HLC for accuracy.`,
 	"parse_interval": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.ParseDInterval(duration.IntervalStyle_POSTGRES, s)
 			},
 			types.Interval,
@@ -3324,7 +3324,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"style", types.String}},
 			ReturnType: tree.FixedReturnType(types.Interval),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				styleStr := string(tree.MustBeDString(args[1]))
 				styleVal, ok := duration.IntervalStyle_value[strings.ToUpper(styleStr)]
@@ -3345,9 +3345,9 @@ value if you rely on the HLC for accuracy.`,
 	"parse_timetz": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(ctx *eval.Context, s string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
 				t, dependsOnContext, err := tree.ParseDTimeTZ(
-					tree.NewParseTimeContext(ctx.GetTxnTimestamp(time.Microsecond).Time),
+					tree.NewParseTimeContext(evalCtx.GetTxnTimestamp(time.Microsecond).Time),
 					s,
 					time.Microsecond,
 				)
@@ -3369,10 +3369,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"string", types.String}, {"timestyle", types.String}},
 			ReturnType: tree.FixedReturnType(types.TimeTZ),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := string(tree.MustBeDString(args[0]))
 				dateStyle := string(tree.MustBeDString(args[1]))
-				parseCtx, err := parseContextFromDateStyle(ctx, dateStyle)
+				parseCtx, err := parseContextFromDateStyle(evalCtx, dateStyle)
 				if err != nil {
 					return nil, err
 				}
@@ -3399,7 +3399,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"delimiter", types.String}},
 			ReturnType: tree.FixedReturnType(types.StringArray),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -3414,7 +3414,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"delimiter", types.String}, {"null", types.String}},
 			ReturnType: tree.FixedReturnType(types.StringArray),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -3433,7 +3433,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"delim", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -3448,7 +3448,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"delimiter", types.String}, {"null", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -3467,7 +3467,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"array_dimension", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLength(arr, dimen), nil
@@ -3483,7 +3483,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				return cardinality(arr), nil
 			},
@@ -3496,7 +3496,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"array_dimension", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLower(arr, dimen), nil
@@ -3512,7 +3512,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.AnyArray}, {"array_dimension", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				dimen := int64(tree.MustBeDInt(args[1]))
 				return arrayLength(arr, dimen), nil
@@ -3535,7 +3535,7 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return types.MakeArray(typ)
 			},
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.AppendToMaybeNullArray(typ, args[0], args[1])
 			},
 			Info:              "Appends `elem` to `array`, returning the result.",
@@ -3555,7 +3555,7 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return types.MakeArray(typ)
 			},
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.PrependToMaybeNullArray(typ, args[0], args[1])
 			},
 			Info:              "Prepends `elem` to `array`, returning the result.",
@@ -3580,7 +3580,7 @@ value if you rely on the HLC for accuracy.`,
 				}
 				return types.MakeArray(typ)
 			},
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.ConcatArrays(typ, args[0], args[1])
 			},
 			Info:              "Appends two arrays.",
@@ -3593,13 +3593,13 @@ value if you rely on the HLC for accuracy.`,
 		return tree.Overload{
 			Types:      tree.ArgTypes{{"array", types.MakeArray(typ)}, {"elem", typ}},
 			ReturnType: tree.IdentityReturnType(0),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
 				result := tree.NewDArray(typ)
 				for _, e := range tree.MustBeDArray(args[0]).Array {
-					cmp, err := e.CompareError(ctx, args[1])
+					cmp, err := e.CompareError(evalCtx, args[1])
 					if err != nil {
 						return nil, err
 					}
@@ -3621,13 +3621,13 @@ value if you rely on the HLC for accuracy.`,
 		return tree.Overload{
 			Types:      tree.ArgTypes{{"array", types.MakeArray(typ)}, {"toreplace", typ}, {"replacewith", typ}},
 			ReturnType: tree.IdentityReturnType(0),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
 				result := tree.NewDArray(typ)
 				for _, e := range tree.MustBeDArray(args[0]).Array {
-					cmp, err := e.CompareError(ctx, args[1])
+					cmp, err := e.CompareError(evalCtx, args[1])
 					if err != nil {
 						return nil, err
 					}
@@ -3653,12 +3653,12 @@ value if you rely on the HLC for accuracy.`,
 		return tree.Overload{
 			Types:      tree.ArgTypes{{"array", types.MakeArray(typ)}, {"elem", typ}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
 				for i, e := range tree.MustBeDArray(args[0]).Array {
-					cmp, err := e.CompareError(ctx, args[1])
+					cmp, err := e.CompareError(evalCtx, args[1])
 					if err != nil {
 						return nil, err
 					}
@@ -3678,13 +3678,13 @@ value if you rely on the HLC for accuracy.`,
 		return tree.Overload{
 			Types:      tree.ArgTypes{{"array", types.MakeArray(typ)}, {"elem", typ}},
 			ReturnType: tree.FixedReturnType(types.IntArray),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
 				result := tree.NewDArray(types.Int)
 				for i, e := range tree.MustBeDArray(args[0]).Array {
-					cmp, err := e.CompareError(ctx, args[1])
+					cmp, err := e.CompareError(evalCtx, args[1])
 					if err != nil {
 						return nil, err
 					}
@@ -3739,7 +3739,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"source", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				t := fuzzystrmatch.Soundex(s)
 				return tree.NewDString(t), nil
@@ -3756,7 +3756,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"source", types.String}, {"target", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, t := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				diff := fuzzystrmatch.Difference(s, t)
 				return tree.NewDString(strconv.Itoa(diff)), nil
@@ -3770,7 +3770,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"source", types.String}, {"target", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, t := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				const maxLen = 255
 				if len(s) > maxLen || len(t) > maxLen {
@@ -3787,7 +3787,7 @@ value if you rely on the HLC for accuracy.`,
 			Types: tree.ArgTypes{{"source", types.String}, {"target", types.String},
 				{"ins_cost", types.Int}, {"del_cost", types.Int}, {"sub_cost", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, t := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				ins, del, sub := int(tree.MustBeDInt(args[2])), int(tree.MustBeDInt(args[3])), int(tree.MustBeDInt(args[4]))
 				const maxLen = 255
@@ -3822,7 +3822,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Jsonb}, {"path", types.StringArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ary := *tree.MustBeDArray(args[1])
 				if err := checkHasNulls(ary); err != nil {
 					return nil, err
@@ -3857,7 +3857,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Jsonb}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, err := json.Pretty(tree.MustBeDJSON(args[0]).JSON)
 				if err != nil {
 					return nil, err
@@ -3907,7 +3907,7 @@ value if you rely on the HLC for accuracy.`,
 				{"array", types.StringArray},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(e *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.JSONExistsAny(tree.MustBeDJSON(args[0]), tree.MustBeDArray(args[1]))
 			},
 			Info:       "Returns whether any of the strings in the text array exist as top-level keys or array elements",
@@ -3922,8 +3922,8 @@ value if you rely on the HLC for accuracy.`,
 				{"string", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(e *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return jsonValidate(e, tree.MustBeDString(args[0])), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return jsonValidate(evalCtx, tree.MustBeDString(args[0])), nil
 			},
 			Info:       "Returns whether the given string is a valid JSON or not",
 			Volatility: volatility.Immutable,
@@ -3957,7 +3957,7 @@ value if you rely on the HLC for accuracy.`,
 						{"data", types.Bytes},
 					},
 					ReturnType: returnType,
-					Fn: func(context *eval.Context, args tree.Datums) (tree.Datum, error) {
+					Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 						return pbToJSON(
 							string(tree.MustBeDString(args[0])),
 							[]byte(tree.MustBeDBytes(args[1])),
@@ -3974,7 +3974,7 @@ value if you rely on the HLC for accuracy.`,
 						{"emit_defaults", types.Bool},
 					},
 					ReturnType: returnType,
-					Fn: func(context *eval.Context, args tree.Datums) (tree.Datum, error) {
+					Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 						return pbToJSON(
 							string(tree.MustBeDString(args[0])),
 							[]byte(tree.MustBeDBytes(args[1])),
@@ -3995,7 +3995,7 @@ value if you rely on the HLC for accuracy.`,
 						{"emit_redacted", types.Bool},
 					},
 					ReturnType: returnType,
-					Fn: func(context *eval.Context, args tree.Datums) (tree.Datum, error) {
+					Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 						return pbToJSON(
 							string(tree.MustBeDString(args[0])),
 							[]byte(tree.MustBeDBytes(args[1])),
@@ -4017,7 +4017,7 @@ value if you rely on the HLC for accuracy.`,
 				{"json", types.Jsonb},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				msg, err := protoreflect.NewMessage(string(tree.MustBeDString(args[0])))
 				if err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "invalid proto name")
@@ -4039,7 +4039,7 @@ value if you rely on the HLC for accuracy.`,
 				{"uri", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				uri := string(tree.MustBeDString(args[0]))
 				content, err := evalCtx.Planner.ExternalReadFile(evalCtx.Ctx(), uri)
 				return tree.NewDBytes(tree.DBytes(content)), err
@@ -4056,7 +4056,7 @@ value if you rely on the HLC for accuracy.`,
 				{"uri", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				data := tree.MustBeDBytes(args[0])
 				uri := string(tree.MustBeDString(args[1]))
 				if err := evalCtx.Planner.ExternalWriteFile(evalCtx.Ctx(), uri, []byte(data)); err != nil {
@@ -4080,7 +4080,7 @@ value if you rely on the HLC for accuracy.`,
 				"Supports NULLs and all data types which may be used in index keys",
 			Types:      tree.VariadicType{VarType: types.Any},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var out []byte
 				for i, arg := range args {
 					var err error
@@ -4103,7 +4103,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.JSONArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				var aggregatedStats roachpb.StatementStatistics
 				for _, statsDatum := range arr.Array {
@@ -4134,7 +4134,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.JSONArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				var aggregatedStats roachpb.TransactionStatistics
 				for _, statsDatum := range arr.Array {
@@ -4168,7 +4168,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.JSONArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				metadata := &roachpb.AggregatedStatementMetadata{}
 
@@ -4284,7 +4284,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"lower", types.AnyEnum}, {"upper", types.AnyEnum}},
 			ReturnType: tree.ArrayOfFirstNonNullReturnType(),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull && args[1] == tree.DNull {
 					return nil, pgerror.Newf(pgcode.NullValueNotAllowed, "both arguments cannot be NULL")
 				}
@@ -4359,7 +4359,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(build.GetInfo().Short()), nil
 			},
 			Info:       "Returns the node's version of CockroachDB.",
@@ -4373,11 +4373,11 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if len(ctx.SessionData().Database) == 0 {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if len(evalCtx.SessionData().Database) == 0 {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(ctx.SessionData().Database), nil
+				return tree.NewDString(evalCtx.SessionData().Database), nil
 			},
 			Info:       "Returns the current database.",
 			Volatility: volatility.Stable,
@@ -4399,8 +4399,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ctx := evalCtx.Ctx()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				curDb := evalCtx.SessionData().Database
 				iter := evalCtx.SessionData().SearchPath.IterWithoutImplicitPGSchemas()
 				for scName, ok := iter.Next(); ok; scName, ok = iter.Next() {
@@ -4436,8 +4435,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"include_pg_catalog", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.StringArray),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ctx := evalCtx.Ctx()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				curDb := evalCtx.SessionData().Database
 				includeImplicitPgSchemas := *(args[0].(*tree.DBool))
 				schemas := tree.NewDArray(types.String)
@@ -4470,11 +4468,11 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if ctx.SessionData().User().Undefined() {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if evalCtx.SessionData().User().Undefined() {
 					return tree.DNull, nil
 				}
-				return tree.NewDString(ctx.SessionData().User().Normalized()), nil
+				return tree.NewDString(evalCtx.SessionData().User().Normalized()), nil
 			},
 			Info: "Returns the current user. This function is provided for " +
 				"compatibility with PostgreSQL.",
@@ -4487,8 +4485,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				u := ctx.SessionData().SessionUser()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				u := evalCtx.SessionData().SessionUser()
 				if u.Undefined() {
 					return tree.DNull, nil
 				}
@@ -4506,9 +4504,9 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -4516,7 +4514,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, errInsufficientPriv
 				}
 
-				sp := tracing.SpanFromContext(ctx.Context)
+				sp := tracing.SpanFromContext(evalCtx.Context)
 				if sp == nil {
 					return tree.DNull, nil
 				}
@@ -4542,9 +4540,9 @@ value if you rely on the HLC for accuracy.`,
 				{"verbosity", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -4556,10 +4554,10 @@ value if you rely on the HLC for accuracy.`,
 				verbosity := bool(*(args[1].(*tree.DBool)))
 
 				var rootSpan tracing.RegistrySpan
-				if ctx.Tracer == nil {
+				if evalCtx.Tracer == nil {
 					return nil, errors.AssertionFailedf("Tracer not configured")
 				}
-				if err := ctx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
+				if err := evalCtx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
 					if span.TraceID() == traceID && rootSpan == nil {
 						rootSpan = span
 					}
@@ -4591,14 +4589,14 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"key", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				key := string(s)
-				for i := range ctx.Locality.Tiers {
-					tier := &ctx.Locality.Tiers[i]
+				for i := range evalCtx.Locality.Tiers {
+					tier := &evalCtx.Locality.Tiers[i]
 					if tier.Key == key {
 						return tree.NewDString(tier.Value), nil
 					}
@@ -4615,14 +4613,14 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"setting", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.AssertionFailedf("expected string value, got %T", args[0])
 				}
 				name := strings.ToLower(string(s))
 				rawSetting, ok := settings.Lookup(
-					name, settings.LookupForLocalAccess, ctx.Codec.ForSystemTenant(),
+					name, settings.LookupForLocalAccess, evalCtx.Codec.ForSystemTenant(),
 				)
 				if !ok {
 					return nil, errors.Newf("unknown cluster setting '%s'", name)
@@ -4649,7 +4647,7 @@ value if you rely on the HLC for accuracy.`,
 				{"value", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.AssertionFailedf("expected string value, got %T", args[0])
@@ -4660,7 +4658,7 @@ value if you rely on the HLC for accuracy.`,
 				}
 				name := strings.ToLower(string(s))
 				rawSetting, ok := settings.Lookup(
-					name, settings.LookupForLocalAccess, ctx.Codec.ForSystemTenant(),
+					name, settings.LookupForLocalAccess, evalCtx.Codec.ForSystemTenant(),
 				)
 				if !ok {
 					return nil, errors.Newf("unknown cluster setting '%s'", name)
@@ -4687,8 +4685,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				v := ctx.Settings.Version.BinaryVersion().String()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				v := evalCtx.Settings.Version.BinaryVersion().String()
 				return tree.NewDString(v), nil
 			},
 			Info:       "Returns the version of CockroachDB this node is running.",
@@ -4701,8 +4699,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				activeVersion := ctx.Settings.Version.ActiveVersionOrEmpty(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(evalCtx.Context)
 				jsonStr, err := gojson.Marshal(&activeVersion.Version)
 				if err != nil {
 					return nil, err
@@ -4723,7 +4721,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"version", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
@@ -4732,7 +4730,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				activeVersion := ctx.Settings.Version.ActiveVersionOrEmpty(ctx.Context)
+				activeVersion := evalCtx.Settings.Version.ActiveVersionOrEmpty(evalCtx.Context)
 				if activeVersion == (clusterversion.ClusterVersion{}) {
 					return nil, errors.AssertionFailedf("invalid uninitialized version")
 				}
@@ -4751,7 +4749,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"timestamp", types.Decimal}},
 			ReturnType: tree.FixedReturnType(types.Timestamp),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return eval.DecimalToInexactDTimestamp(args[0].(*tree.DDecimal))
 			},
 			Info:       "Converts the crdb_internal_mvcc_timestamp column into an approximate timestamp.",
@@ -4764,8 +4762,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDUuid(tree.DUuid{UUID: ctx.ClusterID}), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDUuid(tree.DUuid{UUID: evalCtx.ClusterID}), nil
 			},
 			Info:       "Returns the logical cluster ID for this tenant.",
 			Volatility: volatility.Stable,
@@ -4777,9 +4775,9 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				dNodeID := tree.DNull
-				if nodeID, ok := ctx.NodeID.OptionalNodeID(); ok {
+				if nodeID, ok := evalCtx.NodeID.OptionalNodeID(); ok {
 					dNodeID = tree.NewDInt(tree.DInt(nodeID))
 				}
 				return dNodeID, nil
@@ -4794,8 +4792,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDString(ctx.ClusterName), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return tree.NewDString(evalCtx.ClusterName), nil
 			},
 			Info:       "Returns the cluster name.",
 			Volatility: volatility.Volatile,
@@ -4812,7 +4810,7 @@ value if you rely on the HLC for accuracy.`,
 				{"id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := requireNonNull(args[0]); err != nil {
 					return nil, err
 				}
@@ -4820,7 +4818,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				if err := ctx.Tenant.CreateTenant(ctx.Context, uint64(sTenID)); err != nil {
+				if err := evalCtx.Tenant.CreateTenant(evalCtx.Context, uint64(sTenID)); err != nil {
 					return nil, err
 				}
 				return args[0], nil
@@ -4836,8 +4834,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				token, err := ctx.JoinTokenCreator.CreateJoinToken(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				token, err := evalCtx.JoinTokenCreator.CreateJoinToken(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -4858,13 +4856,13 @@ value if you rely on the HLC for accuracy.`,
 				{"id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sTenID, err := mustBeDIntInTenantRange(args[0])
 				if err != nil {
 					return nil, err
 				}
-				if err := ctx.Tenant.DestroyTenant(
-					ctx.Context, uint64(sTenID), false, /* synchronous */
+				if err := evalCtx.Tenant.DestroyTenant(
+					evalCtx.Context, uint64(sTenID), false, /* synchronous */
 				); err != nil {
 					return nil, err
 				}
@@ -4879,14 +4877,14 @@ value if you rely on the HLC for accuracy.`,
 				{"synchronous", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sTenID, err := mustBeDIntInTenantRange(args[0])
 				if err != nil {
 					return nil, err
 				}
 				synchronous := tree.MustBeDBool(args[1])
-				if err := ctx.Tenant.DestroyTenant(
-					ctx.Context, uint64(sTenID), bool(synchronous),
+				if err := evalCtx.Tenant.DestroyTenant(
+					evalCtx.Context, uint64(sTenID), bool(synchronous),
 				); err != nil {
 					return nil, err
 				}
@@ -4903,12 +4901,12 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"key", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
-				ok, err := ctx.Gossip.TryClearGossipInfo(ctx.Context, string(key))
+				ok, err := evalCtx.Gossip.TryClearGossipInfo(evalCtx.Context, string(key))
 				if err != nil {
 					return nil, err
 				}
@@ -4928,7 +4926,7 @@ value if you rely on the HLC for accuracy.`,
 				{"row_tuple", types.Any},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
 				rowDatums, ok := tree.AsDTuple(args[2])
@@ -4939,12 +4937,12 @@ value if you rely on the HLC for accuracy.`,
 						args[2],
 					)
 				}
-				res, err := ctx.CatalogBuiltins.EncodeTableIndexKey(
-					ctx.Ctx(), tableID, indexID, rowDatums,
+				res, err := evalCtx.CatalogBuiltins.EncodeTableIndexKey(
+					evalCtx.Ctx(), tableID, indexID, rowDatums,
 					func(
 						_ context.Context, d tree.Datum, t *types.T,
 					) (tree.Datum, error) {
-						return eval.PerformCast(ctx, d, t)
+						return eval.PerformCast(evalCtx, d, t)
 					},
 				)
 				if err != nil {
@@ -4964,7 +4962,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"errorCode", types.String}, {"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
@@ -4994,13 +4992,13 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				msg := string(s)
-				return crdbInternalSendNotice(ctx, "NOTICE", msg)
+				return crdbInternalSendNotice(evalCtx, "NOTICE", msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Volatile,
@@ -5008,7 +5006,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"severity", types.String}, {"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
@@ -5022,7 +5020,7 @@ value if you rely on the HLC for accuracy.`,
 				if _, ok := pgnotice.ParseDisplaySeverity(severityString); !ok {
 					return nil, pgerror.Newf(pgcode.InvalidParameterValue, "severity %s is invalid", severityString)
 				}
-				return crdbInternalSendNotice(ctx, severityString, msg)
+				return crdbInternalSendNotice(evalCtx, severityString, msg)
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Volatile,
@@ -5036,7 +5034,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
@@ -5056,7 +5054,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.DVoidDatum, nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -5071,8 +5069,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -5104,8 +5102,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"msg", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -5117,7 +5115,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				msg := string(s)
-				log.Fatalf(ctx.Ctx(), "force_log_fatal(): %s", msg)
+				log.Fatalf(evalCtx.Ctx(), "force_log_fatal(): %s", msg)
 				return nil, nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -5137,12 +5135,12 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Interval}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				minDuration := args[0].(*tree.DInterval).Duration
-				elapsed := duration.MakeDuration(int64(ctx.StmtTimestamp.Sub(ctx.TxnTimestamp)), 0, 0)
+				elapsed := duration.MakeDuration(int64(evalCtx.StmtTimestamp.Sub(evalCtx.TxnTimestamp)), 0, 0)
 				if elapsed.Compare(minDuration) < 0 {
-					return nil, ctx.Txn.GenerateForcedRetryableError(
-						ctx.Ctx(), "forced by crdb_internal.force_retry()")
+					return nil, evalCtx.Txn.GenerateForcedRetryableError(
+						evalCtx.Ctx(), "forced by crdb_internal.force_retry()")
 				}
 				return tree.DZero, nil
 			},
@@ -5159,7 +5157,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"key", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key := []byte(tree.MustBeDBytes(args[0]))
 				b := &kv.Batch{}
 				b.AddRawRequest(&roachpb.LeaseInfoRequest{
@@ -5167,11 +5165,11 @@ value if you rely on the HLC for accuracy.`,
 						Key: key,
 					},
 				})
-				if ctx.Txn == nil { // can occur during backfills
+				if evalCtx.Txn == nil { // can occur during backfills
 					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
 						"cannot use crdb_internal.lease_holder in this context")
 				}
-				if err := ctx.Txn.Run(ctx.Context, b); err != nil {
+				if err := evalCtx.Txn.Run(ctx, b); err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching leaseholder")
 				}
 				resp := b.RawResponse().Responses[0].GetInner().(*roachpb.LeaseInfoResponse)
@@ -5191,7 +5189,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Any}},
 			ReturnType: tree.IdentityReturnType(0),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return args[0], nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -5209,7 +5207,7 @@ value if you rely on the HLC for accuracy.`,
 				{"key", types.Bytes},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key := tree.MustBeDBytes(args[0])
 				remainder, _, err := keys.DecodeTenantPrefix([]byte(key))
 				if err != nil {
@@ -5225,7 +5223,7 @@ value if you rely on the HLC for accuracy.`,
 				{"keys", types.BytesArray},
 			},
 			ReturnType: tree.FixedReturnType(types.BytesArray),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				result := tree.NewDArray(types.Bytes)
 				for _, datum := range arr.Array {
@@ -5255,7 +5253,7 @@ value if you rely on the HLC for accuracy.`,
 				{"tenant_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.BytesArray),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sTenID, err := mustBeDIntInTenantRange(args[0])
 				if err != nil {
 					return nil, err
@@ -5287,7 +5285,7 @@ value if you rely on the HLC for accuracy.`,
 				{"table_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.BytesArray),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tabID := uint32(tree.MustBeDInt(args[0]))
 
 				start := evalCtx.Codec.TablePrefix(tabID)
@@ -5318,7 +5316,7 @@ value if you rely on the HLC for accuracy.`,
 				{"index_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.BytesArray),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tabID := uint32(tree.MustBeDInt(args[0]))
 				indexID := uint32(tree.MustBeDInt(args[1]))
 
@@ -5354,7 +5352,7 @@ value if you rely on the HLC for accuracy.`,
 				{"skip_fields", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(catalogkeys.PrettyKey(
 					nil, /* valDirs */
 					roachpb.Key(tree.MustBeDBytes(args[0])),
@@ -5378,7 +5376,7 @@ value if you rely on the HLC for accuracy.`,
 				{"skip_fields", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				span := roachpb.Span{
 					Key:    roachpb.Key(tree.MustBeDBytes(args[0])),
 					EndKey: roachpb.Key(tree.MustBeDBytes(args[1])),
@@ -5402,11 +5400,11 @@ value if you rely on the HLC for accuracy.`,
 			},
 			SpecializedVecBuiltin: tree.CrdbInternalRangeStats,
 			ReturnType:            tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
-				resps, err := ctx.RangeStatsFetcher.RangeStats(ctx.Ctx(),
+				resps, err := evalCtx.RangeStatsFetcher.RangeStats(evalCtx.Ctx(),
 					roachpb.Key(tree.MustBeDBytes(args[0])))
 				if err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching range stats")
@@ -5436,11 +5434,11 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"parent_id", types.Int}, {"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				parentID := tree.MustBeDInt(args[0])
 				name := tree.MustBeDString(args[1])
-				id, found, err := ctx.PrivilegedAccessor.LookupNamespaceID(
-					ctx.Context,
+				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
+					evalCtx.Context,
 					int64(parentID),
 					0,
 					string(name),
@@ -5461,12 +5459,12 @@ value if you rely on the HLC for accuracy.`,
 				{"parent_schema_id", types.Int},
 				{"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				parentID := tree.MustBeDInt(args[0])
 				parentSchemaID := tree.MustBeDInt(args[1])
 				name := tree.MustBeDString(args[2])
-				id, found, err := ctx.PrivilegedAccessor.LookupNamespaceID(
-					ctx.Context,
+				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
+					evalCtx.Context,
 					int64(parentID),
 					int64(parentSchemaID),
 					string(name),
@@ -5493,10 +5491,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				id, found, err := ctx.PrivilegedAccessor.LookupNamespaceID(
-					ctx.Context,
+				id, found, err := evalCtx.PrivilegedAccessor.LookupNamespaceID(
+					evalCtx.Context,
 					int64(0),
 					int64(0),
 					string(name),
@@ -5521,10 +5519,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"namespace_id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := tree.MustBeDInt(args[0])
-				bytes, found, err := ctx.PrivilegedAccessor.LookupZoneConfigByNamespaceID(
-					ctx.Context,
+				bytes, found, err := evalCtx.PrivilegedAccessor.LookupZoneConfigByNamespaceID(
+					evalCtx.Context,
 					int64(id),
 				)
 				if err != nil {
@@ -5546,8 +5544,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"vmodule_string", types.String}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -5578,9 +5576,9 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				// The user must be an admin to use this builtin.
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -5607,14 +5605,14 @@ value if you rely on the HLC for accuracy.`,
 				{"val", types.Geography},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull || args[2] == tree.DNull {
 					return tree.DZero, nil
 				}
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
 				g := tree.MustBeDGeography(args[2])
-				n, err := ctx.CatalogBuiltins.NumGeographyInvertedIndexEntries(ctx.Ctx(), tableID, indexID, g)
+				n, err := evalCtx.CatalogBuiltins.NumGeographyInvertedIndexEntries(evalCtx.Ctx(), tableID, indexID, g)
 				if err != nil {
 					return nil, err
 				}
@@ -5631,14 +5629,14 @@ value if you rely on the HLC for accuracy.`,
 				{"val", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull || args[2] == tree.DNull {
 					return tree.DZero, nil
 				}
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
 				g := tree.MustBeDGeometry(args[2])
-				n, err := ctx.CatalogBuiltins.NumGeometryInvertedIndexEntries(ctx.Ctx(), tableID, indexID, g)
+				n, err := evalCtx.CatalogBuiltins.NumGeometryInvertedIndexEntries(evalCtx.Ctx(), tableID, indexID, g)
 				if err != nil {
 					return nil, err
 				}
@@ -5657,8 +5655,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Jsonb}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return jsonNumInvertedIndexEntries(ctx, args[0])
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return jsonNumInvertedIndexEntries(evalCtx, args[0])
 			},
 			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility:        volatility.Stable,
@@ -5667,8 +5665,8 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.AnyArray}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return arrayNumInvertedIndexEntries(ctx, args[0], tree.DNull)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return arrayNumInvertedIndexEntries(evalCtx, args[0], tree.DNull)
 			},
 			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility:        volatility.Stable,
@@ -5680,13 +5678,13 @@ value if you rely on the HLC for accuracy.`,
 				{"version", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The version argument is currently ignored for JSON inverted indexes,
 				// since all prior versions of JSON inverted indexes include the same
 				// entries. (The version argument was introduced for array indexes,
 				// since prior versions of array indexes did not include keys for empty
 				// arrays.)
-				return jsonNumInvertedIndexEntries(ctx, args[0])
+				return jsonNumInvertedIndexEntries(evalCtx, args[0])
 			},
 			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility:        volatility.Stable,
@@ -5698,7 +5696,7 @@ value if you rely on the HLC for accuracy.`,
 				{"version", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// TODO(jordan): if we support inverted indexes on more than just trigram
 				// indexes, we will need to thread the inverted index kind through
 				// the backfiller into this function.
@@ -5719,8 +5717,8 @@ value if you rely on the HLC for accuracy.`,
 				{"version", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return arrayNumInvertedIndexEntries(ctx, args[0], args[1])
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return arrayNumInvertedIndexEntries(evalCtx, args[0], args[1])
 			},
 			Info:              "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility:        volatility.Stable,
@@ -5738,11 +5736,10 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				if evalCtx.SessionAccessor == nil {
 					return nil, errors.AssertionFailedf("session accessor not set")
 				}
-				ctx := evalCtx.Ctx()
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
@@ -5766,7 +5763,7 @@ value if you rely on the HLC for accuracy.`,
 				{"option", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if evalCtx.SessionAccessor == nil {
 					return nil, errors.AssertionFailedf("session accessor not set")
 				}
@@ -5775,7 +5772,6 @@ value if you rely on the HLC for accuracy.`,
 				if !ok {
 					return nil, errors.Newf("unrecognized role option %s", optionStr)
 				}
-				ctx := evalCtx.Ctx()
 				ok, err := evalCtx.SessionAccessor.HasRoleOption(ctx, option)
 				if err != nil {
 					return nil, err
@@ -5798,10 +5794,10 @@ value if you rely on the HLC for accuracy.`,
 			},
 			ReturnType: tree.IdentityReturnType(1),
 			FnWithExprs: eval.FnWithExprsOverload(func(
-				evalCtx *eval.Context, args tree.Exprs,
+				ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 			) (tree.Datum, error) {
 				targetType := args[1].(tree.TypedExpr).ResolvedType()
-				val, err := eval.Expr(evalCtx, args[0].(tree.TypedExpr))
+				val, err := eval.Expr(ctx, evalCtx, args[0].(tree.TypedExpr))
 				if err != nil {
 					return nil, err
 				}
@@ -5827,7 +5823,7 @@ value if you rely on the HLC for accuracy.`,
 				{"scale", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Decimal),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				value := args[0].(*tree.DDecimal)
 				scale := int32(tree.MustBeDInt(args[1]))
 				return roundDDecimal(value, scale)
@@ -5841,7 +5837,7 @@ value if you rely on the HLC for accuracy.`,
 				{"scale", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.DecimalArray),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				value := args[0].(*tree.DArray)
 				scale := int32(tree.MustBeDInt(args[1]))
 
@@ -5885,9 +5881,9 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.StringArray),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				prefix := ctx.Codec.StartupMigrationKeyPrefix()
-				keyvals, err := ctx.Txn.Scan(ctx.Context, prefix, prefix.PrefixEnd(), 0 /* maxRows */)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				prefix := evalCtx.Codec.StartupMigrationKeyPrefix()
+				keyvals, err := evalCtx.Txn.Scan(evalCtx.Context, prefix, prefix.PrefixEnd(), 0 /* maxRows */)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to get list of completed migrations")
 				}
@@ -5917,8 +5913,8 @@ value if you rely on the HLC for accuracy.`,
 				{"desc", types.Bytes},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeUpsertDescriptor(evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),
 					[]byte(*args[1].(*tree.DBytes)),
 					false /* force */); err != nil {
@@ -5936,8 +5932,8 @@ value if you rely on the HLC for accuracy.`,
 				{"force", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeUpsertDescriptor(ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeUpsertDescriptor(evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),
 					[]byte(*args[1].(*tree.DBytes)),
 					bool(*args[2].(*tree.DBool))); err != nil {
@@ -5960,8 +5956,8 @@ value if you rely on the HLC for accuracy.`,
 				{"id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeDeleteDescriptor(evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),
 					false, /* force */
 				); err != nil {
@@ -5978,8 +5974,8 @@ value if you rely on the HLC for accuracy.`,
 				{"force", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeDeleteDescriptor(ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeDeleteDescriptor(evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),
 					bool(*args[1].(*tree.DBool)),
 				); err != nil {
@@ -6006,9 +6002,9 @@ value if you rely on the HLC for accuracy.`,
 				{"force", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeUpsertNamespaceEntry(
-					ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeUpsertNamespaceEntry(
+					evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6030,9 +6026,9 @@ value if you rely on the HLC for accuracy.`,
 				{"desc_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeUpsertNamespaceEntry(
-					ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeUpsertNamespaceEntry(
+					evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6061,9 +6057,9 @@ value if you rely on the HLC for accuracy.`,
 				{"desc_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeDeleteNamespaceEntry(
-					ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeDeleteNamespaceEntry(
+					evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6086,9 +6082,9 @@ value if you rely on the HLC for accuracy.`,
 				{"force", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := ctx.Planner.UnsafeDeleteNamespaceEntry(
-					ctx.Context,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if err := evalCtx.Planner.UnsafeDeleteNamespaceEntry(
+					evalCtx.Context,
 					int64(*args[0].(*tree.DInt)),     // parentID
 					int64(*args[1].(*tree.DInt)),     // parentSchemaID
 					string(*args[2].(*tree.DString)), // name
@@ -6113,7 +6109,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"session_id", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sid := sqlliveness.SessionID(*(args[0].(*tree.DBytes)))
 				live, err := evalCtx.SQLLivenessReader.IsAlive(evalCtx.Context, sid)
 				if err != nil {
@@ -6138,12 +6134,12 @@ value if you rely on the HLC for accuracy.`,
 				{"id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sTenID, err := mustBeDIntInTenantRange(args[0])
 				if err != nil {
 					return nil, err
 				}
-				if err := ctx.Tenant.GCTenant(ctx.Context, uint64(sTenID)); err != nil {
+				if err := evalCtx.Tenant.GCTenant(evalCtx.Context, uint64(sTenID)); err != nil {
 					return nil, err
 				}
 				return args[0], nil
@@ -6169,7 +6165,7 @@ value if you rely on the HLC for accuracy.`,
 				{"as_of_consumed_request_units", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				sTenID, err := mustBeDIntInTenantRange(args[0])
 				if err != nil {
 					return nil, err
@@ -6180,8 +6176,8 @@ value if you rely on the HLC for accuracy.`,
 				asOf := tree.MustBeDTimestamp(args[4]).Time
 				asOfConsumed := float64(tree.MustBeDFloat(args[5]))
 
-				if err := ctx.Tenant.UpdateTenantResourceLimits(
-					ctx.Context,
+				if err := evalCtx.Tenant.UpdateTenantResourceLimits(
+					evalCtx.Context,
 					uint64(sTenID),
 					availableRU,
 					refillRate,
@@ -6212,8 +6208,8 @@ value if you rely on the HLC for accuracy.`,
 				{"end_key", types.Bytes},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -6224,8 +6220,8 @@ value if you rely on the HLC for accuracy.`,
 				storeID := int32(tree.MustBeDInt(args[1]))
 				startKey := []byte(tree.MustBeDBytes(args[2]))
 				endKey := []byte(tree.MustBeDBytes(args[3]))
-				if err := ctx.CompactEngineSpan(
-					ctx.Context, nodeID, storeID, startKey, endKey); err != nil {
+				if err := evalCtx.CompactEngineSpan(
+					evalCtx.Context, nodeID, storeID, startKey, endKey); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -6250,7 +6246,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"feature", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
@@ -6274,7 +6270,7 @@ value if you rely on the HLC for accuracy.`,
 				VarType: types.Any,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var numNulls int
 				for _, arg := range args {
 					if arg == tree.DNull {
@@ -6297,7 +6293,7 @@ value if you rely on the HLC for accuracy.`,
 				VarType: types.Any,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var numNonNulls int
 				for _, arg := range args {
 					if arg != tree.DNull {
@@ -6321,7 +6317,7 @@ value if you rely on the HLC for accuracy.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
 				region, found := evalCtx.Locality.Find("region")
 				if !found {
 					return nil, pgerror.Newf(
@@ -6342,7 +6338,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
 				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(evalCtx.Context)
 				if err != nil {
 					return nil, err
@@ -6375,7 +6371,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
 				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(evalCtx.Context)
 				if err != nil {
 					return nil, err
@@ -6414,7 +6410,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Regions.ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
 					evalCtx.Context,
 				); err != nil {
@@ -6437,7 +6433,7 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForTable(
@@ -6462,7 +6458,7 @@ table.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForDatabase(
@@ -6485,7 +6481,7 @@ enabled.`,
 			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		stringOverload1(
-			func(evalCtx *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				stmt, err := parser.ParseOne(s)
 				if err != nil {
 					// Return the same statement if it does not parse.
@@ -6525,7 +6521,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
 				if err != nil {
 					return nil, err
@@ -6536,7 +6532,6 @@ table's zone configuration this will return NULL.`,
 				if evalCtx.IndexUsageStatsController == nil {
 					return nil, errors.AssertionFailedf("index usage stats controller not set")
 				}
-				ctx := evalCtx.Ctx()
 				if err := evalCtx.IndexUsageStatsController.ResetIndexUsageStats(ctx); err != nil {
 					return nil, err
 				}
@@ -6554,7 +6549,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
 				if err != nil {
 					return nil, err
@@ -6565,7 +6560,6 @@ table's zone configuration this will return NULL.`,
 				if evalCtx.SQLStatsController == nil {
 					return nil, errors.AssertionFailedf("sql stats controller not set")
 				}
-				ctx := evalCtx.Ctx()
 				if err := evalCtx.SQLStatsController.ResetClusterSQLStats(ctx); err != nil {
 					return nil, err
 				}
@@ -6586,10 +6580,10 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
-				err := ctx.Planner.ForceDeleteTableData(ctx.Context, id)
+				err := evalCtx.Planner.ForceDeleteTableData(evalCtx.Context, id)
 				if err != nil {
 					return tree.DBoolFalse, err
 				}
@@ -6607,7 +6601,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.Planner.SerializeSessionState()
 			},
 			Info:       `This function serializes the variables in the current session.`,
@@ -6622,7 +6616,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"session", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				state := tree.MustBeDBytes(args[0])
 				return evalCtx.Planner.DeserializeSessionState(evalCtx.Ctx(), tree.NewDBytes(state))
 			},
@@ -6638,7 +6632,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return evalCtx.Planner.CreateSessionRevivalToken()
 			},
 			Info:       `Generate a token that can be used to create a new session for the current user.`,
@@ -6652,7 +6646,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"token", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				token := tree.MustBeDBytes(args[0])
 				return evalCtx.Planner.ValidateSessionRevivalToken(&token)
 			},
@@ -6668,7 +6662,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
@@ -6690,7 +6684,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
@@ -6716,10 +6710,9 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"password", types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arg := []byte(tree.MustBeDBytes(args[0]))
-				ctx := evalCtx.Ctx()
-				isHashed, _, _, schemeName, _, err := password.CheckPasswordHashValidity(ctx, arg)
+				isHashed, _, _, schemeName, _, err := password.CheckPasswordHashValidity(arg)
 				if err != nil {
 					return tree.DNull, pgerror.WithCandidateCode(err, pgcode.Syntax)
 				}
@@ -6740,11 +6733,10 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if evalCtx.SQLStatsController == nil {
 					return nil, errors.AssertionFailedf("sql stats controller not set")
 				}
-				ctx := evalCtx.Ctx()
 				if err := evalCtx.SQLStatsController.CreateSQLStatsCompactionSchedule(ctx); err != nil {
 
 					return tree.DNull, err
@@ -6763,11 +6755,10 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if evalCtx.SchemaTelemetryController == nil {
 					return nil, errors.AssertionFailedf("schema telemetry controller not set")
 				}
-				ctx := evalCtx.Ctx()
 				// The user must be an admin to use this builtin.
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
@@ -6798,7 +6789,7 @@ table's zone configuration this will return NULL.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if err := evalCtx.Planner.RevalidateUniqueConstraintsInCurrentDB(evalCtx.Ctx()); err != nil {
 					return nil, err
 				}
@@ -6817,7 +6808,7 @@ in the current database. Returns an error if validation fails.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"table_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
 				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
 				if err != nil {
@@ -6841,7 +6832,7 @@ table. Returns an error if validation fails.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"table_name", types.String}, {"constraint_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Void),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableName := tree.MustBeDString(args[0])
 				constraintName := tree.MustBeDString(args[1])
 				dOid, err := eval.ParseDOid(evalCtx, string(tableName), types.RegClass)
@@ -6867,7 +6858,7 @@ table. Returns an error if validation fails.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"table_name", types.String}, {"constraint_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableName := tree.MustBeDString(args[0])
 				constraintName := tree.MustBeDString(args[1])
 				dOid, err := eval.ParseDOid(evalCtx, string(tableName), types.RegClass)
@@ -6903,8 +6894,8 @@ active for the current transaction.`,
 				{"active", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -6915,7 +6906,7 @@ active for the current transaction.`,
 				queue := string(tree.MustBeDString(args[0]))
 				active := bool(tree.MustBeDBool(args[1]))
 
-				if err := ctx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
+				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					return store.SetQueueActive(active, queue)
 				}); err != nil {
 					return nil, err
@@ -6935,8 +6926,8 @@ One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC', 'raftlog',
 				{"store_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -6949,7 +6940,7 @@ One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC', 'raftlog',
 				storeID := roachpb.StoreID(tree.MustBeDInt(args[2]))
 
 				var foundStore bool
-				if err := ctx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
+				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					if storeID == store.StoreID() {
 						foundStore = true
 						return store.SetQueueActive(active, queue)
@@ -6984,8 +6975,8 @@ run from. One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC',
 				{"skip_should_queue", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -6998,9 +6989,9 @@ run from. One of 'mvccGC', 'merge', 'split', 'replicate', 'replicaGC',
 				skipShouldQueue := bool(tree.MustBeDBool(args[2]))
 
 				var foundRepl bool
-				if err := ctx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
+				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					var err error
-					_, err = store.Enqueue(ctx.Context, queue, rangeID, skipShouldQueue)
+					_, err = store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
 					if err == nil {
 						foundRepl = true
 						return nil
@@ -7034,8 +7025,8 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 				{"should_return_trace", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -7050,9 +7041,9 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 
 				var foundRepl bool
 				var rec tracingpb.Recording
-				if err := ctx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
+				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					var err error
-					rec, err = store.Enqueue(ctx.Context, queue, rangeID, skipShouldQueue)
+					rec, err = store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
 					if err == nil {
 						foundRepl = true
 						return nil
@@ -7090,8 +7081,8 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 				{"store_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -7105,10 +7096,10 @@ store housing the range on the node it's run from. One of 'mvccGC', 'merge', 'sp
 				storeID := roachpb.StoreID(tree.MustBeDInt(args[3]))
 
 				var foundStore bool
-				if err := ctx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
+				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					if storeID == store.StoreID() {
 						foundStore = true
-						_, err := store.Enqueue(ctx.Context, queue, rangeID, skipShouldQueue)
+						_, err := store.Enqueue(evalCtx.Context, queue, rangeID, skipShouldQueue)
 						return err
 					}
 					return nil
@@ -7142,7 +7133,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{"expiresAfter", types.Interval},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				hasViewActivity, err := evalCtx.SessionAccessor.HasRoleOption(
 					evalCtx.Ctx(), roleoption.VIEWACTIVITY)
 				if err != nil {
@@ -7208,8 +7199,8 @@ expires until the statement bundle is collected`,
 				{"compaction_concurrency", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 				if err != nil {
 					return nil, err
 				}
@@ -7222,8 +7213,8 @@ expires until the statement bundle is collected`,
 				if compactionConcurrency <= 0 {
 					return nil, errors.AssertionFailedf("compaction_concurrency must be > 0")
 				}
-				if err = ctx.SetCompactionConcurrency(
-					ctx.Context, nodeID, storeID, uint64(compactionConcurrency)); err != nil {
+				if err = evalCtx.SetCompactionConcurrency(
+					evalCtx.Context, nodeID, storeID, uint64(compactionConcurrency)); err != nil {
 					return nil, err
 				}
 				return tree.DBoolTrue, nil
@@ -7243,7 +7234,7 @@ expires until the statement bundle is collected`,
 var lengthImpls = func(incBitOverload bool) builtinDefinition {
 	overloads := []tree.Overload{
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(utf8.RuneCountInString(s))), nil
 			},
 			types.Int,
@@ -7251,7 +7242,7 @@ var lengthImpls = func(incBitOverload bool) builtinDefinition {
 			volatility.Immutable,
 		),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(len(s))), nil
 			},
 			types.Int,
@@ -7263,7 +7254,7 @@ var lengthImpls = func(incBitOverload bool) builtinDefinition {
 		overloads = append(
 			overloads,
 			bitsOverload1(
-				func(_ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, s *tree.DBitArray) (tree.Datum, error) {
 					return tree.NewDInt(tree.DInt(s.BitArray.BitLen())), nil
 				}, types.Int, "Calculates the number of bits in `val`.",
 				volatility.Immutable,
@@ -7281,7 +7272,7 @@ func makeSubStringImpls() builtinDefinition {
 				{"start_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				substring := getSubstringFromIndex(string(tree.MustBeDString(args[0])), int(tree.MustBeDInt(args[1])))
 				return tree.NewDString(substring), nil
 			},
@@ -7296,7 +7287,7 @@ func makeSubStringImpls() builtinDefinition {
 			},
 			SpecializedVecBuiltin: tree.SubstringStringIntInt,
 			ReturnType:            tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				str := string(tree.MustBeDString(args[0]))
 				start := int(tree.MustBeDInt(args[1]))
 				length := int(tree.MustBeDInt(args[2]))
@@ -7317,10 +7308,10 @@ func makeSubStringImpls() builtinDefinition {
 				{"regex", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
-				return regexpExtract(ctx, s, pattern, `\`)
+				return regexpExtract(evalCtx, s, pattern, `\`)
 			},
 			Info:       "Returns a substring of `input` that matches the regular expression `regex`.",
 			Volatility: volatility.Immutable,
@@ -7332,11 +7323,11 @@ func makeSubStringImpls() builtinDefinition {
 				{"escape_char", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
 				escape := string(tree.MustBeDString(args[2]))
-				return regexpExtract(ctx, s, pattern, escape)
+				return regexpExtract(evalCtx, s, pattern, escape)
 			},
 			Info: "Returns a substring of `input` that matches the regular expression `regex` using " +
 				"`escape_char` as your escape character instead of `\\`.",
@@ -7348,7 +7339,7 @@ func makeSubStringImpls() builtinDefinition {
 				{"start_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bitString := tree.MustBeDBitArray(args[0])
 				start := int(tree.MustBeDInt(args[1]))
 				substring := getSubstringFromIndex(bitString.BitArray.String(), start)
@@ -7364,7 +7355,7 @@ func makeSubStringImpls() builtinDefinition {
 				{"length", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.VarBit),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bitString := tree.MustBeDBitArray(args[0])
 				start := int(tree.MustBeDInt(args[1]))
 				length := int(tree.MustBeDInt(args[2]))
@@ -7385,7 +7376,7 @@ func makeSubStringImpls() builtinDefinition {
 				{"start_pos", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := string(*args[0].(*tree.DBytes))
 				start := int(tree.MustBeDInt(args[1]))
 				substring := getSubstringFromIndexBytes(byteString, start)
@@ -7401,7 +7392,7 @@ func makeSubStringImpls() builtinDefinition {
 				{"length", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				byteString := string(*args[0].(*tree.DBytes))
 				start := int(tree.MustBeDInt(args[1]))
 				length := int(tree.MustBeDInt(args[2]))
@@ -7423,13 +7414,13 @@ var formatImpls = makeBuiltin(tree.FunctionProperties{Category: builtinconstants
 	tree.Overload{
 		Types:      tree.VariadicType{FixedTypes: []*types.T{types.String}, VarType: types.Any},
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			if args[0] == tree.DNull {
 				return tree.DNull, nil
 			}
 			formatStr := tree.MustBeDString(args[0])
 			formatArgs := args[1:]
-			str, err := pgformat.Format(ctx, string(formatStr), formatArgs...)
+			str, err := pgformat.Format(evalCtx, string(formatStr), formatArgs...)
 			if err != nil {
 				return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error parsing format string")
 			}
@@ -7537,7 +7528,7 @@ func generateRandomUUID4Impl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				uv, err := uuid.NewV4()
 				if err != nil {
 					return nil, err
@@ -7558,7 +7549,7 @@ func strftimeImpl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Timestamp}, {"extract_format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTime := args[0].(*tree.DTimestamp).Time
 				format := string(tree.MustBeDString(args[1]))
 				t, err := strtime.Strftime(fromTime, format)
@@ -7574,7 +7565,7 @@ func strftimeImpl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Date}, {"extract_format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTime, err := args[0].(*tree.DDate).ToTime()
 				if err != nil {
 					return nil, err
@@ -7593,7 +7584,7 @@ func strftimeImpl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.TimestampTZ}, {"extract_format", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTime := args[0].(*tree.DTimestampTZ).Time
 				format := string(tree.MustBeDString(args[1]))
 				t, err := strtime.Strftime(fromTime, format)
@@ -7617,7 +7608,7 @@ func strptimeImpl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}, {"format", types.String}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				toParse := string(tree.MustBeDString(args[0]))
 				format := string(tree.MustBeDString(args[1]))
 				t, err := strtime.Strptime(toParse, format)
@@ -7641,7 +7632,7 @@ func uuidV4Impl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDBytes(tree.DBytes(uuid.MakeV4().GetBytes())), nil
 			},
 			Info:       "Returns a UUID.",
@@ -7658,7 +7649,7 @@ func generateConstantUUIDImpl(id uuid.UUID, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Uuid),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return tree.NewDUuid(tree.DUuid{UUID: id}), nil
 			},
 			Info:       info,
@@ -7694,8 +7685,8 @@ func txnTSOverloads(preferTZOverload bool) []tree.Overload {
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimestampTZ),
 			PreferredOverload: preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return ctx.GetTxnTimestamp(time.Microsecond), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetTxnTimestamp(time.Microsecond), nil
 			},
 			Info:       txnTSDoc + tzAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7704,8 +7695,8 @@ func txnTSOverloads(preferTZOverload bool) []tree.Overload {
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.Timestamp),
 			PreferredOverload: !preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return ctx.GetTxnTimestampNoZone(time.Microsecond), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetTxnTimestampNoZone(time.Microsecond), nil
 			},
 			Info:       txnTSDoc + noTZAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7728,12 +7719,12 @@ func txnTSWithPrecisionOverloads(preferTZOverload bool) []tree.Overload {
 				Types:             tree.ArgTypes{{"precision", types.Int}},
 				ReturnType:        tree.FixedReturnType(types.TimestampTZ),
 				PreferredOverload: preferTZOverload,
-				Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 					prec := int32(tree.MustBeDInt(args[0]))
 					if prec < 0 || prec > 6 {
 						return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "precision %d out of range", prec)
 					}
-					return ctx.GetTxnTimestamp(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
+					return evalCtx.GetTxnTimestamp(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
 				},
 				Info:       txnTSDoc + tzAdditionalDesc,
 				Volatility: volatility.Stable,
@@ -7742,12 +7733,12 @@ func txnTSWithPrecisionOverloads(preferTZOverload bool) []tree.Overload {
 				Types:             tree.ArgTypes{{"precision", types.Int}},
 				ReturnType:        tree.FixedReturnType(types.Timestamp),
 				PreferredOverload: !preferTZOverload,
-				Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 					prec := int32(tree.MustBeDInt(args[0]))
 					if prec < 0 || prec > 6 {
 						return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "precision %d out of range", prec)
 					}
-					return ctx.GetTxnTimestampNoZone(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
+					return evalCtx.GetTxnTimestampNoZone(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
 				},
 				Info:       txnTSDoc + noTZAdditionalDesc,
 				Volatility: volatility.Stable,
@@ -7755,12 +7746,12 @@ func txnTSWithPrecisionOverloads(preferTZOverload bool) []tree.Overload {
 			{
 				Types:      tree.ArgTypes{{"precision", types.Int}},
 				ReturnType: tree.FixedReturnType(types.Date),
-				Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 					prec := int32(tree.MustBeDInt(args[0]))
 					if prec < 0 || prec > 6 {
 						return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "precision %d out of range", prec)
 					}
-					return currentDate(ctx, args)
+					return currentDate(ctx, evalCtx, args)
 				},
 				Info:       txnTSDoc,
 				Volatility: volatility.Stable,
@@ -7796,8 +7787,8 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.TimeTZ),
 			PreferredOverload: preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return ctx.GetTxnTime(time.Microsecond), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetTxnTime(time.Microsecond), nil
 			},
 			Info:       "Returns the current transaction's time with time zone." + tzAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7806,8 +7797,8 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Types:             tree.ArgTypes{},
 			ReturnType:        tree.FixedReturnType(types.Time),
 			PreferredOverload: !preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return ctx.GetTxnTimeNoZone(time.Microsecond), nil
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetTxnTimeNoZone(time.Microsecond), nil
 			},
 			Info:       "Returns the current transaction's time with no time zone." + noTZAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7816,12 +7807,12 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Types:             tree.ArgTypes{{"precision", types.Int}},
 			ReturnType:        tree.FixedReturnType(types.TimeTZ),
 			PreferredOverload: preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				prec := int32(tree.MustBeDInt(args[0]))
 				if prec < 0 || prec > 6 {
 					return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "precision %d out of range", prec)
 				}
-				return ctx.GetTxnTime(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
+				return evalCtx.GetTxnTime(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
 			},
 			Info:       "Returns the current transaction's time with time zone." + tzAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7830,12 +7821,12 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 			Types:             tree.ArgTypes{{"precision", types.Int}},
 			ReturnType:        tree.FixedReturnType(types.Time),
 			PreferredOverload: !preferTZOverload,
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				prec := int32(tree.MustBeDInt(args[0]))
 				if prec < 0 || prec > 6 {
 					return nil, pgerror.Newf(pgcode.NumericValueOutOfRange, "precision %d out of range", prec)
 				}
-				return ctx.GetTxnTimeNoZone(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
+				return evalCtx.GetTxnTimeNoZone(tree.TimeFamilyPrecisionToRoundDuration(prec)), nil
 			},
 			Info:       "Returns the current transaction's time with no time zone." + noTZAdditionalDesc,
 			Volatility: volatility.Stable,
@@ -7843,9 +7834,9 @@ func txnTimeWithPrecisionBuiltin(preferTZOverload bool) builtinDefinition {
 	)
 }
 
-func currentDate(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-	t := ctx.GetTxnTimestamp(time.Microsecond).Time
-	t = t.In(ctx.GetLocation())
+func currentDate(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+	t := evalCtx.GetTxnTimestamp(time.Microsecond).Time
+	t = t.In(evalCtx.GetLocation())
 	return tree.NewDDateFromTime(t)
 }
 
@@ -7870,7 +7861,7 @@ var (
 var jsonExtractPathImpl = tree.Overload{
 	Types:      tree.VariadicType{FixedTypes: []*types.T{types.Jsonb}, VarType: types.String},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		result, err := jsonExtractPathHelper(args)
 		if err != nil {
 			return nil, err
@@ -7887,7 +7878,7 @@ var jsonExtractPathImpl = tree.Overload{
 var jsonExtractPathTextImpl = tree.Overload{
 	Types:      tree.VariadicType{FixedTypes: []*types.T{types.Jsonb}, VarType: types.String},
 	ReturnType: tree.FixedReturnType(types.String),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		result, err := jsonExtractPathHelper(args)
 		if err != nil {
 			return nil, err
@@ -7955,7 +7946,7 @@ var jsonSetImpl = tree.Overload{
 		{"to", types.Jsonb},
 	},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		return jsonDatumSet(args[0], args[1], args[2], tree.DBoolTrue)
 	},
 	Info:       "Returns the JSON value pointed to by the variadic arguments.",
@@ -7970,7 +7961,7 @@ var jsonSetWithCreateMissingImpl = tree.Overload{
 		{"create_missing", types.Bool},
 	},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		return jsonDatumSet(args[0], args[1], args[2], args[3])
 	},
 	Info: "Returns the JSON value pointed to by the variadic arguments. " +
@@ -8006,7 +7997,7 @@ var jsonInsertImpl = tree.Overload{
 		{"new_val", types.Jsonb},
 	},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		return insertToJSONDatum(args[0], args[1], args[2], tree.DBoolFalse)
 	},
 	Info:       "Returns the JSON value pointed to by the variadic arguments. `new_val` will be inserted before path target.",
@@ -8021,7 +8012,7 @@ var jsonInsertWithInsertAfterImpl = tree.Overload{
 		{"insert_after", types.Bool},
 	},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		return insertToJSONDatum(args[0], args[1], args[2], args[3])
 	},
 	Info: "Returns the JSON value pointed to by the variadic arguments. " +
@@ -8053,7 +8044,7 @@ func insertToJSONDatum(
 var jsonTypeOfImpl = tree.Overload{
 	Types:      tree.ArgTypes{{"val", types.Jsonb}},
 	ReturnType: tree.FixedReturnType(types.String),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		t := tree.MustBeDJSON(args[0]).JSON.Type()
 		switch t {
 		case json.NullJSONType:
@@ -8084,7 +8075,7 @@ func jsonProps() tree.FunctionProperties {
 var jsonBuildObjectImpl = tree.Overload{
 	Types:      tree.VariadicType{VarType: types.Any},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 		if len(args)%2 != 0 {
 			return nil, pgerror.New(pgcode.InvalidParameterValue,
 				"argument list must have even number of elements")
@@ -8099,8 +8090,8 @@ var jsonBuildObjectImpl = tree.Overload{
 
 			key, err := asJSONBuildObjectKey(
 				args[i],
-				ctx.SessionData().DataConversionConfig,
-				ctx.GetLocation(),
+				evalCtx.SessionData().DataConversionConfig,
+				evalCtx.GetLocation(),
 			)
 			if err != nil {
 				return nil, err
@@ -8108,8 +8099,8 @@ var jsonBuildObjectImpl = tree.Overload{
 
 			val, err := tree.AsJSON(
 				args[i+1],
-				ctx.SessionData().DataConversionConfig,
-				ctx.GetLocation(),
+				evalCtx.SessionData().DataConversionConfig,
+				evalCtx.GetLocation(),
 			)
 			if err != nil {
 				return nil, err
@@ -8128,8 +8119,8 @@ var jsonBuildObjectImpl = tree.Overload{
 var toJSONImpl = tree.Overload{
 	Types:      tree.ArgTypes{{"val", types.Any}},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-		return toJSONObject(ctx, args[0])
+	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		return toJSONObject(evalCtx, args[0])
 	},
 	Info:       "Returns the value as JSON or JSONB.",
 	Volatility: volatility.Stable,
@@ -8148,12 +8139,12 @@ var arrayToJSONImpls = makeBuiltin(jsonProps(),
 	tree.Overload{
 		Types:      tree.ArgTypes{{"array", types.AnyArray}, {"pretty_bool", types.Bool}},
 		ReturnType: tree.FixedReturnType(types.Jsonb),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			prettyPrint := bool(tree.MustBeDBool(args[1]))
 			if prettyPrint {
 				return nil, prettyPrintNotSupportedError
 			}
-			return toJSONObject(ctx, args[0])
+			return toJSONObject(evalCtx, args[0])
 		},
 		Info:       "Returns the array as JSON or JSONB.",
 		Volatility: volatility.Stable,
@@ -8163,13 +8154,13 @@ var arrayToJSONImpls = makeBuiltin(jsonProps(),
 var jsonBuildArrayImpl = tree.Overload{
 	Types:      tree.VariadicType{VarType: types.Any},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 		builder := json.NewArrayBuilder(len(args))
 		for _, arg := range args {
 			j, err := tree.AsJSON(
 				arg,
-				ctx.SessionData().DataConversionConfig,
-				ctx.GetLocation(),
+				evalCtx.SessionData().DataConversionConfig,
+				evalCtx.GetLocation(),
 			)
 			if err != nil {
 				return nil, err
@@ -8188,7 +8179,7 @@ func jsonObjectImpls() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"texts", types.StringArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				arr := tree.MustBeDArray(args[0])
 				if arr.Len()%2 != 0 {
 					return nil, errJSONObjectNotEvenNumberOfElements
@@ -8204,8 +8195,8 @@ func jsonObjectImpls() builtinDefinition {
 					}
 					val, err := tree.AsJSON(
 						arr.Array[i+1],
-						ctx.SessionData().DataConversionConfig,
-						ctx.GetLocation(),
+						evalCtx.SessionData().DataConversionConfig,
+						evalCtx.GetLocation(),
 					)
 					if err != nil {
 						return nil, err
@@ -8223,7 +8214,7 @@ func jsonObjectImpls() builtinDefinition {
 			Types: tree.ArgTypes{{"keys", types.StringArray},
 				{"values", types.StringArray}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				keys := tree.MustBeDArray(args[0])
 				values := tree.MustBeDArray(args[1])
 				if keys.Len() != values.Len() {
@@ -8240,8 +8231,8 @@ func jsonObjectImpls() builtinDefinition {
 					}
 					val, err := tree.AsJSON(
 						values.Array[i],
-						ctx.SessionData().DataConversionConfig,
-						ctx.GetLocation(),
+						evalCtx.SessionData().DataConversionConfig,
+						evalCtx.GetLocation(),
 					)
 					if err != nil {
 						return nil, err
@@ -8261,7 +8252,7 @@ func jsonObjectImpls() builtinDefinition {
 var jsonStripNullsImpl = tree.Overload{
 	Types:      tree.ArgTypes{{"from_json", types.Jsonb}},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		j, _, err := tree.MustBeDJSON(args[0]).StripNulls()
 		return tree.NewDJSON(j), err
 	},
@@ -8272,7 +8263,7 @@ var jsonStripNullsImpl = tree.Overload{
 var jsonArrayLengthImpl = tree.Overload{
 	Types:      tree.ArgTypes{{"json", types.Jsonb}},
 	ReturnType: tree.FixedReturnType(types.Int),
-	Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 		j := tree.MustBeDJSON(args[0])
 		switch j.Type() {
 		case json.ArrayJSONType:
@@ -8294,7 +8285,7 @@ func similarOverloads(calledOnNullInput bool) []tree.Overload {
 		{
 			Types:      tree.ArgTypes{{"pattern", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -8308,7 +8299,7 @@ func similarOverloads(calledOnNullInput bool) []tree.Overload {
 		{
 			Types:      tree.ArgTypes{{"pattern", types.String}, {"escape", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -8349,7 +8340,7 @@ func setProps(props tree.FunctionProperties, d builtinDefinition) builtinDefinit
 }
 
 func jsonOverload1(
-	f func(*eval.Context, json.JSON) (tree.Datum, error),
+	f func(context.Context, *eval.Context, json.JSON) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8357,8 +8348,8 @@ func jsonOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.Jsonb}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, tree.MustBeDJSON(args[0]).JSON)
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, tree.MustBeDJSON(args[0]).JSON)
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8366,7 +8357,7 @@ func jsonOverload1(
 }
 
 func stringOverload1(
-	f func(*eval.Context, string) (tree.Datum, error),
+	f func(context.Context, *eval.Context, string) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8374,8 +8365,8 @@ func stringOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.String}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, string(tree.MustBeDString(args[0])))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, string(tree.MustBeDString(args[0])))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8384,7 +8375,7 @@ func stringOverload1(
 
 func stringOverload2(
 	a, b string,
-	f func(*eval.Context, string, string) (tree.Datum, error),
+	f func(context.Context, *eval.Context, string, string) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8392,8 +8383,8 @@ func stringOverload2(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.String}, {b, types.String}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1])))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1])))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8402,7 +8393,7 @@ func stringOverload2(
 
 func stringOverload3(
 	a, b, c string,
-	f func(*eval.Context, string, string, string) (tree.Datum, error),
+	f func(context.Context, *eval.Context, string, string, string) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8410,8 +8401,8 @@ func stringOverload3(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.String}, {b, types.String}, {c, types.String}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1])), string(tree.MustBeDString(args[2])))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1])), string(tree.MustBeDString(args[2])))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8419,7 +8410,7 @@ func stringOverload3(
 }
 
 func bytesOverload1(
-	f func(*eval.Context, string) (tree.Datum, error),
+	f func(context.Context, *eval.Context, string) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8427,8 +8418,8 @@ func bytesOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.Bytes}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, string(*args[0].(*tree.DBytes)))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, string(*args[0].(*tree.DBytes)))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8437,7 +8428,7 @@ func bytesOverload1(
 
 func bytesOverload2(
 	a, b string,
-	f func(*eval.Context, string, string) (tree.Datum, error),
+	f func(context.Context, *eval.Context, string, string) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8445,8 +8436,8 @@ func bytesOverload2(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.Bytes}, {b, types.Bytes}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, string(*args[0].(*tree.DBytes)), string(*args[1].(*tree.DBytes)))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, string(*args[0].(*tree.DBytes)), string(*args[1].(*tree.DBytes)))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8454,7 +8445,7 @@ func bytesOverload2(
 }
 
 func bitsOverload1(
-	f func(*eval.Context, *tree.DBitArray) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DBitArray) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8462,8 +8453,8 @@ func bitsOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.VarBit}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, args[0].(*tree.DBitArray))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, args[0].(*tree.DBitArray))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8472,7 +8463,7 @@ func bitsOverload1(
 
 func bitsOverload2(
 	a, b string,
-	f func(*eval.Context, *tree.DBitArray, *tree.DBitArray) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DBitArray, *tree.DBitArray) (tree.Datum, error),
 	returnType *types.T,
 	info string,
 	volatility volatility.V,
@@ -8480,8 +8471,8 @@ func bitsOverload2(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.VarBit}, {b, types.VarBit}},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			return f(evalCtx, args[0].(*tree.DBitArray), args[1].(*tree.DBitArray))
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return f(ctx, evalCtx, args[0].(*tree.DBitArray), args[1].(*tree.DBitArray))
 		},
 		Info:       info,
 		Volatility: volatility,
@@ -8517,7 +8508,7 @@ func hashBuiltin(newHash func() hash.Hash, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.String},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8531,7 +8522,7 @@ func hashBuiltin(newHash func() hash.Hash, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8550,7 +8541,7 @@ func hash32Builtin(newHash func() hash.Hash32, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.String},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8564,7 +8555,7 @@ func hash32Builtin(newHash func() hash.Hash32, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8583,7 +8574,7 @@ func hash64Builtin(newHash func() hash.Hash64, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.String},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8597,7 +8588,7 @@ func hash64Builtin(newHash func() hash.Hash64, info string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.VariadicType{VarType: types.Bytes},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				h := newHash()
 				if ok, err := feedHash(h, args); !ok || err != nil {
 					return tree.DNull, err
@@ -8626,8 +8617,8 @@ func (k regexpEscapeKey) Pattern() (string, error) {
 	return pattern, nil
 }
 
-func regexpExtract(ctx *eval.Context, s, pattern, escape string) (tree.Datum, error) {
-	patternRe, err := ctx.ReCache.GetRegexp(regexpEscapeKey{pattern, escape})
+func regexpExtract(evalCtx *eval.Context, s, pattern, escape string) (tree.Datum, error) {
+	patternRe, err := evalCtx.ReCache.GetRegexp(regexpEscapeKey{pattern, escape})
 	if err != nil {
 		return nil, err
 	}
@@ -8653,22 +8644,24 @@ func (k regexpFlagKey) Pattern() (string, error) {
 	return regexpEvalFlags(k.sqlPattern, k.sqlFlags)
 }
 
-func regexpSplit(ctx *eval.Context, args tree.Datums, hasFlags bool) ([]string, error) {
+func regexpSplit(evalCtx *eval.Context, args tree.Datums, hasFlags bool) ([]string, error) {
 	s := string(tree.MustBeDString(args[0]))
 	pattern := string(tree.MustBeDString(args[1]))
 	sqlFlags := ""
 	if hasFlags {
 		sqlFlags = string(tree.MustBeDString(args[2]))
 	}
-	patternRe, err := ctx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
+	patternRe, err := evalCtx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
 	if err != nil {
 		return nil, err
 	}
 	return patternRe.Split(s, -1), nil
 }
 
-func regexpSplitToArray(ctx *eval.Context, args tree.Datums, hasFlags bool) (tree.Datum, error) {
-	words, err := regexpSplit(ctx, args, hasFlags /* hasFlags */)
+func regexpSplitToArray(
+	evalCtx *eval.Context, args tree.Datums, hasFlags bool,
+) (tree.Datum, error) {
+	words, err := regexpSplit(evalCtx, args, hasFlags /* hasFlags */)
 	if err != nil {
 		return nil, err
 	}
@@ -8681,8 +8674,8 @@ func regexpSplitToArray(ctx *eval.Context, args tree.Datums, hasFlags bool) (tre
 	return result, nil
 }
 
-func regexpReplace(ctx *eval.Context, s, pattern, to, sqlFlags string) (tree.Datum, error) {
-	patternRe, err := ctx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
+func regexpReplace(evalCtx *eval.Context, s, pattern, to, sqlFlags string) (tree.Datum, error) {
+	patternRe, err := evalCtx.ReCache.GetRegexp(regexpFlagKey{pattern, sqlFlags})
 	if err != nil {
 		return nil, err
 	}
@@ -8955,11 +8948,11 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Timestamp}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// extract timeSpan fromTime.
 				fromTS := args[1].(*tree.DTimestamp)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
-				return extractTimeSpanFromTimestamp(ctx, fromTS.Time, timeSpan)
+				return extractTimeSpanFromTimestamp(evalCtx, fromTS.Time, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
 				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
@@ -8970,7 +8963,7 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Interval}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromInterval := args[1].(*tree.DInterval)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				return extractTimeSpanFromInterval(fromInterval, timeSpan)
@@ -8983,14 +8976,14 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Date}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				date := args[1].(*tree.DDate)
 				fromTime, err := date.ToTime()
 				if err != nil {
 					return nil, err
 				}
-				return extractTimeSpanFromTimestamp(ctx, fromTime, timeSpan)
+				return extractTimeSpanFromTimestamp(evalCtx, fromTime, timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
 				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
@@ -9001,10 +8994,10 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.TimestampTZ}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTSTZ := args[1].(*tree.DTimestampTZ)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
-				return extractTimeSpanFromTimestampTZ(ctx, fromTSTZ.Time.In(ctx.GetLocation()), timeSpan)
+				return extractTimeSpanFromTimestampTZ(evalCtx, fromTSTZ.Time.In(evalCtx.GetLocation()), timeSpan)
 			},
 			Info: "Extracts `element` from `input`.\n\n" +
 				"Compatible elements: millennium, century, decade, year, isoyear,\n" +
@@ -9016,7 +9009,7 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.Time}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTime := args[1].(*tree.DTime)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				return extractTimeSpanFromTime(fromTime, timeSpan)
@@ -9028,7 +9021,7 @@ func extractBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"element", types.String}, {"input", types.TimeTZ}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				fromTime := args[1].(*tree.DTimeTZ)
 				timeSpan := strings.ToLower(string(tree.MustBeDString(args[0])))
 				return extractTimeSpanFromTimeTZ(fromTime, timeSpan)
@@ -9113,7 +9106,7 @@ func dateToJulianDay(year int, month int, day int) int {
 }
 
 func extractTimeSpanFromTimestampTZ(
-	ctx *eval.Context, fromTime time.Time, timeSpan string,
+	evalCtx *eval.Context, fromTime time.Time, timeSpan string,
 ) (tree.Datum, error) {
 	_, offsetSecs := fromTime.Zone()
 	if ret := extractTimezoneFromOffset(int32(offsetSecs), timeSpan); ret != nil {
@@ -9122,14 +9115,14 @@ func extractTimeSpanFromTimestampTZ(
 
 	switch timeSpan {
 	case "epoch":
-		return extractTimeSpanFromTimestamp(ctx, fromTime, timeSpan)
+		return extractTimeSpanFromTimestamp(evalCtx, fromTime, timeSpan)
 	default:
 		// time.Time's Year(), Month(), Day(), ISOWeek(), etc. all deal in terms
 		// of UTC, rather than as the timezone.
 		// Remedy this by assuming that the timezone is UTC (to prevent confusion)
 		// and offsetting time when using extractTimeSpanFromTimestamp.
 		pretendTime := fromTime.In(time.UTC).Add(time.Duration(offsetSecs) * time.Second)
-		return extractTimeSpanFromTimestamp(ctx, pretendTime, timeSpan)
+		return extractTimeSpanFromTimestamp(evalCtx, pretendTime, timeSpan)
 	}
 }
 
@@ -9281,7 +9274,7 @@ func extractTimeSpanFromTimestamp(
 // type.
 func makeEnumTypeFunc(impl func(t *types.T) (tree.Datum, error)) tree.FnWithExprsOverload {
 	return eval.FnWithExprsOverload(func(
-		evalCtx *eval.Context, args tree.Exprs,
+		ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 	) (tree.Datum, error) {
 		enumType := args[0].(tree.TypedExpr).ResolvedType()
 		if enumType == types.Unknown || enumType == types.AnyEnum {
@@ -9666,8 +9659,8 @@ func asJSONObjectKey(d tree.Datum) (string, error) {
 	}
 }
 
-func toJSONObject(ctx *eval.Context, d tree.Datum) (tree.Datum, error) {
-	j, err := tree.AsJSON(d, ctx.SessionData().DataConversionConfig, ctx.GetLocation())
+func toJSONObject(evalCtx *eval.Context, d tree.Datum) (tree.Datum, error) {
+	j, err := tree.AsJSON(d, evalCtx.SessionData().DataConversionConfig, evalCtx.GetLocation())
 	if err != nil {
 		return nil, err
 	}
@@ -9772,27 +9765,27 @@ var errInsufficientPriv = pgerror.New(
 // if an enterprise license is not installed.
 var EvalFollowerReadOffset func(logicalClusterID uuid.UUID, _ *cluster.Settings) (time.Duration, error)
 
-func recentTimestamp(ctx *eval.Context) (time.Time, error) {
+func recentTimestamp(evalCtx *eval.Context) (time.Time, error) {
 	if EvalFollowerReadOffset == nil {
 		telemetry.Inc(sqltelemetry.FollowerReadDisabledCCLCounter)
-		ctx.ClientNoticeSender.BufferClientNotice(
-			ctx.Context,
+		evalCtx.ClientNoticeSender.BufferClientNotice(
+			evalCtx.Context,
 			pgnotice.Newf("follower reads disabled because you are running a non-CCL distribution"),
 		)
-		return ctx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
+		return evalCtx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
 	}
-	offset, err := EvalFollowerReadOffset(ctx.ClusterID, ctx.Settings)
+	offset, err := EvalFollowerReadOffset(evalCtx.ClusterID, evalCtx.Settings)
 	if err != nil {
 		if code := pgerror.GetPGCode(err); code == pgcode.CCLValidLicenseRequired {
 			telemetry.Inc(sqltelemetry.FollowerReadDisabledNoEnterpriseLicense)
-			ctx.ClientNoticeSender.BufferClientNotice(
-				ctx.Context, pgnotice.Newf("follower reads disabled: %s", err.Error()),
+			evalCtx.ClientNoticeSender.BufferClientNotice(
+				evalCtx.Context, pgnotice.Newf("follower reads disabled: %s", err.Error()),
 			)
-			return ctx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
+			return evalCtx.StmtTimestamp.Add(builtinconstants.DefaultFollowerReadDuration), nil
 		}
 		return time.Time{}, err
 	}
-	return ctx.StmtTimestamp.Add(offset), nil
+	return evalCtx.StmtTimestamp.Add(offset), nil
 }
 
 func requireNonNull(d tree.Datum) error {
@@ -9802,8 +9795,10 @@ func requireNonNull(d tree.Datum) error {
 	return nil
 }
 
-func followerReadTimestamp(ctx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-	ts, err := recentTimestamp(ctx)
+func followerReadTimestamp(
+	ctx context.Context, evalCtx *eval.Context, _ tree.Datums,
+) (tree.Datum, error) {
+	ts, err := recentTimestamp(evalCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -9813,7 +9808,7 @@ func followerReadTimestamp(ctx *eval.Context, _ tree.Datums) (tree.Datum, error)
 var (
 	// WithMinTimestamp is an injectable function containing the implementation of the
 	// with_min_timestamp builtin.
-	WithMinTimestamp = func(ctx *eval.Context, t time.Time) (time.Time, error) {
+	WithMinTimestamp = func(_ context.Context, _ *eval.Context, t time.Time) (time.Time, error) {
 		return time.Time{}, pgerror.Newf(
 			pgcode.CCLRequired,
 			"%s can only be used with a CCL distribution",
@@ -9822,7 +9817,7 @@ var (
 	}
 	// WithMaxStaleness is an injectable function containing the implementation of the
 	// with_max_staleness builtin.
-	WithMaxStaleness = func(ctx *eval.Context, d duration.Duration) (time.Time, error) {
+	WithMaxStaleness = func(_ context.Context, _ *eval.Context, d duration.Duration) (time.Time, error) {
 		return time.Time{}, pgerror.Newf(
 			pgcode.CCLRequired,
 			"%s can only be used with a CCL distribution",
@@ -9867,16 +9862,18 @@ Note this function requires an enterprise license on a CCL distribution.`,
 	)
 }
 
-func withMinTimestamp(ctx *eval.Context, t time.Time) (tree.Datum, error) {
-	t, err := WithMinTimestamp(ctx, t)
+func withMinTimestamp(ctx context.Context, evalCtx *eval.Context, t time.Time) (tree.Datum, error) {
+	t, err := WithMinTimestamp(ctx, evalCtx, t)
 	if err != nil {
 		return nil, err
 	}
 	return tree.MakeDTimestampTZ(t, time.Microsecond)
 }
 
-func withMaxStaleness(ctx *eval.Context, d duration.Duration) (tree.Datum, error) {
-	t, err := WithMaxStaleness(ctx, d)
+func withMaxStaleness(
+	ctx context.Context, evalCtx *eval.Context, d duration.Duration,
+) (tree.Datum, error) {
+	t, err := WithMaxStaleness(ctx, evalCtx, d)
 	if err != nil {
 		return nil, err
 	}
@@ -9894,7 +9891,9 @@ func jsonNumInvertedIndexEntries(_ *eval.Context, val tree.Datum) (tree.Datum, e
 	return tree.NewDInt(tree.DInt(n)), nil
 }
 
-func arrayNumInvertedIndexEntries(ctx *eval.Context, val, version tree.Datum) (tree.Datum, error) {
+func arrayNumInvertedIndexEntries(
+	evalCtx *eval.Context, val, version tree.Datum,
+) (tree.Datum, error) {
 	if val == tree.DNull {
 		return tree.DZero, nil
 	}
@@ -9913,7 +9912,7 @@ func arrayNumInvertedIndexEntries(ctx *eval.Context, val, version tree.Datum) (t
 }
 
 func parseContextFromDateStyle(
-	ctx *eval.Context, dateStyleStr string,
+	evalCtx *eval.Context, dateStyleStr string,
 ) (tree.ParseTimeContext, error) {
 	ds, err := pgdate.ParseDateStyle(dateStyleStr, pgdate.DefaultDateStyle())
 	if err != nil {
@@ -9923,7 +9922,7 @@ func parseContextFromDateStyle(
 		return nil, unimplemented.NewWithIssue(41773, "only ISO style is supported")
 	}
 	return tree.NewParseTimeContext(
-		ctx.GetTxnTimestamp(time.Microsecond).Time,
+		evalCtx.GetTxnTimestamp(time.Microsecond).Time,
 		tree.NewParseTimeContextOptionDateStyle(ds),
 	), nil
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1051,7 +1051,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.INet),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				inet, err := eval.PerformCast(evalCtx, args[0], types.INet)
+				inet, err := eval.PerformCast(ctx, evalCtx, args[0], types.INet)
 				if err != nil {
 					return nil, pgerror.WithCandidateCode(err, pgcode.InvalidTextRepresentation)
 				}
@@ -1967,7 +1967,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				// PostgreSQL specifies that this variant first casts to the SQL string type,
 				// and only then quotes. We can't use (Datum).String() directly.
 				d := eval.UnwrapDatum(evalCtx, args[0])
-				strD, err := eval.PerformCast(evalCtx, d, types.String)
+				strD, err := eval.PerformCast(ctx, evalCtx, d, types.String)
 				if err != nil {
 					return nil, err
 				}
@@ -2008,7 +2008,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				// PostgreSQL specifies that this variant first casts to the SQL string type,
 				// and only then quotes. We can't use (Datum).String() directly.
 				d := eval.UnwrapDatum(evalCtx, args[0])
-				strD, err := eval.PerformCast(evalCtx, d, types.String)
+				strD, err := eval.PerformCast(ctx, evalCtx, d, types.String)
 				if err != nil {
 					return nil, err
 				}
@@ -2167,11 +2167,11 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(name), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(dOid.Oid))
+				res, err := evalCtx.Sequence.IncrementSequenceByID(ctx, int64(dOid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2185,7 +2185,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				res, err := evalCtx.Sequence.IncrementSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
+				res, err := evalCtx.Sequence.IncrementSequenceByID(ctx, int64(oid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2207,11 +2207,11 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(name), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(dOid.Oid))
+				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(ctx, int64(dOid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2225,7 +2225,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(evalCtx.Ctx(), int64(oid.Oid))
+				res, err := evalCtx.Sequence.GetLatestValueInSessionForSequenceByID(ctx, int64(oid.Oid))
 				if err != nil {
 					return nil, err
 				}
@@ -2268,14 +2268,14 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(name), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(dOid.Oid), int64(newVal), true /* isCalled */); err != nil {
+					ctx, uint32(dOid.Oid), int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2291,7 +2291,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				oid := tree.MustBeDOid(args[0])
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(oid.Oid), int64(newVal), true /* isCalled */); err != nil {
+					ctx, uint32(oid.Oid), int64(newVal), true /* isCalled */); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2307,7 +2307,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(name), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
@@ -2315,7 +2315,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(dOid.Oid), int64(newVal), isCalled); err != nil {
+					ctx, uint32(dOid.Oid), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -2335,7 +2335,7 @@ var regularBuiltins = map[string]builtinDefinition{
 
 				newVal := tree.MustBeDInt(args[1])
 				if err := evalCtx.Sequence.SetSequenceValueByID(
-					evalCtx.Ctx(), uint32(oid.Oid), int64(newVal), isCalled); err != nil {
+					ctx, uint32(oid.Oid), int64(newVal), isCalled); err != nil {
 					return nil, err
 				}
 				return args[1], nil
@@ -4041,7 +4041,7 @@ value if you rely on the HLC for accuracy.`,
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				uri := string(tree.MustBeDString(args[0]))
-				content, err := evalCtx.Planner.ExternalReadFile(evalCtx.Ctx(), uri)
+				content, err := evalCtx.Planner.ExternalReadFile(ctx, uri)
 				return tree.NewDBytes(tree.DBytes(content)), err
 			},
 			Info:       "Read the content of the file at the supplied external storage URI",
@@ -4059,7 +4059,7 @@ value if you rely on the HLC for accuracy.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				data := tree.MustBeDBytes(args[0])
 				uri := string(tree.MustBeDString(args[1]))
-				if err := evalCtx.Planner.ExternalWriteFile(evalCtx.Ctx(), uri, []byte(data)); err != nil {
+				if err := evalCtx.Planner.ExternalWriteFile(ctx, uri, []byte(data)); err != nil {
 					return nil, err
 				}
 				return tree.NewDInt(tree.DInt(len(data))), nil
@@ -4938,11 +4938,11 @@ value if you rely on the HLC for accuracy.`,
 					)
 				}
 				res, err := evalCtx.CatalogBuiltins.EncodeTableIndexKey(
-					evalCtx.Ctx(), tableID, indexID, rowDatums,
+					ctx, tableID, indexID, rowDatums,
 					func(
-						_ context.Context, d tree.Datum, t *types.T,
+						ctx context.Context, d tree.Datum, t *types.T,
 					) (tree.Datum, error) {
-						return eval.PerformCast(evalCtx, d, t)
+						return eval.PerformCast(ctx, evalCtx, d, t)
 					},
 				)
 				if err != nil {
@@ -5115,7 +5115,7 @@ value if you rely on the HLC for accuracy.`,
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				msg := string(s)
-				log.Fatalf(evalCtx.Ctx(), "force_log_fatal(): %s", msg)
+				log.Fatalf(ctx, "force_log_fatal(): %s", msg)
 				return nil, nil
 			},
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
@@ -5140,7 +5140,7 @@ value if you rely on the HLC for accuracy.`,
 				elapsed := duration.MakeDuration(int64(evalCtx.StmtTimestamp.Sub(evalCtx.TxnTimestamp)), 0, 0)
 				if elapsed.Compare(minDuration) < 0 {
 					return nil, evalCtx.Txn.GenerateForcedRetryableError(
-						evalCtx.Ctx(), "forced by crdb_internal.force_retry()")
+						ctx, "forced by crdb_internal.force_retry()")
 				}
 				return tree.DZero, nil
 			},
@@ -5404,7 +5404,7 @@ value if you rely on the HLC for accuracy.`,
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
-				resps, err := evalCtx.RangeStatsFetcher.RangeStats(evalCtx.Ctx(),
+				resps, err := evalCtx.RangeStatsFetcher.RangeStats(ctx,
 					roachpb.Key(tree.MustBeDBytes(args[0])))
 				if err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching range stats")
@@ -5612,7 +5612,7 @@ value if you rely on the HLC for accuracy.`,
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
 				g := tree.MustBeDGeography(args[2])
-				n, err := evalCtx.CatalogBuiltins.NumGeographyInvertedIndexEntries(evalCtx.Ctx(), tableID, indexID, g)
+				n, err := evalCtx.CatalogBuiltins.NumGeographyInvertedIndexEntries(ctx, tableID, indexID, g)
 				if err != nil {
 					return nil, err
 				}
@@ -5636,7 +5636,7 @@ value if you rely on the HLC for accuracy.`,
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
 				g := tree.MustBeDGeometry(args[2])
-				n, err := evalCtx.CatalogBuiltins.NumGeometryInvertedIndexEntries(evalCtx.Ctx(), tableID, indexID, g)
+				n, err := evalCtx.CatalogBuiltins.NumGeometryInvertedIndexEntries(ctx, tableID, indexID, g)
 				if err != nil {
 					return nil, err
 				}
@@ -5801,7 +5801,7 @@ value if you rely on the HLC for accuracy.`,
 				if err != nil {
 					return nil, err
 				}
-				return eval.PerformAssignmentCast(evalCtx, val, targetType)
+				return eval.PerformAssignmentCast(ctx, evalCtx, val, targetType)
 			}),
 			Info: "This function is used internally to perform assignment casts during mutations.",
 			// The volatility of an assignment cast depends on the argument
@@ -6522,7 +6522,7 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6550,7 +6550,7 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -6618,7 +6618,7 @@ table's zone configuration this will return NULL.`,
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				state := tree.MustBeDBytes(args[0])
-				return evalCtx.Planner.DeserializeSessionState(evalCtx.Ctx(), tree.NewDBytes(state))
+				return evalCtx.Planner.DeserializeSessionState(ctx, tree.NewDBytes(state))
 			},
 			Info:       `This function deserializes the serialized variables into the current session.`,
 			Volatility: volatility.Volatile,
@@ -6693,7 +6693,7 @@ table's zone configuration this will return NULL.`,
 					return nil, errInsufficientPriv
 				}
 				oid := tree.MustBeDOid(args[0])
-				if err := evalCtx.Planner.RepairTTLScheduledJobForTable(evalCtx.Ctx(), int64(oid.Oid)); err != nil {
+				if err := evalCtx.Planner.RepairTTLScheduledJobForTable(ctx, int64(oid.Oid)); err != nil {
 					return nil, err
 				}
 				return tree.DVoidDatum, nil
@@ -6790,7 +6790,7 @@ table's zone configuration this will return NULL.`,
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if err := evalCtx.Planner.RevalidateUniqueConstraintsInCurrentDB(evalCtx.Ctx()); err != nil {
+				if err := evalCtx.Planner.RevalidateUniqueConstraintsInCurrentDB(ctx); err != nil {
 					return nil, err
 				}
 				return tree.DVoidDatum, nil
@@ -6810,11 +6810,11 @@ in the current database. Returns an error if validation fails.`,
 			ReturnType: tree.FixedReturnType(types.Void),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				name := tree.MustBeDString(args[0])
-				dOid, err := eval.ParseDOid(evalCtx, string(name), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(name), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
-				if err := evalCtx.Planner.RevalidateUniqueConstraintsInTable(evalCtx.Ctx(), int(dOid.Oid)); err != nil {
+				if err := evalCtx.Planner.RevalidateUniqueConstraintsInTable(ctx, int(dOid.Oid)); err != nil {
 					return nil, err
 				}
 				return tree.DVoidDatum, nil
@@ -6835,12 +6835,12 @@ table. Returns an error if validation fails.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableName := tree.MustBeDString(args[0])
 				constraintName := tree.MustBeDString(args[1])
-				dOid, err := eval.ParseDOid(evalCtx, string(tableName), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(tableName), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
 				if err = evalCtx.Planner.RevalidateUniqueConstraint(
-					evalCtx.Ctx(), int(dOid.Oid), string(constraintName),
+					ctx, int(dOid.Oid), string(constraintName),
 				); err != nil {
 					return nil, err
 				}
@@ -6861,12 +6861,12 @@ table. Returns an error if validation fails.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableName := tree.MustBeDString(args[0])
 				constraintName := tree.MustBeDString(args[1])
-				dOid, err := eval.ParseDOid(evalCtx, string(tableName), types.RegClass)
+				dOid, err := eval.ParseDOid(ctx, evalCtx, string(tableName), types.RegClass)
 				if err != nil {
 					return nil, err
 				}
 				active, err := evalCtx.Planner.IsConstraintActive(
-					evalCtx.Ctx(), int(dOid.Oid), string(constraintName),
+					ctx, int(dOid.Oid), string(constraintName),
 				)
 				if err != nil {
 					return nil, err
@@ -7135,7 +7135,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				hasViewActivity, err := evalCtx.SessionAccessor.HasRoleOption(
-					evalCtx.Ctx(), roleoption.VIEWACTIVITY)
+					ctx, roleoption.VIEWACTIVITY)
 				if err != nil {
 					return nil, err
 				}
@@ -7145,13 +7145,13 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 						"VIEWACTIVITY or ADMIN role option")
 				}
 
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
 
 				hasViewActivityRedacted, err := evalCtx.SessionAccessor.HasRoleOption(
-					evalCtx.Ctx(), roleoption.VIEWACTIVITYREDACTED)
+					ctx, roleoption.VIEWACTIVITYREDACTED)
 				if err != nil {
 					return nil, err
 				}
@@ -7167,7 +7167,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				expiresAfter := time.Duration(tree.MustBeDInterval(args[3]).Nanos())
 
 				if err := evalCtx.StmtDiagnosticsRequestInserter(
-					evalCtx.Ctx(),
+					ctx,
 					stmtFingerprint,
 					samplingProbability,
 					minExecutionLatency,
@@ -7420,7 +7420,7 @@ var formatImpls = makeBuiltin(tree.FunctionProperties{Category: builtinconstants
 			}
 			formatStr := tree.MustBeDString(args[0])
 			formatArgs := args[1:]
-			str, err := pgformat.Format(evalCtx, string(formatStr), formatArgs...)
+			str, err := pgformat.Format(ctx, evalCtx, string(formatStr), formatArgs...)
 			if err != nil {
 				return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error parsing format string")
 			}

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1570,7 +1570,7 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 func makeJSONPopulateRecordGenerator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 ) (eval.ValueGenerator, error) {
-	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
+	tuple, j, err := jsonPopulateRecordEvalArgs(ctx, evalCtx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -1593,12 +1593,12 @@ func makeJSONPopulateRecordGenerator(
 // one of the jsonPopulateRecord variants, and returns the correctly-typed
 // tuple of default values, and the JSON input or nil if it was SQL NULL.
 func jsonPopulateRecordEvalArgs(
-	evalCtx *eval.Context, args tree.Exprs,
+	ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 ) (tuple *tree.DTuple, jsonInputOrNil json.JSON, err error) {
 	evalled := make(tree.Datums, len(args))
 	for i := range args {
 		var err error
-		evalled[i], err = eval.Expr(evalCtx.Context, evalCtx, args[i].(tree.TypedExpr))
+		evalled[i], err = eval.Expr(ctx, evalCtx, args[i].(tree.TypedExpr))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1665,7 +1665,7 @@ func (j jsonPopulateRecordGenerator) Values() (tree.Datums, error) {
 func makeJSONPopulateRecordSetGenerator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 ) (eval.ValueGenerator, error) {
-	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
+	tuple, j, err := jsonPopulateRecordEvalArgs(ctx, evalCtx, args)
 	if err != nil {
 		return nil, err
 	}
@@ -2184,7 +2184,7 @@ func makeRangeKeyIterator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2254,7 +2254,7 @@ func makePayloadsForSpanGenerator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2355,7 +2355,7 @@ func makePayloadsForTraceGenerator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -106,7 +106,7 @@ var generators = map[string]builtinDefinition{
 		makeGeneratorOverload(
 			tree.ArgTypes{{"aclitems", types.StringArray}},
 			aclexplodeGeneratorType,
-			func(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			func(_ context.Context, _ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 				return aclexplodeGenerator{}, nil
 			},
 			"Produces a virtual table containing aclitem stuff ("+
@@ -121,7 +121,7 @@ var generators = map[string]builtinDefinition{
 				{"end_key", types.Bytes},
 			},
 			spanKeyIteratorType,
-			func(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
 				if err != nil {
 					return nil, err
@@ -144,7 +144,7 @@ var generators = map[string]builtinDefinition{
 				{"span", types.BytesArray},
 			},
 			spanKeyIteratorType,
-			func(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
 				if err != nil {
 					return nil, err
@@ -205,13 +205,13 @@ var generators = map[string]builtinDefinition{
 		makeGeneratorOverload(
 			tree.ArgTypes{{"name", types.String}},
 			types.Int,
-			func(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 				s, ok := tree.AsDString(args[0])
 				if !ok {
 					return nil, errors.Newf("expected string value, got %T", args[0])
 				}
 				name := string(s)
-				gen, ok := ctx.TestingKnobs.CallbackGenerators[name]
+				gen, ok := evalCtx.TestingKnobs.CallbackGenerators[name]
 				if !ok {
 					return nil, errors.Errorf("callback %q not registered", name)
 				}
@@ -587,16 +587,18 @@ func (g *gistPlanGenerator) Values() (tree.Datums, error) {
 	return tree.Datums{tree.NewDString(g.rows[g.index])}, nil
 }
 
-func makeDecodePlanGistGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeDecodePlanGistGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	gist := string(tree.MustBeDString(args[0]))
-	return &gistPlanGenerator{gist: gist, evalCtx: ctx, external: false}, nil
+	return &gistPlanGenerator{gist: gist, evalCtx: evalCtx, external: false}, nil
 }
 
 func makeDecodeExternalPlanGistGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	gist := string(tree.MustBeDString(args[0]))
-	return &gistPlanGenerator{gist: gist, evalCtx: ctx, external: true}, nil
+	return &gistPlanGenerator{gist: gist, evalCtx: evalCtx, external: true}, nil
 }
 
 func makeGeneratorOverload(
@@ -605,12 +607,12 @@ func makeGeneratorOverload(
 	return makeGeneratorOverloadWithReturnType(in, tree.FixedReturnType(ret), g, info, volatility)
 }
 
-var unsuitableUseOfGeneratorFn = func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+var unsuitableUseOfGeneratorFn = func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("generator functions cannot be evaluated as scalars")
 }
 
 var unsuitableUseOfGeneratorFnWithExprs eval.FnWithExprsOverload = func(
-	_ *eval.Context, _ tree.Exprs,
+	_ context.Context, _ *eval.Context, _ tree.Exprs,
 ) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("generator functions cannot be evaluated as scalars")
 }
@@ -639,9 +641,9 @@ type regexpSplitToTableGenerator struct {
 
 func makeRegexpSplitToTableGeneratorFactory(hasFlags bool) eval.GeneratorOverload {
 	return func(
-		ctx *eval.Context, args tree.Datums,
+		ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 	) (eval.ValueGenerator, error) {
-		words, err := regexpSplit(ctx, args, hasFlags)
+		words, err := regexpSplit(evalCtx, args, hasFlags)
 		if err != nil {
 			return nil, err
 		}
@@ -680,7 +682,9 @@ type optionsToTableGenerator struct {
 	idx int
 }
 
-func makeOptionsToTableGenerator(_ *eval.Context, d tree.Datums) (eval.ValueGenerator, error) {
+func makeOptionsToTableGenerator(
+	_ context.Context, _ *eval.Context, d tree.Datums,
+) (eval.ValueGenerator, error) {
 	arr := tree.MustBeDArray(d[0])
 	return &optionsToTableGenerator{arr: arr, idx: -1}, nil
 }
@@ -745,7 +749,9 @@ var keywordsValueGeneratorType = types.MakeLabeledTuple(
 	[]string{"word", "catcode", "catdesc"},
 )
 
-func makeKeywordsGenerator(_ *eval.Context, _ tree.Datums) (eval.ValueGenerator, error) {
+func makeKeywordsGenerator(
+	_ context.Context, _ *eval.Context, _ tree.Datums,
+) (eval.ValueGenerator, error) {
 	return &keywordsValueGenerator{}, nil
 }
 
@@ -862,7 +868,9 @@ func seriesGenTSTZValue(s *seriesValueGenerator) (tree.Datums, error) {
 	return tree.Datums{ts}, nil
 }
 
-func makeSeriesGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeSeriesGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	start := int64(tree.MustBeDInt(args[0]))
 	stop := int64(tree.MustBeDInt(args[1]))
 	step := int64(1)
@@ -882,7 +890,9 @@ func makeSeriesGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator
 	}, nil
 }
 
-func makeTSSeriesGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeTSSeriesGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	start := args[0].(*tree.DTimestamp).Time
 	stop := args[1].(*tree.DTimestamp).Time
 	step := args[2].(*tree.DInterval).Duration
@@ -901,7 +911,9 @@ func makeTSSeriesGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerat
 	}, nil
 }
 
-func makeTSTZSeriesGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeTSTZSeriesGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	start := args[0].(*tree.DTimestampTZ).Time
 	stop := args[1].(*tree.DTimestampTZ).Time
 	step := args[2].(*tree.DInterval).Duration
@@ -946,7 +958,9 @@ func (s *seriesValueGenerator) Values() (tree.Datums, error) {
 	return s.genValue(s)
 }
 
-func makeVariadicUnnestGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeVariadicUnnestGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	var arrays []*tree.DArray
 	for _, a := range args {
 		arrays = append(arrays, tree.MustBeDArray(a))
@@ -1008,7 +1022,9 @@ func (s *multipleArrayValueGenerator) Values() (tree.Datums, error) {
 	return s.datums, nil
 }
 
-func makeArrayGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeArrayGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	arr := tree.MustBeDArray(args[0])
 	return &arrayValueGenerator{array: arr}, nil
 }
@@ -1049,7 +1065,7 @@ func (s *arrayValueGenerator) Values() (tree.Datums, error) {
 }
 
 func makeExpandArrayGenerator(
-	evalCtx *eval.Context, args tree.Datums,
+	_ context.Context, _ *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	arr := tree.MustBeDArray(args[0])
 	g := &expandArrayValueGenerator{avg: arrayValueGenerator{array: arr}}
@@ -1098,7 +1114,7 @@ func (s *expandArrayValueGenerator) Values() (tree.Datums, error) {
 }
 
 func makeGenerateSubscriptsGenerator(
-	evalCtx *eval.Context, args tree.Datums,
+	_ context.Context, _ *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	var arr *tree.DArray
 	dim := 1
@@ -1185,7 +1201,9 @@ type unaryValueGenerator struct {
 
 var unaryValueGeneratorType = types.EmptyTuple
 
-func makeUnaryGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeUnaryGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	return &unaryValueGenerator{}, nil
 }
 
@@ -1264,11 +1282,15 @@ type jsonArrayGenerator struct {
 var errJSONCallOnNonArray = pgerror.New(pgcode.InvalidParameterValue,
 	"cannot be called on a non-array")
 
-func makeJSONArrayAsJSONGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONArrayAsJSONGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	return makeJSONArrayGenerator(args, false)
 }
 
-func makeJSONArrayAsTextGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONArrayAsTextGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	return makeJSONArrayGenerator(args, true)
 }
 
@@ -1339,7 +1361,9 @@ type jsonObjectKeysGenerator struct {
 	iter *json.ObjectIterator
 }
 
-func makeJSONObjectKeysGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONObjectKeysGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	target := tree.MustBeDJSON(args[0])
 	iter, err := target.ObjectIter()
 	if err != nil {
@@ -1436,11 +1460,15 @@ type jsonEachGenerator struct {
 	asText bool
 }
 
-func makeJSONEachImplGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONEachImplGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	return makeJSONEachGenerator(args, false)
 }
 
-func makeJSONEachTextImplGenerator(_ *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONEachTextImplGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	return makeJSONEachGenerator(args, true)
 }
 
@@ -1540,7 +1568,7 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 }
 
 func makeJSONPopulateRecordGenerator(
-	evalCtx *eval.Context, args tree.Exprs,
+	ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 ) (eval.ValueGenerator, error) {
 	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
 	if err != nil {
@@ -1570,7 +1598,7 @@ func jsonPopulateRecordEvalArgs(
 	evalled := make(tree.Datums, len(args))
 	for i := range args {
 		var err error
-		evalled[i], err = eval.Expr(evalCtx, args[i].(tree.TypedExpr))
+		evalled[i], err = eval.Expr(evalCtx.Context, evalCtx, args[i].(tree.TypedExpr))
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1635,7 +1663,7 @@ func (j jsonPopulateRecordGenerator) Values() (tree.Datums, error) {
 }
 
 func makeJSONPopulateRecordSetGenerator(
-	evalCtx *eval.Context, args tree.Exprs,
+	ctx context.Context, evalCtx *eval.Context, args tree.Exprs,
 ) (eval.ValueGenerator, error) {
 	tuple, j, err := jsonPopulateRecordEvalArgs(evalCtx, args)
 	if err != nil {
@@ -1700,7 +1728,9 @@ func (j *jsonPopulateRecordSetGenerator) Values() (tree.Datums, error) {
 	return output.D, nil
 }
 
-func makeJSONRecordGenerator(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeJSONRecordGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	target := tree.MustBeDJSON(args[0])
 	return &jsonRecordGenerator{
 		evalCtx: evalCtx,
@@ -1788,7 +1818,7 @@ type jsonRecordSetGenerator struct {
 }
 
 func makeJSONRecordSetGenerator(
-	evalCtx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	arr := tree.MustBeDJSON(args[0])
 	return &jsonRecordSetGenerator{
@@ -1854,9 +1884,9 @@ type checkConsistencyGenerator struct {
 var _ eval.ValueGenerator = &checkConsistencyGenerator{}
 
 func makeCheckConsistencyGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
-	if !ctx.Codec.ForSystemTenant() {
+	if !evalCtx.Codec.ForSystemTenant() {
 		return nil, errorutil.UnsupportedWithMultiTenancy(
 			errorutil.FeatureNotAvailableToNonSystemTenantsIssue)
 	}
@@ -1890,7 +1920,7 @@ func makeCheckConsistencyGenerator(
 		mode = roachpb.ChecksumMode_CHECK_STATS
 	}
 
-	if ctx.ConsistencyChecker == nil {
+	if evalCtx.ConsistencyChecker == nil {
 		return nil, errors.WithIssueLink(
 			errors.AssertionFailedf("no consistency checker configured"),
 			errors.IssueLink{IssueURL: "https://github.com/cockroachdb/cockroach/issues/88222"},
@@ -1898,8 +1928,8 @@ func makeCheckConsistencyGenerator(
 	}
 
 	return &checkConsistencyGenerator{
-		txn:                ctx.Txn,
-		consistencyChecker: ctx.ConsistencyChecker,
+		txn:                evalCtx.Txn,
+		consistencyChecker: evalCtx.ConsistencyChecker,
 		from:               keyFrom,
 		to:                 keyTo,
 		mode:               mode,
@@ -2150,9 +2180,11 @@ type rangeKeyIterator struct {
 var _ eval.ValueGenerator = &rangeKeyIterator{}
 var _ eval.ValueGenerator = &spanKeyIterator{}
 
-func makeRangeKeyIterator(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeRangeKeyIterator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -2162,7 +2194,7 @@ func makeRangeKeyIterator(ctx *eval.Context, args tree.Datums) (eval.ValueGenera
 	rangeID := roachpb.RangeID(tree.MustBeDInt(args[0]))
 	return &rangeKeyIterator{
 		spanKeyIterator: spanKeyIterator{
-			acc: ctx.Planner.Mon().MakeBoundAccount(),
+			acc: evalCtx.Planner.Mon().MakeBoundAccount(),
 		},
 		rangeID: rangeID,
 	}, nil
@@ -2219,10 +2251,10 @@ type payloadsForSpanGenerator struct {
 }
 
 func makePayloadsForSpanGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -2233,7 +2265,7 @@ func makePayloadsForSpanGenerator(
 		)
 	}
 	spanID := tracingpb.SpanID(*(args[0].(*tree.DInt)))
-	span := ctx.Tracer.GetActiveSpanByID(spanID)
+	span := evalCtx.Tracer.GetActiveSpanByID(spanID)
 	if span == nil {
 		return nil, nil
 	}
@@ -2320,10 +2352,10 @@ type payloadsForTraceGenerator struct {
 }
 
 func makePayloadsForTraceGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := ctx.SessionAccessor.HasAdminRole(ctx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 	if err != nil {
 		return nil, err
 	}
@@ -2342,8 +2374,8 @@ func makePayloadsForTraceGenerator(
 									) SELECT *
 										FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id)`
 
-	it, err := ctx.Planner.QueryIteratorEx(
-		ctx.Ctx(),
+	it, err := evalCtx.Planner.QueryIteratorEx(
+		evalCtx.Ctx(),
 		"crdb_internal.payloads_for_trace",
 		sessiondata.NoSessionDataOverride,
 		query,
@@ -2469,13 +2501,13 @@ func (s *showCreateAllSchemasGenerator) Close(ctx context.Context) {
 // We use the timestamp of when the generator is created as the
 // timestamp to pass to AS OF SYSTEM TIME for looking up the create schema
 func makeShowCreateAllSchemasGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	dbName := string(tree.MustBeDString(args[0]))
 	return &showCreateAllSchemasGenerator{
-		evalPlanner: ctx.Planner,
+		evalPlanner: evalCtx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Planner.Mon().MakeBoundAccount(),
+		acc:         evalCtx.Planner.Mon().MakeBoundAccount(),
 	}, nil
 }
 
@@ -2625,14 +2657,14 @@ func (s *showCreateAllTablesGenerator) Close(ctx context.Context) {
 // timestamp to pass to AS OF SYSTEM TIME for looking up the create table
 // and alter table statements.
 func makeShowCreateAllTablesGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	dbName := string(tree.MustBeDString(args[0]))
 	return &showCreateAllTablesGenerator{
-		evalPlanner: ctx.Planner,
+		evalPlanner: evalCtx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Planner.Mon().MakeBoundAccount(),
-		sessionData: ctx.SessionData(),
+		acc:         evalCtx.Planner.Mon().MakeBoundAccount(),
+		sessionData: evalCtx.SessionData(),
 	}, nil
 }
 
@@ -2706,12 +2738,12 @@ func (s *showCreateAllTypesGenerator) Close(ctx context.Context) {
 // We use the timestamp of when the generator is created as the
 // timestamp to pass to AS OF SYSTEM TIME for looking up the create type
 func makeShowCreateAllTypesGenerator(
-	ctx *eval.Context, args tree.Datums,
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	dbName := string(tree.MustBeDString(args[0]))
 	return &showCreateAllTypesGenerator{
-		evalPlanner: ctx.Planner,
+		evalPlanner: evalCtx.Planner,
 		dbName:      dbName,
-		acc:         ctx.Planner.Mon().MakeBoundAccount(),
+		acc:         evalCtx.Planner.Mon().MakeBoundAccount(),
 	}, nil
 }

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -122,7 +122,7 @@ var generators = map[string]builtinDefinition{
 			},
 			spanKeyIteratorType,
 			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -145,7 +145,7 @@ var generators = map[string]builtinDefinition{
 			},
 			spanKeyIteratorType,
 			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
-				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Ctx())
+				isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 				if err != nil {
 					return nil, err
 				}
@@ -1631,6 +1631,7 @@ type jsonPopulateRecordGenerator struct {
 	target json.JSON
 
 	wasCalled bool
+	ctx       context.Context
 	evalCtx   *eval.Context
 }
 
@@ -1640,13 +1641,17 @@ func (j jsonPopulateRecordGenerator) ResolvedType() *types.T {
 }
 
 // Start is part of the tree.ValueGenerator interface.
-func (j *jsonPopulateRecordGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
+func (j *jsonPopulateRecordGenerator) Start(ctx context.Context, _ *kv.Txn) error {
+	j.ctx = ctx
+	return nil
+}
 
 // Close is part of the tree.ValueGenerator interface.
 func (j *jsonPopulateRecordGenerator) Close(_ context.Context) {}
 
 // Next is part of the tree.ValueGenerator interface.
-func (j *jsonPopulateRecordGenerator) Next(_ context.Context) (bool, error) {
+func (j *jsonPopulateRecordGenerator) Next(ctx context.Context) (bool, error) {
+	j.ctx = ctx
 	if !j.wasCalled {
 		j.wasCalled = true
 		return true, nil
@@ -1656,7 +1661,7 @@ func (j *jsonPopulateRecordGenerator) Next(_ context.Context) (bool, error) {
 
 // Values is part of the tree.ValueGenerator interface.
 func (j jsonPopulateRecordGenerator) Values() (tree.Datums, error) {
-	if err := eval.PopulateRecordWithJSON(j.evalCtx, j.target, j.input.ResolvedType(), j.input); err != nil {
+	if err := eval.PopulateRecordWithJSON(j.ctx, j.evalCtx, j.target, j.input.ResolvedType(), j.input); err != nil {
 		return nil, err
 	}
 	return j.input.D, nil
@@ -1697,13 +1702,17 @@ type jsonPopulateRecordSetGenerator struct {
 func (j jsonPopulateRecordSetGenerator) ResolvedType() *types.T { return j.input.ResolvedType() }
 
 // Start is part of the tree.ValueGenerator interface.
-func (j jsonPopulateRecordSetGenerator) Start(_ context.Context, _ *kv.Txn) error { return nil }
+func (j jsonPopulateRecordSetGenerator) Start(ctx context.Context, _ *kv.Txn) error {
+	j.ctx = ctx
+	return nil
+}
 
 // Close is part of the tree.ValueGenerator interface.
 func (j jsonPopulateRecordSetGenerator) Close(_ context.Context) {}
 
 // Next is part of the tree.ValueGenerator interface.
-func (j *jsonPopulateRecordSetGenerator) Next(_ context.Context) (bool, error) {
+func (j *jsonPopulateRecordSetGenerator) Next(ctx context.Context) (bool, error) {
+	j.ctx = ctx
 	if j.nextIdx >= j.target.Len() {
 		return false, nil
 	}
@@ -1722,7 +1731,7 @@ func (j *jsonPopulateRecordSetGenerator) Values() (tree.Datums, error) {
 	}
 	output := tree.NewDTupleWithLen(j.input.ResolvedType(), j.input.D.Len())
 	copy(output.D, j.input.D)
-	if err := eval.PopulateRecordWithJSON(j.evalCtx, obj, j.input.ResolvedType(), output); err != nil {
+	if err := eval.PopulateRecordWithJSON(j.ctx, j.evalCtx, obj, j.input.ResolvedType(), output); err != nil {
 		return nil, err
 	}
 	return output.D, nil
@@ -1793,7 +1802,7 @@ func (j *jsonRecordGenerator) Next(ctx context.Context) (bool, error) {
 			continue
 		}
 		v := iter.Value()
-		datum, err := eval.PopulateDatumWithJSON(j.evalCtx, v, j.types[idx])
+		datum, err := eval.PopulateDatumWithJSON(ctx, j.evalCtx, v, j.types[idx])
 		if err != nil {
 			return false, err
 		}
@@ -2375,7 +2384,7 @@ func makePayloadsForTraceGenerator(
 										FROM spans, LATERAL crdb_internal.payloads_for_span(spans.span_id)`
 
 	it, err := evalCtx.Planner.QueryIteratorEx(
-		evalCtx.Ctx(),
+		ctx,
 		"crdb_internal.payloads_for_trace",
 		sessiondata.NoSessionDataOverride,
 		query,

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -121,7 +121,9 @@ type probeRangeGenerator struct {
 	ranges []kv.KeyValue
 }
 
-func makeProbeRangeGenerator(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeProbeRangeGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
 	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
 	if err != nil {

--- a/pkg/sql/sem/builtins/generator_probe_ranges.go
+++ b/pkg/sql/sem/builtins/generator_probe_ranges.go
@@ -125,7 +125,7 @@ func makeProbeRangeGenerator(
 	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
 	// The user must be an admin to use this builtin.
-	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(evalCtx.Context)
+	isAdmin, err := evalCtx.SessionAccessor.HasAdminRole(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -141,7 +141,7 @@ func makeProbeRangeGenerator(
 	var ranges []kv.KeyValue
 	{
 		ctx, sp := tracing.EnsureChildSpan(
-			evalCtx.Context, evalCtx.Tracer, "meta2scan",
+			ctx, evalCtx.Tracer, "meta2scan",
 			tracing.WithRecording(tracingpb.RecordingVerbose),
 		)
 		defer sp.Finish()

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -98,7 +98,7 @@ func (ib infoBuilder) String() string {
 
 // geomFromWKTOverload converts an (E)WKT string to its Geometry form.
 var geomFromWKTOverload = stringOverload1(
-	func(_ *eval.Context, s string) (tree.Datum, error) {
+	func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 		g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
 		if err != nil {
 			return nil, err
@@ -113,7 +113,7 @@ var geomFromWKTOverload = stringOverload1(
 
 // geomFromWKBOverload converts a WKB bytea to its Geometry form.
 var geomFromWKBOverload = bytesOverload1(
-	func(_ *eval.Context, s string) (tree.Datum, error) {
+	func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 		g, err := geo.ParseGeometryFromEWKB([]byte(s))
 		if err != nil {
 			return nil, err
@@ -130,7 +130,7 @@ func geometryFromTextCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefinit
 	return makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
 				if err != nil {
 					return nil, err
@@ -152,7 +152,7 @@ func geometryFromTextCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefinit
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
@@ -180,7 +180,7 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 	return makeBuiltin(
 		defProps(),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeometryFromEWKB(geopb.EWKB(s))
 				if err != nil {
 					return nil, err
@@ -202,7 +202,7 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 		tree.Overload{
 			Types:      tree.ArgTypes{{"wkb", types.Bytes}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDBytes(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeometryFromEWKBAndSRID(geopb.EWKB(s), srid)
@@ -226,7 +226,7 @@ func geometryFromWKBCheckShapeBuiltin(shapeType geopb.ShapeType) builtinDefiniti
 }
 
 var areaOverloadGeometry1 = geometryOverload1(
-	func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+	func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 		ret, err := geomfn.Area(g.Geometry)
 		if err != nil {
 			return nil, err
@@ -242,7 +242,7 @@ var areaOverloadGeometry1 = geometryOverload1(
 )
 
 var lengthOverloadGeometry1 = geometryOverload1(
-	func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+	func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 		ret, err := geomfn.Length(g.Geometry)
 		if err != nil {
 			return nil, err
@@ -260,7 +260,7 @@ Note ST_Length is only valid for LineString - use ST_Perimeter for Polygon.`,
 )
 
 var perimeterOverloadGeometry1 = geometryOverload1(
-	func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+	func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 		ret, err := geomfn.Perimeter(g.Geometry)
 		if err != nil {
 			return nil, err
@@ -374,7 +374,9 @@ func fitMaxDecimalDigitsToBounds(maxDecimalDigits int) int {
 	return maxDecimalDigits
 }
 
-func makeMinimumBoundGenerator(ctx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+func makeMinimumBoundGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
 	geometry := tree.MustBeDGeometry(args[0])
 
 	_, center, radius, err := geomfn.MinimumBoundingCircle(geometry.Geometry)
@@ -424,7 +426,7 @@ func (m *minimumBoundRadiusGen) Close(_ context.Context) {}
 
 func makeSubdividedGeometriesGeneratorFactory(expectMaxVerticesArg bool) eval.GeneratorOverload {
 	return func(
-		ctx *eval.Context, args tree.Datums,
+		_ context.Context, _ *eval.Context, args tree.Datums,
 	) (eval.ValueGenerator, error) {
 		geometry := tree.MustBeDGeometry(args[0])
 		var maxVertices int
@@ -475,7 +477,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"postgis_addbbox": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return g, nil
 			},
 			types.Geometry,
@@ -488,7 +490,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"postgis_dropbbox": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return g, nil
 			},
 			types.Geometry,
@@ -501,7 +503,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"postgis_hasbbox": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				if g.Geometry.Empty() {
 					return tree.DBoolFalse, nil
 				}
@@ -520,7 +522,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"postgis_getbbox": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				bbox := g.CartesianBoundingBox()
 				if bbox == nil {
 					return tree.DNull, nil
@@ -559,7 +561,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_s2covering": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(evalCtx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				cfg, err := geoindex.GeometryIndexConfigForSRID(g.SRID())
 				if err != nil {
 					return nil, err
@@ -579,7 +581,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"settings", types.String}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				params := tree.MustBeDString(args[1])
 
@@ -608,7 +610,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		geographyOverload1(
-			func(evalCtx *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(ctx context.Context, evalCtx *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				cfg := geoindex.DefaultGeographyIndexConfig().S2Geography
 				ret, err := geoindex.NewS2GeographyIndex(*cfg).CoveringGeography(evalCtx.Context, g.Geography)
 				if err != nil {
@@ -625,7 +627,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geography", types.Geography}, {"settings", types.String}},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				params := tree.MustBeDString(args[1])
 
@@ -662,7 +664,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
@@ -680,7 +682,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geomfromewkt": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeometryFromEWKT(geopb.EWKT(s), geopb.DefaultGeometrySRID, geo.DefaultSRIDIsHint)
 				if err != nil {
 					return nil, err
@@ -700,7 +702,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"bytes", types.Bytes}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				b := string(tree.MustBeDBytes(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeometryFromEWKBAndSRID(geopb.EWKB(b), srid)
@@ -718,7 +720,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geomfromewkb": makeBuiltin(
 		defProps(),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeometryFromEWKB([]byte(s))
 				if err != nil {
 					return nil, err
@@ -735,7 +737,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.String}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g, err := geo.ParseGeometryFromGeoJSON([]byte(tree.MustBeDString(args[0])))
 				if err != nil {
 					return nil, err
@@ -749,7 +751,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility:        volatility.Immutable,
 		},
 		jsonOverload1(
-			func(_ *eval.Context, s json.JSON) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s json.JSON) (tree.Datum, error) {
 				// TODO(otan): optimize to not string it first.
 				asString, err := s.AsText()
 				if err != nil {
@@ -774,7 +776,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := float64(tree.MustBeDFloat(args[0]))
 				y := float64(tree.MustBeDFloat(args[1]))
 				g, err := geo.MakeGeometryFromLayoutAndPointCoords(geom.XY, []float64{x, y})
@@ -789,7 +791,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}, {"z", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := float64(tree.MustBeDFloat(args[0]))
 				y := float64(tree.MustBeDFloat(args[1]))
 				z := float64(tree.MustBeDFloat(args[2]))
@@ -805,7 +807,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}, {"z", types.Float}, {"m", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := float64(tree.MustBeDFloat(args[0]))
 				y := float64(tree.MustBeDFloat(args[1]))
 				z := float64(tree.MustBeDFloat(args[2]))
@@ -825,7 +827,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}, {"m", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := float64(tree.MustBeDFloat(args[0]))
 				y := float64(tree.MustBeDFloat(args[1]))
 				m := float64(tree.MustBeDFloat(args[2]))
@@ -842,7 +844,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_makepolygon": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, outer *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, outer *tree.DGeometry) (tree.Datum, error) {
 				g, err := geomfn.MakePolygon(outer.Geometry)
 				if err != nil {
 					return nil, err
@@ -861,7 +863,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"interior", types.AnyArray},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				outer := tree.MustBeDGeometry(args[0])
 				interiorArr := tree.MustBeDArray(args[1])
 				interior := make([]geo.Geometry, len(interiorArr.Array))
@@ -892,7 +894,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				srid := tree.MustBeDInt(args[1])
 				polygon, err := geomfn.MakePolygonWithSRID(g.Geometry, int(srid))
@@ -945,7 +947,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geographyfromtext": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
 				if err != nil {
 					return nil, err
@@ -959,7 +961,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.String}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), srid, geo.DefaultSRIDShouldOverwrite)
@@ -978,7 +980,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geogfromewkt": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeographyFromEWKT(geopb.EWKT(s), geopb.DefaultGeographySRID, geo.DefaultSRIDIsHint)
 				if err != nil {
 					return nil, err
@@ -993,7 +995,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geogfromwkb": makeBuiltin(
 		defProps(),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeographyFromEWKB([]byte(s))
 				if err != nil {
 					return nil, err
@@ -1007,7 +1009,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"bytes", types.Bytes}, {"srid", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				b := string(tree.MustBeDBytes(args[0]))
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseGeographyFromEWKBAndSRID(geopb.EWKB(b), srid)
@@ -1025,7 +1027,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geogfromewkb": makeBuiltin(
 		defProps(),
 		bytesOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeographyFromEWKB([]byte(s))
 				if err != nil {
 					return nil, err
@@ -1040,7 +1042,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geogfromgeojson": makeBuiltin(
 		defProps(),
 		stringOverload1(
-			func(_ *eval.Context, s string) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s string) (tree.Datum, error) {
 				g, err := geo.ParseGeographyFromGeoJSON([]byte(s))
 				if err != nil {
 					return nil, err
@@ -1052,7 +1054,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		jsonOverload1(
-			func(_ *eval.Context, s json.JSON) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, s json.JSON) (tree.Datum, error) {
 				// TODO(otan): optimize to not string it first.
 				asString, err := s.AsText()
 				if err != nil {
@@ -1077,7 +1079,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Float}, {"y", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := float64(tree.MustBeDFloat(args[0]))
 				y := float64(tree.MustBeDFloat(args[1]))
 				g, err := geo.MakeGeometryFromPointCoords(x, y)
@@ -1098,7 +1100,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDString(args[0])
 				p := tree.MustBeDInt(args[1])
 				ret, err := geo.ParseGeometryPointFromGeoHash(string(g), int(p))
@@ -1117,7 +1119,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"geohash", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDString(args[0])
 				p := len(string(g))
 				ret, err := geo.ParseGeometryPointFromGeoHash(string(g), p)
@@ -1140,7 +1142,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDString(args[0])
 				p := tree.MustBeDInt(args[1])
 				bbox, err := geo.ParseCartesianBoundingBoxFromGeoHash(string(g), int(p))
@@ -1163,7 +1165,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"geohash", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDString(args[0])
 				p := len(string(g))
 				bbox, err := geo.ParseCartesianBoundingBoxFromGeoHash(string(g), p)
@@ -1190,7 +1192,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -1221,7 +1223,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"geohash", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -1248,7 +1250,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_astext": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				wkt, err := geo.SpatialObjectToWKT(g.Geometry.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(wkt)), err
 			},
@@ -1264,7 +1266,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				wkt, err := geo.SpatialObjectToWKT(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
@@ -1276,7 +1278,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				wkt, err := geo.SpatialObjectToWKT(g.Geography.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(wkt)), err
 			},
@@ -1292,7 +1294,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				wkt, err := geo.SpatialObjectToWKT(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
@@ -1307,7 +1309,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_asewkt": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ewkt, err := geo.SpatialObjectToEWKT(g.Geometry.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(ewkt)), err
 			},
@@ -1323,7 +1325,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				ewkt, err := geo.SpatialObjectToEWKT(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
@@ -1335,7 +1337,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				ewkt, err := geo.SpatialObjectToEWKT(g.Geography.SpatialObject(), defaultWKTDecimalDigits)
 				return tree.NewDString(string(ewkt)), err
 			},
@@ -1351,7 +1353,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				ewkt, err := geo.SpatialObjectToEWKT(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits))
@@ -1366,7 +1368,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_asbinary": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				wkb, err := geo.SpatialObjectToWKB(g.Geometry.SpatialObject(), geo.DefaultEWKBEncodingFormat)
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
@@ -1375,7 +1377,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				wkb, err := geo.SpatialObjectToWKB(g.Geography.SpatialObject(), geo.DefaultEWKBEncodingFormat)
 				return tree.NewDBytes(tree.DBytes(wkb)), err
 			},
@@ -1389,7 +1391,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"xdr_or_ndr", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				text := string(tree.MustBeDString(args[1]))
 
@@ -1408,7 +1410,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"xdr_or_ndr", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				text := string(tree.MustBeDString(args[1]))
 
@@ -1425,7 +1427,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_asewkb": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return tree.NewDBytes(tree.DBytes(g.EWKB())), nil
 			},
 			types.Bytes,
@@ -1433,7 +1435,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				return tree.NewDBytes(tree.DBytes(g.EWKB())), nil
 			},
 			types.Bytes,
@@ -1444,7 +1446,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_ashexwkb": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				hexwkb, err := geo.SpatialObjectToWKBHex(g.Geometry.SpatialObject())
 				return tree.NewDString(hexwkb), err
 			},
@@ -1453,7 +1455,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				hexwkb, err := geo.SpatialObjectToWKBHex(g.Geography.SpatialObject())
 				return tree.NewDString(hexwkb), err
 			},
@@ -1465,7 +1467,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_ashexewkb": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return tree.NewDString(g.Geometry.EWKBHex()), nil
 			},
 			types.String,
@@ -1473,7 +1475,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				return tree.NewDString(g.Geography.EWKBHex()), nil
 			},
 			types.String,
@@ -1486,7 +1488,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"xdr_or_ndr", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				text := string(tree.MustBeDString(args[1]))
 
@@ -1519,7 +1521,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"xdr_or_ndr", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				text := string(tree.MustBeDString(args[1]))
 
@@ -1555,7 +1557,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision_xy", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
 				if err != nil {
 					return nil, err
@@ -1581,7 +1583,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision_z", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
 				if err != nil {
 					return nil, err
@@ -1609,7 +1611,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision_m", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				t, err := tree.MustBeDGeometry(args[0]).AsGeomT()
 				if err != nil {
 					return nil, err
@@ -1634,7 +1636,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_askml": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				kml, err := geo.SpatialObjectToKML(g.Geometry.SpatialObject())
 				return tree.NewDString(kml), err
 			},
@@ -1643,7 +1645,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				kml, err := geo.SpatialObjectToKML(g.Geography.SpatialObject())
 				return tree.NewDString(kml), err
 			},
@@ -1655,7 +1657,7 @@ var geoBuiltins = map[string]builtinDefinition{
 	"st_geohash": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geo.SpatialObjectToGeoHash(g.Geometry.SpatialObject(), geo.GeoHashAutoPrecision)
 				if err != nil {
 					return nil, err
@@ -1674,7 +1676,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				p := tree.MustBeDInt(args[1])
 				ret, err := geo.SpatialObjectToGeoHash(g.Geometry.SpatialObject(), int(p))
@@ -1689,7 +1691,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				ret, err := geo.SpatialObjectToGeoHash(g.Geography.SpatialObject(), geo.GeoHashAutoPrecision)
 				if err != nil {
 					return nil, err
@@ -1708,7 +1710,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"precision", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				p := tree.MustBeDInt(args[1])
 				ret, err := geo.SpatialObjectToGeoHash(g.Geography.SpatialObject(), int(p))
@@ -1728,10 +1730,10 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"row", types.AnyTuple}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tuple := tree.MustBeDTuple(args[0])
 				return stAsGeoJSONFromTuple(
-					ctx,
+					evalCtx,
 					tuple,
 					"", /* geoColumn */
 					geo.DefaultGeoJSONDecimalDigits,
@@ -1749,10 +1751,10 @@ var geoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"row", types.AnyTuple}, {"geo_column", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tuple := tree.MustBeDTuple(args[0])
 				return stAsGeoJSONFromTuple(
-					ctx,
+					evalCtx,
 					tuple,
 					string(tree.MustBeDString(args[1])),
 					geo.DefaultGeoJSONDecimalDigits,
@@ -1774,10 +1776,10 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tuple := tree.MustBeDTuple(args[0])
 				return stAsGeoJSONFromTuple(
-					ctx,
+					evalCtx,
 					tuple,
 					string(tree.MustBeDString(args[1])),
 					fitMaxDecimalDigitsToBounds(int(tree.MustBeDInt(args[2]))),
@@ -1800,10 +1802,10 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"pretty", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tuple := tree.MustBeDTuple(args[0])
 				return stAsGeoJSONFromTuple(
-					ctx,
+					evalCtx,
 					tuple,
 					string(tree.MustBeDString(args[1])),
 					fitMaxDecimalDigitsToBounds(int(tree.MustBeDInt(args[2]))),
@@ -1819,7 +1821,7 @@ var geoBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Stable,
 		},
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
 				return tree.NewDString(string(geojson)), err
 			},
@@ -1838,7 +1840,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				geojson, err := geo.SpatialObjectToGeoJSON(g.Geometry.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.SpatialObjectToGeoJSONFlagShortCRSIfNot4326)
@@ -1856,7 +1858,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				{"options", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				options := geo.SpatialObjectToGeoJSONFlag(tree.MustBeDInt(args[2]))
@@ -1876,7 +1878,7 @@ Options is a flag that can be bitmasked. The options are:
 			Volatility: volatility.Immutable,
 		},
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), geo.DefaultGeoJSONDecimalDigits, geo.SpatialObjectToGeoJSONFlagZero)
 				return tree.NewDString(string(geojson)), err
 			},
@@ -1895,7 +1897,7 @@ Options is a flag that can be bitmasked. The options are:
 				{"max_decimal_digits", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				geojson, err := geo.SpatialObjectToGeoJSON(g.Geography.SpatialObject(), fitMaxDecimalDigitsToBounds(maxDecimalDigits), geo.SpatialObjectToGeoJSONFlagZero)
@@ -1913,7 +1915,7 @@ Options is a flag that can be bitmasked. The options are:
 				{"options", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				maxDecimalDigits := int(tree.MustBeDInt(args[1]))
 				options := geo.SpatialObjectToGeoJSONFlag(tree.MustBeDInt(args[2]))
@@ -1942,7 +1944,7 @@ Options is a flag that can be bitmasked. The options are:
 				{"azimuth", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				distance := float64(tree.MustBeDFloat(args[1]))
 				azimuth := float64(tree.MustBeDFloat(args[2]))
@@ -1975,7 +1977,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 	"st_ndims": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2000,7 +2002,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 	"st_dimension": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				dim, err := geomfn.Dimension(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -2017,7 +2019,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 	"st_startpoint": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2048,7 +2050,7 @@ Negative azimuth values and values greater than 2π (360 degrees) are supported.
 	"st_summary": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2076,7 +2078,7 @@ Flags shown square brackets after the geometry type have the following meaning:
 			volatility.Immutable,
 		),
 		geographyOverload1(
-			func(ctx *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				t, err := g.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2107,7 +2109,7 @@ Flags shown square brackets after the geometry type have the following meaning:
 	"st_endpoint": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2140,7 +2142,7 @@ Flags shown square brackets after the geometry type have the following meaning:
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"npoints", types.Int4}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geometry := tree.MustBeDGeometry(args[0]).Geometry
 				npoints := int(tree.MustBeDInt(args[1]))
 				seed := timeutil.Now().Unix()
@@ -2162,7 +2164,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"npoints", types.Int4}, {"seed", types.Int4}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geometry := tree.MustBeDGeometry(args[0]).Geometry
 				npoints := int(tree.MustBeDInt(args[1]))
 				seed := int64(tree.MustBeDInt(args[2]))
@@ -2188,7 +2190,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_numpoints": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2209,7 +2211,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_hasarc": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				// We don't support CIRCULARSTRINGs, so always return false.
 				return tree.DBoolFalse, nil
 			},
@@ -2223,7 +2225,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_npoints": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2240,7 +2242,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_points": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				points, err := geomfn.Points(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -2257,7 +2259,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_exteriorring": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2291,7 +2293,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"n", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				n := int(tree.MustBeDInt(args[1]))
 				t, err := g.Geometry.AsGeomT()
@@ -2325,7 +2327,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"n", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				n := int(tree.MustBeDInt(args[1])) - 1
 				if n < 0 {
@@ -2359,7 +2361,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"n", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				n := int(tree.MustBeDInt(args[1])) - 1
 				if n < 0 {
@@ -2427,7 +2429,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_minimumclearance": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.MinimumClearance(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -2445,7 +2447,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_minimumclearanceline": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.MinimumClearanceLine(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -2464,7 +2466,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_numinteriorrings": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2489,7 +2491,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_nrings": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2510,7 +2512,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_force2d": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForceLayout(g.Geometry, geom.XY)
 				if err != nil {
 					return nil, err
@@ -2528,7 +2530,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_force3dz": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYZ)
 				if err != nil {
 					return nil, err
@@ -2546,7 +2548,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				defaultZ := tree.MustBeDFloat(args[1])
 
@@ -2565,7 +2567,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_force3dm": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYM)
 				if err != nil {
 					return nil, err
@@ -2583,7 +2585,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultM", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				defaultM := tree.MustBeDFloat(args[1])
 
@@ -2602,7 +2604,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_force4d": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForceLayout(g.Geometry, geom.XYZM)
 				if err != nil {
 					return nil, err
@@ -2620,7 +2622,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				defaultZ := tree.MustBeDFloat(args[1])
 
@@ -2638,7 +2640,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"defaultZ", types.Float}, {"defaultM", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				defaultZ := tree.MustBeDFloat(args[1])
 				defaultM := tree.MustBeDFloat(args[2])
@@ -2658,7 +2660,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_forcepolygoncw": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForcePolygonOrientation(g.Geometry, geomfn.OrientationCW)
 				if err != nil {
 					return nil, err
@@ -2675,7 +2677,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_forcepolygonccw": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForcePolygonOrientation(g.Geometry, geomfn.OrientationCCW)
 				if err != nil {
 					return nil, err
@@ -2714,7 +2716,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_numgeometries": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2768,7 +2770,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_x": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2793,7 +2795,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_xmin": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				bbox := g.BoundingBoxRef()
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2812,7 +2814,7 @@ The requested number of points must be not larger than 65336.`,
 				{"box2d", types.Box2D},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2829,7 +2831,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_xmax": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				bbox := g.BoundingBoxRef()
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2848,7 +2850,7 @@ The requested number of points must be not larger than 65336.`,
 				{"box2d", types.Box2D},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2865,7 +2867,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_y": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2890,7 +2892,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_ymin": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				bbox := g.BoundingBoxRef()
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2909,7 +2911,7 @@ The requested number of points must be not larger than 65336.`,
 				{"box2d", types.Box2D},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2926,7 +2928,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_ymax": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				bbox := g.BoundingBoxRef()
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2945,7 +2947,7 @@ The requested number of points must be not larger than 65336.`,
 				{"box2d", types.Box2D},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				if bbox == nil {
 					return tree.DNull, nil
@@ -2962,7 +2964,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_z": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(evalContext *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -2987,7 +2989,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_m": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(evalContext *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -3012,7 +3014,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_zmflag": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(evalContext *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				t, err := g.Geometry.AsGeomT()
 				if err != nil {
 					return nil, err
@@ -3041,7 +3043,7 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		append(
 			geographyOverload1WithUseSpheroid(
-				func(ctx *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
 					ret, err := geogfn.Area(g.Geography, useSphereOrSpheroid)
 					if err != nil {
 						return nil, err
@@ -3065,7 +3067,7 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		append(
 			geographyOverload1WithUseSpheroid(
-				func(ctx *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
 					ret, err := geogfn.Length(g.Geography, useSphereOrSpheroid)
 					if err != nil {
 						return nil, err
@@ -3089,7 +3091,7 @@ The requested number of points must be not larger than 65336.`,
 		defProps(),
 		append(
 			geographyOverload1WithUseSpheroid(
-				func(ctx *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
 					ret, err := geogfn.Perimeter(g.Geography, useSphereOrSpheroid)
 					if err != nil {
 						return nil, err
@@ -3112,7 +3114,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_srid": makeBuiltin(
 		defProps(),
 		geographyOverload1(
-			func(_ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(g.SRID())), nil
 			},
 			types.Int,
@@ -3122,7 +3124,7 @@ The requested number of points must be not larger than 65336.`,
 			volatility.Immutable,
 		),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return tree.NewDInt(tree.DInt(g.SRID())), nil
 			},
 			types.Int,
@@ -3135,7 +3137,7 @@ The requested number of points must be not larger than 65336.`,
 	"geometrytype": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return tree.NewDString(g.ShapeType2D().String()), nil
 			},
 			types.String,
@@ -3149,7 +3151,7 @@ The requested number of points must be not larger than 65336.`,
 	"st_geometrytype": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				return tree.NewDString(fmt.Sprintf("ST_%s", g.ShapeType2D().String())), nil
 			},
 			types.String,
@@ -3165,7 +3167,7 @@ The requested number of points must be not larger than 65336.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"start", types.Float}, {"end", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				start := tree.MustBeDFloat(args[1])
 				end := tree.MustBeDFloat(args[2])
@@ -3205,7 +3207,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 				{"repeat", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				fraction := float64(tree.MustBeDFloat(args[1]))
 				repeat := bool(tree.MustBeDBool(args[2]))
@@ -3228,7 +3230,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_multi": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				multi, err := geomfn.Multi(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3251,7 +3253,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 				{"type", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				shapeType := tree.MustBeDInt(args[1])
 				res, err := geomfn.CollectionExtract(g.Geometry, geopb.ShapeType(shapeType))
@@ -3271,7 +3273,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_collectionhomogenize": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.CollectionHomogenize(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3290,7 +3292,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_forcecollection": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ForceCollection(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3307,7 +3309,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_linefrommultipoint": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				line, err := geomfn.LineStringFromMultiPoint(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3324,7 +3326,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_linemerge": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				line, err := geomfn.LineMerge(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3344,7 +3346,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_shiftlongitude": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ShiftLongitude(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3422,7 +3424,7 @@ Note If the result has zero or one points, it will be returned as a POINT. If it
 	"st_azimuth": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				azimuth, err := geomfn.Azimuth(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -3443,7 +3445,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 			volatility.Immutable,
 		),
 		geographyOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeography) (tree.Datum, error) {
 				azimuth, err := geogfn.Azimuth(a.Geography, b.Geography)
 				if err != nil {
 					return nil, err
@@ -3468,7 +3470,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_distance": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.MinDistance(a.Geometry, b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -3485,7 +3487,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 			volatility.Immutable,
 		),
 		geographyOverload2(
-			func(ctx *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
 				ret, err := geogfn.Distance(a.Geography, b.Geography, geogfn.UseSpheroid)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -3509,7 +3511,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 				{"use_spheroid", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeography(args[0])
 				b := tree.MustBeDGeography(args[1])
 				useSpheroid := tree.MustBeDBool(args[2])
@@ -3533,7 +3535,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_distancesphere": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				aGeog, err := a.Geometry.AsGeography()
 				if err != nil {
 					return nil, err
@@ -3563,7 +3565,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_distancespheroid": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				aGeog, err := a.Geometry.AsGeography()
 				if err != nil {
 					return nil, err
@@ -3593,7 +3595,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_frechetdistance": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.FrechetDistance(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -3617,7 +3619,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 				{"densify_frac", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				densifyFrac := tree.MustBeDFloat(args[2])
@@ -3644,7 +3646,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_hausdorffdistance": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.HausdorffDistance(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -3668,7 +3670,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 				{"densify_frac", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				densifyFrac := tree.MustBeDFloat(args[2])
@@ -3693,7 +3695,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_maxdistance": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.MaxDistance(a.Geometry, b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -3714,7 +3716,7 @@ The azimuth is angle is referenced from north, and is positive clockwise: North 
 	"st_longestline": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				longestLineString, err := geomfn.LongestLineString(a.Geometry, b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -3739,7 +3741,7 @@ Note if geometries are the same, it will return the LineString with the maximum 
 	"st_shortestline": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				shortestLineString, err := geomfn.ShortestLineString(a.Geometry, b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -3851,7 +3853,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				dist := tree.MustBeDFloat(args[2])
@@ -3893,7 +3895,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 	"st_normalize": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.Normalize(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -3967,7 +3969,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 	"st_relate": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.Relate(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -3988,7 +3990,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				{"pattern", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				pattern := tree.MustBeDString(args[2])
@@ -4011,7 +4013,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				{"bnr", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				bnr := tree.MustBeDInt(args[2])
@@ -4036,7 +4038,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				{"intersection_matrix", types.String},
 				{"pattern", types.String},
 			},
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				matrix := string(tree.MustBeDString(args[0]))
 				pattern := string(tree.MustBeDString(args[1]))
 
@@ -4061,7 +4063,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 	"st_isvalid": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.IsValid(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4081,7 +4083,7 @@ Note if geometries are the same, it will return the LineString with the minimum 
 				{"flags", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				flags := int(tree.MustBeDInt(args[1]))
 				validDetail, err := geomfn.IsValidDetail(g.Geometry, flags)
@@ -4104,7 +4106,7 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 	"st_isvalidreason": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.IsValidReason(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4124,7 +4126,7 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 				{"flags", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				flags := int(tree.MustBeDInt(args[1]))
 				validDetail, err := geomfn.IsValidDetail(g.Geometry, flags)
@@ -4150,7 +4152,7 @@ For flags=1, validity considers self-intersecting rings forming holes as valid a
 	"st_isvalidtrajectory": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.IsValidTrajectory(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4169,7 +4171,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_makevalid": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				validGeom, err := geomfn.MakeValid(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4192,7 +4194,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_boundary": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				centroid, err := geomfn.Boundary(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4211,7 +4213,7 @@ Note the geometry must be a LineString with M coordinates.`,
 		defProps(),
 		append(
 			geographyOverload1WithUseSpheroid(
-				func(ctx *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, g *tree.DGeography, useSphereOrSpheroid geogfn.UseSphereOrSpheroid) (tree.Datum, error) {
 					ret, err := geogfn.Centroid(g.Geography, useSphereOrSpheroid)
 					if err != nil {
 						return nil, err
@@ -4225,7 +4227,7 @@ Note the geometry must be a LineString with M coordinates.`,
 				volatility.Immutable,
 			),
 			geometryOverload1(
-				func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+				func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 					centroid, err := geomfn.Centroid(g.Geometry)
 					if err != nil {
 						return nil, err
@@ -4246,7 +4248,7 @@ Note the geometry must be a LineString with M coordinates.`,
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"box2d", types.Box2D}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				bbox := tree.MustBeDBox2D(args[1])
 				ret, err := geomfn.ClipByRect(g.Geometry, bbox.CartesianBoundingBox)
@@ -4264,7 +4266,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_convexhull": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				convexHull, err := geomfn.ConvexHull(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4282,7 +4284,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_difference": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				diff, err := geomfn.Difference(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -4300,7 +4302,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_pointonsurface": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				pointOnSurface, err := geomfn.PointOnSurface(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -4318,7 +4320,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_intersection": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
 				intersection, err := geomfn.Intersection(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -4333,7 +4335,7 @@ Note the geometry must be a LineString with M coordinates.`,
 			volatility.Immutable,
 		),
 		geographyOverload2(
-			func(ctx *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
 				proj, err := geogfn.BestGeomProjection(a.Geography.BoundingRect().Union(b.Geography.BoundingRect()))
 				if err != nil {
 					return nil, err
@@ -4410,7 +4412,7 @@ Note the geometry must be a LineString with M coordinates.`,
 	"st_sharedpaths": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.SharedPaths(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -4432,7 +4434,7 @@ The paths themselves are given in the direction of the first geometry.`,
 	"st_closestpoint": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.ClosestPoint(a.Geometry, b.Geometry)
 				if err != nil {
 					if geo.IsEmptyGeometryError(err) {
@@ -4453,7 +4455,7 @@ The paths themselves are given in the direction of the first geometry.`,
 	"st_symdifference": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a, b *tree.DGeometry) (tree.Datum, error) {
 				ret, err := geomfn.SymDifference(a.Geometry, b.Geometry)
 				if err != nil {
 					return nil, err
@@ -4476,7 +4478,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := float64(tree.MustBeDFloat(args[1]))
 				// TODO(#spatial): post v21.1, use the geomfn.Simplify we have implemented internally.
@@ -4500,7 +4502,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"preserve_collapsed", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := float64(tree.MustBeDFloat(args[1]))
 				preserveCollapsed := bool(tree.MustBeDBool(args[2]))
@@ -4527,7 +4529,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := float64(tree.MustBeDFloat(args[1]))
 				ret, err := geomfn.SimplifyPreserveTopology(g.Geometry, tolerance)
@@ -4555,7 +4557,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				srid := tree.MustBeDInt(args[1])
 				newGeom, err := g.Geometry.CloneWithSRID(geopb.SRID(srid))
@@ -4575,7 +4577,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				srid := tree.MustBeDInt(args[1])
 				newGeom, err := g.Geography.CloneWithSRID(geopb.SRID(srid))
@@ -4598,7 +4600,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				srid := geopb.SRID(tree.MustBeDInt(args[1]))
 
@@ -4628,7 +4630,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"to_proj_text", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				toProj := string(tree.MustBeDString(args[1]))
 
@@ -4660,7 +4662,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"to_proj_text", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				fromProj := string(tree.MustBeDString(args[1]))
 				toProj := string(tree.MustBeDString(args[2]))
@@ -4689,7 +4691,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				fromProj := string(tree.MustBeDString(args[1]))
 				srid := geopb.SRID(tree.MustBeDInt(args[2]))
@@ -4725,7 +4727,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"delta_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				deltaX := float64(tree.MustBeDFloat(args[1]))
 				deltaY := float64(tree.MustBeDFloat(args[2]))
@@ -4750,7 +4752,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"delta_z", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				deltaX := float64(tree.MustBeDFloat(args[1]))
 				deltaY := float64(tree.MustBeDFloat(args[2]))
@@ -4782,7 +4784,7 @@ The paths themselves are given in the direction of the first geometry.`,
 				{"y_off", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				ret, err := geomfn.Affine(
 					g.Geometry,
@@ -4826,7 +4828,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"z_off", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				ret, err := geomfn.Affine(
 					g.Geometry,
@@ -4864,7 +4866,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"y_factor", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				xFactor := float64(tree.MustBeDFloat(args[1]))
 				yFactor := float64(tree.MustBeDFloat(args[2]))
@@ -4887,7 +4889,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"factor", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				factor, err := tree.MustBeDGeometry(args[1]).AsGeomT()
 				if err != nil {
@@ -4924,7 +4926,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"origin", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				factor := tree.MustBeDGeometry(args[1])
 				origin := tree.MustBeDGeometry(args[2])
@@ -4950,7 +4952,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"angle_radians", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 
@@ -4974,7 +4976,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"origin_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 				x := float64(tree.MustBeDFloat(args[2]))
@@ -4997,7 +4999,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"origin_point", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 				originPoint := tree.MustBeDGeometry(args[2])
@@ -5026,7 +5028,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"angle_radians", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 
@@ -5051,7 +5053,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"angle_radians", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 
@@ -5076,7 +5078,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"angle_radians", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				rotRadians := float64(tree.MustBeDFloat(args[1]))
 
@@ -5102,7 +5104,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"index", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				lineString := tree.MustBeDGeometry(args[0])
 				point := tree.MustBeDGeometry(args[1])
 				index := int(tree.MustBeDInt(args[2]))
@@ -5125,7 +5127,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"point", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				lineString := tree.MustBeDGeometry(args[0])
 				point := tree.MustBeDGeometry(args[1])
 
@@ -5151,7 +5153,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"point", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				lineString := tree.MustBeDGeometry(args[0])
 				index := int(tree.MustBeDInt(args[1]))
 				point := tree.MustBeDGeometry(args[2])
@@ -5177,7 +5179,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"index", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				lineString := tree.MustBeDGeometry(args[0])
 				index := int(tree.MustBeDInt(args[1]))
 
@@ -5202,7 +5204,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := float64(tree.MustBeDFloat(args[1]))
 
@@ -5223,7 +5225,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				ret, err := geomfn.RemoveRepeatedPoints(g.Geometry, 0)
 				if err != nil {
@@ -5245,7 +5247,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geometry := tree.MustBeDGeometry(args[0])
 
 				ret, err := geomfn.Reverse(geometry.Geometry)
@@ -5269,7 +5271,7 @@ The matrix transformation will be applied as follows for each coordinate:
 				{"max_segment_length_meters", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				segmentMaxLength := float64(tree.MustBeDFloat(args[1]))
 				segGeography, err := geogfn.Segmentize(g.Geography, segmentMaxLength)
@@ -5292,7 +5294,7 @@ The calculations are done on a sphere.`,
 				{"max_segment_length", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				segmentMaxLength := float64(tree.MustBeDFloat(args[1]))
 				segGeometry, err := geomfn.Segmentize(g.Geometry, segmentMaxLength)
@@ -5316,7 +5318,7 @@ The calculations are done on a sphere.`,
 				{"size", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				size := float64(tree.MustBeDFloat(args[1]))
 				ret, err := geomfn.SnapToGrid(g.Geometry, geom.Coord{0, 0, 0, 0}, geom.Coord{size, size, 0, 0})
@@ -5338,7 +5340,7 @@ The calculations are done on a sphere.`,
 				{"size_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				sizeX := float64(tree.MustBeDFloat(args[1]))
 				sizeY := float64(tree.MustBeDFloat(args[2]))
@@ -5362,7 +5364,7 @@ The calculations are done on a sphere.`,
 				{"size_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				originX := float64(tree.MustBeDFloat(args[1]))
 				originY := float64(tree.MustBeDFloat(args[2]))
@@ -5389,7 +5391,7 @@ The calculations are done on a sphere.`,
 				{"size_m", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				origin := tree.MustBeDGeometry(args[1])
 				sizeX := float64(tree.MustBeDFloat(args[2]))
@@ -5434,7 +5436,7 @@ The calculations are done on a sphere.`,
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g1 := tree.MustBeDGeometry(args[0])
 				g2 := tree.MustBeDGeometry(args[1])
 				tolerance := tree.MustBeDFloat(args[2])
@@ -5460,7 +5462,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"distance", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				distance := tree.MustBeDInt(args[1])
 
@@ -5479,7 +5481,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				distance := tree.MustBeDFloat(args[1])
 
@@ -5498,7 +5500,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"distance", types.Decimal},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				distanceDec := tree.MustBeDDecimal(args[1])
 
@@ -5523,7 +5525,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"quad_segs", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				distance := tree.MustBeDFloat(args[1])
 				quadSegs := tree.MustBeDInt(args[2])
@@ -5548,7 +5550,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"buffer_style_params", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				distance := tree.MustBeDFloat(args[1])
 				paramsString := tree.MustBeDString(args[2])
@@ -5577,7 +5579,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				distance := tree.MustBeDFloat(args[1])
 
@@ -5603,7 +5605,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"quad_segs", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				distance := tree.MustBeDFloat(args[1])
 				quadSegs := tree.MustBeDInt(args[2])
@@ -5633,7 +5635,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 				{"buffer_style_params", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geography),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeography(args[0])
 				distance := tree.MustBeDFloat(args[1])
 				paramsString := tree.MustBeDString(args[2])
@@ -5665,7 +5667,7 @@ If no snapping occurs then the input geometry is returned unchanged.`,
 	"st_envelope": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(ctx *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				envelope, err := geomfn.Envelope(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -5688,7 +5690,7 @@ Bottom Left.`,
 				{"box2d", types.Box2D},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0]).CartesianBoundingBox
 				ret, err := geo.MakeGeometryFromGeomT(bbox.ToGeomT(0 /* SRID */))
 				if err != nil {
@@ -5713,7 +5715,7 @@ Bottom Left.`,
 				{"srid", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return stEnvelopeFromArgs(args)
 			},
 			Info: infoBuilder{
@@ -5729,7 +5731,7 @@ Bottom Left.`,
 				{"ymax", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return stEnvelopeFromArgs(args)
 			},
 			Info: infoBuilder{
@@ -5745,7 +5747,7 @@ Bottom Left.`,
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 
 				ret, err := geomfn.FlipCoordinates(g.Geometry)
@@ -5775,7 +5777,7 @@ Bottom Left.`,
 				},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				cString := tree.MustBeDString(args[1])
 
@@ -5804,7 +5806,7 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 				{"point4", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g1 := tree.MustBeDGeometry(args[0]).Geometry
 				g2 := tree.MustBeDGeometry(args[1]).Geometry
 				g3 := tree.MustBeDGeometry(args[2]).Geometry
@@ -5831,7 +5833,7 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 				{"point3", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g1 := tree.MustBeDGeometry(args[0]).Geometry
 				g2 := tree.MustBeDGeometry(args[1]).Geometry
 				g3 := tree.MustBeDGeometry(args[2]).Geometry
@@ -5860,7 +5862,7 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 				{"line2", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g1 := tree.MustBeDGeometry(args[0]).Geometry
 				g2 := tree.MustBeDGeometry(args[1]).Geometry
 				angle, err := geomfn.AngleLineString(g1, g2)
@@ -5886,7 +5888,7 @@ The swap_ordinate_string parameter is a 2-character string naming the ordinates 
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0]).Geometry
 				s, err := geo.GeometryToEncodedPolyline(g, 5)
 				if err != nil {
@@ -5907,7 +5909,7 @@ Preserves 5 decimal places.`,
 				{"precision", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0]).Geometry
 				p := int(tree.MustBeDInt(args[1]))
 				s, err := geo.GeometryToEncodedPolyline(g, p)
@@ -5930,7 +5932,7 @@ Precision specifies how many decimal places will be preserved in Encoded Polylin
 				{"encoded_polyline", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				p := 5
 				g, err := geo.ParseEncodedPolyline(s, p)
@@ -5954,7 +5956,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 				{"precision", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				p := int(tree.MustBeDInt(args[1]))
 				g, err := geo.ParseEncodedPolyline(s, p)
@@ -5976,7 +5978,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 	"st_unaryunion": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				res, err := geomfn.UnaryUnion(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -5993,7 +5995,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 	"st_node": makeBuiltin(
 		defProps(),
 		geometryOverload1(
-			func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				res, err := geomfn.Node(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -6037,7 +6039,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 	"st_makebox2d": makeBuiltin(
 		defProps(),
 		geometryOverload2(
-			func(ctx *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
 				if a.Geometry.SRID() != b.Geometry.SRID() {
 					return nil, geo.NewMismatchingSRIDsError(a.Geometry.SpatialObject(), b.Geometry.SpatialObject())
 				}
@@ -6078,7 +6080,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 		tree.Overload{
 			Types:      tree.ArgTypes{{"box2d", types.Box2D}, {"geometry", types.Geometry}},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[1] == tree.DNull {
 					return args[0], nil
 				}
@@ -6109,7 +6111,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 		tree.Overload{
 			Types:      tree.ArgTypes{{"box2d", types.Box2D}, {"delta", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				delta := float64(tree.MustBeDFloat(args[1]))
 				bboxBuffered := bbox.Buffer(delta, delta)
@@ -6130,7 +6132,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 				{"delta_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				bbox := tree.MustBeDBox2D(args[0])
 				deltaX := float64(tree.MustBeDFloat(args[1]))
 				deltaY := float64(tree.MustBeDFloat(args[2]))
@@ -6148,7 +6150,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 		tree.Overload{
 			Types:      tree.ArgTypes{{"geometry", types.Geometry}, {"delta", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				delta := float64(tree.MustBeDFloat(args[1]))
 				if g.Empty() {
@@ -6173,7 +6175,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 				{"delta_y", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				deltaX := float64(tree.MustBeDFloat(args[1]))
 				deltaY := float64(tree.MustBeDFloat(args[2]))
@@ -6210,7 +6212,7 @@ See http://developers.google.com/maps/documentation/utilities/polylinealgorithm`
 				{"parent_only", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// TODO(#64257): implement by looking at statistics.
 				return tree.DNull, nil
 			},
@@ -6228,7 +6230,7 @@ The parent_only boolean is always ignored.`,
 				{"geocolumn_name", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// TODO(#64257): implement by looking at statistics.
 				return tree.DNull, nil
 			},
@@ -6243,7 +6245,7 @@ The parent_only boolean is always ignored.`,
 				{"geocolumn_name", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Box2D),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// TODO(#64257): implement by looking at statistics.
 				return tree.DNull, nil
 			},
@@ -6273,9 +6275,9 @@ The parent_only boolean is always ignored.`,
 				{"use_typmod", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					"", /* schemaName */
 					string(tree.MustBeDString(args[0])),
@@ -6286,9 +6288,9 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[5])),
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					"", /* schemaName */
 					string(tree.MustBeDString(args[0])),
@@ -6315,9 +6317,9 @@ The parent_only boolean is always ignored.`,
 				{"use_typmod", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
@@ -6328,9 +6330,9 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[6])),
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
@@ -6358,9 +6360,9 @@ The parent_only boolean is always ignored.`,
 				{"use_typmod", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
 					string(tree.MustBeDString(args[2])),
@@ -6371,9 +6373,9 @@ The parent_only boolean is always ignored.`,
 					bool(tree.MustBeDBool(args[7])),
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
 					string(tree.MustBeDString(args[2])),
@@ -6398,9 +6400,9 @@ The parent_only boolean is always ignored.`,
 				{"dimension", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					"", /* schemaName */
 					string(tree.MustBeDString(args[0])),
@@ -6411,9 +6413,9 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					"", /* schemaName */
 					string(tree.MustBeDString(args[0])),
@@ -6439,9 +6441,9 @@ The parent_only boolean is always ignored.`,
 				{"dimension", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
@@ -6452,9 +6454,9 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					"", /* catalogName */
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
@@ -6481,9 +6483,9 @@ The parent_only boolean is always ignored.`,
 				{"dimension", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			SQLFn: eval.SQLFnOverload(func(ctx *eval.Context, args tree.Datums) (string, error) {
+			SQLFn: eval.SQLFnOverload(func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (string, error) {
 				return addGeometryColumnSQL(
-					ctx,
+					evalCtx,
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
 					string(tree.MustBeDString(args[2])),
@@ -6494,9 +6496,9 @@ The parent_only boolean is always ignored.`,
 					true, /* useTypmod */
 				)
 			}),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return addGeometryColumnSummary(
-					ctx,
+					evalCtx,
 					string(tree.MustBeDString(args[0])),
 					string(tree.MustBeDString(args[1])),
 					string(tree.MustBeDString(args[2])),
@@ -6523,7 +6525,7 @@ The parent_only boolean is always ignored.`,
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				dist := tree.MustBeDFloat(args[2])
@@ -6550,7 +6552,7 @@ The parent_only boolean is always ignored.`,
 				{"radius", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				point := tree.MustBeDGeometry(args[0])
 
 				geomT, err := point.AsGeomT()
@@ -6600,7 +6602,7 @@ The parent_only boolean is always ignored.`,
 				},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				geo := tree.MustBeDGeometry(args[0])
 				return tree.NewDInt(tree.DInt(geo.Size())), nil
 			},
@@ -6621,7 +6623,7 @@ The parent_only boolean is always ignored.`,
 				},
 			},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				line := tree.MustBeDGeometry(args[0])
 				p := tree.MustBeDGeometry(args[1])
 
@@ -6648,7 +6650,7 @@ The parent_only boolean is always ignored.`,
 
 	"st_minimumboundingcircle": makeBuiltin(defProps(),
 		geometryOverload1(
-			func(evalContext *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 				polygon, _, _, err := geomfn.MinimumBoundingCircle(g.Geometry)
 				if err != nil {
 					return nil, err
@@ -6668,7 +6670,7 @@ The parent_only boolean is always ignored.`,
 				info: "Returns the smallest circle polygon that can fully contain a geometry.",
 			}.String(),
 			Volatility: volatility.Immutable,
-			Fn: func(evalContext *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				numOfSeg := tree.MustBeDInt(args[1])
 				_, centroid, radius, err := geomfn.MinimumBoundingCircle(g.Geometry)
@@ -6703,7 +6705,7 @@ The parent_only boolean is always ignored.`,
 			Info: infoBuilder{
 				info: "Translates the geometry using the deltaX and deltaY args, then scales it using the XFactor, YFactor args, working in 2D only.",
 			}.String(),
-			Fn: func(_ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(datums[0])
 				deltaX := float64(tree.MustBeDFloat(datums[1]))
 				deltaY := float64(tree.MustBeDFloat(datums[2]))
@@ -6723,7 +6725,7 @@ The parent_only boolean is always ignored.`,
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				var env *geo.Geometry
 				ret, err := geomfn.VoronoiDiagram(g.Geometry, env, 0.0, false /* onlyEdges */)
@@ -6743,7 +6745,7 @@ The parent_only boolean is always ignored.`,
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := tree.MustBeDFloat(args[1])
 				var env *geo.Geometry
@@ -6765,7 +6767,7 @@ The parent_only boolean is always ignored.`,
 				{"extend_to", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := tree.MustBeDFloat(args[1])
 				env := tree.MustBeDGeometry(args[2])
@@ -6788,7 +6790,7 @@ The parent_only boolean is always ignored.`,
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				var env *geo.Geometry
 				ret, err := geomfn.VoronoiDiagram(g.Geometry, env, 0.0, true /* onlyEdges */)
@@ -6809,7 +6811,7 @@ The parent_only boolean is always ignored.`,
 				{"tolerance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := tree.MustBeDFloat(args[1])
 				var env *geo.Geometry
@@ -6832,7 +6834,7 @@ The parent_only boolean is always ignored.`,
 				{"extend_to", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				tolerance := tree.MustBeDFloat(args[1])
 				env := tree.MustBeDGeometry(args[2])
@@ -6856,7 +6858,7 @@ The parent_only boolean is always ignored.`,
 				{"geometry", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Geometry),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(args[0])
 				ret, err := geomfn.MinimumRotatedRectangle(g.Geometry)
 				if err != nil {
@@ -6884,7 +6886,7 @@ May return a Point or LineString in the case of degenerate inputs.`,
 			Info: infoBuilder{
 				info: "Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.",
 			}.String(),
-			Fn: func(_ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(datums[0])
 				startFraction := float64(tree.MustBeDFloat(datums[1]))
 				endFraction := float64(tree.MustBeDFloat(datums[2]))
@@ -6906,7 +6908,7 @@ May return a Point or LineString in the case of degenerate inputs.`,
 			Info: infoBuilder{
 				info: "Return a linestring being a substring of the input one starting and ending at the given fractions of total 2D length. Second and third arguments are float8 values between 0 and 1.",
 			}.String(),
-			Fn: func(_ *eval.Context, datums tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, datums tree.Datums) (tree.Datum, error) {
 				g := tree.MustBeDGeometry(datums[0])
 				startFraction := tree.MustBeDDecimal(datums[1])
 				startFractionFloat, err := startFraction.Float64()
@@ -6938,7 +6940,7 @@ May return a Point or LineString in the case of degenerate inputs.`,
 				{"linestring_b", types.Geometry},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				linestringA := tree.MustBeDGeometry(args[0])
 				linestringB := tree.MustBeDGeometry(args[1])
 
@@ -7011,7 +7013,7 @@ func returnCompatibilityFixedStringBuiltin(ret string) builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(ret), nil
 			},
 			Info: infoBuilder{
@@ -7024,7 +7026,7 @@ func returnCompatibilityFixedStringBuiltin(ret string) builtinDefinition {
 
 // geometryOverload1 hides the boilerplate for builtins operating on one geometry.
 func geometryOverload1(
-	f func(*eval.Context, *tree.DGeometry) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DGeometry) (tree.Datum, error),
 	returnType *types.T,
 	ib infoBuilder,
 	volatility volatility.V,
@@ -7034,9 +7036,9 @@ func geometryOverload1(
 			{"geometry", types.Geometry},
 		},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			a := tree.MustBeDGeometry(args[0])
-			return f(ctx, a)
+			return f(ctx, evalCtx, a)
 		},
 		Info:       ib.String(),
 		Volatility: volatility,
@@ -7049,7 +7051,7 @@ func geometryOverload1UnaryPredicate(
 	f func(geo.Geometry) (bool, error), ib infoBuilder,
 ) tree.Overload {
 	return geometryOverload1(
-		func(_ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+		func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
 			ret, err := f(g.Geometry)
 			if err != nil {
 				return nil, err
@@ -7064,7 +7066,7 @@ func geometryOverload1UnaryPredicate(
 
 // geometryOverload2 hides the boilerplate for builtins operating on two geometries.
 func geometryOverload2(
-	f func(*eval.Context, *tree.DGeometry, *tree.DGeometry) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DGeometry, *tree.DGeometry) (tree.Datum, error),
 	returnType *types.T,
 	ib infoBuilder,
 	volatility volatility.V,
@@ -7075,10 +7077,10 @@ func geometryOverload2(
 			{"geometry_b", types.Geometry},
 		},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			a := tree.MustBeDGeometry(args[0])
 			b := tree.MustBeDGeometry(args[1])
-			return f(ctx, a, b)
+			return f(ctx, evalCtx, a, b)
 		},
 		Info:       ib.String(),
 		Volatility: volatility,
@@ -7091,7 +7093,7 @@ func geometryOverload2BinaryPredicate(
 	f func(geo.Geometry, geo.Geometry) (bool, error), ib infoBuilder,
 ) tree.Overload {
 	return geometryOverload2(
-		func(_ *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
+		func(_ context.Context, _ *eval.Context, a *tree.DGeometry, b *tree.DGeometry) (tree.Datum, error) {
 			ret, err := f(a.Geometry, b.Geometry)
 			if err != nil {
 				return nil, err
@@ -7106,7 +7108,7 @@ func geometryOverload2BinaryPredicate(
 
 // geographyOverload1 hides the boilerplate for builtins operating on one geography.
 func geographyOverload1(
-	f func(*eval.Context, *tree.DGeography) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DGeography) (tree.Datum, error),
 	returnType *types.T,
 	ib infoBuilder,
 	volatility volatility.V,
@@ -7116,9 +7118,9 @@ func geographyOverload1(
 			{"geography", types.Geography},
 		},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			a := tree.MustBeDGeography(args[0])
-			return f(ctx, a)
+			return f(ctx, evalCtx, a)
 		},
 		Info:       ib.String(),
 		Volatility: volatility,
@@ -7128,7 +7130,7 @@ func geographyOverload1(
 // geographyOverload1WithUseSpheroid hides the boilerplate for builtins operating on one geography
 // with an optional spheroid argument.
 func geographyOverload1WithUseSpheroid(
-	f func(*eval.Context, *tree.DGeography, geogfn.UseSphereOrSpheroid) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DGeography, geogfn.UseSphereOrSpheroid) (tree.Datum, error),
 	returnType *types.T,
 	ib infoBuilder,
 	volatility volatility.V,
@@ -7145,9 +7147,9 @@ func geographyOverload1WithUseSpheroid(
 				{"geography", types.Geography},
 			},
 			ReturnType: tree.FixedReturnType(returnType),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeography(args[0])
-				return f(ctx, a, geogfn.UseSpheroid)
+				return f(ctx, evalCtx, a, geogfn.UseSpheroid)
 			},
 			Info:       infoWithSpheroid.String(),
 			Volatility: volatility,
@@ -7158,10 +7160,10 @@ func geographyOverload1WithUseSpheroid(
 				{"use_spheroid", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(returnType),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeography(args[0])
 				b := tree.MustBeDBool(args[1])
-				return f(ctx, a, toUseSphereOrSpheroid(b))
+				return f(ctx, evalCtx, a, toUseSphereOrSpheroid(b))
 			},
 			Info:       infoWithSphereAndSpheroid.String(),
 			Volatility: volatility,
@@ -7171,7 +7173,7 @@ func geographyOverload1WithUseSpheroid(
 
 // geographyOverload2 hides the boilerplate for builtins operating on two geographys.
 func geographyOverload2(
-	f func(*eval.Context, *tree.DGeography, *tree.DGeography) (tree.Datum, error),
+	f func(context.Context, *eval.Context, *tree.DGeography, *tree.DGeography) (tree.Datum, error),
 	returnType *types.T,
 	ib infoBuilder,
 	volatility volatility.V,
@@ -7182,10 +7184,10 @@ func geographyOverload2(
 			{"geography_b", types.Geography},
 		},
 		ReturnType: tree.FixedReturnType(returnType),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			a := tree.MustBeDGeography(args[0])
 			b := tree.MustBeDGeography(args[1])
-			return f(ctx, a, b)
+			return f(ctx, evalCtx, a, b)
 		},
 		Info:       ib.String(),
 		Volatility: volatility,
@@ -7198,7 +7200,7 @@ func geographyOverload2BinaryPredicate(
 	f func(geo.Geography, geo.Geography) (bool, error), ib infoBuilder,
 ) tree.Overload {
 	return geographyOverload2(
-		func(_ *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
+		func(_ context.Context, _ *eval.Context, a *tree.DGeography, b *tree.DGeography) (tree.Datum, error) {
 			ret, err := f(a.Geography, b.Geography)
 			if err != nil {
 				return nil, err
@@ -7314,7 +7316,7 @@ func init() {
 // addGeometryColumnSQL returns the SQL statement that should be executed to
 // add a geometry column.
 func addGeometryColumnSQL(
-	ctx *eval.Context,
+	evalCtx *eval.Context,
 	catalogName string,
 	schemaName string,
 	tableName string,
@@ -7350,7 +7352,7 @@ func addGeometryColumnSQL(
 // addGeometryColumnSummary returns metadata about the geometry column that
 // was added.
 func addGeometryColumnSummary(
-	ctx *eval.Context,
+	evalCtx *eval.Context,
 	catalogName string,
 	schemaName string,
 	tableName string,
@@ -7387,7 +7389,7 @@ func lineInterpolatePointForRepeatOverload(repeat bool, builtinInfo string) tree
 			{"fraction", types.Float},
 		},
 		ReturnType: tree.FixedReturnType(types.Geometry),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 			g := tree.MustBeDGeometry(args[0])
 			fraction := float64(tree.MustBeDFloat(args[1]))
 			interpolatedPoints, err := geomfn.LineInterpolatePoints(g.Geometry, fraction, repeat)
@@ -7447,7 +7449,7 @@ func appendStrArgOverloadForGeometryArgOverloads(def builtinDefinition) builtinD
 
 		// Wrap the overloads to cast to Geometry.
 		newOverload.Types = newArgTypes
-		newOverload.Fn = func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		newOverload.Fn = func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			for i, ok := argsToCast.Next(0); ok; i, ok = argsToCast.Next(i + 1) {
 				arg := string(tree.MustBeDString(args[i]))
 				g, err := geo.ParseGeometry(arg)
@@ -7456,7 +7458,7 @@ func appendStrArgOverloadForGeometryArgOverloads(def builtinDefinition) builtinD
 				}
 				args[i] = tree.NewDGeometry(g)
 			}
-			return ov.Fn.(eval.FnOverload)(ctx, args)
+			return ov.Fn.(eval.FnOverload)(ctx, evalCtx, args)
 		}
 
 		newOverload.Info += `
@@ -7473,7 +7475,7 @@ This variant will cast all geometry_str arguments into Geometry types.
 // stAsGeoJSONFromTuple returns a *tree.DString representing JSON output
 // for ST_AsGeoJSON.
 func stAsGeoJSONFromTuple(
-	ctx *eval.Context, tuple *tree.DTuple, geoColumn string, numDecimalDigits int, pretty bool,
+	evalCtx *eval.Context, tuple *tree.DTuple, geoColumn string, numDecimalDigits int, pretty bool,
 ) (*tree.DString, error) {
 	typ := tuple.ResolvedType()
 	labels := typ.TupleLabels()
@@ -7534,8 +7536,8 @@ func stAsGeoJSONFromTuple(
 		}
 		tupleJSON, err := tree.AsJSON(
 			d,
-			ctx.SessionData().DataConversionConfig,
-			ctx.GetLocation(),
+			evalCtx.SessionData().DataConversionConfig,
+			evalCtx.GetLocation(),
 		)
 		if err != nil {
 			return nil, err
@@ -7588,7 +7590,7 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeometry(args[0])
 				b := tree.MustBeDGeometry(args[1])
 				dist := tree.MustBeDFloat(args[2])
@@ -7611,7 +7613,7 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 				{"distance", types.Float},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeography(args[0])
 				b := tree.MustBeDGeography(args[1])
 				dist := tree.MustBeDFloat(args[2])
@@ -7637,7 +7639,7 @@ func makeSTDWithinBuiltin(exclusivity geo.FnExclusivity) builtinDefinition {
 				{"use_spheroid", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				a := tree.MustBeDGeography(args[0])
 				b := tree.MustBeDGeography(args[1])
 				dist := tree.MustBeDFloat(args[2])

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -566,7 +566,7 @@ var geoBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				ret, err := geoindex.NewS2GeometryIndex(*cfg.S2Geometry).CoveringGeometry(evalCtx.Context, g.Geometry)
+				ret, err := geoindex.NewS2GeometryIndex(*cfg.S2Geometry).CoveringGeometry(ctx, g.Geometry)
 				if err != nil {
 					return nil, err
 				}
@@ -589,11 +589,11 @@ var geoBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				cfg, err := applyGeoindexConfigStorageParams(evalCtx.Context, evalCtx, *startCfg, string(params))
+				cfg, err := applyGeoindexConfigStorageParams(ctx, evalCtx, *startCfg, string(params))
 				if err != nil {
 					return nil, err
 				}
-				ret, err := geoindex.NewS2GeometryIndex(*cfg.S2Geometry).CoveringGeometry(evalCtx.Context, g.Geometry)
+				ret, err := geoindex.NewS2GeometryIndex(*cfg.S2Geometry).CoveringGeometry(ctx, g.Geometry)
 				if err != nil {
 					return nil, err
 				}
@@ -612,7 +612,7 @@ var geoBuiltins = map[string]builtinDefinition{
 		geographyOverload1(
 			func(ctx context.Context, evalCtx *eval.Context, g *tree.DGeography) (tree.Datum, error) {
 				cfg := geoindex.DefaultGeographyIndexConfig().S2Geography
-				ret, err := geoindex.NewS2GeographyIndex(*cfg).CoveringGeography(evalCtx.Context, g.Geography)
+				ret, err := geoindex.NewS2GeographyIndex(*cfg).CoveringGeography(ctx, g.Geography)
 				if err != nil {
 					return nil, err
 				}
@@ -632,11 +632,11 @@ var geoBuiltins = map[string]builtinDefinition{
 				params := tree.MustBeDString(args[1])
 
 				startCfg := geoindex.DefaultGeographyIndexConfig()
-				cfg, err := applyGeoindexConfigStorageParams(evalCtx.Context, evalCtx, *startCfg, string(params))
+				cfg, err := applyGeoindexConfigStorageParams(ctx, evalCtx, *startCfg, string(params))
 				if err != nil {
 					return nil, err
 				}
-				ret, err := geoindex.NewS2GeographyIndex(*cfg.S2Geography).CoveringGeography(evalCtx.Context, g.Geography)
+				ret, err := geoindex.NewS2GeographyIndex(*cfg.S2Geography).CoveringGeography(ctx, g.Geography)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/builtins/geo_builtins_test.go
+++ b/pkg/sql/sem/builtins/geo_builtins_test.go
@@ -11,6 +11,7 @@
 package builtins_test
 
 import (
+	"context"
 	"math/rand"
 	"strconv"
 	"strings"
@@ -87,15 +88,15 @@ func TestGeoBuiltinsPointEmptyArgs(t *testing.T) {
 								call.WriteByte(')')
 								t.Logf("calling: %s", call.String())
 								if overload.Fn != nil {
-									_, _ = overload.Fn.(eval.FnOverload)(&eval.Context{}, datums)
+									_, _ = overload.Fn.(eval.FnOverload)(context.Background(), &eval.Context{}, datums)
 								} else if overload.Generator != nil {
-									_, _ = overload.Generator.(eval.GeneratorOverload)(&eval.Context{}, datums)
+									_, _ = overload.Generator.(eval.GeneratorOverload)(context.Background(), &eval.Context{}, datums)
 								} else if overload.GeneratorWithExprs != nil {
 									exprs := make(tree.Exprs, len(datums))
 									for i := range datums {
 										exprs[i] = datums[i]
 									}
-									_, _ = overload.GeneratorWithExprs.(eval.GeneratorWithExprsOverload)(&eval.Context{}, exprs)
+									_, _ = overload.GeneratorWithExprs.(eval.GeneratorWithExprsOverload)(context.Background(), &eval.Context{}, exprs)
 								}
 							})
 						}

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -61,7 +62,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := tree.MustBeDInt(args[0])
 				switch {
 				case x == math.MinInt64:
@@ -205,7 +206,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Int}, {"y", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				y := tree.MustBeDInt(args[1])
 				if y == 0 {
 					return nil, tree.ErrDivByZero
@@ -241,7 +242,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDFloat(tree.DFloat(float64(*args[0].(*tree.DInt)))), nil
 			},
 			Info:       "Calculates the largest integer not greater than `val`.",
@@ -255,7 +256,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			// a boolean.
 			Types:      tree.ArgTypes{{"val", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.MakeDBool(tree.DBool(math.IsNaN(float64(*args[0].(*tree.DFloat))))), nil
 			},
 			Info:       "Returns true if `val` is NaN, false otherwise.",
@@ -264,7 +265,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Decimal}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				isNaN := args[0].(*tree.DDecimal).Decimal.Form == apd.NaN
 				return tree.MakeDBool(tree.DBool(isNaN)), nil
 			},
@@ -344,7 +345,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"x", types.Int}, {"y", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				y := tree.MustBeDInt(args[1])
 				if y == 0 {
 					return nil, tree.ErrDivByZero
@@ -361,7 +362,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDFloat(math.Pi), nil
 			},
 			Info:       "Returns the value for pi (3.141592653589793).",
@@ -389,7 +390,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Float}, {"decimal_accuracy", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				f := float64(*args[0].(*tree.DFloat))
 				if math.IsInf(f, 0) || math.IsNaN(f) {
 					return args[0], nil
@@ -421,7 +422,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.Decimal}, {"decimal_accuracy", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Decimal),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// TODO(mjibson): make sure this fits in an int32.
 				scale := int32(tree.MustBeDInt(args[1]))
 				return roundDecimal(&args[0].(*tree.DDecimal).Decimal, scale)
@@ -471,7 +472,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				x := tree.MustBeDInt(args[0])
 				switch {
 				case x < 0:
@@ -529,7 +530,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Decimal}, {"scale", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Decimal),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// The algorithm here is also used in shopspring/decimal; see
 				// https://github.com/shopspring/decimal/blob/f55dd564545cec84cf84f7a53fb3025cdbec1c4f/decimal.go#L1315
 				dec := tree.MustBeDDecimal(args[0]).Decimal
@@ -566,7 +567,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			Types: tree.ArgTypes{{"operand", types.Decimal}, {"b1", types.Decimal},
 				{"b2", types.Decimal}, {"count", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				operand, _ := args[0].(*tree.DDecimal).Float64()
 				b1, _ := args[1].(*tree.DDecimal).Float64()
 				b2, _ := args[2].(*tree.DDecimal).Float64()
@@ -587,7 +588,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			Types: tree.ArgTypes{{"operand", types.Int}, {"b1", types.Int},
 				{"b2", types.Int}, {"count", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				operand := float64(tree.MustBeDInt(args[0]))
 				b1 := float64(tree.MustBeDInt(args[1]))
 				b2 := float64(tree.MustBeDInt(args[2]))
@@ -601,7 +602,7 @@ var mathBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"operand", types.Any}, {"thresholds", types.AnyArray}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				operand := args[0]
 				thresholds := tree.MustBeDArray(args[1])
 
@@ -610,7 +611,7 @@ var mathBuiltins = map[string]builtinDefinition{
 				}
 
 				for i, v := range thresholds.Array {
-					if operand.Compare(ctx, v) < 0 {
+					if operand.Compare(evalCtx, v) < 0 {
 						return tree.NewDInt(tree.DInt(i)), nil
 					}
 				}
@@ -641,7 +642,7 @@ func ceilImpl() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDFloat(tree.DFloat(float64(*args[0].(*tree.DInt)))), nil
 			},
 			Info:       "Calculates the smallest integer not smaller than `val`.",
@@ -666,7 +667,7 @@ func powImpls() builtinDefinition {
 				{"y", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return eval.IntPow(tree.MustBeDInt(args[0]), tree.MustBeDInt(args[1]))
 			},
 			Info:       "Calculates `x`^`y`.",
@@ -697,7 +698,7 @@ func floatOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.Float}},
 		ReturnType: tree.FixedReturnType(types.Float),
-		Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 			return f(float64(*args[0].(*tree.DFloat)))
 		},
 		Info:       info,
@@ -711,7 +712,7 @@ func floatOverload2(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.Float}, {b, types.Float}},
 		ReturnType: tree.FixedReturnType(types.Float),
-		Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 			return f(float64(*args[0].(*tree.DFloat)),
 				float64(*args[1].(*tree.DFloat)))
 		},
@@ -726,7 +727,7 @@ func decimalOverload1(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{"val", types.Decimal}},
 		ReturnType: tree.FixedReturnType(types.Decimal),
-		Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 			dec := &args[0].(*tree.DDecimal).Decimal
 			return f(dec)
 		},
@@ -744,7 +745,7 @@ func decimalOverload2(
 	return tree.Overload{
 		Types:      tree.ArgTypes{{a, types.Decimal}, {b, types.Decimal}},
 		ReturnType: tree.FixedReturnType(types.Decimal),
-		Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 			dec1 := &args[0].(*tree.DDecimal).Decimal
 			dec2 := &args[1].(*tree.DDecimal).Decimal
 			return f(dec1, dec2)

--- a/pkg/sql/sem/builtins/notice.go
+++ b/pkg/sql/sem/builtins/notice.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -23,13 +24,13 @@ import (
 // Note this is extracted to a different file to prevent churn on the pgwire
 // test, which records line numbers.
 func crdbInternalSendNotice(
-	evalCtx *eval.Context, severity string, msg string,
+	ctx context.Context, evalCtx *eval.Context, severity string, msg string,
 ) (tree.Datum, error) {
 	if evalCtx.ClientNoticeSender == nil {
 		return nil, errors.AssertionFailedf("notice sender not set")
 	}
 	evalCtx.ClientNoticeSender.BufferClientNotice(
-		evalCtx.Context,
+		ctx,
 		pgnotice.NewWithSeverityf(strings.ToUpper(severity), "%s", msg),
 	)
 	return tree.NewDInt(0), nil

--- a/pkg/sql/sem/builtins/notice.go
+++ b/pkg/sql/sem/builtins/notice.go
@@ -22,12 +22,14 @@ import (
 // crdbInternalSendNotice sends a notice.
 // Note this is extracted to a different file to prevent churn on the pgwire
 // test, which records line numbers.
-func crdbInternalSendNotice(ctx *eval.Context, severity string, msg string) (tree.Datum, error) {
-	if ctx.ClientNoticeSender == nil {
+func crdbInternalSendNotice(
+	evalCtx *eval.Context, severity string, msg string,
+) (tree.Datum, error) {
+	if evalCtx.ClientNoticeSender == nil {
 		return nil, errors.AssertionFailedf("notice sender not set")
 	}
-	ctx.ClientNoticeSender.BufferClientNotice(
-		ctx.Context,
+	evalCtx.ClientNoticeSender.BufferClientNotice(
+		evalCtx.Context,
 		pgnotice.NewWithSeverityf(strings.ToUpper(severity), "%s", msg),
 	)
 	return tree.NewDInt(0), nil

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -988,7 +988,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					// If the type wasn't statically known, try looking it up as a user
 					// defined type.
 					var err error
-					typ, err = evalCtx.Planner.ResolveTypeByOID(evalCtx.Context, oid)
+					typ, err = evalCtx.Planner.ResolveTypeByOID(ctx, oid)
 					if err != nil {
 						// If the error is a descriptor does not exist error, then swallow it.
 						unknown := tree.NewDString(fmt.Sprintf("unknown (OID=%s)", oidArg))
@@ -1213,7 +1213,7 @@ SELECT description
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
 				isVisible, exists, err := evalCtx.Planner.IsTableVisible(
-					evalCtx.Context, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
+					ctx, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1241,7 +1241,7 @@ SELECT description
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
 				isVisible, exists, err := evalCtx.Planner.IsTypeVisible(
-					evalCtx.Context, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
+					ctx, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1365,7 +1365,7 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1393,7 +1393,7 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1422,7 +1422,7 @@ SELECT description
 				return eval.HasNoPrivilege, err
 			}
 
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1580,7 +1580,7 @@ SELECT description
 				return eval.ObjectNotFound, nil
 			}
 
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1606,7 +1606,7 @@ SELECT description
 			if err != nil {
 				return eval.HasPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1679,7 +1679,7 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, user, privs)
 		},
 	),
 
@@ -1797,15 +1797,15 @@ SELECT description
 				var err error
 				switch privStr {
 				case "USAGE":
-					hasAnyPrivilegeResult, err = hasPrivsOfRole(evalCtx, user, role)
+					hasAnyPrivilegeResult, err = hasPrivsOfRole(ctx, evalCtx, user, role)
 				case "MEMBER":
-					hasAnyPrivilegeResult, err = isMemberOfRole(evalCtx, user, role)
+					hasAnyPrivilegeResult, err = isMemberOfRole(ctx, evalCtx, user, role)
 				case
 					"USAGE WITH GRANT OPTION",
 					"USAGE WITH ADMIN OPTION",
 					"MEMBER WITH GRANT OPTION",
 					"MEMBER WITH ADMIN OPTION":
-					hasAnyPrivilegeResult, err = isAdminOfRole(evalCtx, user, role)
+					hasAnyPrivilegeResult, err = isAdminOfRole(ctx, evalCtx, user, role)
 				default:
 					return eval.HasNoPrivilege, pgerror.Newf(pgcode.InvalidParameterValue,
 						"unrecognized privilege type: %q", privStr)
@@ -1831,7 +1831,7 @@ SELECT description
 			Types:      tree.ArgTypes{{"setting_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getSessionVar(evalCtx, string(tree.MustBeDString(args[0])), false /* missingOk */)
+				return getSessionVar(ctx, evalCtx, string(tree.MustBeDString(args[0])), false /* missingOk */)
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Stable,
@@ -1840,7 +1840,7 @@ SELECT description
 			Types:      tree.ArgTypes{{"setting_name", types.String}, {"missing_ok", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getSessionVar(evalCtx, string(tree.MustBeDString(args[0])), bool(tree.MustBeDBool(args[1])))
+				return getSessionVar(ctx, evalCtx, string(tree.MustBeDString(args[0])), bool(tree.MustBeDBool(args[1])))
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Stable,
@@ -1859,11 +1859,11 @@ SELECT description
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				varName := string(tree.MustBeDString(args[0]))
 				newValue := string(tree.MustBeDString(args[1]))
-				err := setSessionVar(evalCtx, varName, newValue, bool(tree.MustBeDBool(args[2])))
+				err := setSessionVar(ctx, evalCtx, varName, newValue, bool(tree.MustBeDBool(args[2])))
 				if err != nil {
 					return nil, err
 				}
-				return getSessionVar(evalCtx, varName, false /* missingOk */)
+				return getSessionVar(ctx, evalCtx, varName, false /* missingOk */)
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Volatile,
@@ -2153,11 +2153,13 @@ SELECT description
 	),
 }
 
-func getSessionVar(evalCtx *eval.Context, settingName string, missingOk bool) (tree.Datum, error) {
+func getSessionVar(
+	ctx context.Context, evalCtx *eval.Context, settingName string, missingOk bool,
+) (tree.Datum, error) {
 	if evalCtx.SessionAccessor == nil {
 		return nil, errors.AssertionFailedf("session accessor not set")
 	}
-	ok, s, err := evalCtx.SessionAccessor.GetSessionVar(evalCtx.Context, settingName, missingOk)
+	ok, s, err := evalCtx.SessionAccessor.GetSessionVar(ctx, settingName, missingOk)
 	if err != nil {
 		return nil, err
 	}
@@ -2167,11 +2169,13 @@ func getSessionVar(evalCtx *eval.Context, settingName string, missingOk bool) (t
 	return tree.NewDString(s), nil
 }
 
-func setSessionVar(evalCtx *eval.Context, settingName, newVal string, isLocal bool) error {
+func setSessionVar(
+	ctx context.Context, evalCtx *eval.Context, settingName, newVal string, isLocal bool,
+) error {
 	if evalCtx.SessionAccessor == nil {
 		return errors.AssertionFailedf("session accessor not set")
 	}
-	return evalCtx.SessionAccessor.SetSessionVar(evalCtx.Context, settingName, newVal, isLocal)
+	return evalCtx.SessionAccessor.SetSessionVar(ctx, settingName, newVal, isLocal)
 }
 
 // getCatalogOidForComments returns the "catalog table oid" (the oid of a
@@ -2376,9 +2380,9 @@ func pgTrueTypImpl(attrField, typField string, retType *types.T) builtinDefiniti
 // role, so this is currently equivalent to isMemberOfRole.
 // See https://github.com/cockroachdb/cockroach/issues/69583.
 func hasPrivsOfRole(
-	evalCtx *eval.Context, user, role username.SQLUsername,
+	ctx context.Context, evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
-	return isMemberOfRole(evalCtx, user, role)
+	return isMemberOfRole(ctx, evalCtx, user, role)
 }
 
 // isMemberOfRole returns whether the user is a member of the specified role
@@ -2386,7 +2390,7 @@ func hasPrivsOfRole(
 //
 // This is defined to recurse through roles regardless of rolinherit.
 func isMemberOfRole(
-	evalCtx *eval.Context, user, role username.SQLUsername,
+	ctx context.Context, evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
 	// Fast path for simple case.
 	if user == role {
@@ -2394,13 +2398,13 @@ func isMemberOfRole(
 	}
 
 	// Superusers have every privilege and are part of every role.
-	if isSuper, err := evalCtx.Planner.UserHasAdminRole(evalCtx.Context, user); err != nil {
+	if isSuper, err := evalCtx.Planner.UserHasAdminRole(ctx, user); err != nil {
 		return eval.HasNoPrivilege, err
 	} else if isSuper {
 		return eval.HasPrivilege, nil
 	}
 
-	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(evalCtx.Context, user)
+	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(ctx, user)
 	if err != nil {
 		return eval.HasNoPrivilege, err
 	}
@@ -2416,12 +2420,12 @@ func isMemberOfRole(
 // That is, is member the role itself (subject to restrictions below), a
 // member (directly or indirectly) WITH ADMIN OPTION, or a superuser?
 func isAdminOfRole(
-	evalCtx *eval.Context, user, role username.SQLUsername,
+	ctx context.Context, evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
 	// Superusers are an admin of every role.
 	//
 	// NB: this is intentionally before the user == role check here.
-	if isSuper, err := evalCtx.Planner.UserHasAdminRole(evalCtx.Context, user); err != nil {
+	if isSuper, err := evalCtx.Planner.UserHasAdminRole(ctx, user); err != nil {
 		return eval.HasNoPrivilege, err
 	} else if isSuper {
 		return eval.HasPrivilege, nil
@@ -2467,7 +2471,7 @@ func isAdminOfRole(
 		return eval.HasNoPrivilege, nil
 	}
 
-	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(evalCtx.Context, user)
+	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(ctx, user)
 	if err != nil {
 		return eval.HasNoPrivilege, err
 	}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -50,7 +51,7 @@ func makeNotUsableFalseBuiltin() builtinDefinition {
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(*eval.Context, tree.Datums) (tree.Datum, error) {
+			Fn: func(context.Context, *eval.Context, tree.Datums) (tree.Datum, error) {
 				return tree.DBoolFalse, nil
 			},
 			Info:       notUsableInfo,
@@ -159,7 +160,7 @@ func makeTypeIOBuiltin(argTypes tree.TypeList, returnType *types.T) builtinDefin
 		tree.Overload{
 			Types:      argTypes,
 			ReturnType: tree.FixedReturnType(returnType),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return nil, errUnimplemented
 			},
 			Info:       notUsableInfo,
@@ -207,13 +208,13 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 	return tree.Overload{
 		Types:      argTypes,
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			colNumber := *tree.NewDInt(0)
 			if len(args) == 3 {
 				colNumber = *args[1].(*tree.DInt)
 			}
-			r, err := ctx.Planner.QueryRowEx(
-				ctx.Ctx(), "pg_get_indexdef",
+			r, err := evalCtx.Planner.QueryRowEx(
+				evalCtx.Ctx(), "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid = $1", args[0])
 			if err != nil {
@@ -228,8 +229,8 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 				return r[0], nil
 			}
 			// The 3 argument variant for column number other than 0 returns the column name.
-			r, err = ctx.Planner.QueryRowEx(
-				ctx.Ctx(), "pg_get_indexdef",
+			r, err = evalCtx.Planner.QueryRowEx(
+				evalCtx.Ctx(), "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT ischema.column_name as pg_get_indexdef 
 		               FROM information_schema.statistics AS ischema 
@@ -261,9 +262,9 @@ func makePGGetViewDef(argTypes tree.ArgTypes) tree.Overload {
 	return tree.Overload{
 		Types:      argTypes,
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := ctx.Planner.QueryRowEx(
-				ctx.Ctx(), "pg_get_viewdef",
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			r, err := evalCtx.Planner.QueryRowEx(
+				evalCtx.Ctx(), "pg_get_viewdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT definition
  FROM pg_catalog.pg_views v
@@ -292,9 +293,9 @@ func makePGGetConstraintDef(argTypes tree.ArgTypes) tree.Overload {
 	return tree.Overload{
 		Types:      argTypes,
 		ReturnType: tree.FixedReturnType(types.String),
-		Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-			r, err := ctx.Planner.QueryRowEx(
-				ctx.Ctx(), "pg_get_constraintdef",
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			r, err := evalCtx.Planner.QueryRowEx(
+				evalCtx.Ctx(), "pg_get_constraintdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1", args[0])
 			if err != nil {
@@ -330,7 +331,7 @@ var strOrOidTypes = []*types.T{types.String, types.Oid}
 func makePGPrivilegeInquiryDef(
 	infoDetail string,
 	objSpecArgs argTypeOpts,
-	fn func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error),
+	fn func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error),
 ) builtinDefinition {
 	// Collect the different argument type variations.
 	//
@@ -375,11 +376,11 @@ func makePGPrivilegeInquiryDef(
 		variants = append(variants, tree.Overload{
 			Types:      argType,
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var user username.SQLUsername
 				if withUser {
-					arg := eval.UnwrapDatum(ctx, args[0])
-					userS, err := getNameForArg(ctx, arg, "pg_roles", "rolname")
+					arg := eval.UnwrapDatum(evalCtx, args[0])
+					userS, err := getNameForArg(evalCtx, arg, "pg_roles", "rolname")
 					if err != nil {
 						return nil, err
 					}
@@ -400,13 +401,13 @@ func makePGPrivilegeInquiryDef(
 					// Remove the first argument.
 					args = args[1:]
 				} else {
-					if ctx.SessionData().User().Undefined() {
+					if evalCtx.SessionData().User().Undefined() {
 						// Wut... is this possible?
 						return tree.DNull, nil
 					}
-					user = ctx.SessionData().User()
+					user = evalCtx.SessionData().User()
 				}
-				ret, err := fn(ctx, args, user)
+				ret, err := fn(ctx, evalCtx, args, user)
 				if err != nil {
 					return nil, err
 				}
@@ -436,7 +437,7 @@ func makePGPrivilegeInquiryDef(
 // getNameForArg determines the object name for the specified argument, which
 // should be either an unwrapped STRING or an OID. If the object is not found,
 // the returned string will be empty.
-func getNameForArg(ctx *eval.Context, arg tree.Datum, pgTable, pgCol string) (string, error) {
+func getNameForArg(evalCtx *eval.Context, arg tree.Datum, pgTable, pgCol string) (string, error) {
 	var query string
 	switch t := arg.(type) {
 	case *tree.DString:
@@ -446,7 +447,7 @@ func getNameForArg(ctx *eval.Context, arg tree.Datum, pgTable, pgCol string) (st
 	default:
 		return "", errors.AssertionFailedf("unexpected arg type %T", t)
 	}
-	r, err := ctx.Planner.QueryRowEx(ctx.Ctx(), "get-name-for-arg",
+	r, err := evalCtx.Planner.QueryRowEx(evalCtx.Ctx(), "get-name-for-arg",
 		sessiondata.NoSessionDataOverride, query, arg)
 	if err != nil || r == nil {
 		return "", err
@@ -501,7 +502,7 @@ func makeCreateRegDef(typ *types.T) builtinDefinition {
 				{"name", types.String},
 			},
 			ReturnType: tree.FixedReturnType(typ),
-			Fn: func(_ *eval.Context, d tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, d tree.Datums) (tree.Datum, error) {
 				return tree.NewDOidWithName(tree.MustBeDOid(d[0]).Oid, typ, string(tree.MustBeDString(d[1]))), nil
 			},
 			Info:       notUsableInfo,
@@ -517,13 +518,13 @@ func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
 				{"text", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.RegType),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typName := tree.MustBeDString(args[0])
 				int, _ := strconv.Atoi(strings.TrimSpace(string(typName)))
 				if int > 0 {
 					return tree.DNull, nil
 				}
-				typOid, err := eval.ParseDOid(ctx, string(typName), typ)
+				typOid, err := eval.ParseDOid(evalCtx, string(typName), typ)
 				if err != nil {
 					//nolint:returnerrcheck
 					return tree.DNull, nil
@@ -543,8 +544,8 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				pid := ctx.QueryCancelKey.GetPGBackendPID()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				pid := evalCtx.QueryCancelKey.GetPGBackendPID()
 				return tree.NewDInt(tree.DInt(pid)), nil
 			},
 			Info: "Returns a numerical ID attached to this session. This ID is " +
@@ -562,8 +563,8 @@ var pgBuiltins = map[string]builtinDefinition{
 				{"encoding_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if args[0].Compare(ctx, DatEncodingUTFId) == 0 {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				if args[0].Compare(evalCtx, DatEncodingUTFId) == 0 {
 					return datEncodingUTF8ShortName, nil
 				}
 				return tree.DNull, nil
@@ -580,7 +581,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// We only support UTF-8 right now.
 				// If we allow more encodings, we must also change the virtual schema
 				// entry for pg_catalog.pg_database.
@@ -604,7 +605,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				{"relation_oid", types.Oid},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return args[0], nil
 			},
 			Info:       notUsableInfo,
@@ -617,7 +618,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				{"pretty_bool", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return args[0], nil
 			},
 			Info:       notUsableInfo,
@@ -640,7 +641,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.DNull, nil
 			},
 			Info:       notUsableInfo,
@@ -653,7 +654,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				idToQuery := catid.DescID(tree.MustBeDOid(args[0]).Oid)
 				getFuncQuery := `SELECT prosrc FROM pg_proc WHERE oid=$1`
 				if catid.IsOIDUserDefined(oid.Oid(idToQuery)) {
@@ -664,8 +665,8 @@ var pgBuiltins = map[string]builtinDefinition{
 						return nil, err
 					}
 				}
-				results, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_functiondef",
+				results, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_functiondef",
 					sessiondata.NoSessionDataOverride,
 					getFuncQuery,
 					idToQuery,
@@ -693,10 +694,10 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_function_result",
+				t, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_function_result",
 					sessiondata.NoSessionDataOverride,
 					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
@@ -721,10 +722,10 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_function_identity_arguments",
+				t, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_function_identity_arguments",
 					sessiondata.NoSessionDataOverride,
 					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
@@ -783,14 +784,14 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"table_name", types.String}, {"column_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableName := tree.MustBeDString(args[0])
 				columnName := tree.MustBeDString(args[1])
 				qualifiedName, err := parser.ParseQualifiedTableName(string(tableName))
 				if err != nil {
 					return nil, err
 				}
-				res, err := ctx.Sequence.GetSerialSequenceNameFromColumn(ctx.Ctx(), qualifiedName, tree.Name(columnName))
+				res, err := evalCtx.Sequence.GetSerialSequenceNameFromColumn(evalCtx.Ctx(), qualifiedName, tree.Name(columnName))
 				if err != nil {
 					return nil, err
 				}
@@ -813,14 +814,14 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Oid),
-			Fn: func(ctx *eval.Context, _ tree.Datums) (tree.Datum, error) {
-				schema := ctx.SessionData().SearchPath.GetTemporarySchemaName()
+			Fn: func(ctx context.Context, evalCtx *eval.Context, _ tree.Datums) (tree.Datum, error) {
+				schema := evalCtx.SessionData().SearchPath.GetTemporarySchemaName()
 				if schema == "" {
 					// The session has not yet created a temporary schema.
 					return tree.NewDOid(0), nil
 				}
-				oid, errSafeToIgnore, err := ctx.Planner.ResolveOIDFromString(
-					ctx.Ctx(), types.RegNamespace, tree.NewDString(schema))
+				oid, errSafeToIgnore, err := evalCtx.Planner.ResolveOIDFromString(
+					evalCtx.Ctx(), types.RegNamespace, tree.NewDString(schema))
 				if err != nil {
 					// If the OID lookup returns an UndefinedObject error, return 0
 					// instead. We can hit this path if the session created a temporary
@@ -846,9 +847,9 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				schemaArg := eval.UnwrapDatum(ctx, args[0])
-				schema, err := getNameForArg(ctx, schemaArg, "pg_namespace", "nspname")
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				schemaArg := eval.UnwrapDatum(evalCtx, args[0])
+				schema, err := getNameForArg(evalCtx, schemaArg, "pg_namespace", "nspname")
 				if err != nil {
 					return nil, err
 				}
@@ -862,7 +863,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					// This string matching is what Postgres does too. See isAnyTempNamespace.
 					return tree.DBoolFalse, nil
 				}
-				if schema == ctx.SessionData().SearchPath.GetTemporarySchemaName() {
+				if schema == evalCtx.SessionData().SearchPath.GetTemporarySchemaName() {
 					// OID is a reference to this session's temporary schema.
 					return tree.DBoolFalse, nil
 				}
@@ -878,7 +879,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"val", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(args[0].ResolvedType().SQLStandardName()), nil
 			},
 			Info:              notUsableInfo,
@@ -893,7 +894,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"str", types.Any}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var collation string
 				switch t := args[0].(type) {
 				case *tree.DString:
@@ -917,10 +918,10 @@ var pgBuiltins = map[string]builtinDefinition{
 				{"role_oid", types.Oid},
 			},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := args[0]
-				t, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_userbyid",
+				t, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_userbyid",
 					sessiondata.NoSessionDataOverride,
 					"SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
 				if err != nil {
@@ -946,9 +947,9 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"sequence_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				r, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_sequence_parameters",
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				r, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_sequence_parameters",
 					sessiondata.NoSessionDataOverride,
 					`SELECT seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid `+
 						`FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
@@ -974,7 +975,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"type_oid", types.Oid}, {"typemod", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// See format_type.c in Postgres.
 				oidArg := args[0]
 				if oidArg == tree.DNull {
@@ -987,7 +988,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					// If the type wasn't statically known, try looking it up as a user
 					// defined type.
 					var err error
-					typ, err = ctx.Planner.ResolveTypeByOID(ctx.Context, oid)
+					typ, err = evalCtx.Planner.ResolveTypeByOID(evalCtx.Context, oid)
 					if err != nil {
 						// If the error is a descriptor does not exist error, then swallow it.
 						unknown := tree.NewDString(fmt.Sprintf("unknown (OID=%s)", oidArg))
@@ -1021,7 +1022,7 @@ var pgBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"table_oid", types.Oid}, {"column_number", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, nil
 				}
@@ -1042,8 +1043,8 @@ var pgBuiltins = map[string]builtinDefinition{
 				//
 				// TODO(jordanlewis): Really we'd like to query this directly
 				// on pg_description and let predicate push-down do its job.
-				r, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_coldesc",
+				r, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_coldesc",
 					sessiondata.NoSessionDataOverride,
 					`
 SELECT comment FROM system.comments c
@@ -1066,8 +1067,8 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 		tree.Overload{
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getPgObjDesc(ctx, "", args[0].(*tree.DOid).Oid)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return getPgObjDesc(evalCtx, "", args[0].(*tree.DOid).Oid)
 			},
 			Info:       notUsableInfo,
 			Volatility: volatility.Stable,
@@ -1075,8 +1076,8 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 		tree.Overload{
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}, {"catalog_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getPgObjDesc(ctx,
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return getPgObjDesc(evalCtx,
 					string(tree.MustBeDString(args[1])),
 					args[0].(*tree.DOid).Oid,
 				)
@@ -1090,7 +1091,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 		tree.Overload{
 			Types:      tree.ArgTypes{{"int", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Oid),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return eval.PerformCast(evalCtx, args[0], types.Oid)
 			},
 			Info:       "Converts an integer to an OID.",
@@ -1102,7 +1103,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 		tree.Overload{
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}, {"catalog_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				catalogName := string(tree.MustBeDString(args[1]))
 				objOid := args[0].(*tree.DOid).Oid
 
@@ -1112,8 +1113,8 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 					return tree.DNull, nil
 				}
 
-				r, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_get_shobjdesc",
+				r, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_get_shobjdesc",
 					sessiondata.NoSessionDataOverride,
 					fmt.Sprintf(`
 SELECT description
@@ -1141,7 +1142,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"int", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return tree.DBoolTrue, nil
 			},
 			Info:       notUsableInfo,
@@ -1153,7 +1154,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"int", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return tree.DBoolTrue, nil
 			},
 			Info:       notUsableInfo,
@@ -1167,7 +1168,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, _ tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, _ tree.Datums) (tree.Datum, error) {
 				return tree.NewDString("UTF8"), nil
 			},
 			Info:       notUsableInfo,
@@ -1184,10 +1185,10 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
-				t, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "pg_function_is_visible",
+				t, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "pg_function_is_visible",
 					sessiondata.NoSessionDataOverride,
 					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", oid.Oid)
 				if err != nil {
@@ -1209,10 +1210,10 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
-				isVisible, exists, err := ctx.Planner.IsTableVisible(
-					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oidArg.Oid,
+				isVisible, exists, err := evalCtx.Planner.IsTableVisible(
+					evalCtx.Context, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1237,10 +1238,10 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oidArg := tree.MustBeDOid(args[0])
-				isVisible, exists, err := ctx.Planner.IsTypeVisible(
-					ctx.Context, ctx.SessionData().Database, ctx.SessionData().SearchPath, oidArg.Oid,
+				isVisible, exists, err := evalCtx.Planner.IsTypeVisible(
+					evalCtx.Context, evalCtx.SessionData().Database, evalCtx.SessionData().SearchPath, oidArg.Oid,
 				)
 				if err != nil {
 					return nil, err
@@ -1260,8 +1261,8 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"reloid", types.Oid}, {"include_triggers", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.Int4),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ret, err := ctx.CatalogBuiltins.PGRelationIsUpdatable(ctx.Ctx(), tree.MustBeDOid(args[0]))
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				ret, err := evalCtx.CatalogBuiltins.PGRelationIsUpdatable(evalCtx.Ctx(), tree.MustBeDOid(args[0]))
 				if err != nil {
 					return nil, err
 				}
@@ -1281,8 +1282,8 @@ SELECT description
 				{"include_triggers", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ret, err := ctx.CatalogBuiltins.PGColumnIsUpdatable(ctx.Ctx(), tree.MustBeDOid(args[0]), tree.MustBeDInt(args[1]))
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				ret, err := evalCtx.CatalogBuiltins.PGColumnIsUpdatable(evalCtx.Ctx(), tree.MustBeDOid(args[0]), tree.MustBeDInt(args[1]))
 				if err != nil {
 					return nil, err
 				}
@@ -1298,12 +1299,12 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"seconds", types.Float}},
 			ReturnType: tree.FixedReturnType(types.Bool),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				durationNanos := int64(float64(*args[0].(*tree.DFloat)) * float64(1000000000))
 				dur := time.Duration(durationNanos)
 				select {
-				case <-ctx.Ctx().Done():
-					return nil, ctx.Ctx().Err()
+				case <-evalCtx.Ctx().Done():
+					return nil, evalCtx.Ctx().Err()
 				case <-time.After(dur):
 					return tree.DBoolTrue, nil
 				}
@@ -1344,8 +1345,8 @@ SELECT description
 	"has_any_column_privilege": makePGPrivilegeInquiryDef(
 		"any column of table",
 		argTypeOpts{{"table", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			tableArg := eval.UnwrapDatum(ctx, args[0])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			tableArg := eval.UnwrapDatum(evalCtx, args[0])
 			specifier, err := tableHasPrivilegeSpecifier(tableArg, false /* isSequence */)
 			if err != nil {
 				return eval.HasNoPrivilege, err
@@ -1364,16 +1365,16 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_column_privilege": makePGPrivilegeInquiryDef(
 		"column",
 		argTypeOpts{{"table", strOrOidTypes}, {"column", []*types.T{types.String, types.Int}}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			tableArg := eval.UnwrapDatum(ctx, args[0])
-			colArg := eval.UnwrapDatum(ctx, args[1])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			tableArg := eval.UnwrapDatum(evalCtx, args[0])
+			colArg := eval.UnwrapDatum(evalCtx, args[1])
 			specifier, err := columnHasPrivilegeSpecifier(tableArg, colArg)
 			if err != nil {
 				return eval.HasNoPrivilege, err
@@ -1392,16 +1393,16 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_database_privilege": makePGPrivilegeInquiryDef(
 		"database",
 		argTypeOpts{{"database", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 
-			databaseArg := eval.UnwrapDatum(ctx, args[0])
+			databaseArg := eval.UnwrapDatum(evalCtx, args[0])
 			specifier, err := databaseHasPrivilegeSpecifier(databaseArg)
 			if err != nil {
 				return eval.HasNoPrivilege, err
@@ -1421,16 +1422,16 @@ SELECT description
 				return eval.HasNoPrivilege, err
 			}
 
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_foreign_data_wrapper_privilege": makePGPrivilegeInquiryDef(
 		"foreign-data wrapper",
 		argTypeOpts{{"fdw", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			fdwArg := eval.UnwrapDatum(ctx, args[0])
-			fdw, err := getNameForArg(ctx, fdwArg, "pg_foreign_data_wrapper", "fdwname")
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			fdwArg := eval.UnwrapDatum(evalCtx, args[0])
+			fdw, err := getNameForArg(evalCtx, fdwArg, "pg_foreign_data_wrapper", "fdwname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1466,15 +1467,15 @@ SELECT description
 	"has_function_privilege": makePGPrivilegeInquiryDef(
 		"function",
 		argTypeOpts{{"function", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			oidArg := eval.UnwrapDatum(ctx, args[0])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			oidArg := eval.UnwrapDatum(evalCtx, args[0])
 			// When specifying a function by a text string rather than by OID,
 			// the allowed input is the same as for the regprocedure data type.
 			var oid tree.Datum
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = eval.ParseDOid(ctx, string(*t), types.RegProcedure)
+				oid, err = eval.ParseDOid(evalCtx, string(*t), types.RegProcedure)
 				if err != nil {
 					return eval.HasNoPrivilege, err
 				}
@@ -1483,7 +1484,7 @@ SELECT description
 			}
 
 			// Check if the function OID actually exists.
-			_, _, err := ctx.Planner.ResolveFunctionByOID(ctx.Ctx(), oid.(*tree.DOid).Oid)
+			_, _, err := evalCtx.Planner.ResolveFunctionByOID(ctx, oid.(*tree.DOid).Oid)
 			if err != nil {
 				if errors.Is(err, tree.ErrFunctionUndefined) {
 					return eval.ObjectNotFound, nil
@@ -1502,7 +1503,7 @@ SELECT description
 
 			// For user-defined function, utilize the descriptor based way.
 			if catid.IsOIDUserDefined(oid.(*tree.DOid).Oid) {
-				return ctx.Planner.HasAnyPrivilege(ctx.Ctx(), specifier, ctx.SessionData().User(), privs)
+				return evalCtx.Planner.HasAnyPrivilege(ctx, specifier, evalCtx.SessionData().User(), privs)
 			}
 
 			// For builtin functions, all users should have `EXECUTE` privilege, but
@@ -1519,9 +1520,9 @@ SELECT description
 	"has_language_privilege": makePGPrivilegeInquiryDef(
 		"language",
 		argTypeOpts{{"language", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			langArg := eval.UnwrapDatum(ctx, args[0])
-			lang, err := getNameForArg(ctx, langArg, "pg_language", "lanname")
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			langArg := eval.UnwrapDatum(evalCtx, args[0])
+			lang, err := getNameForArg(evalCtx, langArg, "pg_language", "lanname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1557,10 +1558,10 @@ SELECT description
 	"has_schema_privilege": makePGPrivilegeInquiryDef(
 		"schema",
 		argTypeOpts{{"schema", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			schemaArg := eval.UnwrapDatum(ctx, args[0])
-			databaseName := ctx.SessionData().Database
-			specifier, err := schemaHasPrivilegeSpecifier(ctx, schemaArg, databaseName)
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			schemaArg := eval.UnwrapDatum(evalCtx, args[0])
+			databaseName := evalCtx.SessionData().Database
+			specifier, err := schemaHasPrivilegeSpecifier(evalCtx, schemaArg, databaseName)
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1579,15 +1580,15 @@ SELECT description
 				return eval.ObjectNotFound, nil
 			}
 
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_sequence_privilege": makePGPrivilegeInquiryDef(
 		"sequence",
 		argTypeOpts{{"sequence", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			seqArg := eval.UnwrapDatum(ctx, args[0])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			seqArg := eval.UnwrapDatum(evalCtx, args[0])
 			specifier, err := tableHasPrivilegeSpecifier(seqArg, true /* isSequence */)
 			if err != nil {
 				return eval.HasNoPrivilege, err
@@ -1605,16 +1606,16 @@ SELECT description
 			if err != nil {
 				return eval.HasPrivilege, err
 			}
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_server_privilege": makePGPrivilegeInquiryDef(
 		"foreign server",
 		argTypeOpts{{"server", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			serverArg := eval.UnwrapDatum(ctx, args[0])
-			server, err := getNameForArg(ctx, serverArg, "pg_foreign_server", "srvname")
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			serverArg := eval.UnwrapDatum(evalCtx, args[0])
+			server, err := getNameForArg(evalCtx, serverArg, "pg_foreign_server", "srvname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1650,8 +1651,8 @@ SELECT description
 	"has_table_privilege": makePGPrivilegeInquiryDef(
 		"table",
 		argTypeOpts{{"table", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			tableArg := eval.UnwrapDatum(ctx, args[0])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			tableArg := eval.UnwrapDatum(evalCtx, args[0])
 			specifier, err := tableHasPrivilegeSpecifier(tableArg, false /* isSequence */)
 			if err != nil {
 				return eval.HasNoPrivilege, err
@@ -1678,16 +1679,16 @@ SELECT description
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
-			return ctx.Planner.HasAnyPrivilege(ctx.Context, specifier, user, privs)
+			return evalCtx.Planner.HasAnyPrivilege(evalCtx.Context, specifier, user, privs)
 		},
 	),
 
 	"has_tablespace_privilege": makePGPrivilegeInquiryDef(
 		"tablespace",
 		argTypeOpts{{"tablespace", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			tablespaceArg := eval.UnwrapDatum(ctx, args[0])
-			tablespace, err := getNameForArg(ctx, tablespaceArg, "pg_tablespace", "spcname")
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			tablespaceArg := eval.UnwrapDatum(evalCtx, args[0])
+			tablespace, err := getNameForArg(evalCtx, tablespaceArg, "pg_tablespace", "spcname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1723,15 +1724,15 @@ SELECT description
 	"has_type_privilege": makePGPrivilegeInquiryDef(
 		"type",
 		argTypeOpts{{"type", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			oidArg := eval.UnwrapDatum(ctx, args[0])
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			oidArg := eval.UnwrapDatum(evalCtx, args[0])
 			// When specifying a type by a text string rather than by OID, the
 			// allowed input is the same as for the regtype data type.
 			var oid tree.Datum
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = eval.ParseDOid(ctx, string(*t), types.RegType)
+				oid, err = eval.ParseDOid(evalCtx, string(*t), types.RegType)
 				if err != nil {
 					return eval.HasNoPrivilege, err
 				}
@@ -1739,7 +1740,7 @@ SELECT description
 				oid = t
 			}
 
-			typ, err := getNameForArg(ctx, oid, "pg_type", "typname")
+			typ, err := getNameForArg(evalCtx, oid, "pg_type", "typname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1769,9 +1770,9 @@ SELECT description
 	"pg_has_role": makePGPrivilegeInquiryDef(
 		"role",
 		argTypeOpts{{"role", strOrOidTypes}},
-		func(ctx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
-			roleArg := eval.UnwrapDatum(ctx, args[0])
-			roleS, err := getNameForArg(ctx, roleArg, "pg_roles", "rolname")
+		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
+			roleArg := eval.UnwrapDatum(evalCtx, args[0])
+			roleS, err := getNameForArg(evalCtx, roleArg, "pg_roles", "rolname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1796,15 +1797,15 @@ SELECT description
 				var err error
 				switch privStr {
 				case "USAGE":
-					hasAnyPrivilegeResult, err = hasPrivsOfRole(ctx, user, role)
+					hasAnyPrivilegeResult, err = hasPrivsOfRole(evalCtx, user, role)
 				case "MEMBER":
-					hasAnyPrivilegeResult, err = isMemberOfRole(ctx, user, role)
+					hasAnyPrivilegeResult, err = isMemberOfRole(evalCtx, user, role)
 				case
 					"USAGE WITH GRANT OPTION",
 					"USAGE WITH ADMIN OPTION",
 					"MEMBER WITH GRANT OPTION",
 					"MEMBER WITH ADMIN OPTION":
-					hasAnyPrivilegeResult, err = isAdminOfRole(ctx, user, role)
+					hasAnyPrivilegeResult, err = isAdminOfRole(evalCtx, user, role)
 				default:
 					return eval.HasNoPrivilege, pgerror.Newf(pgcode.InvalidParameterValue,
 						"unrecognized privilege type: %q", privStr)
@@ -1829,8 +1830,8 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"setting_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getSessionVar(ctx, string(tree.MustBeDString(args[0])), false /* missingOk */)
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return getSessionVar(evalCtx, string(tree.MustBeDString(args[0])), false /* missingOk */)
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Stable,
@@ -1838,8 +1839,8 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"setting_name", types.String}, {"missing_ok", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getSessionVar(ctx, string(tree.MustBeDString(args[0])), bool(tree.MustBeDBool(args[1])))
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				return getSessionVar(evalCtx, string(tree.MustBeDString(args[0])), bool(tree.MustBeDBool(args[1])))
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Stable,
@@ -1855,14 +1856,14 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{{"setting_name", types.String}, {"new_value", types.String}, {"is_local", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				varName := string(tree.MustBeDString(args[0]))
 				newValue := string(tree.MustBeDString(args[1]))
-				err := setSessionVar(ctx, varName, newValue, bool(tree.MustBeDBool(args[2])))
+				err := setSessionVar(evalCtx, varName, newValue, bool(tree.MustBeDBool(args[2])))
 				if err != nil {
 					return nil, err
 				}
-				return getSessionVar(ctx, varName, false /* missingOk */)
+				return getSessionVar(evalCtx, varName, false /* missingOk */)
 			},
 			Info:       builtinconstants.CategorySystemInfo,
 			Volatility: volatility.Volatile,
@@ -1884,7 +1885,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipaddr.IPAddr{}}), nil
 			},
 			Info:       notUsableInfo,
@@ -1896,7 +1897,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.DZero, nil
 			},
 			Info:       notUsableInfo,
@@ -1908,7 +1909,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.INet),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipaddr.IPAddr{}}), nil
 			},
 			Info:       notUsableInfo,
@@ -1920,7 +1921,7 @@ SELECT description
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.DZero, nil
 			},
 			Info:       notUsableInfo,
@@ -1938,7 +1939,7 @@ SELECT description
 				VarType: types.Any,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var totalSize int
 				for _, arg := range args {
 					encodeTableValue, err := valueside.Encode(nil, valueside.NoColumnID, arg, nil)
@@ -2001,7 +2002,7 @@ SELECT description
 				{"typmod", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typid := args[0].(*tree.DOid).Oid
 				typmod := *args[1].(*tree.DInt)
 				if typmod == -1 {
@@ -2042,9 +2043,9 @@ SELECT description
 				{"col", types.Int2},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				r, err := ctx.Planner.QueryRowEx(
-					ctx.Ctx(), "information_schema._pg_index_position",
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				r, err := evalCtx.Planner.QueryRowEx(
+					evalCtx.Ctx(), "information_schema._pg_index_position",
 					sessiondata.NoSessionDataOverride,
 					`SELECT (ss.a).n FROM
 					  (SELECT information_schema._pg_expandarray(indkey) AS a
@@ -2071,7 +2072,7 @@ SELECT description
 				{"typmod", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typid := tree.MustBeDOid(args[0]).Oid
 				typmod := tree.MustBeDInt(args[1])
 				switch typid {
@@ -2108,7 +2109,7 @@ SELECT description
 				{"typmod", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typid := tree.MustBeDOid(args[0]).Oid
 				if typid == oid.T_int2 || typid == oid.T_int4 || typid == oid.T_int8 || typid == oid.T_float4 || typid == oid.T_float8 {
 					return tree.NewDInt(2), nil
@@ -2130,7 +2131,7 @@ SELECT description
 				{"typmod", types.Int4},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typid := tree.MustBeDOid(args[0]).Oid
 				typmod := tree.MustBeDInt(args[1])
 				if typid == oid.T_int2 || typid == oid.T_int4 || typid == oid.T_int8 {
@@ -2152,11 +2153,11 @@ SELECT description
 	),
 }
 
-func getSessionVar(ctx *eval.Context, settingName string, missingOk bool) (tree.Datum, error) {
-	if ctx.SessionAccessor == nil {
+func getSessionVar(evalCtx *eval.Context, settingName string, missingOk bool) (tree.Datum, error) {
+	if evalCtx.SessionAccessor == nil {
 		return nil, errors.AssertionFailedf("session accessor not set")
 	}
-	ok, s, err := ctx.SessionAccessor.GetSessionVar(ctx.Context, settingName, missingOk)
+	ok, s, err := evalCtx.SessionAccessor.GetSessionVar(evalCtx.Context, settingName, missingOk)
 	if err != nil {
 		return nil, err
 	}
@@ -2166,11 +2167,11 @@ func getSessionVar(ctx *eval.Context, settingName string, missingOk bool) (tree.
 	return tree.NewDString(s), nil
 }
 
-func setSessionVar(ctx *eval.Context, settingName, newVal string, isLocal bool) error {
-	if ctx.SessionAccessor == nil {
+func setSessionVar(evalCtx *eval.Context, settingName, newVal string, isLocal bool) error {
+	if evalCtx.SessionAccessor == nil {
 		return errors.AssertionFailedf("session accessor not set")
 	}
-	return ctx.SessionAccessor.SetSessionVar(ctx.Context, settingName, newVal, isLocal)
+	return evalCtx.SessionAccessor.SetSessionVar(evalCtx.Context, settingName, newVal, isLocal)
 }
 
 // getCatalogOidForComments returns the "catalog table oid" (the oid of a
@@ -2200,7 +2201,7 @@ func getCatalogOidForComments(catalogName string) (id int, ok bool) {
 // getPgObjDesc queries pg_description for object comments. catalog_name, if not
 // empty, provides a constraint on which "system catalog" the comment is in.
 // System catalogs are things like pg_class, pg_type, pg_database, and so on.
-func getPgObjDesc(ctx *eval.Context, catalogName string, oidVal oid.Oid) (tree.Datum, error) {
+func getPgObjDesc(evalCtx *eval.Context, catalogName string, oidVal oid.Oid) (tree.Datum, error) {
 	classOidFilter := ""
 	if catalogName != "" {
 		classOid, ok := getCatalogOidForComments(catalogName)
@@ -2210,8 +2211,8 @@ func getPgObjDesc(ctx *eval.Context, catalogName string, oidVal oid.Oid) (tree.D
 		}
 		classOidFilter = fmt.Sprintf("AND classoid = %d", classOid)
 	}
-	r, err := ctx.Planner.QueryRowEx(
-		ctx.Ctx(), "pg_get_objdesc",
+	r, err := evalCtx.Planner.QueryRowEx(
+		evalCtx.Ctx(), "pg_get_objdesc",
 		sessiondata.NoSessionDataOverride,
 		fmt.Sprintf(`
 SELECT description
@@ -2290,7 +2291,7 @@ func columnHasPrivilegeSpecifier(
 }
 
 func schemaHasPrivilegeSpecifier(
-	ctx *eval.Context, schemaArg tree.Datum, databaseName string,
+	evalCtx *eval.Context, schemaArg tree.Datum, databaseName string,
 ) (eval.HasPrivilegeSpecifier, error) {
 	specifier := eval.HasPrivilegeSpecifier{
 		SchemaDatabaseName: &databaseName,
@@ -2302,7 +2303,7 @@ func schemaHasPrivilegeSpecifier(
 		specifier.SchemaName = &s
 		schemaIsRequired = true
 	case *tree.DOid:
-		schemaName, err := getNameForArg(ctx, schemaArg, "pg_namespace", "nspname")
+		schemaName, err := getNameForArg(evalCtx, schemaArg, "pg_namespace", "nspname")
 		if err != nil {
 			return specifier, err
 		}
@@ -2322,7 +2323,7 @@ func pgTrueTypImpl(attrField, typField string, retType *types.T) builtinDefiniti
 				{"pg_type", types.AnyTuple},
 			},
 			ReturnType: tree.FixedReturnType(retType),
-			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// In Postgres, this builtin is statically typed to accept a
 				// pg_attribute record and a pg_type record. This isn't currently
 				// possible in CockroachDB, so instead, we accept any tuple and then
@@ -2375,9 +2376,9 @@ func pgTrueTypImpl(attrField, typField string, retType *types.T) builtinDefiniti
 // role, so this is currently equivalent to isMemberOfRole.
 // See https://github.com/cockroachdb/cockroach/issues/69583.
 func hasPrivsOfRole(
-	ctx *eval.Context, user, role username.SQLUsername,
+	evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
-	return isMemberOfRole(ctx, user, role)
+	return isMemberOfRole(evalCtx, user, role)
 }
 
 // isMemberOfRole returns whether the user is a member of the specified role
@@ -2385,7 +2386,7 @@ func hasPrivsOfRole(
 //
 // This is defined to recurse through roles regardless of rolinherit.
 func isMemberOfRole(
-	ctx *eval.Context, user, role username.SQLUsername,
+	evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
 	// Fast path for simple case.
 	if user == role {
@@ -2393,13 +2394,13 @@ func isMemberOfRole(
 	}
 
 	// Superusers have every privilege and are part of every role.
-	if isSuper, err := ctx.Planner.UserHasAdminRole(ctx.Context, user); err != nil {
+	if isSuper, err := evalCtx.Planner.UserHasAdminRole(evalCtx.Context, user); err != nil {
 		return eval.HasNoPrivilege, err
 	} else if isSuper {
 		return eval.HasPrivilege, nil
 	}
 
-	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
+	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(evalCtx.Context, user)
 	if err != nil {
 		return eval.HasNoPrivilege, err
 	}
@@ -2415,12 +2416,12 @@ func isMemberOfRole(
 // That is, is member the role itself (subject to restrictions below), a
 // member (directly or indirectly) WITH ADMIN OPTION, or a superuser?
 func isAdminOfRole(
-	ctx *eval.Context, user, role username.SQLUsername,
+	evalCtx *eval.Context, user, role username.SQLUsername,
 ) (eval.HasAnyPrivilegeResult, error) {
 	// Superusers are an admin of every role.
 	//
 	// NB: this is intentionally before the user == role check here.
-	if isSuper, err := ctx.Planner.UserHasAdminRole(ctx.Context, user); err != nil {
+	if isSuper, err := evalCtx.Planner.UserHasAdminRole(evalCtx.Context, user); err != nil {
 		return eval.HasNoPrivilege, err
 	} else if isSuper {
 		return eval.HasPrivilege, nil
@@ -2460,13 +2461,13 @@ func isAdminOfRole(
 		// Because CockroachDB does not have "security-restricted operation", so
 		// for compatibility, we just need to check whether the user matches the
 		// session user.
-		if isSessionUser := user == ctx.SessionData().SessionUser(); isSessionUser {
+		if isSessionUser := user == evalCtx.SessionData().SessionUser(); isSessionUser {
 			return eval.HasPrivilege, nil
 		}
 		return eval.HasNoPrivilege, nil
 	}
 
-	allRoleMemberships, err := ctx.Planner.MemberOfWithAdminOption(ctx.Context, user)
+	allRoleMemberships, err := evalCtx.Planner.MemberOfWithAdminOption(evalCtx.Context, user)
 	if err != nil {
 		return eval.HasNoPrivilege, err
 	}

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -214,7 +214,7 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 				colNumber = *args[1].(*tree.DInt)
 			}
 			r, err := evalCtx.Planner.QueryRowEx(
-				evalCtx.Ctx(), "pg_get_indexdef",
+				ctx, "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT indexdef FROM pg_catalog.pg_indexes WHERE crdb_oid = $1", args[0])
 			if err != nil {
@@ -230,7 +230,7 @@ func makePGGetIndexDef(argTypes tree.ArgTypes) tree.Overload {
 			}
 			// The 3 argument variant for column number other than 0 returns the column name.
 			r, err = evalCtx.Planner.QueryRowEx(
-				evalCtx.Ctx(), "pg_get_indexdef",
+				ctx, "pg_get_indexdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT ischema.column_name as pg_get_indexdef 
 		               FROM information_schema.statistics AS ischema 
@@ -264,7 +264,7 @@ func makePGGetViewDef(argTypes tree.ArgTypes) tree.Overload {
 		ReturnType: tree.FixedReturnType(types.String),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			r, err := evalCtx.Planner.QueryRowEx(
-				evalCtx.Ctx(), "pg_get_viewdef",
+				ctx, "pg_get_viewdef",
 				sessiondata.NoSessionDataOverride,
 				`SELECT definition
  FROM pg_catalog.pg_views v
@@ -295,7 +295,7 @@ func makePGGetConstraintDef(argTypes tree.ArgTypes) tree.Overload {
 		ReturnType: tree.FixedReturnType(types.String),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			r, err := evalCtx.Planner.QueryRowEx(
-				evalCtx.Ctx(), "pg_get_constraintdef",
+				ctx, "pg_get_constraintdef",
 				sessiondata.NoSessionDataOverride,
 				"SELECT condef FROM pg_catalog.pg_constraint WHERE oid=$1", args[0])
 			if err != nil {
@@ -380,7 +380,7 @@ func makePGPrivilegeInquiryDef(
 				var user username.SQLUsername
 				if withUser {
 					arg := eval.UnwrapDatum(evalCtx, args[0])
-					userS, err := getNameForArg(evalCtx, arg, "pg_roles", "rolname")
+					userS, err := getNameForArg(ctx, evalCtx, arg, "pg_roles", "rolname")
 					if err != nil {
 						return nil, err
 					}
@@ -437,7 +437,9 @@ func makePGPrivilegeInquiryDef(
 // getNameForArg determines the object name for the specified argument, which
 // should be either an unwrapped STRING or an OID. If the object is not found,
 // the returned string will be empty.
-func getNameForArg(evalCtx *eval.Context, arg tree.Datum, pgTable, pgCol string) (string, error) {
+func getNameForArg(
+	ctx context.Context, evalCtx *eval.Context, arg tree.Datum, pgTable, pgCol string,
+) (string, error) {
 	var query string
 	switch t := arg.(type) {
 	case *tree.DString:
@@ -447,7 +449,7 @@ func getNameForArg(evalCtx *eval.Context, arg tree.Datum, pgTable, pgCol string)
 	default:
 		return "", errors.AssertionFailedf("unexpected arg type %T", t)
 	}
-	r, err := evalCtx.Planner.QueryRowEx(evalCtx.Ctx(), "get-name-for-arg",
+	r, err := evalCtx.Planner.QueryRowEx(ctx, "get-name-for-arg",
 		sessiondata.NoSessionDataOverride, query, arg)
 	if err != nil || r == nil {
 		return "", err
@@ -524,7 +526,7 @@ func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
 				if int > 0 {
 					return tree.DNull, nil
 				}
-				typOid, err := eval.ParseDOid(evalCtx, string(typName), typ)
+				typOid, err := eval.ParseDOid(ctx, evalCtx, string(typName), typ)
 				if err != nil {
 					//nolint:returnerrcheck
 					return tree.DNull, nil
@@ -666,7 +668,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					}
 				}
 				results, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_functiondef",
+					ctx, "pg_get_functiondef",
 					sessiondata.NoSessionDataOverride,
 					getFuncQuery,
 					idToQuery,
@@ -697,7 +699,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
 				t, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_function_result",
+					ctx, "pg_get_function_result",
 					sessiondata.NoSessionDataOverride,
 					`SELECT prorettype::REGTYPE::TEXT FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
@@ -725,7 +727,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				funcOid := tree.MustBeDOid(args[0])
 				t, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_function_identity_arguments",
+					ctx, "pg_get_function_identity_arguments",
 					sessiondata.NoSessionDataOverride,
 					`SELECT array_agg(unnest(proargtypes)::REGTYPE::TEXT) FROM pg_proc WHERE oid=$1`, funcOid.Oid)
 				if err != nil {
@@ -791,7 +793,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				res, err := evalCtx.Sequence.GetSerialSequenceNameFromColumn(evalCtx.Ctx(), qualifiedName, tree.Name(columnName))
+				res, err := evalCtx.Sequence.GetSerialSequenceNameFromColumn(ctx, qualifiedName, tree.Name(columnName))
 				if err != nil {
 					return nil, err
 				}
@@ -821,7 +823,7 @@ var pgBuiltins = map[string]builtinDefinition{
 					return tree.NewDOid(0), nil
 				}
 				oid, errSafeToIgnore, err := evalCtx.Planner.ResolveOIDFromString(
-					evalCtx.Ctx(), types.RegNamespace, tree.NewDString(schema))
+					ctx, types.RegNamespace, tree.NewDString(schema))
 				if err != nil {
 					// If the OID lookup returns an UndefinedObject error, return 0
 					// instead. We can hit this path if the session created a temporary
@@ -849,7 +851,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				schemaArg := eval.UnwrapDatum(evalCtx, args[0])
-				schema, err := getNameForArg(evalCtx, schemaArg, "pg_namespace", "nspname")
+				schema, err := getNameForArg(ctx, evalCtx, schemaArg, "pg_namespace", "nspname")
 				if err != nil {
 					return nil, err
 				}
@@ -921,7 +923,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := args[0]
 				t, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_userbyid",
+					ctx, "pg_get_userbyid",
 					sessiondata.NoSessionDataOverride,
 					"SELECT rolname FROM pg_catalog.pg_roles WHERE oid=$1", oid)
 				if err != nil {
@@ -949,7 +951,7 @@ var pgBuiltins = map[string]builtinDefinition{
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				r, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_sequence_parameters",
+					ctx, "pg_sequence_parameters",
 					sessiondata.NoSessionDataOverride,
 					`SELECT seqstart, seqmin, seqmax, seqincrement, seqcycle, seqcache, seqtypid `+
 						`FROM pg_catalog.pg_sequence WHERE seqrelid=$1`, args[0])
@@ -1044,7 +1046,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				// TODO(jordanlewis): Really we'd like to query this directly
 				// on pg_description and let predicate push-down do its job.
 				r, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_coldesc",
+					ctx, "pg_get_coldesc",
 					sessiondata.NoSessionDataOverride,
 					`
 SELECT comment FROM system.comments c
@@ -1068,7 +1070,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getPgObjDesc(evalCtx, "", args[0].(*tree.DOid).Oid)
+				return getPgObjDesc(ctx, evalCtx, "", args[0].(*tree.DOid).Oid)
 			},
 			Info:       notUsableInfo,
 			Volatility: volatility.Stable,
@@ -1077,7 +1079,9 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			Types:      tree.ArgTypes{{"object_oid", types.Oid}, {"catalog_name", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return getPgObjDesc(evalCtx,
+				return getPgObjDesc(
+					ctx,
+					evalCtx,
 					string(tree.MustBeDString(args[1])),
 					args[0].(*tree.DOid).Oid,
 				)
@@ -1092,7 +1096,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 			Types:      tree.ArgTypes{{"int", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Oid),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return eval.PerformCast(evalCtx, args[0], types.Oid)
+				return eval.PerformCast(ctx, evalCtx, args[0], types.Oid)
 			},
 			Info:       "Converts an integer to an OID.",
 			Volatility: volatility.Immutable,
@@ -1114,7 +1118,7 @@ WHERE c.type=$1::int AND c.object_id=$2::int AND c.sub_id=$3::int LIMIT 1
 				}
 
 				r, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_get_shobjdesc",
+					ctx, "pg_get_shobjdesc",
 					sessiondata.NoSessionDataOverride,
 					fmt.Sprintf(`
 SELECT description
@@ -1188,7 +1192,7 @@ SELECT description
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				oid := tree.MustBeDOid(args[0])
 				t, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "pg_function_is_visible",
+					ctx, "pg_function_is_visible",
 					sessiondata.NoSessionDataOverride,
 					"SELECT * from pg_proc WHERE oid=$1 LIMIT 1", oid.Oid)
 				if err != nil {
@@ -1262,7 +1266,7 @@ SELECT description
 			Types:      tree.ArgTypes{{"reloid", types.Oid}, {"include_triggers", types.Bool}},
 			ReturnType: tree.FixedReturnType(types.Int4),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ret, err := evalCtx.CatalogBuiltins.PGRelationIsUpdatable(evalCtx.Ctx(), tree.MustBeDOid(args[0]))
+				ret, err := evalCtx.CatalogBuiltins.PGRelationIsUpdatable(ctx, tree.MustBeDOid(args[0]))
 				if err != nil {
 					return nil, err
 				}
@@ -1283,7 +1287,7 @@ SELECT description
 			},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ret, err := evalCtx.CatalogBuiltins.PGColumnIsUpdatable(evalCtx.Ctx(), tree.MustBeDOid(args[0]), tree.MustBeDInt(args[1]))
+				ret, err := evalCtx.CatalogBuiltins.PGColumnIsUpdatable(ctx, tree.MustBeDOid(args[0]), tree.MustBeDInt(args[1]))
 				if err != nil {
 					return nil, err
 				}
@@ -1303,8 +1307,8 @@ SELECT description
 				durationNanos := int64(float64(*args[0].(*tree.DFloat)) * float64(1000000000))
 				dur := time.Duration(durationNanos)
 				select {
-				case <-evalCtx.Ctx().Done():
-					return nil, evalCtx.Ctx().Err()
+				case <-ctx.Done():
+					return nil, ctx.Err()
 				case <-time.After(dur):
 					return tree.DBoolTrue, nil
 				}
@@ -1431,7 +1435,7 @@ SELECT description
 		argTypeOpts{{"fdw", strOrOidTypes}},
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			fdwArg := eval.UnwrapDatum(evalCtx, args[0])
-			fdw, err := getNameForArg(evalCtx, fdwArg, "pg_foreign_data_wrapper", "fdwname")
+			fdw, err := getNameForArg(ctx, evalCtx, fdwArg, "pg_foreign_data_wrapper", "fdwname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1475,7 +1479,7 @@ SELECT description
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = eval.ParseDOid(evalCtx, string(*t), types.RegProcedure)
+				oid, err = eval.ParseDOid(ctx, evalCtx, string(*t), types.RegProcedure)
 				if err != nil {
 					return eval.HasNoPrivilege, err
 				}
@@ -1522,7 +1526,7 @@ SELECT description
 		argTypeOpts{{"language", strOrOidTypes}},
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			langArg := eval.UnwrapDatum(evalCtx, args[0])
-			lang, err := getNameForArg(evalCtx, langArg, "pg_language", "lanname")
+			lang, err := getNameForArg(ctx, evalCtx, langArg, "pg_language", "lanname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1561,7 +1565,7 @@ SELECT description
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			schemaArg := eval.UnwrapDatum(evalCtx, args[0])
 			databaseName := evalCtx.SessionData().Database
-			specifier, err := schemaHasPrivilegeSpecifier(evalCtx, schemaArg, databaseName)
+			specifier, err := schemaHasPrivilegeSpecifier(ctx, evalCtx, schemaArg, databaseName)
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1615,7 +1619,7 @@ SELECT description
 		argTypeOpts{{"server", strOrOidTypes}},
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			serverArg := eval.UnwrapDatum(evalCtx, args[0])
-			server, err := getNameForArg(evalCtx, serverArg, "pg_foreign_server", "srvname")
+			server, err := getNameForArg(ctx, evalCtx, serverArg, "pg_foreign_server", "srvname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1688,7 +1692,7 @@ SELECT description
 		argTypeOpts{{"tablespace", strOrOidTypes}},
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			tablespaceArg := eval.UnwrapDatum(evalCtx, args[0])
-			tablespace, err := getNameForArg(evalCtx, tablespaceArg, "pg_tablespace", "spcname")
+			tablespace, err := getNameForArg(ctx, evalCtx, tablespaceArg, "pg_tablespace", "spcname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1732,7 +1736,7 @@ SELECT description
 			switch t := oidArg.(type) {
 			case *tree.DString:
 				var err error
-				oid, err = eval.ParseDOid(evalCtx, string(*t), types.RegType)
+				oid, err = eval.ParseDOid(ctx, evalCtx, string(*t), types.RegType)
 				if err != nil {
 					return eval.HasNoPrivilege, err
 				}
@@ -1740,7 +1744,7 @@ SELECT description
 				oid = t
 			}
 
-			typ, err := getNameForArg(evalCtx, oid, "pg_type", "typname")
+			typ, err := getNameForArg(ctx, evalCtx, oid, "pg_type", "typname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -1772,7 +1776,7 @@ SELECT description
 		argTypeOpts{{"role", strOrOidTypes}},
 		func(ctx context.Context, evalCtx *eval.Context, args tree.Datums, user username.SQLUsername) (eval.HasAnyPrivilegeResult, error) {
 			roleArg := eval.UnwrapDatum(evalCtx, args[0])
-			roleS, err := getNameForArg(evalCtx, roleArg, "pg_roles", "rolname")
+			roleS, err := getNameForArg(ctx, evalCtx, roleArg, "pg_roles", "rolname")
 			if err != nil {
 				return eval.HasNoPrivilege, err
 			}
@@ -2045,7 +2049,7 @@ SELECT description
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				r, err := evalCtx.Planner.QueryRowEx(
-					evalCtx.Ctx(), "information_schema._pg_index_position",
+					ctx, "information_schema._pg_index_position",
 					sessiondata.NoSessionDataOverride,
 					`SELECT (ss.a).n FROM
 					  (SELECT information_schema._pg_expandarray(indkey) AS a
@@ -2205,7 +2209,9 @@ func getCatalogOidForComments(catalogName string) (id int, ok bool) {
 // getPgObjDesc queries pg_description for object comments. catalog_name, if not
 // empty, provides a constraint on which "system catalog" the comment is in.
 // System catalogs are things like pg_class, pg_type, pg_database, and so on.
-func getPgObjDesc(evalCtx *eval.Context, catalogName string, oidVal oid.Oid) (tree.Datum, error) {
+func getPgObjDesc(
+	ctx context.Context, evalCtx *eval.Context, catalogName string, oidVal oid.Oid,
+) (tree.Datum, error) {
 	classOidFilter := ""
 	if catalogName != "" {
 		classOid, ok := getCatalogOidForComments(catalogName)
@@ -2216,7 +2222,7 @@ func getPgObjDesc(evalCtx *eval.Context, catalogName string, oidVal oid.Oid) (tr
 		classOidFilter = fmt.Sprintf("AND classoid = %d", classOid)
 	}
 	r, err := evalCtx.Planner.QueryRowEx(
-		evalCtx.Ctx(), "pg_get_objdesc",
+		ctx, "pg_get_objdesc",
 		sessiondata.NoSessionDataOverride,
 		fmt.Sprintf(`
 SELECT description
@@ -2295,7 +2301,7 @@ func columnHasPrivilegeSpecifier(
 }
 
 func schemaHasPrivilegeSpecifier(
-	evalCtx *eval.Context, schemaArg tree.Datum, databaseName string,
+	ctx context.Context, evalCtx *eval.Context, schemaArg tree.Datum, databaseName string,
 ) (eval.HasPrivilegeSpecifier, error) {
 	specifier := eval.HasPrivilegeSpecifier{
 		SchemaDatabaseName: &databaseName,
@@ -2307,7 +2313,7 @@ func schemaHasPrivilegeSpecifier(
 		specifier.SchemaName = &s
 		schemaIsRequired = true
 	case *tree.DOid:
-		schemaName, err := getNameForArg(evalCtx, schemaArg, "pg_namespace", "nspname")
+		schemaName, err := getNameForArg(ctx, evalCtx, schemaArg, "pg_namespace", "nspname")
 		if err != nil {
 			return specifier, err
 		}

--- a/pkg/sql/sem/builtins/pgcrypto_builtins.go
+++ b/pkg/sql/sem/builtins/pgcrypto_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/md5"
 	"crypto/rand"
@@ -48,7 +49,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"password", types.String}, {"salt", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				password := tree.MustBeDString(args[0])
 				salt := tree.MustBeDString(args[1])
 				hash, err := crypt(string(password), string(salt))
@@ -67,7 +68,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.String}, {"type", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				alg := tree.MustBeDString(args[1])
 				hashFunc, err := getHashFunc(string(alg))
 				if err != nil {
@@ -86,7 +87,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"type", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				alg := tree.MustBeDString(args[1])
 				hashFunc, err := getHashFunc(string(alg))
 				if err != nil {
@@ -111,7 +112,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"type", types.String}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typ := tree.MustBeDString(args[0])
 				salt, err := genSalt(string(typ), 0)
 				if err != nil {
@@ -125,7 +126,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"type", types.String}, {"iter_count", types.Int}},
 			ReturnType: tree.FixedReturnType(types.String),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typ := tree.MustBeDString(args[0])
 				rounds := tree.MustBeDInt(args[1])
 				salt, err := genSalt(string(typ), int(rounds))
@@ -144,7 +145,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.String}, {"key", types.String}, {"type", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key := tree.MustBeDString(args[1])
 				alg := tree.MustBeDString(args[2])
 				hashFunc, err := getHashFunc(string(alg))
@@ -163,7 +164,7 @@ var pgcryptoBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"data", types.Bytes}, {"key", types.Bytes}, {"type", types.String}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(_ *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				key := tree.MustBeDBytes(args[1])
 				alg := tree.MustBeDString(args[2])
 				hashFunc, err := getHashFunc(string(alg))

--- a/pkg/sql/sem/builtins/pgformat/format.go
+++ b/pkg/sql/sem/builtins/pgformat/format.go
@@ -11,6 +11,8 @@
 package pgformat
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -51,12 +53,14 @@ func (p *pp) popInt() (v int, ok bool) {
 
 // Format formats according to a format specifier in the style of postgres format()
 // and returns the resulting string.
-func Format(evalCtx *eval.Context, format string, a ...tree.Datum) (string, error) {
+func Format(
+	ctx context.Context, evalCtx *eval.Context, format string, a ...tree.Datum,
+) (string, error) {
 	p := pp{
 		evalCtx: evalCtx,
 		buf:     evalCtx.FmtCtx(tree.FmtArrayToString),
 	}
-	err := p.doPrintf(format, a)
+	err := p.doPrintf(ctx, format, a)
 	if err != nil {
 		return "", err
 	}
@@ -86,7 +90,7 @@ func parsenum(s string, start, end int) (num int, isnum bool, newi int) {
 	return
 }
 
-func (p *pp) printArg(arg tree.Datum, verb rune) (err error) {
+func (p *pp) printArg(ctx context.Context, arg tree.Datum, verb rune) (err error) {
 	var writeFunc func(*tree.FmtCtx) (numBytesWritten int)
 	if arg == tree.DNull {
 		switch verb {
@@ -118,7 +122,7 @@ func (p *pp) printArg(arg tree.Datum, verb rune) (err error) {
 			writeFunc = func(buf *tree.FmtCtx) int {
 				lenBefore := buf.Len()
 				var dStr tree.Datum
-				dStr, err = eval.PerformCast(p.evalCtx, arg, types.String)
+				dStr, err = eval.PerformCast(ctx, p.evalCtx, arg, types.String)
 				// This shouldn't be possible--anything can be cast to
 				// a string. err will be returned by printArg().
 				if err != nil {
@@ -159,7 +163,7 @@ func (p *pp) printArg(arg tree.Datum, verb rune) (err error) {
 
 // intFromArg gets the argNumth element of a. On return, isInt reports whether the argument has integer type.
 func intFromArg(
-	evalCtx *eval.Context, a []tree.Datum, argNum int,
+	ctx context.Context, evalCtx *eval.Context, a []tree.Datum, argNum int,
 ) (num int, isInt bool, newArgNum int) {
 	newArgNum = argNum
 	if argNum < len(a) && argNum >= 0 {
@@ -169,7 +173,7 @@ func intFromArg(
 			return 0, true, argNum + 1
 		}
 		if cast.ValidCast(datum.ResolvedType(), types.Int, cast.ContextImplicit) {
-			dInt, err := eval.PerformCast(evalCtx, datum, types.Int)
+			dInt, err := eval.PerformCast(ctx, evalCtx, datum, types.Int)
 			if err == nil {
 				num = int(tree.MustBeDInt(dInt))
 				isInt = true
@@ -187,7 +191,7 @@ func intFromArg(
 // doPrintf is copied from golang's internal implementation of fmt,
 // but modified to use the sql function format()'s syntax for width
 // and positional arguments.
-func (p *pp) doPrintf(format string, a []tree.Datum) error {
+func (p *pp) doPrintf(ctx context.Context, format string, a []tree.Datum) error {
 	end := len(format)
 	argNum := 0 // we process one argument per non-trivial format
 formatLoop:
@@ -223,7 +227,7 @@ formatLoop:
 				if argNum < 0 {
 					return errors.New("positions must be positive and 1-indexed")
 				}
-				err := p.printArg(a[argNum], rune(c))
+				err := p.printArg(ctx, a[argNum], rune(c))
 				if err != nil {
 					return err
 				}
@@ -260,12 +264,12 @@ formatLoop:
 					if rawArgNum < 1 {
 						return errors.New("positions must be positive and 1-indexed")
 					}
-					p.width, isNum, argNum = intFromArg(p.evalCtx, a, rawArgNum-1)
+					p.width, isNum, argNum = intFromArg(ctx, p.evalCtx, a, rawArgNum-1)
 					if !isNum {
 						return errors.New("non-numeric width")
 					}
 				} else {
-					p.width, isNum, argNum = intFromArg(p.evalCtx, a, argNum)
+					p.width, isNum, argNum = intFromArg(ctx, p.evalCtx, a, argNum)
 					if !isNum {
 						return errors.New("non-numeric width")
 					}

--- a/pkg/sql/sem/builtins/pgformat/format_test.go
+++ b/pkg/sql/sem/builtins/pgformat/format_test.go
@@ -179,7 +179,7 @@ func TestFormatWithWeirdFormatStrings(t *testing.T) {
 		}
 		str := string(b)
 		// Mostly just making sure no panics
-		_, err := pgformat.Format(evalContext, str, datums...)
+		_, err := pgformat.Format(context.Background(), evalContext, str, datums...)
 		if err != nil {
 			require.Regexp(t, `position|width|not enough arguments|unrecognized verb|unterminated format`, err.Error(),
 				"input string was %s", str)

--- a/pkg/sql/sem/builtins/pgformat/fuzz.go
+++ b/pkg/sql/sem/builtins/pgformat/fuzz.go
@@ -14,6 +14,8 @@
 package pgformat
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
@@ -21,13 +23,13 @@ import (
 // FuzzFormat passes the input to pgformat.Format()
 // as both the format string and format arguments.
 func FuzzFormat(input []byte) int {
-	ctx := eval.MakeTestingEvalContext(nil)
+	evalCtx := eval.MakeTestingEvalContext(nil)
 	str := string(input)
 	args := make(tree.Datums, 16)
 	for i := range args {
 		args[i] = tree.NewDString(string(input))
 	}
-	_, err := Format(&ctx, str, args...)
+	_, err := Format(context.Background(), &evalCtx, str, args...)
 
 	if err == nil {
 		return 0

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -58,7 +58,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				ingestionJobID := jobspb.JobID(*args[0].(*tree.DInt))
 				cutoverTime := args[1].(*tree.DTimestampTZ).Time
 				cutoverTimestamp := hlc.Timestamp{WallTime: cutoverTime.UnixNano()}
-				err = mgr.CompleteStreamIngestion(evalCtx, evalCtx.Txn, ingestionJobID, cutoverTimestamp)
+				err = mgr.CompleteStreamIngestion(ctx, evalCtx, evalCtx.Txn, ingestionJobID, cutoverTimestamp)
 				if err != nil {
 					return nil, err
 				}
@@ -96,7 +96,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 					return nil, err
 				}
 				ingestionJobID := int64(tree.MustBeDInt(args[0]))
-				stats, err := mgr.GetStreamIngestionStats(evalCtx, evalCtx.Txn, jobspb.JobID(ingestionJobID))
+				stats, err := mgr.GetStreamIngestionStats(ctx, evalCtx, evalCtx.Txn, jobspb.JobID(ingestionJobID))
 				if err != nil {
 					return nil, err
 				}
@@ -136,7 +136,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 					return nil, err
 				}
 				ingestionJobID := int64(tree.MustBeDInt(args[0]))
-				stats, err := mgr.GetStreamIngestionStats(evalCtx, evalCtx.Txn, jobspb.JobID(ingestionJobID))
+				stats, err := mgr.GetStreamIngestionStats(ctx, evalCtx, evalCtx.Txn, jobspb.JobID(ingestionJobID))
 				if err != nil {
 					return nil, err
 				}
@@ -172,7 +172,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				jobID, err := mgr.StartReplicationStream(evalCtx, evalCtx.Txn, uint64(tenantID))
+				jobID, err := mgr.StartReplicationStream(ctx, evalCtx, evalCtx.Txn, uint64(tenantID))
 				if err != nil {
 					return nil, err
 				}
@@ -210,7 +210,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 					return nil, err
 				}
 				streamID := streaming.StreamID(int(tree.MustBeDInt(args[0])))
-				sps, err := mgr.HeartbeatReplicationStream(evalCtx, streamID, frontier, evalCtx.Txn)
+				sps, err := mgr.HeartbeatReplicationStream(ctx, evalCtx, streamID, frontier, evalCtx.Txn)
 				if err != nil {
 					return nil, err
 				}
@@ -275,7 +275,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				}
 
 				streamID := int64(tree.MustBeDInt(args[0]))
-				spec, err := mgr.GetReplicationStreamSpec(evalCtx, evalCtx.Txn, streaming.StreamID(streamID))
+				spec, err := mgr.GetReplicationStreamSpec(ctx, evalCtx, evalCtx.Txn, streaming.StreamID(streamID))
 				if err != nil {
 					return nil, err
 				}
@@ -311,8 +311,9 @@ var replicationBuiltins = map[string]builtinDefinition{
 
 				streamID := int64(tree.MustBeDInt(args[0]))
 				successfulIngestion := bool(tree.MustBeDBool(args[1]))
-				if err := mgr.CompleteReplicationStream(evalCtx, evalCtx.Txn,
-					streaming.StreamID(streamID), successfulIngestion); err != nil {
+				if err := mgr.CompleteReplicationStream(
+					ctx, evalCtx, evalCtx.Txn, streaming.StreamID(streamID), successfulIngestion,
+				); err != nil {
 					return nil, err
 				}
 				return tree.NewDInt(tree.DInt(streamID)), err

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -11,6 +11,7 @@
 package builtins
 
 import (
+	"context"
 	gojson "encoding/json"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -48,7 +49,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"cutover_ts", types.TimestampTZ},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				mgr, err := streaming.GetStreamIngestManager(evalCtx)
 				if err != nil {
 					return nil, err
@@ -86,7 +87,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"job_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, errors.New("job_id cannot be specified with null argument")
 				}
@@ -126,7 +127,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"job_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
 					return tree.DNull, errors.New("job_id cannot be specified with null argument")
 				}
@@ -162,7 +163,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"tenant_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
 				if err != nil {
 					return nil, err
@@ -196,7 +197,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"frontier_ts", types.String},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, errors.New("stream_id or frontier_ts cannot be specified with null argument")
 				}
@@ -241,7 +242,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				[]*types.T{types.Bytes},
 				[]string{"stream_event"},
 			),
-			func(evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
+			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
 				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
 				if err != nil {
 					return nil, err
@@ -267,7 +268,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"stream_id", types.Int},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
 				if err != nil {
 					return nil, err
@@ -302,7 +303,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				{"successful_ingestion", types.Bool},
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
 				if err != nil {
 					return nil, err

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -50,7 +50,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				mgr, err := streaming.GetStreamIngestManager(evalCtx)
+				mgr, err := streaming.GetStreamIngestManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -91,7 +91,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if args[0] == tree.DNull {
 					return tree.DNull, errors.New("job_id cannot be specified with null argument")
 				}
-				mgr, err := streaming.GetStreamIngestManager(evalCtx)
+				mgr, err := streaming.GetStreamIngestManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -131,7 +131,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if args[0] == tree.DNull {
 					return tree.DNull, errors.New("job_id cannot be specified with null argument")
 				}
-				mgr, err := streaming.GetStreamIngestManager(evalCtx)
+				mgr, err := streaming.GetStreamIngestManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -164,7 +164,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetReplicationStreamManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -201,7 +201,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if args[0] == tree.DNull || args[1] == tree.DNull {
 					return tree.DNull, errors.New("stream_id or frontier_ts cannot be specified with null argument")
 				}
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetReplicationStreamManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -243,7 +243,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 				[]string{"stream_event"},
 			),
 			func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (eval.ValueGenerator, error) {
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetReplicationStreamManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -269,7 +269,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetReplicationStreamManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}
@@ -304,7 +304,7 @@ var replicationBuiltins = map[string]builtinDefinition{
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				mgr, err := streaming.GetReplicationStreamManager(evalCtx)
+				mgr, err := streaming.GetReplicationStreamManager(ctx, evalCtx)
 				if err != nil {
 					return nil, err
 				}

--- a/pkg/sql/sem/builtins/trigram_builtins.go
+++ b/pkg/sql/sem/builtins/trigram_builtins.go
@@ -11,6 +11,8 @@
 package builtins
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -34,7 +36,7 @@ var trigramBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"left", types.String}, {"right", types.String}},
 			ReturnType: tree.FixedReturnType(types.Float),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				l, r := string(tree.MustBeDString(args[0])), string(tree.MustBeDString(args[1]))
 				f := trigram.Similarity(l, r)
 				return tree.NewDFloat(tree.DFloat(f)), nil
@@ -51,7 +53,7 @@ var trigramBuiltins = map[string]builtinDefinition{
 		tree.Overload{
 			Types:      tree.ArgTypes{{"input", types.String}},
 			ReturnType: tree.FixedReturnType(types.StringArray),
-			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				s := string(tree.MustBeDString(args[0]))
 				arr := trigram.MakeTrigrams(s, true /* pad */)
 				ret := tree.NewDArray(types.String)

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -33,8 +33,10 @@ import (
 )
 
 // BinaryOp evaluates a tree.BinaryEvalOp.
-func BinaryOp(evalCtx *Context, op tree.BinaryEvalOp, left, right tree.Datum) (tree.Datum, error) {
-	return op.Eval(evalCtx.Context, (*evaluator)(evalCtx), left, right)
+func BinaryOp(
+	ctx context.Context, evalCtx *Context, op tree.BinaryEvalOp, left, right tree.Datum,
+) (tree.Datum, error) {
+	return op.Eval(ctx, (*evaluator)(evalCtx), left, right)
 }
 
 func (e *evaluator) EvalAppendToMaybeNullArrayOp(

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -223,7 +223,7 @@ func (e *evaluator) EvalConcatOp(
 	ctx context.Context, op *tree.ConcatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	if op.Left == types.String {
-		casted, err := PerformCast(e.ctx(), right, types.String)
+		casted, err := PerformCast(ctx, e.ctx(), right, types.String)
 		if err != nil {
 			return nil, err
 		}
@@ -232,7 +232,7 @@ func (e *evaluator) EvalConcatOp(
 		), nil
 	}
 	if op.Right == types.String {
-		casted, err := PerformCast(e.ctx(), left, types.String)
+		casted, err := PerformCast(ctx, e.ctx(), left, types.String)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -11,6 +11,7 @@
 package eval
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -32,23 +33,25 @@ import (
 )
 
 // BinaryOp evaluates a tree.BinaryEvalOp.
-func BinaryOp(ctx *Context, op tree.BinaryEvalOp, left, right tree.Datum) (tree.Datum, error) {
-	return op.Eval((*evaluator)(ctx), left, right)
+func BinaryOp(evalCtx *Context, op tree.BinaryEvalOp, left, right tree.Datum) (tree.Datum, error) {
+	return op.Eval(evalCtx.Context, (*evaluator)(evalCtx), left, right)
 }
 
 func (e *evaluator) EvalAppendToMaybeNullArrayOp(
-	op *tree.AppendToMaybeNullArrayOp, a, b tree.Datum,
+	ctx context.Context, op *tree.AppendToMaybeNullArrayOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	return tree.AppendToMaybeNullArray(op.Typ, a, b)
 }
 
 func (e *evaluator) EvalArrayOverlapsOp(
-	_ *tree.OverlapsArrayOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.OverlapsArrayOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	return tree.ArrayOverlaps(e.ctx(), tree.MustBeDArray(a), tree.MustBeDArray(b))
 }
 
-func (e *evaluator) EvalBitAndINetOp(_ *tree.BitAndINetOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitAndINetOp(
+	ctx context.Context, _ *tree.BitAndINetOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(a).IPAddr
 	other := tree.MustBeDIPAddr(b).IPAddr
 	newIPAddr, err := ipAddr.And(&other)
@@ -57,12 +60,14 @@ func (e *evaluator) EvalBitAndINetOp(_ *tree.BitAndINetOp, a, b tree.Datum) (tre
 	}), err
 }
 
-func (e *evaluator) EvalBitAndIntOp(_ *tree.BitAndIntOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitAndIntOp(
+	ctx context.Context, _ *tree.BitAndIntOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	return tree.NewDInt(tree.MustBeDInt(a) & tree.MustBeDInt(b)), nil
 }
 
 func (e *evaluator) EvalBitAndVarBitOp(
-	_ *tree.BitAndVarBitOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.BitAndVarBitOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(a)
 	rhs := tree.MustBeDBitArray(b)
@@ -74,7 +79,9 @@ func (e *evaluator) EvalBitAndVarBitOp(
 	}, nil
 }
 
-func (e *evaluator) EvalBitOrINetOp(_ *tree.BitOrINetOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitOrINetOp(
+	ctx context.Context, _ *tree.BitOrINetOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(a).IPAddr
 	other := tree.MustBeDIPAddr(b).IPAddr
 	newIPAddr, err := ipAddr.Or(&other)
@@ -83,11 +90,15 @@ func (e *evaluator) EvalBitOrINetOp(_ *tree.BitOrINetOp, a, b tree.Datum) (tree.
 	}), err
 }
 
-func (e *evaluator) EvalBitOrIntOp(_ *tree.BitOrIntOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitOrIntOp(
+	ctx context.Context, _ *tree.BitOrIntOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	return tree.NewDInt(tree.MustBeDInt(a) | tree.MustBeDInt(b)), nil
 }
 
-func (e *evaluator) EvalBitOrVarBitOp(_ *tree.BitOrVarBitOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitOrVarBitOp(
+	ctx context.Context, _ *tree.BitOrVarBitOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(a)
 	rhs := tree.MustBeDBitArray(b)
 	if lhs.BitLen() != rhs.BitLen() {
@@ -98,12 +109,14 @@ func (e *evaluator) EvalBitOrVarBitOp(_ *tree.BitOrVarBitOp, a, b tree.Datum) (t
 	}, nil
 }
 
-func (e *evaluator) EvalBitXorIntOp(_ *tree.BitXorIntOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalBitXorIntOp(
+	ctx context.Context, _ *tree.BitXorIntOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	return tree.NewDInt(tree.MustBeDInt(a) ^ tree.MustBeDInt(b)), nil
 }
 
 func (e *evaluator) EvalBitXorVarBitOp(
-	_ *tree.BitXorVarBitOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.BitXorVarBitOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(a)
 	rhs := tree.MustBeDBitArray(b)
@@ -116,7 +129,7 @@ func (e *evaluator) EvalBitXorVarBitOp(
 }
 
 func (e *evaluator) EvalCompareBox2DOp(
-	op *tree.CompareBox2DOp, left, right tree.Datum,
+	ctx context.Context, op *tree.CompareBox2DOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	if err := checkExperimentalBox2DComparisonOperatorEnabled(e.Settings); err != nil {
 		return nil, err
@@ -125,7 +138,7 @@ func (e *evaluator) EvalCompareBox2DOp(
 }
 
 func (e *evaluator) EvalCompareScalarOp(
-	op *tree.CompareScalarOp, left, right tree.Datum,
+	ctx context.Context, op *tree.CompareScalarOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// Before deferring to the Datum.Compare method, check for values that should
 	// be handled differently during SQL comparison evaluation than they should when
@@ -148,7 +161,7 @@ func (e *evaluator) EvalCompareScalarOp(
 }
 
 func (e *evaluator) EvalCompareTupleOp(
-	op *tree.CompareTupleOp, leftDatum, rightDatum tree.Datum,
+	ctx context.Context, op *tree.CompareTupleOp, leftDatum, rightDatum tree.Datum,
 ) (tree.Datum, error) {
 	left, right := leftDatum.(*tree.DTuple), rightDatum.(*tree.DTuple)
 	cmp := 0
@@ -199,12 +212,14 @@ func (e *evaluator) EvalCompareTupleOp(
 }
 
 func (e *evaluator) EvalConcatArraysOp(
-	op *tree.ConcatArraysOp, a, b tree.Datum,
+	ctx context.Context, op *tree.ConcatArraysOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	return tree.ConcatArrays(op.Typ, a, b)
 }
 
-func (e *evaluator) EvalConcatOp(op *tree.ConcatOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalConcatOp(
+	ctx context.Context, op *tree.ConcatOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	if op.Left == types.String {
 		casted, err := PerformCast(e.ctx(), right, types.String)
 		if err != nil {
@@ -227,13 +242,13 @@ func (e *evaluator) EvalConcatOp(op *tree.ConcatOp, left, right tree.Datum) (tre
 }
 
 func (e *evaluator) EvalConcatBytesOp(
-	_ *tree.ConcatBytesOp, left tree.Datum, right tree.Datum,
+	ctx context.Context, _ *tree.ConcatBytesOp, left tree.Datum, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDBytes(*left.(*tree.DBytes) + *right.(*tree.DBytes)), nil
 }
 
 func (e *evaluator) EvalConcatJsonbOp(
-	_ *tree.ConcatJsonbOp, left tree.Datum, right tree.Datum,
+	ctx context.Context, _ *tree.ConcatJsonbOp, left tree.Datum, right tree.Datum,
 ) (tree.Datum, error) {
 	j, err := tree.MustBeDJSON(left).JSON.Concat(
 		tree.MustBeDJSON(right).JSON,
@@ -245,7 +260,7 @@ func (e *evaluator) EvalConcatJsonbOp(
 }
 
 func (e *evaluator) EvalConcatStringOp(
-	_ *tree.ConcatStringOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ConcatStringOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDString(
 		string(tree.MustBeDString(left) + tree.MustBeDString(right)),
@@ -254,7 +269,7 @@ func (e *evaluator) EvalConcatStringOp(
 }
 
 func (e *evaluator) EvalConcatVarBitOp(
-	_ *tree.ConcatVarBitOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ConcatVarBitOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(left)
 	rhs := tree.MustBeDBitArray(right)
@@ -264,7 +279,7 @@ func (e *evaluator) EvalConcatVarBitOp(
 }
 
 func (e *evaluator) EvalContainedByArrayOp(
-	_ *tree.ContainedByArrayOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.ContainedByArrayOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	needles := tree.MustBeDArray(a)
 	haystack := tree.MustBeDArray(b)
@@ -272,7 +287,7 @@ func (e *evaluator) EvalContainedByArrayOp(
 }
 
 func (e *evaluator) EvalContainedByJsonbOp(
-	_ *tree.ContainedByJsonbOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.ContainedByJsonbOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	c, err := json.Contains(b.(*tree.DJSON).JSON, a.(*tree.DJSON).JSON)
 	if err != nil {
@@ -282,7 +297,7 @@ func (e *evaluator) EvalContainedByJsonbOp(
 }
 
 func (e *evaluator) EvalContainsArrayOp(
-	_ *tree.ContainsArrayOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.ContainsArrayOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	haystack := tree.MustBeDArray(a)
 	needles := tree.MustBeDArray(b)
@@ -290,7 +305,7 @@ func (e *evaluator) EvalContainsArrayOp(
 }
 
 func (e *evaluator) EvalContainsJsonbOp(
-	_ *tree.ContainsJsonbOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.ContainsJsonbOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	c, err := json.Contains(a.(*tree.DJSON).JSON, b.(*tree.DJSON).JSON)
 	if err != nil {
@@ -300,7 +315,7 @@ func (e *evaluator) EvalContainsJsonbOp(
 }
 
 func (e *evaluator) EvalDivDecimalIntOp(
-	_ *tree.DivDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.DivDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -314,7 +329,7 @@ func (e *evaluator) EvalDivDecimalIntOp(
 }
 
 func (e *evaluator) EvalDivDecimalOp(
-	_ *tree.DivDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.DivDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -326,7 +341,9 @@ func (e *evaluator) EvalDivDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalDivFloatOp(_ *tree.DivFloatOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalDivFloatOp(
+	ctx context.Context, _ *tree.DivFloatOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	r := *right.(*tree.DFloat)
 	if r == 0.0 {
 		return nil, tree.ErrDivByZero
@@ -335,7 +352,7 @@ func (e *evaluator) EvalDivFloatOp(_ *tree.DivFloatOp, left, right tree.Datum) (
 }
 
 func (e *evaluator) EvalDivIntDecimalOp(
-	_ *tree.DivIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.DivIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -348,7 +365,9 @@ func (e *evaluator) EvalDivIntDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalDivIntOp(_ *tree.DivIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalDivIntOp(
+	ctx context.Context, _ *tree.DivIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	rInt := tree.MustBeDInt(right)
 	if rInt == 0 {
 		return nil, tree.ErrDivByZero
@@ -362,7 +381,7 @@ func (e *evaluator) EvalDivIntOp(_ *tree.DivIntOp, left, right tree.Datum) (tree
 }
 
 func (e *evaluator) EvalDivIntervalFloatOp(
-	_ *tree.DivIntervalFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.DivIntervalFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	r := float64(*right.(*tree.DFloat))
 	if r == 0.0 {
@@ -374,7 +393,7 @@ func (e *evaluator) EvalDivIntervalFloatOp(
 }
 
 func (e *evaluator) EvalDivIntervalIntOp(
-	_ *tree.DivIntervalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.DivIntervalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rInt := tree.MustBeDInt(right)
 	if rInt == 0 {
@@ -386,7 +405,7 @@ func (e *evaluator) EvalDivIntervalIntOp(
 }
 
 func (e *evaluator) EvalFloorDivDecimalIntOp(
-	_ *tree.FloorDivDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.FloorDivDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -400,7 +419,7 @@ func (e *evaluator) EvalFloorDivDecimalIntOp(
 }
 
 func (e *evaluator) EvalFloorDivDecimalOp(
-	_ *tree.FloorDivDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.FloorDivDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -413,7 +432,7 @@ func (e *evaluator) EvalFloorDivDecimalOp(
 }
 
 func (e *evaluator) EvalFloorDivFloatOp(
-	_ *tree.FloorDivFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.FloorDivFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := float64(*left.(*tree.DFloat))
 	r := float64(*right.(*tree.DFloat))
@@ -424,7 +443,7 @@ func (e *evaluator) EvalFloorDivFloatOp(
 }
 
 func (e *evaluator) EvalFloorDivIntDecimalOp(
-	_ *tree.FloorDivIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.FloorDivIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -438,7 +457,7 @@ func (e *evaluator) EvalFloorDivIntDecimalOp(
 }
 
 func (e *evaluator) EvalFloorDivIntOp(
-	_ *tree.FloorDivIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.FloorDivIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rInt := tree.MustBeDInt(right)
 	if rInt == 0 {
@@ -447,7 +466,9 @@ func (e *evaluator) EvalFloorDivIntOp(
 	return tree.NewDInt(tree.MustBeDInt(left) / rInt), nil
 }
 
-func (e *evaluator) EvalInTupleOp(_ *tree.InTupleOp, arg, values tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalInTupleOp(
+	ctx context.Context, _ *tree.InTupleOp, arg, values tree.Datum,
+) (tree.Datum, error) {
 	vtuple := values.(*tree.DTuple)
 	// If the tuple was sorted during normalization, we can perform an
 	// efficient binary search to find if the arg is in the tuple (as
@@ -509,7 +530,7 @@ func (e *evaluator) EvalInTupleOp(_ *tree.InTupleOp, arg, values tree.Datum) (tr
 }
 
 func (e *evaluator) EvalJSONAllExistsOp(
-	_ *tree.JSONAllExistsOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.JSONAllExistsOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	// TODO(justin): this can be optimized.
 	for _, k := range tree.MustBeDArray(b).Array {
@@ -527,7 +548,9 @@ func (e *evaluator) EvalJSONAllExistsOp(
 	return tree.DBoolTrue, nil
 }
 
-func (e *evaluator) EvalJSONExistsOp(_ *tree.JSONExistsOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalJSONExistsOp(
+	ctx context.Context, _ *tree.JSONExistsOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	exists, err := a.(*tree.DJSON).JSON.Exists(string(tree.MustBeDString(b)))
 	if err != nil {
 		return nil, err
@@ -539,7 +562,7 @@ func (e *evaluator) EvalJSONExistsOp(_ *tree.JSONExistsOp, a, b tree.Datum) (tre
 }
 
 func (e *evaluator) EvalJSONFetchTextIntOp(
-	_ *tree.JSONFetchTextIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchTextIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	res, err := left.(*tree.DJSON).JSON.FetchValIdx(int(tree.MustBeDInt(right)))
 	if err != nil {
@@ -559,7 +582,7 @@ func (e *evaluator) EvalJSONFetchTextIntOp(
 }
 
 func (e *evaluator) EvalJSONFetchTextPathOp(
-	_ *tree.JSONFetchTextPathOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchTextPathOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	res, err := tree.GetJSONPath(
 		left.(*tree.DJSON).JSON, *tree.MustBeDArray(right),
@@ -581,7 +604,7 @@ func (e *evaluator) EvalJSONFetchTextPathOp(
 }
 
 func (e *evaluator) EvalJSONFetchTextStringOp(
-	_ *tree.JSONFetchTextStringOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchTextStringOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	res, err := left.(*tree.DJSON).JSON.FetchValKey(
 		string(tree.MustBeDString(right)),
@@ -603,7 +626,7 @@ func (e *evaluator) EvalJSONFetchTextStringOp(
 }
 
 func (e *evaluator) EvalJSONFetchValIntOp(
-	_ *tree.JSONFetchValIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchValIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	j, err := left.(*tree.DJSON).JSON.FetchValIdx(int(tree.MustBeDInt(right)))
 	if err != nil {
@@ -616,7 +639,7 @@ func (e *evaluator) EvalJSONFetchValIntOp(
 }
 
 func (e *evaluator) EvalJSONFetchValPathOp(
-	_ *tree.JSONFetchValPathOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchValPathOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	path, err := tree.GetJSONPath(
 		left.(*tree.DJSON).JSON, *tree.MustBeDArray(right),
@@ -631,7 +654,7 @@ func (e *evaluator) EvalJSONFetchValPathOp(
 }
 
 func (e *evaluator) EvalJSONFetchValStringOp(
-	_ *tree.JSONFetchValStringOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.JSONFetchValStringOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	j, err := left.(*tree.DJSON).JSON.FetchValKey(
 		string(tree.MustBeDString(right)),
@@ -646,13 +669,13 @@ func (e *evaluator) EvalJSONFetchValStringOp(
 }
 
 func (e *evaluator) EvalJSONSomeExistsOp(
-	_ *tree.JSONSomeExistsOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.JSONSomeExistsOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	return tree.JSONExistsAny(tree.MustBeDJSON(a), tree.MustBeDArray(b))
 }
 
 func (e *evaluator) EvalLShiftINetOp(
-	_ *tree.LShiftINetOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.LShiftINetOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	other := tree.MustBeDIPAddr(right).IPAddr
@@ -660,7 +683,7 @@ func (e *evaluator) EvalLShiftINetOp(
 }
 
 func (e *evaluator) EvalLShiftIntOp(
-	_ *tree.LShiftIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.LShiftIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rval := tree.MustBeDInt(right)
 	if rval < 0 || rval >= 64 {
@@ -671,7 +694,7 @@ func (e *evaluator) EvalLShiftIntOp(
 }
 
 func (e *evaluator) EvalLShiftVarBitIntOp(
-	_ *tree.LShiftVarBitIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.LShiftVarBitIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(left)
 	rhs := tree.MustBeDInt(right)
@@ -680,17 +703,21 @@ func (e *evaluator) EvalLShiftVarBitIntOp(
 	}, nil
 }
 
-func (e *evaluator) EvalMatchLikeOp(op *tree.MatchLikeOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalMatchLikeOp(
+	ctx context.Context, op *tree.MatchLikeOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	return matchLike(e.ctx(), a, b, op.CaseInsensitive)
 }
 
-func (e *evaluator) EvalMatchRegexpOp(op *tree.MatchRegexpOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalMatchRegexpOp(
+	ctx context.Context, op *tree.MatchRegexpOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	key := regexpKey{s: string(tree.MustBeDString(b)), caseInsensitive: op.CaseInsensitive}
 	return matchRegexpWithKey(e.ctx(), a, key)
 }
 
 func (e *evaluator) EvalMinusDateIntOp(
-	_ *tree.MinusDateIntOp, a, b tree.Datum,
+	ctx context.Context, _ *tree.MinusDateIntOp, a, b tree.Datum,
 ) (tree.Datum, error) {
 	d, err := a.(*tree.DDate).SubDays(int64(tree.MustBeDInt(b)))
 	if err != nil {
@@ -700,7 +727,7 @@ func (e *evaluator) EvalMinusDateIntOp(
 }
 
 func (e *evaluator) EvalMinusDateIntervalOp(
-	_ *tree.MinusDateIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusDateIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	leftTime, err := left.(*tree.DDate).ToTime()
 	if err != nil {
@@ -710,7 +737,9 @@ func (e *evaluator) EvalMinusDateIntervalOp(
 	return tree.MakeDTimestamp(t, time.Microsecond)
 }
 
-func (e *evaluator) EvalMinusDateOp(_ *tree.MinusDateOp, a, b tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalMinusDateOp(
+	ctx context.Context, _ *tree.MinusDateOp, a, b tree.Datum,
+) (tree.Datum, error) {
 	l, r := a.(*tree.DDate).Date, b.(*tree.DDate).Date
 	if !l.IsFinite() || !r.IsFinite() {
 		return nil, pgerror.New(pgcode.DatetimeFieldOverflow, "cannot subtract infinite dates")
@@ -722,7 +751,7 @@ func (e *evaluator) EvalMinusDateOp(_ *tree.MinusDateOp, a, b tree.Datum) (tree.
 }
 
 func (e *evaluator) EvalMinusDateTimeOp(
-	_ *tree.MinusDateTimeOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusDateTimeOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	leftTime, err := left.(*tree.DDate).ToTime()
 	if err != nil {
@@ -733,7 +762,7 @@ func (e *evaluator) EvalMinusDateTimeOp(
 }
 
 func (e *evaluator) EvalMinusDecimalIntOp(
-	_ *tree.MinusDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -744,7 +773,7 @@ func (e *evaluator) EvalMinusDecimalIntOp(
 }
 
 func (e *evaluator) EvalMinusDecimalOp(
-	_ *tree.MinusDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -754,13 +783,13 @@ func (e *evaluator) EvalMinusDecimalOp(
 }
 
 func (e *evaluator) EvalMinusFloatOp(
-	_ *tree.MinusFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDFloat(*left.(*tree.DFloat) - *right.(*tree.DFloat)), nil
 }
 
 func (e *evaluator) EvalMinusINetIntOp(
-	_ *tree.MinusINetIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusINetIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	i := tree.MustBeDInt(right)
@@ -769,7 +798,7 @@ func (e *evaluator) EvalMinusINetIntOp(
 }
 
 func (e *evaluator) EvalMinusINetOp(
-	_ *tree.MinusINetOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusINetOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	other := tree.MustBeDIPAddr(right).IPAddr
@@ -778,7 +807,7 @@ func (e *evaluator) EvalMinusINetOp(
 }
 
 func (e *evaluator) EvalMinusIntDecimalOp(
-	_ *tree.MinusIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -788,7 +817,9 @@ func (e *evaluator) EvalMinusIntDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalMinusIntOp(_ *tree.MinusIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalMinusIntOp(
+	ctx context.Context, _ *tree.MinusIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	a, b := tree.MustBeDInt(left), tree.MustBeDInt(right)
 	r, ok := arith.SubWithOverflow(int64(a), int64(b))
 	if !ok {
@@ -798,7 +829,7 @@ func (e *evaluator) EvalMinusIntOp(_ *tree.MinusIntOp, left, right tree.Datum) (
 }
 
 func (e *evaluator) EvalMinusIntervalOp(
-	_ *tree.MinusIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l, r := left.(*tree.DInterval), right.(*tree.DInterval)
 	return &tree.DInterval{
@@ -807,7 +838,7 @@ func (e *evaluator) EvalMinusIntervalOp(
 }
 
 func (e *evaluator) EvalMinusJsonbIntOp(
-	_ *tree.MinusJsonbIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusJsonbIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	j, _, err := left.(*tree.DJSON).JSON.RemoveIndex(int(tree.MustBeDInt(right)))
 	if err != nil {
@@ -817,7 +848,7 @@ func (e *evaluator) EvalMinusJsonbIntOp(
 }
 
 func (e *evaluator) EvalMinusJsonbStringArrayOp(
-	_ *tree.MinusJsonbStringArrayOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusJsonbStringArrayOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	j := left.(*tree.DJSON).JSON
 	arr := *tree.MustBeDArray(right)
@@ -836,7 +867,7 @@ func (e *evaluator) EvalMinusJsonbStringArrayOp(
 }
 
 func (e *evaluator) EvalMinusJsonbStringOp(
-	_ *tree.MinusJsonbStringOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusJsonbStringOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	j, _, err := left.(*tree.DJSON).JSON.RemoveString(
 		string(tree.MustBeDString(right)),
@@ -848,14 +879,14 @@ func (e *evaluator) EvalMinusJsonbStringOp(
 }
 
 func (e *evaluator) EvalMinusTimeIntervalOp(
-	_ *tree.MinusTimeIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimeIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := timeofday.TimeOfDay(*left.(*tree.DTime))
 	return tree.MakeDTime(t.Add(right.(*tree.DInterval).Duration.Mul(-1))), nil
 }
 
 func (e *evaluator) EvalMinusTimeOp(
-	_ *tree.MinusTimeOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimeOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t1 := timeofday.TimeOfDay(*left.(*tree.DTime))
 	t2 := timeofday.TimeOfDay(*right.(*tree.DTime))
@@ -864,7 +895,7 @@ func (e *evaluator) EvalMinusTimeOp(
 }
 
 func (e *evaluator) EvalMinusTimeTZIntervalOp(
-	_ *tree.MinusTimeTZIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimeTZIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := left.(*tree.DTimeTZ)
 	d := right.(*tree.DInterval).Duration
@@ -872,7 +903,7 @@ func (e *evaluator) EvalMinusTimeTZIntervalOp(
 }
 
 func (e *evaluator) EvalMinusTimestampIntervalOp(
-	_ *tree.MinusTimestampIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.MakeDTimestamp(
 		duration.Add(
@@ -884,7 +915,7 @@ func (e *evaluator) EvalMinusTimestampIntervalOp(
 }
 
 func (e *evaluator) EvalMinusTimestampOp(
-	_ *tree.MinusTimestampOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	nanos := left.(*tree.DTimestamp).Sub(
 		right.(*tree.DTimestamp).Time,
@@ -895,7 +926,7 @@ func (e *evaluator) EvalMinusTimestampOp(
 }
 
 func (e *evaluator) EvalMinusTimestampTZIntervalOp(
-	_ *tree.MinusTimestampTZIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampTZIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := duration.Add(
 		left.(*tree.DTimestampTZ).Time.In(e.ctx().GetLocation()),
@@ -905,7 +936,7 @@ func (e *evaluator) EvalMinusTimestampTZIntervalOp(
 }
 
 func (e *evaluator) EvalMinusTimestampTZOp(
-	_ *tree.MinusTimestampTZOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampTZOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	nanos := left.(*tree.DTimestampTZ).Sub(
 		right.(*tree.DTimestampTZ).Time,
@@ -916,7 +947,7 @@ func (e *evaluator) EvalMinusTimestampTZOp(
 }
 
 func (e *evaluator) EvalMinusTimestampTZTimestampOp(
-	_ *tree.MinusTimestampTZTimestampOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampTZTimestampOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// These two quantities aren't directly comparable. Convert the
 	// TimestampTZ to a timestamp first.
@@ -932,7 +963,7 @@ func (e *evaluator) EvalMinusTimestampTZTimestampOp(
 }
 
 func (e *evaluator) EvalMinusTimestampTimestampTZOp(
-	_ *tree.MinusTimestampTimestampTZOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MinusTimestampTimestampTZOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// These two quantities aren't directly comparable. Convert the
 	// TimestampTZ to a timestamp first.
@@ -948,7 +979,7 @@ func (e *evaluator) EvalMinusTimestampTimestampTZOp(
 }
 
 func (e *evaluator) EvalModDecimalIntOp(
-	_ *tree.ModDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ModDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -962,7 +993,7 @@ func (e *evaluator) EvalModDecimalIntOp(
 }
 
 func (e *evaluator) EvalModDecimalOp(
-	_ *tree.ModDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ModDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -974,7 +1005,9 @@ func (e *evaluator) EvalModDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalModFloatOp(_ *tree.ModFloatOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalModFloatOp(
+	ctx context.Context, _ *tree.ModFloatOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	l := float64(*left.(*tree.DFloat))
 	r := float64(*right.(*tree.DFloat))
 	if r == 0.0 {
@@ -984,7 +1017,7 @@ func (e *evaluator) EvalModFloatOp(_ *tree.ModFloatOp, left, right tree.Datum) (
 }
 
 func (e *evaluator) EvalModIntDecimalOp(
-	_ *tree.ModIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ModIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -997,7 +1030,9 @@ func (e *evaluator) EvalModIntDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalModIntOp(_ *tree.ModIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalModIntOp(
+	ctx context.Context, _ *tree.ModIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	r := tree.MustBeDInt(right)
 	if r == 0 {
 		return nil, tree.ErrDivByZero
@@ -1006,7 +1041,7 @@ func (e *evaluator) EvalModIntOp(_ *tree.ModIntOp, left, right tree.Datum) (tree
 }
 
 func (e *evaluator) EvalModStringOp(
-	_ *tree.ModStringOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.ModStringOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// The string % string operator returns whether the two strings have a
 	// greater or equal trigram similarity() than the threshold in
@@ -1020,7 +1055,7 @@ func (e *evaluator) EvalModStringOp(
 }
 
 func (e *evaluator) EvalMultDecimalIntOp(
-	_ *tree.MultDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -1031,7 +1066,7 @@ func (e *evaluator) EvalMultDecimalIntOp(
 }
 
 func (e *evaluator) EvalMultDecimalIntervalOp(
-	_ *tree.MultDecimalIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultDecimalIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	t, err := l.Float64()
@@ -1044,7 +1079,7 @@ func (e *evaluator) EvalMultDecimalIntervalOp(
 }
 
 func (e *evaluator) EvalMultDecimalOp(
-	_ *tree.MultDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -1054,7 +1089,7 @@ func (e *evaluator) EvalMultDecimalOp(
 }
 
 func (e *evaluator) EvalMultFloatIntervalOp(
-	_ *tree.MultFloatIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultFloatIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := float64(*left.(*tree.DFloat))
 	return &tree.DInterval{
@@ -1063,13 +1098,13 @@ func (e *evaluator) EvalMultFloatIntervalOp(
 }
 
 func (e *evaluator) EvalMultFloatOp(
-	_ *tree.MultFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDFloat(*left.(*tree.DFloat) * *right.(*tree.DFloat)), nil
 }
 
 func (e *evaluator) EvalMultIntDecimalOp(
-	_ *tree.MultIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -1080,7 +1115,7 @@ func (e *evaluator) EvalMultIntDecimalOp(
 }
 
 func (e *evaluator) EvalMultIntIntervalOp(
-	_ *tree.MultIntIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultIntIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return &tree.DInterval{
 		Duration: right.(*tree.DInterval).Duration.
@@ -1088,7 +1123,9 @@ func (e *evaluator) EvalMultIntIntervalOp(
 	}, nil
 }
 
-func (e *evaluator) EvalMultIntOp(_ *tree.MultIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalMultIntOp(
+	ctx context.Context, _ *tree.MultIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	// See Rob Pike's implementation from
 	// https://groups.google.com/d/msg/golang-nuts/h5oSN5t3Au4/KaNQREhZh0QJ
 
@@ -1106,7 +1143,7 @@ func (e *evaluator) EvalMultIntOp(_ *tree.MultIntOp, left, right tree.Datum) (tr
 }
 
 func (e *evaluator) EvalMultIntervalDecimalOp(
-	_ *tree.MultIntervalDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultIntervalDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	r := &right.(*tree.DDecimal).Decimal
 	t, err := r.Float64()
@@ -1119,7 +1156,7 @@ func (e *evaluator) EvalMultIntervalDecimalOp(
 }
 
 func (e *evaluator) EvalMultIntervalFloatOp(
-	_ *tree.MultIntervalFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultIntervalFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	r := float64(*right.(*tree.DFloat))
 	return &tree.DInterval{
@@ -1128,7 +1165,7 @@ func (e *evaluator) EvalMultIntervalFloatOp(
 }
 
 func (e *evaluator) EvalMultIntervalIntOp(
-	_ *tree.MultIntervalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.MultIntervalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return &tree.DInterval{
 		Duration: left.(*tree.DInterval).Duration.
@@ -1137,7 +1174,7 @@ func (e *evaluator) EvalMultIntervalIntOp(
 }
 
 func (e *evaluator) EvalOverlapsArrayOp(
-	_ *tree.OverlapsArrayOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.OverlapsArrayOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	array := tree.MustBeDArray(left)
 	other := tree.MustBeDArray(right)
@@ -1145,7 +1182,7 @@ func (e *evaluator) EvalOverlapsArrayOp(
 }
 
 func (e *evaluator) EvalOverlapsINetOp(
-	_ *tree.OverlapsINetOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.OverlapsINetOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	other := tree.MustBeDIPAddr(right).IPAddr
@@ -1153,7 +1190,7 @@ func (e *evaluator) EvalOverlapsINetOp(
 }
 
 func (e *evaluator) EvalPlusDateIntOp(
-	_ *tree.PlusDateIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDateIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	d, err := left.(*tree.DDate).AddDays(int64(tree.MustBeDInt(right)))
 	if err != nil {
@@ -1163,7 +1200,7 @@ func (e *evaluator) EvalPlusDateIntOp(
 }
 
 func (e *evaluator) EvalPlusDateIntervalOp(
-	_ *tree.PlusDateIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDateIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	leftTime, err := left.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1174,7 +1211,7 @@ func (e *evaluator) EvalPlusDateIntervalOp(
 }
 
 func (e *evaluator) EvalPlusDateTimeOp(
-	_ *tree.PlusDateTimeOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDateTimeOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	leftTime, err := left.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1185,7 +1222,7 @@ func (e *evaluator) EvalPlusDateTimeOp(
 }
 
 func (e *evaluator) EvalPlusDateTimeTZOp(
-	_ *tree.PlusDateTimeTZOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDateTimeTZOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	leftTime, err := left.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1196,7 +1233,7 @@ func (e *evaluator) EvalPlusDateTimeTZOp(
 }
 
 func (e *evaluator) EvalPlusDecimalIntOp(
-	_ *tree.PlusDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -1207,7 +1244,7 @@ func (e *evaluator) EvalPlusDecimalIntOp(
 }
 
 func (e *evaluator) EvalPlusDecimalOp(
-	_ *tree.PlusDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -1217,13 +1254,13 @@ func (e *evaluator) EvalPlusDecimalOp(
 }
 
 func (e *evaluator) EvalPlusFloatOp(
-	_ *tree.PlusFloatOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusFloatOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDFloat(*left.(*tree.DFloat) + *right.(*tree.DFloat)), nil
 }
 
 func (e *evaluator) EvalPlusINetIntOp(
-	_ *tree.PlusINetIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusINetIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	i := tree.MustBeDInt(right)
@@ -1232,7 +1269,7 @@ func (e *evaluator) EvalPlusINetIntOp(
 }
 
 func (e *evaluator) EvalPlusIntDecimalOp(
-	_ *tree.PlusIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -1243,7 +1280,7 @@ func (e *evaluator) EvalPlusIntDecimalOp(
 }
 
 func (e *evaluator) EvalPlusIntDateOp(
-	_ *tree.PlusIntDateOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntDateOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	d, err := right.(*tree.DDate).AddDays(int64(tree.MustBeDInt(left)))
 	if err != nil {
@@ -1253,7 +1290,7 @@ func (e *evaluator) EvalPlusIntDateOp(
 }
 
 func (e *evaluator) EvalPlusIntINetOp(
-	_ *tree.PlusIntINetOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntINetOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	i := tree.MustBeDInt(left)
 	ipAddr := tree.MustBeDIPAddr(right).IPAddr
@@ -1261,7 +1298,9 @@ func (e *evaluator) EvalPlusIntINetOp(
 	return tree.NewDIPAddr(tree.DIPAddr{IPAddr: newIPAddr}), err
 }
 
-func (e *evaluator) EvalPlusIntOp(_ *tree.PlusIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalPlusIntOp(
+	ctx context.Context, _ *tree.PlusIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	a, b := tree.MustBeDInt(left), tree.MustBeDInt(right)
 	r, ok := arith.AddWithOverflow(int64(a), int64(b))
 	if !ok {
@@ -1271,7 +1310,7 @@ func (e *evaluator) EvalPlusIntOp(_ *tree.PlusIntOp, left, right tree.Datum) (tr
 }
 
 func (e *evaluator) EvalPlusIntervalDateOp(
-	_ *tree.PlusIntervalDateOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalDateOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rightTime, err := right.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1282,7 +1321,7 @@ func (e *evaluator) EvalPlusIntervalDateOp(
 }
 
 func (e *evaluator) EvalPlusIntervalOp(
-	_ *tree.PlusIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return &tree.DInterval{
 		Duration: left.(*tree.DInterval).Duration.Add(
@@ -1292,14 +1331,14 @@ func (e *evaluator) EvalPlusIntervalOp(
 }
 
 func (e *evaluator) EvalPlusIntervalTimeOp(
-	_ *tree.PlusIntervalTimeOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalTimeOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := timeofday.TimeOfDay(*right.(*tree.DTime))
 	return tree.MakeDTime(t.Add(left.(*tree.DInterval).Duration)), nil
 }
 
 func (e *evaluator) EvalPlusIntervalTimeTZOp(
-	_ *tree.PlusIntervalTimeTZOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalTimeTZOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := right.(*tree.DTimeTZ)
 	d := left.(*tree.DInterval).Duration
@@ -1307,7 +1346,7 @@ func (e *evaluator) EvalPlusIntervalTimeTZOp(
 }
 
 func (e *evaluator) EvalPlusIntervalTimestampOp(
-	_ *tree.PlusIntervalTimestampOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalTimestampOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.MakeDTimestamp(duration.Add(
 		right.(*tree.DTimestamp).Time, left.(*tree.DInterval).Duration,
@@ -1315,7 +1354,7 @@ func (e *evaluator) EvalPlusIntervalTimestampOp(
 }
 
 func (e *evaluator) EvalPlusIntervalTimestampTZOp(
-	_ *tree.PlusIntervalTimestampTZOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusIntervalTimestampTZOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// Convert time to be in the given timezone, as math relies on matching timezones..
 	t := duration.Add(
@@ -1326,7 +1365,7 @@ func (e *evaluator) EvalPlusIntervalTimestampTZOp(
 }
 
 func (e *evaluator) EvalPlusTimeDateOp(
-	_ *tree.PlusTimeDateOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimeDateOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rightTime, err := right.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1337,14 +1376,14 @@ func (e *evaluator) EvalPlusTimeDateOp(
 }
 
 func (e *evaluator) EvalPlusTimeIntervalOp(
-	_ *tree.PlusTimeIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimeIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := timeofday.TimeOfDay(*left.(*tree.DTime))
 	return tree.MakeDTime(t.Add(right.(*tree.DInterval).Duration)), nil
 }
 
 func (e *evaluator) EvalPlusTimeTZDateOp(
-	_ *tree.PlusTimeTZDateOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimeTZDateOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rightTime, err := right.(*tree.DDate).ToTime()
 	if err != nil {
@@ -1355,7 +1394,7 @@ func (e *evaluator) EvalPlusTimeTZDateOp(
 }
 
 func (e *evaluator) EvalPlusTimeTZIntervalOp(
-	_ *tree.PlusTimeTZIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimeTZIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	t := left.(*tree.DTimeTZ)
 	d := right.(*tree.DInterval).Duration
@@ -1363,7 +1402,7 @@ func (e *evaluator) EvalPlusTimeTZIntervalOp(
 }
 
 func (e *evaluator) EvalPlusTimestampIntervalOp(
-	_ *tree.PlusTimestampIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimestampIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.MakeDTimestamp(
 		duration.Add(
@@ -1374,7 +1413,7 @@ func (e *evaluator) EvalPlusTimestampIntervalOp(
 }
 
 func (e *evaluator) EvalPlusTimestampTZIntervalOp(
-	_ *tree.PlusTimestampTZIntervalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PlusTimestampTZIntervalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	// Convert time to be in the given timezone, as math relies on matching timezones..
 	t := duration.Add(
@@ -1385,7 +1424,7 @@ func (e *evaluator) EvalPlusTimestampTZIntervalOp(
 }
 
 func (e *evaluator) EvalPowDecimalIntOp(
-	_ *tree.PowDecimalIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PowDecimalIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := tree.MustBeDInt(right)
@@ -1396,7 +1435,7 @@ func (e *evaluator) EvalPowDecimalIntOp(
 }
 
 func (e *evaluator) EvalPowDecimalOp(
-	_ *tree.PowDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PowDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
@@ -1405,13 +1444,15 @@ func (e *evaluator) EvalPowDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalPowFloatOp(_ *tree.PowFloatOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalPowFloatOp(
+	ctx context.Context, _ *tree.PowFloatOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	f := math.Pow(float64(*left.(*tree.DFloat)), float64(*right.(*tree.DFloat)))
 	return tree.NewDFloat(tree.DFloat(f)), nil
 }
 
 func (e *evaluator) EvalPowIntDecimalOp(
-	_ *tree.PowIntDecimalOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.PowIntDecimalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	l := tree.MustBeDInt(left)
 	r := &right.(*tree.DDecimal).Decimal
@@ -1421,18 +1462,20 @@ func (e *evaluator) EvalPowIntDecimalOp(
 	return dd, err
 }
 
-func (e *evaluator) EvalPowIntOp(_ *tree.PowIntOp, left, right tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalPowIntOp(
+	ctx context.Context, _ *tree.PowIntOp, left, right tree.Datum,
+) (tree.Datum, error) {
 	return IntPow(tree.MustBeDInt(left), tree.MustBeDInt(right))
 }
 
 func (e *evaluator) EvalPrependToMaybeNullArrayOp(
-	op *tree.PrependToMaybeNullArrayOp, left, right tree.Datum,
+	ctx context.Context, op *tree.PrependToMaybeNullArrayOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	return tree.PrependToMaybeNullArray(op.Typ, left, right)
 }
 
 func (e *evaluator) EvalRShiftINetOp(
-	_ *tree.RShiftINetOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.RShiftINetOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(left).IPAddr
 	other := tree.MustBeDIPAddr(right).IPAddr
@@ -1440,7 +1483,7 @@ func (e *evaluator) EvalRShiftINetOp(
 }
 
 func (e *evaluator) EvalRShiftIntOp(
-	_ *tree.RShiftIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.RShiftIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	rval := tree.MustBeDInt(right)
 	if rval < 0 || rval >= 64 {
@@ -1451,7 +1494,7 @@ func (e *evaluator) EvalRShiftIntOp(
 }
 
 func (e *evaluator) EvalRShiftVarBitIntOp(
-	_ *tree.RShiftVarBitIntOp, left, right tree.Datum,
+	ctx context.Context, _ *tree.RShiftVarBitIntOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	lhs := tree.MustBeDBitArray(left)
 	rhs := tree.MustBeDInt(right)
@@ -1461,7 +1504,7 @@ func (e *evaluator) EvalRShiftVarBitIntOp(
 }
 
 func (e *evaluator) EvalSimilarToOp(
-	op *tree.SimilarToOp, left, right tree.Datum,
+	ctx context.Context, op *tree.SimilarToOp, left, right tree.Datum,
 ) (tree.Datum, error) {
 	key := similarToKey{s: string(tree.MustBeDString(right)), escape: '\\'}
 	return matchRegexpWithKey(e.ctx(), left, key)

--- a/pkg/sql/sem/eval/cast_map_test.go
+++ b/pkg/sql/sem/eval/cast_map_test.go
@@ -11,6 +11,7 @@
 package eval_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -54,7 +55,7 @@ func TestCastMap(t *testing.T) {
 			}
 		}
 
-		_, err := eval.PerformCast(&evalCtx, srcDatum, tgtType)
+		_, err := eval.PerformCast(context.Background(), &evalCtx, srcDatum, tgtType)
 		// If the error is a CannotCoerce error, then PerformCast does not
 		// support casting from src to tgt. The one exception is negative
 		// integers to bit types which return the same error code (see the TODO

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -130,8 +130,11 @@ type Context struct {
 	// need to restore once we finish evaluating it.
 	iVarContainerStack []tree.IndexedVarContainer
 
-	// Context holds the context in which the expression is evaluated.
-	Context context.Context
+	// deprecatedContext holds the context in which the expression is evaluated.
+	//
+	// Deprecated: this field should not be used because an effort to remove it
+	// from Context is under way.
+	deprecatedContext context.Context
 
 	Planner Planner
 
@@ -269,6 +272,17 @@ type RangeProber interface {
 	) error
 }
 
+// SetDeprecatedContext updates the context.Context of this Context. Previously
+// stored context is returned.
+//
+// Deprecated: this method should not be used because an effort to remove the
+// context.Context from Context is under way.
+func (ec *Context) SetDeprecatedContext(ctx context.Context) context.Context {
+	oldCtx := ec.deprecatedContext
+	ec.deprecatedContext = ctx
+	return oldCtx
+}
+
 // UnwrapDatum encapsulates UnwrapDatum for use in the tree.CompareContext.
 func (ec *Context) UnwrapDatum(d tree.Datum) tree.Datum {
 	return UnwrapDatum(ec, d)
@@ -280,7 +294,7 @@ func (ec *Context) MustGetPlaceholderValue(p *tree.Placeholder) tree.Datum {
 	if !ok {
 		panic(errors.AssertionFailedf("fail"))
 	}
-	out, err := Expr(ec.Context, ec, e)
+	out, err := Expr(ec.deprecatedContext, ec, e)
 	if err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "fail"))
 	}
@@ -315,7 +329,7 @@ func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonit
 	monitor.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))
 	ctx.TestingMon = monitor
 	ctx.Planner = &fakePlannerWithMonitor{monitor: monitor}
-	ctx.Context = context.TODO()
+	ctx.deprecatedContext = context.TODO()
 	now := timeutil.Now()
 	ctx.SetTxnTimestamp(now)
 	ctx.SetStmtTimestamp(now)
@@ -641,7 +655,7 @@ func arrayOfType(typ *types.T) (*tree.DArray, error) {
 func UnwrapDatum(evalCtx *Context, d tree.Datum) tree.Datum {
 	d = tree.UnwrapDOidWrapper(d)
 	if p, ok := d.(*tree.Placeholder); ok && evalCtx != nil && evalCtx.HasPlaceholders() {
-		ret, err := Expr(evalCtx.Context, evalCtx, p)
+		ret, err := Expr(evalCtx.deprecatedContext, evalCtx, p)
 		if err != nil {
 			// If we fail to evaluate the placeholder, it's because we don't have
 			// a placeholder available. Just return the placeholder and someone else

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -280,7 +280,7 @@ func (ec *Context) MustGetPlaceholderValue(p *tree.Placeholder) tree.Datum {
 	if !ok {
 		panic(errors.AssertionFailedf("fail"))
 	}
-	out, err := Expr(ec, e)
+	out, err := Expr(ec.Context, ec, e)
 	if err != nil {
 		panic(errors.NewAssertionErrorWithWrappedErrf(err, "fail"))
 	}
@@ -646,7 +646,7 @@ func arrayOfType(typ *types.T) (*tree.DArray, error) {
 func UnwrapDatum(evalCtx *Context, d tree.Datum) tree.Datum {
 	d = tree.UnwrapDOidWrapper(d)
 	if p, ok := d.(*tree.Placeholder); ok && evalCtx != nil && evalCtx.HasPlaceholders() {
-		ret, err := Expr(evalCtx, p)
+		ret, err := Expr(evalCtx.Context, evalCtx, p)
 		if err != nil {
 			// If we fail to evaluate the placeholder, it's because we don't have
 			// a placeholder available. Just return the placeholder and someone else

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -606,11 +606,6 @@ func (ec *Context) GetDateStyle() pgdate.DateStyle {
 	return ec.SessionData().GetDateStyle()
 }
 
-// Ctx returns the session's context.
-func (ec *Context) Ctx() context.Context {
-	return ec.Context
-}
-
 // BoundedStaleness returns true if this query uses bounded staleness.
 func (ec *Context) BoundedStaleness() bool {
 	return ec.AsOfSystemTime != nil &&

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -66,7 +66,7 @@ func TestEval(t *testing.T) {
 			if err != nil {
 				return fmt.Sprint(err)
 			}
-			r, err := eval.Expr(evalCtx, e)
+			r, err := eval.Expr(ctx, evalCtx, e)
 			if err != nil {
 				return fmt.Sprint(err)
 			}
@@ -206,7 +206,7 @@ func TestTimeConversion(t *testing.T) {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
 		}
-		r, err := eval.Expr(ctx, typedExpr)
+		r, err := eval.Expr(context.Background(), ctx, typedExpr)
 		if err != nil {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
@@ -245,7 +245,7 @@ func TestTimeConversion(t *testing.T) {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
 		}
-		r, err = eval.Expr(ctx, typedExpr)
+		r, err = eval.Expr(context.Background(), ctx, typedExpr)
 		if err != nil {
 			t.Errorf("%s: %v", exprStr, err)
 			continue
@@ -365,8 +365,8 @@ func TestEvalError(t *testing.T) {
 		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
 		if err == nil {
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer evalCtx.Stop(context.Background())
-			_, err = eval.Expr(evalCtx, typedExpr)
+			defer evalCtx.Stop(ctx)
+			_, err = eval.Expr(ctx, evalCtx, typedExpr)
 		}
 		if !testutils.IsError(err, strings.Replace(regexp.QuoteMeta(d.expected), `\.\*`, `.*`, -1)) {
 			t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -88,7 +88,7 @@ func TestEval(t *testing.T) {
 			if err != nil {
 				return nil, err
 			}
-			return normalize.Expr(evalCtx, typedExpr)
+			return normalize.Expr(ctx, evalCtx, typedExpr)
 		})
 	})
 }
@@ -104,7 +104,7 @@ func optBuildScalar(evalCtx *eval.Context, e tree.Expr) (tree.TypedExpr, error) 
 	}
 
 	bld := execbuilder.New(
-		nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
+		ctx, nil /* factory */, &o, o.Memo(), nil /* catalog */, o.Memo().RootExpr(),
 		evalCtx, false, /* allowAutoCommit */
 	)
 	expr, err := bld.BuildScalar()
@@ -193,7 +193,7 @@ func TestTimeConversion(t *testing.T) {
 
 	for _, test := range tests {
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.TestingMon.Stop(context.Background())
+		defer ctx.Stop(context.Background())
 		exprStr := fmt.Sprintf("experimental_strptime('%s', '%s')", test.start, test.format)
 		expr, err := parser.ParseExpr(exprStr)
 		if err != nil {

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -187,7 +187,7 @@ func (e *evaluator) EvalCastExpr(ctx context.Context, expr *tree.CastExpr) (tree
 		return d, nil
 	}
 	d = UnwrapDatum(e.ctx(), d)
-	return PerformCast(e.ctx(), d, expr.ResolvedType())
+	return PerformCast(ctx, e.ctx(), d, expr.ResolvedType())
 }
 
 func (e *evaluator) EvalCoalesceExpr(

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -145,7 +145,7 @@ func (e *evaluator) EvalCaseExpr(ctx context.Context, expr *tree.CaseExpr) (tree
 			if err != nil {
 				return nil, err
 			}
-			d, err := evalComparison(e.ctx(), treecmp.MakeComparisonOperator(treecmp.EQ), val, arg)
+			d, err := evalComparison(ctx, e.ctx(), treecmp.MakeComparisonOperator(treecmp.EQ), val, arg)
 			if err != nil {
 				return nil, err
 			}
@@ -257,7 +257,7 @@ func (e *evaluator) EvalComparisonExpr(
 
 	op := expr.Operator
 	if op.Symbol.HasSubOperator() {
-		return ComparisonExprWithSubOperator(e.ctx(), expr, left, right)
+		return ComparisonExprWithSubOperator(ctx, e.ctx(), expr, left, right)
 	}
 
 	_, newLeft, newRight, _, not := tree.FoldComparisonExprWithDatums(op, left, right)
@@ -452,7 +452,7 @@ func (e *evaluator) EvalNullIfExpr(ctx context.Context, expr *tree.NullIfExpr) (
 	if err != nil {
 		return nil, err
 	}
-	cond, err := evalComparison(e.ctx(), treecmp.MakeComparisonOperator(treecmp.EQ), expr1, expr2)
+	cond, err := evalComparison(ctx, e.ctx(), treecmp.MakeComparisonOperator(treecmp.EQ), expr1, expr2)
 	if err != nil {
 		return nil, err
 	}
@@ -632,7 +632,7 @@ func (e *evaluator) EvalRoutineExpr(
 			}
 		}
 	}
-	return e.Planner.EvalRoutineExpr(e.Context, routine, input)
+	return e.Planner.EvalRoutineExpr(ctx, routine, input)
 }
 
 func (e *evaluator) EvalTuple(ctx context.Context, t *tree.Tuple) (tree.Datum, error) {

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -11,6 +11,8 @@
 package eval
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -20,20 +22,22 @@ import (
 )
 
 // Expr evaluates a TypedExpr into a Datum.
-func Expr(ctx *Context, n tree.TypedExpr) (tree.Datum, error) {
-	return n.Eval((*evaluator)(ctx))
+func Expr(ctx context.Context, evalCtx *Context, n tree.TypedExpr) (tree.Datum, error) {
+	return n.Eval(ctx, (*evaluator)(evalCtx))
 }
 
 type evaluator Context
 
 func (e *evaluator) ctx() *Context { return (*Context)(e) }
 
-func (e *evaluator) EvalAllColumnsSelector(selector *tree.AllColumnsSelector) (tree.Datum, error) {
+func (e *evaluator) EvalAllColumnsSelector(
+	ctx context.Context, selector *tree.AllColumnsSelector,
+) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", selector)
 }
 
-func (e *evaluator) EvalAndExpr(expr *tree.AndExpr) (tree.Datum, error) {
-	left, err := expr.Left.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalAndExpr(ctx context.Context, expr *tree.AndExpr) (tree.Datum, error) {
+	left, err := expr.Left.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +48,7 @@ func (e *evaluator) EvalAndExpr(expr *tree.AndExpr) (tree.Datum, error) {
 			return left, nil
 		}
 	}
-	right, err := expr.Right.(tree.TypedExpr).Eval(e)
+	right, err := expr.Right.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -59,14 +63,14 @@ func (e *evaluator) EvalAndExpr(expr *tree.AndExpr) (tree.Datum, error) {
 	return left, nil
 }
 
-func (e *evaluator) EvalArray(t *tree.Array) (tree.Datum, error) {
+func (e *evaluator) EvalArray(ctx context.Context, t *tree.Array) (tree.Datum, error) {
 	array, err := arrayOfType(t.ResolvedType())
 	if err != nil {
 		return nil, err
 	}
 
 	for _, ae := range t.Exprs {
-		d, err := ae.(tree.TypedExpr).Eval(e)
+		d, err := ae.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return nil, err
 		}
@@ -77,13 +81,15 @@ func (e *evaluator) EvalArray(t *tree.Array) (tree.Datum, error) {
 	return array, nil
 }
 
-func (e *evaluator) EvalArrayFlatten(t *tree.ArrayFlatten) (tree.Datum, error) {
+func (e *evaluator) EvalArrayFlatten(
+	ctx context.Context, t *tree.ArrayFlatten,
+) (tree.Datum, error) {
 	array, err := arrayOfType(t.ResolvedType())
 	if err != nil {
 		return nil, err
 	}
 
-	d, err := t.Subquery.(tree.TypedExpr).Eval(e)
+	d, err := t.Subquery.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -96,22 +102,22 @@ func (e *evaluator) EvalArrayFlatten(t *tree.ArrayFlatten) (tree.Datum, error) {
 	return array, nil
 }
 
-func (e *evaluator) EvalBinaryExpr(expr *tree.BinaryExpr) (tree.Datum, error) {
-	left, err := expr.Left.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalBinaryExpr(ctx context.Context, expr *tree.BinaryExpr) (tree.Datum, error) {
+	left, err := expr.Left.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
 	if left == tree.DNull && !expr.Op.CalledOnNullInput {
 		return tree.DNull, nil
 	}
-	right, err := expr.Right.(tree.TypedExpr).Eval(e)
+	right, err := expr.Right.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
 	if right == tree.DNull && !expr.Op.CalledOnNullInput {
 		return tree.DNull, nil
 	}
-	res, err := expr.Op.EvalOp.Eval(e, left, right)
+	res, err := expr.Op.EvalOp.Eval(ctx, e, left, right)
 	if err != nil {
 		return nil, err
 	}
@@ -124,18 +130,18 @@ func (e *evaluator) EvalBinaryExpr(expr *tree.BinaryExpr) (tree.Datum, error) {
 	return res, err
 }
 
-func (e *evaluator) EvalCaseExpr(expr *tree.CaseExpr) (tree.Datum, error) {
+func (e *evaluator) EvalCaseExpr(ctx context.Context, expr *tree.CaseExpr) (tree.Datum, error) {
 	if expr.Expr != nil {
 		// CASE <val> WHEN <expr> THEN ...
 		//
 		// For each "when" expression we compare for equality to <val>.
-		val, err := expr.Expr.(tree.TypedExpr).Eval(e)
+		val, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return nil, err
 		}
 
 		for _, when := range expr.Whens {
-			arg, err := when.Cond.(tree.TypedExpr).Eval(e)
+			arg, err := when.Cond.(tree.TypedExpr).Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
@@ -146,32 +152,32 @@ func (e *evaluator) EvalCaseExpr(expr *tree.CaseExpr) (tree.Datum, error) {
 			if db, err := tree.GetBool(d); err != nil {
 				return nil, err
 			} else if db {
-				return when.Val.(tree.TypedExpr).Eval(e)
+				return when.Val.(tree.TypedExpr).Eval(ctx, e)
 			}
 		}
 	} else {
 		// CASE WHEN <bool-expr> THEN ...
 		for _, when := range expr.Whens {
-			d, err := when.Cond.(tree.TypedExpr).Eval(e)
+			d, err := when.Cond.(tree.TypedExpr).Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
 			if db, err := tree.GetBool(d); err != nil {
 				return nil, err
 			} else if db {
-				return when.Val.(tree.TypedExpr).Eval(e)
+				return when.Val.(tree.TypedExpr).Eval(ctx, e)
 			}
 		}
 	}
 
 	if expr.Else != nil {
-		return expr.Else.(tree.TypedExpr).Eval(e)
+		return expr.Else.(tree.TypedExpr).Eval(ctx, e)
 	}
 	return tree.DNull, nil
 }
 
-func (e *evaluator) EvalCastExpr(expr *tree.CastExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalCastExpr(ctx context.Context, expr *tree.CastExpr) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -184,9 +190,11 @@ func (e *evaluator) EvalCastExpr(expr *tree.CastExpr) (tree.Datum, error) {
 	return PerformCast(e.ctx(), d, expr.ResolvedType())
 }
 
-func (e *evaluator) EvalCoalesceExpr(expr *tree.CoalesceExpr) (tree.Datum, error) {
+func (e *evaluator) EvalCoalesceExpr(
+	ctx context.Context, expr *tree.CoalesceExpr,
+) (tree.Datum, error) {
 	for _, ex := range expr.Exprs {
-		d, err := ex.(tree.TypedExpr).Eval(e)
+		d, err := ex.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return nil, err
 		}
@@ -197,8 +205,10 @@ func (e *evaluator) EvalCoalesceExpr(expr *tree.CoalesceExpr) (tree.Datum, error
 	return tree.DNull, nil
 }
 
-func (e *evaluator) EvalCollateExpr(expr *tree.CollateExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalCollateExpr(
+	ctx context.Context, expr *tree.CollateExpr,
+) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -216,8 +226,10 @@ func (e *evaluator) EvalCollateExpr(expr *tree.CollateExpr) (tree.Datum, error) 
 	}
 }
 
-func (e *evaluator) EvalColumnAccessExpr(expr *tree.ColumnAccessExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalColumnAccessExpr(
+	ctx context.Context, expr *tree.ColumnAccessExpr,
+) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -227,16 +239,18 @@ func (e *evaluator) EvalColumnAccessExpr(expr *tree.ColumnAccessExpr) (tree.Datu
 	return d.(*tree.DTuple).D[expr.ColIndex], nil
 }
 
-func (e *evaluator) EvalColumnItem(expr *tree.ColumnItem) (tree.Datum, error) {
+func (e *evaluator) EvalColumnItem(ctx context.Context, expr *tree.ColumnItem) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", expr)
 }
 
-func (e *evaluator) EvalComparisonExpr(expr *tree.ComparisonExpr) (tree.Datum, error) {
-	left, err := expr.Left.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalComparisonExpr(
+	ctx context.Context, expr *tree.ComparisonExpr,
+) (tree.Datum, error) {
+	left, err := expr.Left.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
-	right, err := expr.Right.(tree.TypedExpr).Eval(e)
+	right, err := expr.Right.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +264,7 @@ func (e *evaluator) EvalComparisonExpr(expr *tree.ComparisonExpr) (tree.Datum, e
 	if !expr.Op.CalledOnNullInput && (newLeft == tree.DNull || newRight == tree.DNull) {
 		return tree.DNull, nil
 	}
-	d, err := expr.Op.EvalOp.Eval(e, newLeft, newRight)
+	d, err := expr.Op.EvalOp.Eval(ctx, e, newLeft, newRight)
 	if d == tree.DNull || err != nil {
 		return d, err
 	}
@@ -261,7 +275,7 @@ func (e *evaluator) EvalComparisonExpr(expr *tree.ComparisonExpr) (tree.Datum, e
 	return tree.MakeDBool(*b != tree.DBool(not)), nil
 }
 
-func (e *evaluator) EvalIndexedVar(iv *tree.IndexedVar) (tree.Datum, error) {
+func (e *evaluator) EvalIndexedVar(ctx context.Context, iv *tree.IndexedVar) (tree.Datum, error) {
 	if e.IVarContainer == nil {
 		return nil, errors.AssertionFailedf(
 			"indexed var must be bound to a container before evaluation")
@@ -271,13 +285,15 @@ func (e *evaluator) EvalIndexedVar(iv *tree.IndexedVar) (tree.Datum, error) {
 		return nil, errors.AssertionFailedf(
 			"indexed var container of type %T may not be evaluated", e.IVarContainer)
 	}
-	return eivc.IndexedVarEval(iv.Idx, e)
+	return eivc.IndexedVarEval(ctx, iv.Idx, e)
 }
 
-func (e *evaluator) EvalIndirectionExpr(expr *tree.IndirectionExpr) (tree.Datum, error) {
+func (e *evaluator) EvalIndirectionExpr(
+	ctx context.Context, expr *tree.IndirectionExpr,
+) (tree.Datum, error) {
 	var subscriptIdx int
 
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -292,7 +308,7 @@ func (e *evaluator) EvalIndirectionExpr(expr *tree.IndirectionExpr) (tree.Datum,
 				return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
 			}
 
-			beginDatum, err := t.Begin.(tree.TypedExpr).Eval(e)
+			beginDatum, err := t.Begin.(tree.TypedExpr).Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
@@ -321,7 +337,7 @@ func (e *evaluator) EvalIndirectionExpr(expr *tree.IndirectionExpr) (tree.Datum,
 				return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
 			}
 
-			field, err := t.Begin.(tree.TypedExpr).Eval(e)
+			field, err := t.Begin.(tree.TypedExpr).Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
@@ -349,12 +365,14 @@ func (e *evaluator) EvalIndirectionExpr(expr *tree.IndirectionExpr) (tree.Datum,
 	return nil, errors.AssertionFailedf("unsupported feature should have been rejected during planning")
 }
 
-func (e *evaluator) EvalDefaultVal(expr *tree.DefaultVal) (tree.Datum, error) {
+func (e *evaluator) EvalDefaultVal(ctx context.Context, expr *tree.DefaultVal) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", expr)
 }
 
-func (e *evaluator) EvalIsNotNullExpr(expr *tree.IsNotNullExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalIsNotNullExpr(
+	ctx context.Context, expr *tree.IsNotNullExpr,
+) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -373,8 +391,8 @@ func (e *evaluator) EvalIsNotNullExpr(expr *tree.IsNotNullExpr) (tree.Datum, err
 	return tree.MakeDBool(true), nil
 }
 
-func (e *evaluator) EvalIsNullExpr(expr *tree.IsNullExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalIsNullExpr(ctx context.Context, expr *tree.IsNullExpr) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +411,10 @@ func (e *evaluator) EvalIsNullExpr(expr *tree.IsNullExpr) (tree.Datum, error) {
 	return tree.MakeDBool(false), nil
 }
 
-func (e *evaluator) EvalIsOfTypeExpr(expr *tree.IsOfTypeExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalIsOfTypeExpr(
+	ctx context.Context, expr *tree.IsOfTypeExpr,
+) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -408,8 +428,8 @@ func (e *evaluator) EvalIsOfTypeExpr(expr *tree.IsOfTypeExpr) (tree.Datum, error
 	return tree.MakeDBool(tree.DBool(expr.Not)), nil
 }
 
-func (e *evaluator) EvalNotExpr(expr *tree.NotExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalNotExpr(ctx context.Context, expr *tree.NotExpr) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -423,12 +443,12 @@ func (e *evaluator) EvalNotExpr(expr *tree.NotExpr) (tree.Datum, error) {
 	return tree.MakeDBool(!got), nil
 }
 
-func (e *evaluator) EvalNullIfExpr(expr *tree.NullIfExpr) (tree.Datum, error) {
-	expr1, err := expr.Expr1.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalNullIfExpr(ctx context.Context, expr *tree.NullIfExpr) (tree.Datum, error) {
+	expr1, err := expr.Expr1.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
-	expr2, err := expr.Expr2.(tree.TypedExpr).Eval(e)
+	expr2, err := expr.Expr2.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -442,13 +462,13 @@ func (e *evaluator) EvalNullIfExpr(expr *tree.NullIfExpr) (tree.Datum, error) {
 	return expr1, nil
 }
 
-func (e *evaluator) EvalFuncExpr(expr *tree.FuncExpr) (tree.Datum, error) {
+func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree.Datum, error) {
 	fn := expr.ResolvedOverload()
 	if fn.FnWithExprs != nil {
-		return fn.FnWithExprs.(FnWithExprsOverload)(e.ctx(), expr.Exprs)
+		return fn.FnWithExprs.(FnWithExprsOverload)(ctx, e.ctx(), expr.Exprs)
 	}
 
-	nullResult, args, err := e.evalFuncArgs(expr)
+	nullResult, args, err := e.evalFuncArgs(ctx, expr)
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +476,7 @@ func (e *evaluator) EvalFuncExpr(expr *tree.FuncExpr) (tree.Datum, error) {
 		return tree.DNull, err
 	}
 
-	res, err := fn.Fn.(FnOverload)(e.ctx(), args)
+	res, err := fn.Fn.(FnOverload)(ctx, e.ctx(), args)
 	if err != nil {
 		return nil, expr.MaybeWrapError(err)
 	}
@@ -469,11 +489,11 @@ func (e *evaluator) EvalFuncExpr(expr *tree.FuncExpr) (tree.Datum, error) {
 }
 
 func (e *evaluator) evalFuncArgs(
-	expr *tree.FuncExpr,
+	ctx context.Context, expr *tree.FuncExpr,
 ) (propagateNulls bool, args tree.Datums, _ error) {
 	args = make(tree.Datums, len(expr.Exprs))
 	for i, argExpr := range expr.Exprs {
-		arg, err := argExpr.(tree.TypedExpr).Eval(e)
+		arg, err := argExpr.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return false, nil, err
 		}
@@ -485,8 +505,8 @@ func (e *evaluator) evalFuncArgs(
 	return false, args, nil
 }
 
-func (e *evaluator) EvalIfErrExpr(expr *tree.IfErrExpr) (tree.Datum, error) {
-	cond, evalErr := expr.Cond.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalIfErrExpr(ctx context.Context, expr *tree.IfErrExpr) (tree.Datum, error) {
+	cond, evalErr := expr.Cond.(tree.TypedExpr).Eval(ctx, e)
 	if evalErr == nil {
 		if expr.Else == nil {
 			return tree.DBoolFalse, nil
@@ -494,7 +514,7 @@ func (e *evaluator) EvalIfErrExpr(expr *tree.IfErrExpr) (tree.Datum, error) {
 		return cond, nil
 	}
 	if expr.ErrCode != nil {
-		errpat, err := expr.ErrCode.(tree.TypedExpr).Eval(e)
+		errpat, err := expr.ErrCode.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return nil, err
 		}
@@ -509,22 +529,22 @@ func (e *evaluator) EvalIfErrExpr(expr *tree.IfErrExpr) (tree.Datum, error) {
 	if expr.Else == nil {
 		return tree.DBoolTrue, nil
 	}
-	return expr.Else.(tree.TypedExpr).Eval(e)
+	return expr.Else.(tree.TypedExpr).Eval(ctx, e)
 }
 
-func (e *evaluator) EvalIfExpr(expr *tree.IfExpr) (tree.Datum, error) {
-	cond, err := expr.Cond.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalIfExpr(ctx context.Context, expr *tree.IfExpr) (tree.Datum, error) {
+	cond, err := expr.Cond.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
 	if cond == tree.DBoolTrue {
-		return expr.True.(tree.TypedExpr).Eval(e)
+		return expr.True.(tree.TypedExpr).Eval(ctx, e)
 	}
-	return expr.Else.(tree.TypedExpr).Eval(e)
+	return expr.Else.(tree.TypedExpr).Eval(ctx, e)
 }
 
-func (e *evaluator) EvalOrExpr(expr *tree.OrExpr) (tree.Datum, error) {
-	left, err := expr.Left.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalOrExpr(ctx context.Context, expr *tree.OrExpr) (tree.Datum, error) {
+	left, err := expr.Left.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +555,7 @@ func (e *evaluator) EvalOrExpr(expr *tree.OrExpr) (tree.Datum, error) {
 			return left, nil
 		}
 	}
-	right, err := expr.Right.(tree.TypedExpr).Eval(e)
+	right, err := expr.Right.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -553,11 +573,11 @@ func (e *evaluator) EvalOrExpr(expr *tree.OrExpr) (tree.Datum, error) {
 	return tree.DBoolFalse, nil
 }
 
-func (e *evaluator) EvalParenExpr(expr *tree.ParenExpr) (tree.Datum, error) {
-	return expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalParenExpr(ctx context.Context, expr *tree.ParenExpr) (tree.Datum, error) {
+	return expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 }
 
-func (e *evaluator) EvalPlaceholder(t *tree.Placeholder) (tree.Datum, error) {
+func (e *evaluator) EvalPlaceholder(ctx context.Context, t *tree.Placeholder) (tree.Datum, error) {
 	if !e.ctx().HasPlaceholders() {
 		// While preparing a query, there will be no available placeholders. A
 		// placeholder evaluates to itself at this point.
@@ -582,20 +602,22 @@ func (e *evaluator) EvalPlaceholder(t *tree.Placeholder) (tree.Datum, error) {
 		// TODO(jordan,mgartner): Introduce a restriction on what casts are
 		// allowed here. Most likely, only implicit casts should be allowed.
 		cast := tree.NewTypedCastExpr(ex, typ)
-		return cast.Eval(e)
+		return cast.Eval(ctx, e)
 	}
-	return ex.Eval(e)
+	return ex.Eval(ctx, e)
 }
 
-func (e *evaluator) EvalRangeCond(cond *tree.RangeCond) (tree.Datum, error) {
+func (e *evaluator) EvalRangeCond(ctx context.Context, cond *tree.RangeCond) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", cond)
 }
 
-func (e *evaluator) EvalSubquery(subquery *tree.Subquery) (tree.Datum, error) {
+func (e *evaluator) EvalSubquery(ctx context.Context, subquery *tree.Subquery) (tree.Datum, error) {
 	return e.Planner.EvalSubquery(subquery)
 }
 
-func (e *evaluator) EvalRoutineExpr(routine *tree.RoutineExpr) (tree.Datum, error) {
+func (e *evaluator) EvalRoutineExpr(
+	ctx context.Context, routine *tree.RoutineExpr,
+) (tree.Datum, error) {
 	var err error
 	var input tree.Datums
 	if len(routine.Input) > 0 {
@@ -604,7 +626,7 @@ func (e *evaluator) EvalRoutineExpr(routine *tree.RoutineExpr) (tree.Datum, erro
 		// every invocation.
 		input = make(tree.Datums, len(routine.Input))
 		for i := range routine.Input {
-			input[i], err = routine.Input[i].Eval(e)
+			input[i], err = routine.Input[i].Eval(ctx, e)
 			if err != nil {
 				return nil, err
 			}
@@ -613,10 +635,10 @@ func (e *evaluator) EvalRoutineExpr(routine *tree.RoutineExpr) (tree.Datum, erro
 	return e.Planner.EvalRoutineExpr(e.Context, routine, input)
 }
 
-func (e *evaluator) EvalTuple(t *tree.Tuple) (tree.Datum, error) {
+func (e *evaluator) EvalTuple(ctx context.Context, t *tree.Tuple) (tree.Datum, error) {
 	tuple := tree.NewDTupleWithLen(t.ResolvedType(), len(t.Exprs))
 	for i, expr := range t.Exprs {
-		d, err := expr.(tree.TypedExpr).Eval(e)
+		d, err := expr.(tree.TypedExpr).Eval(ctx, e)
 		if err != nil {
 			return nil, err
 		}
@@ -625,16 +647,16 @@ func (e *evaluator) EvalTuple(t *tree.Tuple) (tree.Datum, error) {
 	return tuple, nil
 }
 
-func (e *evaluator) EvalTupleStar(star *tree.TupleStar) (tree.Datum, error) {
+func (e *evaluator) EvalTupleStar(ctx context.Context, star *tree.TupleStar) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", star)
 }
 
-func (e *evaluator) EvalTypedDummy(*tree.TypedDummy) (tree.Datum, error) {
+func (e *evaluator) EvalTypedDummy(context.Context, *tree.TypedDummy) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("should not eval typed dummy")
 }
 
-func (e *evaluator) EvalUnaryExpr(expr *tree.UnaryExpr) (tree.Datum, error) {
-	d, err := expr.Expr.(tree.TypedExpr).Eval(e)
+func (e *evaluator) EvalUnaryExpr(ctx context.Context, expr *tree.UnaryExpr) (tree.Datum, error) {
+	d, err := expr.Expr.(tree.TypedExpr).Eval(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -642,7 +664,7 @@ func (e *evaluator) EvalUnaryExpr(expr *tree.UnaryExpr) (tree.Datum, error) {
 		return d, nil
 	}
 	op := expr.GetOp()
-	res, err := op.EvalOp.Eval(e, d)
+	res, err := op.EvalOp.Eval(ctx, e, d)
 	if err != nil {
 		return nil, err
 	}
@@ -654,11 +676,15 @@ func (e *evaluator) EvalUnaryExpr(expr *tree.UnaryExpr) (tree.Datum, error) {
 	return res, err
 }
 
-func (e *evaluator) EvalUnresolvedName(name *tree.UnresolvedName) (tree.Datum, error) {
+func (e *evaluator) EvalUnresolvedName(
+	ctx context.Context, name *tree.UnresolvedName,
+) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", name)
 }
 
-func (e *evaluator) EvalUnqualifiedStar(star tree.UnqualifiedStar) (tree.Datum, error) {
+func (e *evaluator) EvalUnqualifiedStar(
+	ctx context.Context, star tree.UnqualifiedStar,
+) (tree.Datum, error) {
 	return nil, errors.AssertionFailedf("unhandled type %T", star)
 }
 

--- a/pkg/sql/sem/eval/generators.go
+++ b/pkg/sql/sem/eval/generators.go
@@ -20,7 +20,9 @@ import (
 )
 
 // GetGenerator is used to construct a ValueGenerator from a FuncExpr.
-func GetGenerator(evalCtx *Context, expr *tree.FuncExpr) (ValueGenerator, error) {
+func GetGenerator(
+	ctx context.Context, evalCtx *Context, expr *tree.FuncExpr,
+) (ValueGenerator, error) {
 	if !expr.IsGeneratorClass() {
 		return nil, errors.AssertionFailedf(
 			"cannot call EvalArgsAndGetGenerator() on non-aggregate function: %q",
@@ -29,13 +31,13 @@ func GetGenerator(evalCtx *Context, expr *tree.FuncExpr) (ValueGenerator, error)
 	}
 	ol := expr.ResolvedOverload()
 	if ol.GeneratorWithExprs != nil {
-		return ol.GeneratorWithExprs.(GeneratorWithExprsOverload)(evalCtx.Context, evalCtx, expr.Exprs)
+		return ol.GeneratorWithExprs.(GeneratorWithExprsOverload)(ctx, evalCtx, expr.Exprs)
 	}
-	nullArg, args, err := (*evaluator)(evalCtx).evalFuncArgs(evalCtx.Context, expr)
+	nullArg, args, err := (*evaluator)(evalCtx).evalFuncArgs(ctx, expr)
 	if err != nil || nullArg {
 		return nil, err
 	}
-	return ol.Generator.(GeneratorOverload)(evalCtx.Context, evalCtx, args)
+	return ol.Generator.(GeneratorOverload)(ctx, evalCtx, args)
 }
 
 // Table generators, also called "set-generating functions", are

--- a/pkg/sql/sem/eval/generators.go
+++ b/pkg/sql/sem/eval/generators.go
@@ -20,7 +20,7 @@ import (
 )
 
 // GetGenerator is used to construct a ValueGenerator from a FuncExpr.
-func GetGenerator(ctx *Context, expr *tree.FuncExpr) (ValueGenerator, error) {
+func GetGenerator(evalCtx *Context, expr *tree.FuncExpr) (ValueGenerator, error) {
 	if !expr.IsGeneratorClass() {
 		return nil, errors.AssertionFailedf(
 			"cannot call EvalArgsAndGetGenerator() on non-aggregate function: %q",
@@ -29,13 +29,13 @@ func GetGenerator(ctx *Context, expr *tree.FuncExpr) (ValueGenerator, error) {
 	}
 	ol := expr.ResolvedOverload()
 	if ol.GeneratorWithExprs != nil {
-		return ol.GeneratorWithExprs.(GeneratorWithExprsOverload)(ctx, expr.Exprs)
+		return ol.GeneratorWithExprs.(GeneratorWithExprsOverload)(evalCtx.Context, evalCtx, expr.Exprs)
 	}
-	nullArg, args, err := (*evaluator)(ctx).evalFuncArgs(expr)
+	nullArg, args, err := (*evaluator)(evalCtx).evalFuncArgs(evalCtx.Context, expr)
 	if err != nil || nullArg {
 		return nil, err
 	}
-	return ol.Generator.(GeneratorOverload)(ctx, args)
+	return ol.Generator.(GeneratorOverload)(evalCtx.Context, evalCtx, args)
 }
 
 // Table generators, also called "set-generating functions", are

--- a/pkg/sql/sem/eval/indexed_vars.go
+++ b/pkg/sql/sem/eval/indexed_vars.go
@@ -10,12 +10,16 @@
 
 package eval
 
-import "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+import (
+	"context"
 
-// IndexedVarContainer extends tree.IndexedVarContainer with the ability
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// IndexedVarContainer extends tree.IndexedVarContainer with the ability to
 // evaluate the underlying expression.
 type IndexedVarContainer interface {
 	tree.IndexedVarContainer
 
-	IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error)
+	IndexedVarEval(ctx context.Context, idx int, e tree.ExprEvaluator) (tree.Datum, error)
 }

--- a/pkg/sql/sem/eval/json.go
+++ b/pkg/sql/sem/eval/json.go
@@ -11,6 +11,8 @@
 package eval
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -22,7 +24,9 @@ import (
 // PopulateDatumWithJSON is used for the json to record function family, like
 // json_populate_record. It's less restrictive than the casting system, which
 // is why it's implemented separately.
-func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tree.Datum, error) {
+func PopulateDatumWithJSON(
+	ctx context.Context, evalCtx *Context, j json.JSON, desiredType *types.T,
+) (tree.Datum, error) {
 	if j == json.NullJSONValue {
 		return tree.DNull, nil
 	}
@@ -40,7 +44,7 @@ func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tre
 			if err != nil {
 				return nil, err
 			}
-			d.Array[i], err = PopulateDatumWithJSON(ctx, elt, elementTyp)
+			d.Array[i], err = PopulateDatumWithJSON(ctx, evalCtx, elt, elementTyp)
 			if err != nil {
 				return nil, err
 			}
@@ -51,7 +55,7 @@ func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tre
 		for i := range tup.D {
 			tup.D[i] = tree.DNull
 		}
-		err := PopulateRecordWithJSON(ctx, j, desiredType, tup)
+		err := PopulateRecordWithJSON(ctx, evalCtx, j, desiredType, tup)
 		return tup, err
 	}
 	var s string
@@ -68,7 +72,7 @@ func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tre
 	default:
 		s = j.String()
 	}
-	return PerformCast(ctx, tree.NewDString(s), desiredType)
+	return PerformCast(ctx, evalCtx, tree.NewDString(s), desiredType)
 }
 
 // PopulateRecordWithJSON is used for the json to record function family, like
@@ -81,7 +85,7 @@ func PopulateDatumWithJSON(ctx *Context, j json.JSON, desiredType *types.T) (tre
 // Each field will be set by a best-effort coercion to its type from the JSON
 // field. The logic is more permissive than casts.
 func PopulateRecordWithJSON(
-	ctx *Context, j json.JSON, desiredType *types.T, tup *tree.DTuple,
+	ctx context.Context, evalCtx *Context, j json.JSON, desiredType *types.T, tup *tree.DTuple,
 ) error {
 	if j.Type() != json.ObjectJSONType {
 		return pgerror.Newf(pgcode.InvalidParameterValue, "expected JSON object")
@@ -100,7 +104,7 @@ func PopulateRecordWithJSON(
 			// No value? Use the value that was already in the tuple.
 			continue
 		}
-		tup.D[i], err = PopulateDatumWithJSON(ctx, val, tupleTypes[i])
+		tup.D[i], err = PopulateDatumWithJSON(ctx, evalCtx, val, tupleTypes[i])
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/eval/like_test.go
+++ b/pkg/sql/sem/eval/like_test.go
@@ -145,7 +145,7 @@ var benchmarkLikePatterns = []string{
 	`also\%`,
 }
 
-func benchmarkLike(b *testing.B, ctx *Context, caseInsensitive bool) {
+func benchmarkLike(b *testing.B, evalCtx *Context, caseInsensitive bool) {
 	op := treecmp.Like
 	if caseInsensitive {
 		op = treecmp.ILike
@@ -154,7 +154,7 @@ func benchmarkLike(b *testing.B, ctx *Context, caseInsensitive bool) {
 	iter := func() {
 		for _, p := range benchmarkLikePatterns {
 			if _, err := BinaryOp(
-				ctx, likeFn.EvalOp, tree.NewDString("test"), tree.NewDString(p),
+				context.Background(), evalCtx, likeFn.EvalOp, tree.NewDString("test"), tree.NewDString(p),
 			); err != nil {
 				b.Fatalf("LIKE evaluation failed with error: %v", err)
 			}
@@ -171,7 +171,7 @@ func benchmarkLike(b *testing.B, ctx *Context, caseInsensitive bool) {
 func BenchmarkLikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = tree.NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.TestingMon.Stop(context.Background())
+	defer ctx.Stop(context.Background())
 
 	benchmarkLike(b, ctx, false)
 }
@@ -186,7 +186,7 @@ func BenchmarkLikeWithoutCache(b *testing.B) {
 func BenchmarkILikeWithCache(b *testing.B) {
 	ctx := NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	ctx.ReCache = tree.NewRegexpCache(len(benchmarkLikePatterns))
-	defer ctx.TestingMon.Stop(context.Background())
+	defer ctx.Stop(context.Background())
 
 	benchmarkLike(b, ctx, true)
 }

--- a/pkg/sql/sem/eval/overload.go
+++ b/pkg/sql/sem/eval/overload.go
@@ -56,25 +56,25 @@ type AggregateFunc interface {
 
 // FnOverload is a function generally defined as a builtin. It doesn't have
 // a concrete type with a marker method only because it's onerous to add.
-type FnOverload = func(*Context, tree.Datums) (tree.Datum, error)
+type FnOverload = func(context.Context, *Context, tree.Datums) (tree.Datum, error)
 
 // FnWithExprsOverload is the concrete type for the tree.Overload.FnWithExprs
 // field.
-type FnWithExprsOverload func(*Context, tree.Exprs) (tree.Datum, error)
+type FnWithExprsOverload func(context.Context, *Context, tree.Exprs) (tree.Datum, error)
 
 // FnWithExprs is a marker to indicate that this is a
 // tree.FnWithExprsOverload.
 func (fo FnWithExprsOverload) FnWithExprs() {}
 
 // SQLFnOverload is the concrete type for the tree.Overload.SQLFn field.
-type SQLFnOverload func(*Context, tree.Datums) (string, error)
+type SQLFnOverload func(context.Context, *Context, tree.Datums) (string, error)
 
 // SQLFn is a marker to indicate that this is a tree.SQLFnOverload.
 func (so SQLFnOverload) SQLFn() {}
 
 // GeneratorOverload is the type of constructor functions for
 // ValueGenerator objects.
-type GeneratorOverload func(ctx *Context, args tree.Datums) (ValueGenerator, error)
+type GeneratorOverload func(ctx context.Context, evalCtx *Context, args tree.Datums) (ValueGenerator, error)
 
 // Generator is a marker to indicate that this is a tree.GeneratorOverload.
 func (geo GeneratorOverload) Generator() {}
@@ -82,7 +82,7 @@ func (geo GeneratorOverload) Generator() {}
 // GeneratorWithExprsOverload is an alternative constructor function type for
 // ValueGenerators that gives implementations the ability to see the builtin's
 // arguments before evaluation, as Exprs.
-type GeneratorWithExprsOverload func(ctx *Context, args tree.Exprs) (ValueGenerator, error)
+type GeneratorWithExprsOverload func(ctx context.Context, evalCtx *Context, args tree.Exprs) (ValueGenerator, error)
 
 // GeneratorWithExprs is a marker to indicate that this is a
 // tree.GeneratorWithExprsOverload.

--- a/pkg/sql/sem/eval/tuple.go
+++ b/pkg/sql/sem/eval/tuple.go
@@ -11,21 +11,25 @@
 package eval
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 )
 
 // PickFromTuple picks the greatest (or least value) from a tuple.
-func PickFromTuple(ctx *Context, greatest bool, args tree.Datums) (tree.Datum, error) {
+func PickFromTuple(
+	ctx context.Context, evalCtx *Context, greatest bool, args tree.Datums,
+) (tree.Datum, error) {
 	g := args[0]
 	// Pick a greater (or smaller) value.
 	for _, d := range args[1:] {
 		var eval tree.Datum
 		var err error
 		if greatest {
-			eval, err = evalComparison(ctx, treecmp.MakeComparisonOperator(treecmp.LT), g, d)
+			eval, err = evalComparison(ctx, evalCtx, treecmp.MakeComparisonOperator(treecmp.LT), g, d)
 		} else {
-			eval, err = evalComparison(ctx, treecmp.MakeComparisonOperator(treecmp.LT), d, g)
+			eval, err = evalComparison(ctx, evalCtx, treecmp.MakeComparisonOperator(treecmp.LT), d, g)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/eval/unary_op.go
+++ b/pkg/sql/sem/eval/unary_op.go
@@ -11,6 +11,7 @@
 package eval
 
 import (
+	"context"
 	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -18,32 +19,40 @@ import (
 )
 
 // UnaryOp will evaluate a tree.UnaryEvalOp on a Datum into another Datum.
-func UnaryOp(ctx *Context, op tree.UnaryEvalOp, in tree.Datum) (tree.Datum, error) {
-	return op.Eval((*evaluator)(ctx), in)
+func UnaryOp(
+	ctx context.Context, evalCtx *Context, op tree.UnaryEvalOp, in tree.Datum,
+) (tree.Datum, error) {
+	return op.Eval(ctx, (*evaluator)(evalCtx), in)
 }
 
-func (e *evaluator) EvalCbrtDecimalOp(_ *tree.CbrtDecimalOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalCbrtDecimalOp(
+	ctx context.Context, _ *tree.CbrtDecimalOp, d tree.Datum,
+) (tree.Datum, error) {
 	dec := &d.(*tree.DDecimal).Decimal
 	return DecimalCbrt(dec)
 }
 
-func (e *evaluator) EvalCbrtFloatOp(_ *tree.CbrtFloatOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalCbrtFloatOp(
+	ctx context.Context, _ *tree.CbrtFloatOp, d tree.Datum,
+) (tree.Datum, error) {
 	return Cbrt(float64(*d.(*tree.DFloat)))
 }
 
 func (e *evaluator) EvalComplementINetOp(
-	_ *tree.ComplementINetOp, d tree.Datum,
+	ctx context.Context, _ *tree.ComplementINetOp, d tree.Datum,
 ) (tree.Datum, error) {
 	ipAddr := tree.MustBeDIPAddr(d).IPAddr
 	return tree.NewDIPAddr(tree.DIPAddr{IPAddr: ipAddr.Complement()}), nil
 }
 
-func (e *evaluator) EvalComplementIntOp(_ *tree.ComplementIntOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalComplementIntOp(
+	ctx context.Context, _ *tree.ComplementIntOp, d tree.Datum,
+) (tree.Datum, error) {
 	return tree.NewDInt(^tree.MustBeDInt(d)), nil
 }
 
 func (e *evaluator) EvalComplementVarBitOp(
-	_ *tree.ComplementVarBitOp, d tree.Datum,
+	ctx context.Context, _ *tree.ComplementVarBitOp, d tree.Datum,
 ) (tree.Datum, error) {
 	p := tree.MustBeDBitArray(d)
 	return &tree.DBitArray{
@@ -51,17 +60,21 @@ func (e *evaluator) EvalComplementVarBitOp(
 	}, nil
 }
 
-func (e *evaluator) EvalSqrtDecimalOp(_ *tree.SqrtDecimalOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalSqrtDecimalOp(
+	ctx context.Context, _ *tree.SqrtDecimalOp, d tree.Datum,
+) (tree.Datum, error) {
 	dec := &d.(*tree.DDecimal).Decimal
 	return DecimalSqrt(dec)
 }
 
-func (e *evaluator) EvalSqrtFloatOp(_ *tree.SqrtFloatOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalSqrtFloatOp(
+	ctx context.Context, _ *tree.SqrtFloatOp, d tree.Datum,
+) (tree.Datum, error) {
 	return Sqrt(float64(*d.(*tree.DFloat)))
 }
 
 func (e *evaluator) EvalUnaryMinusDecimalOp(
-	_ *tree.UnaryMinusDecimalOp, d tree.Datum,
+	ctx context.Context, _ *tree.UnaryMinusDecimalOp, d tree.Datum,
 ) (tree.Datum, error) {
 	dec := &d.(*tree.DDecimal).Decimal
 	dd := &tree.DDecimal{}
@@ -70,12 +83,14 @@ func (e *evaluator) EvalUnaryMinusDecimalOp(
 }
 
 func (e *evaluator) EvalUnaryMinusFloatOp(
-	_ *tree.UnaryMinusFloatOp, d tree.Datum,
+	ctx context.Context, _ *tree.UnaryMinusFloatOp, d tree.Datum,
 ) (tree.Datum, error) {
 	return tree.NewDFloat(-*d.(*tree.DFloat)), nil
 }
 
-func (e *evaluator) EvalUnaryMinusIntOp(_ *tree.UnaryMinusIntOp, d tree.Datum) (tree.Datum, error) {
+func (e *evaluator) EvalUnaryMinusIntOp(
+	ctx context.Context, _ *tree.UnaryMinusIntOp, d tree.Datum,
+) (tree.Datum, error) {
 	i := tree.MustBeDInt(d)
 	if i == math.MinInt64 {
 		return nil, tree.ErrIntOutOfRange
@@ -84,7 +99,7 @@ func (e *evaluator) EvalUnaryMinusIntOp(_ *tree.UnaryMinusIntOp, d tree.Datum) (
 }
 
 func (e *evaluator) EvalUnaryMinusIntervalOp(
-	_ *tree.UnaryMinusIntervalOp, d tree.Datum,
+	ctx context.Context, _ *tree.UnaryMinusIntervalOp, d tree.Datum,
 ) (tree.Datum, error) {
 	i := d.(*tree.DInterval).Duration
 	i.SetNanos(-i.Nanos())

--- a/pkg/sql/sem/eval/window_funcs.go
+++ b/pkg/sql/sem/eval/window_funcs.go
@@ -125,7 +125,7 @@ func (wfr *WindowFrameRun) getValueByOffset(
 	if value == tree.DNull {
 		return tree.DNull, nil
 	}
-	return binOp.EvalOp.Eval((*evaluator)(evalCtx), value, offset)
+	return binOp.EvalOp.Eval(ctx, (*evaluator)(evalCtx), value, offset)
 }
 
 // FrameStartIdx returns the index of starting row in the frame (which is the first to be included).

--- a/pkg/sql/sem/normalize/constant.go
+++ b/pkg/sql/sem/normalize/constant.go
@@ -18,8 +18,8 @@ import (
 
 // ConstantEvalVisitor replaces constant TypedExprs with the result of Eval.
 type ConstantEvalVisitor struct {
-	ctx *eval.Context
-	err error
+	evalCtx *eval.Context
+	err     error
 
 	fastIsConstVisitor fastIsConstVisitor
 }
@@ -27,8 +27,8 @@ type ConstantEvalVisitor struct {
 var _ tree.Visitor = &ConstantEvalVisitor{}
 
 // MakeConstantEvalVisitor creates a ConstantEvalVisitor instance.
-func MakeConstantEvalVisitor(ctx *eval.Context) ConstantEvalVisitor {
-	return ConstantEvalVisitor{ctx: ctx, fastIsConstVisitor: fastIsConstVisitor{ctx: ctx}}
+func MakeConstantEvalVisitor(evalCtx *eval.Context) ConstantEvalVisitor {
+	return ConstantEvalVisitor{evalCtx: evalCtx, fastIsConstVisitor: fastIsConstVisitor{evalCtx: evalCtx}}
 }
 
 // Err retrieves the error field in the ConstantEvalVisitor.
@@ -53,7 +53,7 @@ func (v *ConstantEvalVisitor) VisitPost(expr tree.Expr) tree.Expr {
 		return expr
 	}
 
-	value, err := eval.Expr(v.ctx, typedExpr)
+	value, err := eval.Expr(v.evalCtx.Context, v.evalCtx, typedExpr)
 	if err != nil {
 		// Ignore any errors here (e.g. division by zero), so they can happen
 		// during execution where they are correctly handled. Note that in some

--- a/pkg/sql/sem/normalize/constant_eval_test.go
+++ b/pkg/sql/sem/normalize/constant_eval_test.go
@@ -42,9 +42,9 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-	defer ctx.TestingMon.Stop(context.Background())
-	c := normalize.MakeConstantEvalVisitor(ctx)
+	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	defer evalCtx.Stop(context.Background())
+	c := normalize.MakeConstantEvalVisitor(context.Background(), evalCtx)
 	expr, _ = tree.WalkExpr(&c, typedExpr)
 	if err := c.Err(); err != nil {
 		t.Fatal(err)

--- a/pkg/sql/sem/normalize/normalize_exprs.go
+++ b/pkg/sql/sem/normalize/normalize_exprs.go
@@ -58,7 +58,7 @@ func normalizeAndExpr(v *Visitor, expr *tree.AndExpr) tree.TypedExpr {
 
 	// Use short-circuit evaluation to simplify AND expressions.
 	if v.isConst(left) {
-		dleft, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, left)
+		dleft, v.err = eval.Expr(v.ctx, v.evalCtx, left)
 		if v.err != nil {
 			return expr
 		}
@@ -77,7 +77,7 @@ func normalizeAndExpr(v *Visitor, expr *tree.AndExpr) tree.TypedExpr {
 		)
 	}
 	if v.isConst(right) {
-		dright, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, right)
+		dright, v.err = eval.Expr(v.ctx, v.evalCtx, right)
 		if v.err != nil {
 			return expr
 		}
@@ -172,7 +172,7 @@ func normalizeCoalesceExpr(v *Visitor, expr *tree.CoalesceExpr) tree.TypedExpr {
 			return &exprCopy
 		}
 
-		val, err := eval.Expr(v.evalCtx.Context, v.evalCtx, subExpr)
+		val, err := eval.Expr(v.ctx, v.evalCtx, subExpr)
 		if err != nil {
 			v.err = err
 			return expr
@@ -297,7 +297,7 @@ func normalizeComparisonExpr(v *Visitor, expr *tree.ComparisonExpr) tree.TypedEx
 
 func normalizeIfExpr(v *Visitor, expr *tree.IfExpr) tree.TypedExpr {
 	if v.isConst(expr.Cond) {
-		cond, err := eval.Expr(v.evalCtx.Context, v.evalCtx, expr.TypedCondExpr())
+		cond, err := eval.Expr(v.ctx, v.evalCtx, expr.TypedCondExpr())
 		if err != nil {
 			v.err = err
 			return expr
@@ -333,7 +333,7 @@ func normalizeOrExpr(v *Visitor, expr *tree.OrExpr) tree.TypedExpr {
 
 	// Use short-circuit evaluation to simplify OR expressions.
 	if v.isConst(left) {
-		dleft, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, left)
+		dleft, v.err = eval.Expr(v.ctx, v.evalCtx, left)
 		if v.err != nil {
 			return expr
 		}
@@ -352,7 +352,7 @@ func normalizeOrExpr(v *Visitor, expr *tree.OrExpr) tree.TypedExpr {
 		)
 	}
 	if v.isConst(right) {
-		dright, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, right)
+		dright, v.err = eval.Expr(v.ctx, v.evalCtx, right)
 		if v.err != nil {
 			return expr
 		}
@@ -381,7 +381,7 @@ func normalizeRangeCond(v *Visitor, expr *tree.RangeCond) tree.TypedExpr {
 	leftFrom, from := expr.TypedLeftFrom(), expr.TypedFrom()
 	leftTo, to := expr.TypedLeftTo(), expr.TypedTo()
 	// The visitor hasn't walked down into leftTo; do it now.
-	if leftTo, v.err = Expr(v.evalCtx, leftTo); v.err != nil {
+	if leftTo, v.err = Expr(v.ctx, v.evalCtx, leftTo); v.err != nil {
 		return expr
 	}
 
@@ -453,7 +453,7 @@ func normalizeTuple(v *Visitor, expr *tree.Tuple) tree.TypedExpr {
 	if !isConst {
 		return expr
 	}
-	e, err := eval.Expr(v.evalCtx.Context, v.evalCtx, expr)
+	e, err := eval.Expr(v.ctx, v.evalCtx, expr)
 	if err != nil {
 		v.err = err
 	}

--- a/pkg/sql/sem/normalize/normalize_exprs.go
+++ b/pkg/sql/sem/normalize/normalize_exprs.go
@@ -58,7 +58,7 @@ func normalizeAndExpr(v *Visitor, expr *tree.AndExpr) tree.TypedExpr {
 
 	// Use short-circuit evaluation to simplify AND expressions.
 	if v.isConst(left) {
-		dleft, v.err = eval.Expr(v.ctx, left)
+		dleft, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, left)
 		if v.err != nil {
 			return expr
 		}
@@ -77,7 +77,7 @@ func normalizeAndExpr(v *Visitor, expr *tree.AndExpr) tree.TypedExpr {
 		)
 	}
 	if v.isConst(right) {
-		dright, v.err = eval.Expr(v.ctx, right)
+		dright, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, right)
 		if v.err != nil {
 			return expr
 		}
@@ -172,7 +172,7 @@ func normalizeCoalesceExpr(v *Visitor, expr *tree.CoalesceExpr) tree.TypedExpr {
 			return &exprCopy
 		}
 
-		val, err := eval.Expr(v.ctx, subExpr)
+		val, err := eval.Expr(v.evalCtx.Context, v.evalCtx, subExpr)
 		if err != nil {
 			v.err = err
 			return expr
@@ -248,7 +248,7 @@ func normalizeComparisonExpr(v *Visitor, expr *tree.ComparisonExpr) tree.TypedEx
 		tuple, ok := expr.Right.(*tree.DTuple)
 		if ok {
 			tupleCopy := *tuple
-			tupleCopy.Normalize(v.ctx)
+			tupleCopy.Normalize(v.evalCtx)
 
 			// If the tuple only contains NULL values, Normalize will have reduced
 			// it to a single NULL value.
@@ -297,7 +297,7 @@ func normalizeComparisonExpr(v *Visitor, expr *tree.ComparisonExpr) tree.TypedEx
 
 func normalizeIfExpr(v *Visitor, expr *tree.IfExpr) tree.TypedExpr {
 	if v.isConst(expr.Cond) {
-		cond, err := eval.Expr(v.ctx, expr.TypedCondExpr())
+		cond, err := eval.Expr(v.evalCtx.Context, v.evalCtx, expr.TypedCondExpr())
 		if err != nil {
 			v.err = err
 			return expr
@@ -333,7 +333,7 @@ func normalizeOrExpr(v *Visitor, expr *tree.OrExpr) tree.TypedExpr {
 
 	// Use short-circuit evaluation to simplify OR expressions.
 	if v.isConst(left) {
-		dleft, v.err = eval.Expr(v.ctx, left)
+		dleft, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, left)
 		if v.err != nil {
 			return expr
 		}
@@ -352,7 +352,7 @@ func normalizeOrExpr(v *Visitor, expr *tree.OrExpr) tree.TypedExpr {
 		)
 	}
 	if v.isConst(right) {
-		dright, v.err = eval.Expr(v.ctx, right)
+		dright, v.err = eval.Expr(v.evalCtx.Context, v.evalCtx, right)
 		if v.err != nil {
 			return expr
 		}
@@ -381,7 +381,7 @@ func normalizeRangeCond(v *Visitor, expr *tree.RangeCond) tree.TypedExpr {
 	leftFrom, from := expr.TypedLeftFrom(), expr.TypedFrom()
 	leftTo, to := expr.TypedLeftTo(), expr.TypedTo()
 	// The visitor hasn't walked down into leftTo; do it now.
-	if leftTo, v.err = Expr(v.ctx, leftTo); v.err != nil {
+	if leftTo, v.err = Expr(v.evalCtx, leftTo); v.err != nil {
 		return expr
 	}
 
@@ -453,7 +453,7 @@ func normalizeTuple(v *Visitor, expr *tree.Tuple) tree.TypedExpr {
 	if !isConst {
 		return expr
 	}
-	e, err := eval.Expr(v.ctx, expr)
+	e, err := eval.Expr(v.evalCtx.Context, v.evalCtx, expr)
 	if err != nil {
 		v.err = err
 	}

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -235,9 +235,9 @@ func TestNormalizeExpr(t *testing.T) {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
 			rOrig := typedExpr.String()
-			ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-			defer ctx.TestingMon.Stop(context.Background())
-			r, err := normalize.Expr(ctx, typedExpr)
+			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+			defer evalCtx.Stop(context.Background())
+			r, err := normalize.Expr(context.Background(), evalCtx, typedExpr)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
@@ -245,7 +245,7 @@ func TestNormalizeExpr(t *testing.T) {
 				t.Errorf("%s: expected %s, but found %s", d.expr, d.expected, s)
 			}
 			// Normalizing again should be a no-op.
-			r2, err := normalize.Expr(ctx, r)
+			r2, err := normalize.Expr(context.Background(), evalCtx, r)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}

--- a/pkg/sql/sem/normalize/visitor.go
+++ b/pkg/sql/sem/normalize/visitor.go
@@ -18,8 +18,8 @@ import (
 )
 
 // Expr normalizes the provided expr.
-func Expr(ctx *eval.Context, typedExpr tree.TypedExpr) (tree.TypedExpr, error) {
-	v := MakeNormalizeVisitor(ctx)
+func Expr(evalCtx *eval.Context, typedExpr tree.TypedExpr) (tree.TypedExpr, error) {
+	v := MakeNormalizeVisitor(evalCtx)
 	expr, _ := tree.WalkExpr(&v, typedExpr)
 	if v.err != nil {
 		return nil, v.err
@@ -29,8 +29,8 @@ func Expr(ctx *eval.Context, typedExpr tree.TypedExpr) (tree.TypedExpr, error) {
 
 // Visitor supports the execution of Expr.
 type Visitor struct {
-	ctx *eval.Context
-	err error
+	evalCtx *eval.Context
+	err     error
 
 	fastIsConstVisitor fastIsConstVisitor
 }
@@ -38,8 +38,8 @@ type Visitor struct {
 var _ tree.Visitor = &Visitor{}
 
 // MakeNormalizeVisitor creates a Visitor instance.
-func MakeNormalizeVisitor(ctx *eval.Context) Visitor {
-	return Visitor{ctx: ctx, fastIsConstVisitor: fastIsConstVisitor{ctx: ctx}}
+func MakeNormalizeVisitor(evalCtx *eval.Context) Visitor {
+	return Visitor{evalCtx: evalCtx, fastIsConstVisitor: fastIsConstVisitor{evalCtx: evalCtx}}
 }
 
 // Err retrieves the error field in the Visitor.
@@ -80,7 +80,7 @@ func (v *Visitor) VisitPost(expr tree.Expr) tree.Expr {
 
 	// Evaluate all constant expressions.
 	if v.isConst(expr) {
-		value, err := eval.Expr(v.ctx, expr.(tree.TypedExpr))
+		value, err := eval.Expr(v.evalCtx.Context, v.evalCtx, expr.(tree.TypedExpr))
 		if err != nil {
 			// Ignore any errors here (e.g. division by zero), so they can happen
 			// during execution where they are correctly handled. Note that in some
@@ -112,7 +112,7 @@ func (v *Visitor) isConst(expr tree.Expr) bool {
 // zero.
 func (v *Visitor) isNumericZero(expr tree.TypedExpr) bool {
 	if d, ok := expr.(tree.Datum); ok {
-		switch t := eval.UnwrapDatum(v.ctx, d).(type) {
+		switch t := eval.UnwrapDatum(v.evalCtx, d).(type) {
 		case *tree.DDecimal:
 			return t.Decimal.Sign() == 0
 		case *tree.DFloat:
@@ -128,7 +128,7 @@ func (v *Visitor) isNumericZero(expr tree.TypedExpr) bool {
 // one.
 func (v *Visitor) isNumericOne(expr tree.TypedExpr) bool {
 	if d, ok := expr.(tree.Datum); ok {
-		switch t := eval.UnwrapDatum(v.ctx, d).(type) {
+		switch t := eval.UnwrapDatum(v.evalCtx, d).(type) {
 		case *tree.DDecimal:
 			return t.Decimal.Cmp(&DecimalOne.Decimal) == 0
 		case *tree.DFloat:
@@ -166,7 +166,7 @@ func invertComparisonOp(op treecmp.ComparisonOperator) (treecmp.ComparisonOperat
 // bottom-up. If a child is *not* a const tree.Datum, that means it was already
 // determined to be non-constant, and therefore was not evaluated.
 type fastIsConstVisitor struct {
-	ctx     *eval.Context
+	evalCtx *eval.Context
 	isConst bool
 
 	// visited indicates whether we have already visited one level of the tree.
@@ -185,7 +185,7 @@ func (v *fastIsConstVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tre
 			// Visitor may have wrapped a NULL.
 			return true, expr
 		}
-		if _, ok := expr.(tree.Datum); !ok || eval.IsVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
+		if _, ok := expr.(tree.Datum); !ok || eval.IsVar(v.evalCtx, expr, true /*allowConstPlaceholders*/) {
 			// If the child expression is not a const tree.Datum, the parent expression is
 			// not constant. Note that all constant literals have already been
 			// normalized to tree.Datum in TypeCheck.
@@ -199,7 +199,7 @@ func (v *fastIsConstVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tre
 	// that it is not constant.
 
 	if !tree.OperatorIsImmutable(expr) ||
-		eval.IsVar(v.ctx, expr, true /*allowConstPlaceholders*/) {
+		eval.IsVar(v.evalCtx, expr, true /*allowConstPlaceholders*/) {
 		v.isConst = false
 		return false, expr
 	}

--- a/pkg/sql/sem/transform/expr_transform.go
+++ b/pkg/sql/sem/transform/expr_transform.go
@@ -32,12 +32,12 @@ type ExprTransformContext struct {
 // avoids allocation of a normalizeVisitor. See var_expr.go for
 // details.
 func (t *ExprTransformContext) NormalizeExpr(
-	ctx *eval.Context, typedExpr tree.TypedExpr,
+	evalCtx *eval.Context, typedExpr tree.TypedExpr,
 ) (tree.TypedExpr, error) {
-	if ctx.SkipNormalize {
+	if evalCtx.SkipNormalize {
 		return typedExpr, nil
 	}
-	t.normalizeVisitor = normalize.MakeNormalizeVisitor(ctx)
+	t.normalizeVisitor = normalize.MakeNormalizeVisitor(evalCtx)
 	expr, _ := tree.WalkExpr(&t.normalizeVisitor, typedExpr)
 	if err := t.normalizeVisitor.Err(); err != nil {
 		return nil, err

--- a/pkg/sql/sem/transform/expr_transform.go
+++ b/pkg/sql/sem/transform/expr_transform.go
@@ -32,12 +32,12 @@ type ExprTransformContext struct {
 // avoids allocation of a normalizeVisitor. See var_expr.go for
 // details.
 func (t *ExprTransformContext) NormalizeExpr(
-	evalCtx *eval.Context, typedExpr tree.TypedExpr,
+	ctx context.Context, evalCtx *eval.Context, typedExpr tree.TypedExpr,
 ) (tree.TypedExpr, error) {
 	if evalCtx.SkipNormalize {
 		return typedExpr, nil
 	}
-	t.normalizeVisitor = normalize.MakeNormalizeVisitor(evalCtx)
+	t.normalizeVisitor = normalize.MakeNormalizeVisitor(ctx, evalCtx)
 	expr, _ := tree.WalkExpr(&t.normalizeVisitor, typedExpr)
 	if err := t.normalizeVisitor.Err(); err != nil {
 		return nil, err

--- a/pkg/sql/sem/tree/collatedstring_test.go
+++ b/pkg/sql/sem/tree/collatedstring_test.go
@@ -50,7 +50,7 @@ func TestCastToCollatedString(t *testing.T) {
 			}
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
-			val, err := eval.Expr(evalCtx, typedexpr)
+			val, err := eval.Expr(ctx, evalCtx, typedexpr)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -62,7 +62,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}
-		if _, err := eval.Expr(ctx, typedExpr); err != nil {
+		if _, err := eval.Expr(context.Background(), ctx, typedExpr); err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}
 		if typedExpr.(*tree.ComparisonExpr).Op.EvalOp == nil {

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -56,7 +56,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 			Right:    tree.NewDString(d.right),
 		}
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.TestingMon.Stop(context.Background())
+		defer ctx.Stop(context.Background())
 		ctx.ReCache = tree.NewRegexpCache(8)
 		typedExpr, err := tree.TypeCheck(context.Background(), expr, nil, types.Any)
 		if err != nil {

--- a/pkg/sql/sem/tree/constant_test.go
+++ b/pkg/sql/sem/tree/constant_test.go
@@ -608,7 +608,7 @@ func TestStringConstantResolveAvailableTypes(t *testing.T) {
 			typedExpr, err := test.c.ResolveAsType(context.Background(), &semaCtx, availType)
 			var res tree.Datum
 			if err == nil {
-				res, err = eval.Expr(evalCtx, typedExpr)
+				res, err = eval.Expr(context.Background(), evalCtx, typedExpr)
 			}
 			if err != nil {
 				if !strings.Contains(err.Error(), "could not parse") &&

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -54,7 +54,7 @@ func prepareExpr(t *testing.T, datumExpr string) tree.Datum {
 	// Normalization ensures that casts are processed.
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
-	typedExpr, err = normalize.Expr(evalCtx, typedExpr)
+	typedExpr, err = normalize.Expr(context.Background(), evalCtx, typedExpr)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -58,7 +58,7 @@ func prepareExpr(t *testing.T, datumExpr string) tree.Datum {
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}
-	d, err := eval.Expr(evalCtx, typedExpr)
+	d, err := eval.Expr(ctx, evalCtx, typedExpr)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}

--- a/pkg/sql/sem/tree/eval_binary_ops.go
+++ b/pkg/sql/sem/tree/eval_binary_ops.go
@@ -11,6 +11,8 @@
 package tree
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
@@ -43,11 +45,11 @@ type CompareAnyTupleOp CompareTupleOp
 
 // Eval suppresses an auto-generated binding and membership in the
 // OpEvaluator interface.
-func (t *CompareAnyTupleOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
+func (t *CompareAnyTupleOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
 	if a == DNull || b == DNull {
 		return MakeDBool(a == DNull && b == DNull), nil
 	}
-	return e.EvalCompareTupleOp((*CompareTupleOp)(t), a, b)
+	return e.EvalCompareTupleOp(ctx, (*CompareTupleOp)(t), a, b)
 }
 
 // MatchLikeOp is a BinaryEvalOp.

--- a/pkg/sql/sem/tree/eval_expr_generated.go
+++ b/pkg/sql/sem/tree/eval_expr_generated.go
@@ -19,358 +19,360 @@
 // Run './dev generate bazel' to fix this.
 package tree
 
+import "context"
+
 // ExprEvaluator is used to evaluate TypedExpr expressions.
 type ExprEvaluator interface {
-	EvalAllColumnsSelector(*AllColumnsSelector) (Datum, error)
-	EvalAndExpr(*AndExpr) (Datum, error)
-	EvalArray(*Array) (Datum, error)
-	EvalArrayFlatten(*ArrayFlatten) (Datum, error)
-	EvalBinaryExpr(*BinaryExpr) (Datum, error)
-	EvalCaseExpr(*CaseExpr) (Datum, error)
-	EvalCastExpr(*CastExpr) (Datum, error)
-	EvalCoalesceExpr(*CoalesceExpr) (Datum, error)
-	EvalCollateExpr(*CollateExpr) (Datum, error)
-	EvalColumnAccessExpr(*ColumnAccessExpr) (Datum, error)
-	EvalColumnItem(*ColumnItem) (Datum, error)
-	EvalComparisonExpr(*ComparisonExpr) (Datum, error)
-	EvalDefaultVal(*DefaultVal) (Datum, error)
-	EvalFuncExpr(*FuncExpr) (Datum, error)
-	EvalIfErrExpr(*IfErrExpr) (Datum, error)
-	EvalIfExpr(*IfExpr) (Datum, error)
-	EvalIndexedVar(*IndexedVar) (Datum, error)
-	EvalIndirectionExpr(*IndirectionExpr) (Datum, error)
-	EvalIsNotNullExpr(*IsNotNullExpr) (Datum, error)
-	EvalIsNullExpr(*IsNullExpr) (Datum, error)
-	EvalIsOfTypeExpr(*IsOfTypeExpr) (Datum, error)
-	EvalNotExpr(*NotExpr) (Datum, error)
-	EvalNullIfExpr(*NullIfExpr) (Datum, error)
-	EvalOrExpr(*OrExpr) (Datum, error)
-	EvalParenExpr(*ParenExpr) (Datum, error)
-	EvalPlaceholder(*Placeholder) (Datum, error)
-	EvalRangeCond(*RangeCond) (Datum, error)
-	EvalRoutineExpr(*RoutineExpr) (Datum, error)
-	EvalSubquery(*Subquery) (Datum, error)
-	EvalTuple(*Tuple) (Datum, error)
-	EvalTupleStar(*TupleStar) (Datum, error)
-	EvalTypedDummy(*TypedDummy) (Datum, error)
-	EvalUnaryExpr(*UnaryExpr) (Datum, error)
-	EvalUnqualifiedStar(UnqualifiedStar) (Datum, error)
-	EvalUnresolvedName(*UnresolvedName) (Datum, error)
+	EvalAllColumnsSelector(context.Context, *AllColumnsSelector) (Datum, error)
+	EvalAndExpr(context.Context, *AndExpr) (Datum, error)
+	EvalArray(context.Context, *Array) (Datum, error)
+	EvalArrayFlatten(context.Context, *ArrayFlatten) (Datum, error)
+	EvalBinaryExpr(context.Context, *BinaryExpr) (Datum, error)
+	EvalCaseExpr(context.Context, *CaseExpr) (Datum, error)
+	EvalCastExpr(context.Context, *CastExpr) (Datum, error)
+	EvalCoalesceExpr(context.Context, *CoalesceExpr) (Datum, error)
+	EvalCollateExpr(context.Context, *CollateExpr) (Datum, error)
+	EvalColumnAccessExpr(context.Context, *ColumnAccessExpr) (Datum, error)
+	EvalColumnItem(context.Context, *ColumnItem) (Datum, error)
+	EvalComparisonExpr(context.Context, *ComparisonExpr) (Datum, error)
+	EvalDefaultVal(context.Context, *DefaultVal) (Datum, error)
+	EvalFuncExpr(context.Context, *FuncExpr) (Datum, error)
+	EvalIfErrExpr(context.Context, *IfErrExpr) (Datum, error)
+	EvalIfExpr(context.Context, *IfExpr) (Datum, error)
+	EvalIndexedVar(context.Context, *IndexedVar) (Datum, error)
+	EvalIndirectionExpr(context.Context, *IndirectionExpr) (Datum, error)
+	EvalIsNotNullExpr(context.Context, *IsNotNullExpr) (Datum, error)
+	EvalIsNullExpr(context.Context, *IsNullExpr) (Datum, error)
+	EvalIsOfTypeExpr(context.Context, *IsOfTypeExpr) (Datum, error)
+	EvalNotExpr(context.Context, *NotExpr) (Datum, error)
+	EvalNullIfExpr(context.Context, *NullIfExpr) (Datum, error)
+	EvalOrExpr(context.Context, *OrExpr) (Datum, error)
+	EvalParenExpr(context.Context, *ParenExpr) (Datum, error)
+	EvalPlaceholder(context.Context, *Placeholder) (Datum, error)
+	EvalRangeCond(context.Context, *RangeCond) (Datum, error)
+	EvalRoutineExpr(context.Context, *RoutineExpr) (Datum, error)
+	EvalSubquery(context.Context, *Subquery) (Datum, error)
+	EvalTuple(context.Context, *Tuple) (Datum, error)
+	EvalTupleStar(context.Context, *TupleStar) (Datum, error)
+	EvalTypedDummy(context.Context, *TypedDummy) (Datum, error)
+	EvalUnaryExpr(context.Context, *UnaryExpr) (Datum, error)
+	EvalUnqualifiedStar(context.Context, UnqualifiedStar) (Datum, error)
+	EvalUnresolvedName(context.Context, *UnresolvedName) (Datum, error)
 }
 
 
 // Eval is part of the TypedExpr interface.
-func (node *AllColumnsSelector) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalAllColumnsSelector(node)
+func (node *AllColumnsSelector) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalAllColumnsSelector(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *AndExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalAndExpr(node)
+func (node *AndExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalAndExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *Array) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalArray(node)
+func (node *Array) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalArray(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *ArrayFlatten) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalArrayFlatten(node)
+func (node *ArrayFlatten) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalArrayFlatten(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *BinaryExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalBinaryExpr(node)
+func (node *BinaryExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalBinaryExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *CaseExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalCaseExpr(node)
+func (node *CaseExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalCaseExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *CastExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalCastExpr(node)
+func (node *CastExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalCastExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *CoalesceExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalCoalesceExpr(node)
+func (node *CoalesceExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalCoalesceExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *CollateExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalCollateExpr(node)
+func (node *CollateExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalCollateExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *ColumnAccessExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalColumnAccessExpr(node)
+func (node *ColumnAccessExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalColumnAccessExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *ColumnItem) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalColumnItem(node)
+func (node *ColumnItem) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalColumnItem(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *ComparisonExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalComparisonExpr(node)
+func (node *ComparisonExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalComparisonExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DArray) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DArray) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DBitArray) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DBitArray) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DBool) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DBool) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DBox2D) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DBox2D) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DBytes) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DBytes) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DCollatedString) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DCollatedString) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DDate) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DDate) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DDecimal) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DDecimal) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DEncodedKey) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DEncodedKey) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DEnum) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DEnum) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DFloat) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DFloat) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DGeography) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DGeography) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DGeometry) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DGeometry) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DIPAddr) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DIPAddr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DInt) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DInt) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DInterval) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DInterval) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DJSON) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DJSON) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DOid) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DOid) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DOidWrapper) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DOidWrapper) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DString) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DString) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DTime) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DTime) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DTimeTZ) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DTimeTZ) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DTimestamp) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DTimestamp) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DTimestampTZ) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DTimestampTZ) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DTuple) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DTuple) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DUuid) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DUuid) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DVoid) Eval(v ExprEvaluator) (Datum, error) {
+func (node *DVoid) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *DefaultVal) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalDefaultVal(node)
+func (node *DefaultVal) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalDefaultVal(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *FuncExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalFuncExpr(node)
+func (node *FuncExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalFuncExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IfErrExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIfErrExpr(node)
+func (node *IfErrExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIfErrExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IfExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIfExpr(node)
+func (node *IfExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIfExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IndexedVar) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIndexedVar(node)
+func (node *IndexedVar) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIndexedVar(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IndirectionExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIndirectionExpr(node)
+func (node *IndirectionExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIndirectionExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IsNotNullExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIsNotNullExpr(node)
+func (node *IsNotNullExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIsNotNullExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IsNullExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIsNullExpr(node)
+func (node *IsNullExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIsNullExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *IsOfTypeExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalIsOfTypeExpr(node)
+func (node *IsOfTypeExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalIsOfTypeExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *NotExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalNotExpr(node)
+func (node *NotExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalNotExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *NullIfExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalNullIfExpr(node)
+func (node *NullIfExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalNullIfExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *OrExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalOrExpr(node)
+func (node *OrExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalOrExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *ParenExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalParenExpr(node)
+func (node *ParenExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalParenExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *Placeholder) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalPlaceholder(node)
+func (node *Placeholder) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalPlaceholder(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *RangeCond) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalRangeCond(node)
+func (node *RangeCond) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalRangeCond(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *RoutineExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalRoutineExpr(node)
+func (node *RoutineExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalRoutineExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *Subquery) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalSubquery(node)
+func (node *Subquery) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalSubquery(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *Tuple) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalTuple(node)
+func (node *Tuple) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalTuple(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *TupleStar) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalTupleStar(node)
+func (node *TupleStar) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalTupleStar(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *TypedDummy) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalTypedDummy(node)
+func (node *TypedDummy) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalTypedDummy(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *UnaryExpr) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalUnaryExpr(node)
+func (node *UnaryExpr) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalUnaryExpr(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node UnqualifiedStar) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalUnqualifiedStar(node)
+func (node UnqualifiedStar) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalUnqualifiedStar(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node *UnresolvedName) Eval(v ExprEvaluator) (Datum, error) {
-	return v.EvalUnresolvedName(node)
+func (node *UnresolvedName) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	return v.EvalUnresolvedName(ctx, node)
 }
 
 // Eval is part of the TypedExpr interface.
-func (node dNull) Eval(v ExprEvaluator) (Datum, error) {
+func (node dNull) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
 	return node, nil
 }
 

--- a/pkg/sql/sem/tree/eval_op_generated.go
+++ b/pkg/sql/sem/tree/eval_op_generated.go
@@ -19,15 +19,17 @@
 // Run './dev generate bazel' to fix this.
 package tree
 
+import "context"
+
 
 // UnaryEvalOp is a unary operation which can be evaluated.
 type UnaryEvalOp interface {
-	Eval(OpEvaluator, Datum) (Datum, error)
+	Eval(context.Context, OpEvaluator, Datum) (Datum, error)
 }
 
 // BinaryEvalOp is a binary operation which can be evaluated.
 type BinaryEvalOp interface {
-	Eval(OpEvaluator, Datum, Datum) (Datum, error)
+	Eval(context.Context, OpEvaluator, Datum, Datum) (Datum, error)
 }
 
 // OpEvaluator is an evaluator for UnaryEvalOp and BinaryEvalOp operations.
@@ -38,832 +40,832 @@ type OpEvaluator interface {
 
 // UnaryOpEvaluator knows how to evaluate UnaryEvalOps.
 type UnaryOpEvaluator interface {
-	EvalCbrtDecimalOp(*CbrtDecimalOp, Datum) (Datum, error)
-	EvalCbrtFloatOp(*CbrtFloatOp, Datum) (Datum, error)
-	EvalComplementINetOp(*ComplementINetOp, Datum) (Datum, error)
-	EvalComplementIntOp(*ComplementIntOp, Datum) (Datum, error)
-	EvalComplementVarBitOp(*ComplementVarBitOp, Datum) (Datum, error)
-	EvalSqrtDecimalOp(*SqrtDecimalOp, Datum) (Datum, error)
-	EvalSqrtFloatOp(*SqrtFloatOp, Datum) (Datum, error)
-	EvalUnaryMinusDecimalOp(*UnaryMinusDecimalOp, Datum) (Datum, error)
-	EvalUnaryMinusFloatOp(*UnaryMinusFloatOp, Datum) (Datum, error)
-	EvalUnaryMinusIntOp(*UnaryMinusIntOp, Datum) (Datum, error)
-	EvalUnaryMinusIntervalOp(*UnaryMinusIntervalOp, Datum) (Datum, error)
+	EvalCbrtDecimalOp(context.Context, *CbrtDecimalOp, Datum) (Datum, error)
+	EvalCbrtFloatOp(context.Context, *CbrtFloatOp, Datum) (Datum, error)
+	EvalComplementINetOp(context.Context, *ComplementINetOp, Datum) (Datum, error)
+	EvalComplementIntOp(context.Context, *ComplementIntOp, Datum) (Datum, error)
+	EvalComplementVarBitOp(context.Context, *ComplementVarBitOp, Datum) (Datum, error)
+	EvalSqrtDecimalOp(context.Context, *SqrtDecimalOp, Datum) (Datum, error)
+	EvalSqrtFloatOp(context.Context, *SqrtFloatOp, Datum) (Datum, error)
+	EvalUnaryMinusDecimalOp(context.Context, *UnaryMinusDecimalOp, Datum) (Datum, error)
+	EvalUnaryMinusFloatOp(context.Context, *UnaryMinusFloatOp, Datum) (Datum, error)
+	EvalUnaryMinusIntOp(context.Context, *UnaryMinusIntOp, Datum) (Datum, error)
+	EvalUnaryMinusIntervalOp(context.Context, *UnaryMinusIntervalOp, Datum) (Datum, error)
 }
 
 // UnaryOpEvaluator knows how to evaluate BinaryEvalOps.
 type BinaryOpEvaluator interface {
-	EvalAppendToMaybeNullArrayOp(*AppendToMaybeNullArrayOp, Datum, Datum) (Datum, error)
-	EvalBitAndINetOp(*BitAndINetOp, Datum, Datum) (Datum, error)
-	EvalBitAndIntOp(*BitAndIntOp, Datum, Datum) (Datum, error)
-	EvalBitAndVarBitOp(*BitAndVarBitOp, Datum, Datum) (Datum, error)
-	EvalBitOrINetOp(*BitOrINetOp, Datum, Datum) (Datum, error)
-	EvalBitOrIntOp(*BitOrIntOp, Datum, Datum) (Datum, error)
-	EvalBitOrVarBitOp(*BitOrVarBitOp, Datum, Datum) (Datum, error)
-	EvalBitXorIntOp(*BitXorIntOp, Datum, Datum) (Datum, error)
-	EvalBitXorVarBitOp(*BitXorVarBitOp, Datum, Datum) (Datum, error)
-	EvalCompareBox2DOp(*CompareBox2DOp, Datum, Datum) (Datum, error)
-	EvalCompareScalarOp(*CompareScalarOp, Datum, Datum) (Datum, error)
-	EvalCompareTupleOp(*CompareTupleOp, Datum, Datum) (Datum, error)
-	EvalConcatArraysOp(*ConcatArraysOp, Datum, Datum) (Datum, error)
-	EvalConcatBytesOp(*ConcatBytesOp, Datum, Datum) (Datum, error)
-	EvalConcatJsonbOp(*ConcatJsonbOp, Datum, Datum) (Datum, error)
-	EvalConcatOp(*ConcatOp, Datum, Datum) (Datum, error)
-	EvalConcatStringOp(*ConcatStringOp, Datum, Datum) (Datum, error)
-	EvalConcatVarBitOp(*ConcatVarBitOp, Datum, Datum) (Datum, error)
-	EvalContainedByArrayOp(*ContainedByArrayOp, Datum, Datum) (Datum, error)
-	EvalContainedByJsonbOp(*ContainedByJsonbOp, Datum, Datum) (Datum, error)
-	EvalContainsArrayOp(*ContainsArrayOp, Datum, Datum) (Datum, error)
-	EvalContainsJsonbOp(*ContainsJsonbOp, Datum, Datum) (Datum, error)
-	EvalDivDecimalIntOp(*DivDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalDivDecimalOp(*DivDecimalOp, Datum, Datum) (Datum, error)
-	EvalDivFloatOp(*DivFloatOp, Datum, Datum) (Datum, error)
-	EvalDivIntDecimalOp(*DivIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalDivIntOp(*DivIntOp, Datum, Datum) (Datum, error)
-	EvalDivIntervalFloatOp(*DivIntervalFloatOp, Datum, Datum) (Datum, error)
-	EvalDivIntervalIntOp(*DivIntervalIntOp, Datum, Datum) (Datum, error)
-	EvalFloorDivDecimalIntOp(*FloorDivDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalFloorDivDecimalOp(*FloorDivDecimalOp, Datum, Datum) (Datum, error)
-	EvalFloorDivFloatOp(*FloorDivFloatOp, Datum, Datum) (Datum, error)
-	EvalFloorDivIntDecimalOp(*FloorDivIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalFloorDivIntOp(*FloorDivIntOp, Datum, Datum) (Datum, error)
-	EvalInTupleOp(*InTupleOp, Datum, Datum) (Datum, error)
-	EvalJSONAllExistsOp(*JSONAllExistsOp, Datum, Datum) (Datum, error)
-	EvalJSONExistsOp(*JSONExistsOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchTextIntOp(*JSONFetchTextIntOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchTextPathOp(*JSONFetchTextPathOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchTextStringOp(*JSONFetchTextStringOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchValIntOp(*JSONFetchValIntOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchValPathOp(*JSONFetchValPathOp, Datum, Datum) (Datum, error)
-	EvalJSONFetchValStringOp(*JSONFetchValStringOp, Datum, Datum) (Datum, error)
-	EvalJSONSomeExistsOp(*JSONSomeExistsOp, Datum, Datum) (Datum, error)
-	EvalLShiftINetOp(*LShiftINetOp, Datum, Datum) (Datum, error)
-	EvalLShiftIntOp(*LShiftIntOp, Datum, Datum) (Datum, error)
-	EvalLShiftVarBitIntOp(*LShiftVarBitIntOp, Datum, Datum) (Datum, error)
-	EvalMatchLikeOp(*MatchLikeOp, Datum, Datum) (Datum, error)
-	EvalMatchRegexpOp(*MatchRegexpOp, Datum, Datum) (Datum, error)
-	EvalMinusDateIntOp(*MinusDateIntOp, Datum, Datum) (Datum, error)
-	EvalMinusDateIntervalOp(*MinusDateIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusDateOp(*MinusDateOp, Datum, Datum) (Datum, error)
-	EvalMinusDateTimeOp(*MinusDateTimeOp, Datum, Datum) (Datum, error)
-	EvalMinusDecimalIntOp(*MinusDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalMinusDecimalOp(*MinusDecimalOp, Datum, Datum) (Datum, error)
-	EvalMinusFloatOp(*MinusFloatOp, Datum, Datum) (Datum, error)
-	EvalMinusINetIntOp(*MinusINetIntOp, Datum, Datum) (Datum, error)
-	EvalMinusINetOp(*MinusINetOp, Datum, Datum) (Datum, error)
-	EvalMinusIntDecimalOp(*MinusIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalMinusIntOp(*MinusIntOp, Datum, Datum) (Datum, error)
-	EvalMinusIntervalOp(*MinusIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusJsonbIntOp(*MinusJsonbIntOp, Datum, Datum) (Datum, error)
-	EvalMinusJsonbStringArrayOp(*MinusJsonbStringArrayOp, Datum, Datum) (Datum, error)
-	EvalMinusJsonbStringOp(*MinusJsonbStringOp, Datum, Datum) (Datum, error)
-	EvalMinusTimeIntervalOp(*MinusTimeIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusTimeOp(*MinusTimeOp, Datum, Datum) (Datum, error)
-	EvalMinusTimeTZIntervalOp(*MinusTimeTZIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampIntervalOp(*MinusTimestampIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampOp(*MinusTimestampOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampTZIntervalOp(*MinusTimestampTZIntervalOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampTZOp(*MinusTimestampTZOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampTZTimestampOp(*MinusTimestampTZTimestampOp, Datum, Datum) (Datum, error)
-	EvalMinusTimestampTimestampTZOp(*MinusTimestampTimestampTZOp, Datum, Datum) (Datum, error)
-	EvalModDecimalIntOp(*ModDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalModDecimalOp(*ModDecimalOp, Datum, Datum) (Datum, error)
-	EvalModFloatOp(*ModFloatOp, Datum, Datum) (Datum, error)
-	EvalModIntDecimalOp(*ModIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalModIntOp(*ModIntOp, Datum, Datum) (Datum, error)
-	EvalModStringOp(*ModStringOp, Datum, Datum) (Datum, error)
-	EvalMultDecimalIntOp(*MultDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalMultDecimalIntervalOp(*MultDecimalIntervalOp, Datum, Datum) (Datum, error)
-	EvalMultDecimalOp(*MultDecimalOp, Datum, Datum) (Datum, error)
-	EvalMultFloatIntervalOp(*MultFloatIntervalOp, Datum, Datum) (Datum, error)
-	EvalMultFloatOp(*MultFloatOp, Datum, Datum) (Datum, error)
-	EvalMultIntDecimalOp(*MultIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalMultIntIntervalOp(*MultIntIntervalOp, Datum, Datum) (Datum, error)
-	EvalMultIntOp(*MultIntOp, Datum, Datum) (Datum, error)
-	EvalMultIntervalDecimalOp(*MultIntervalDecimalOp, Datum, Datum) (Datum, error)
-	EvalMultIntervalFloatOp(*MultIntervalFloatOp, Datum, Datum) (Datum, error)
-	EvalMultIntervalIntOp(*MultIntervalIntOp, Datum, Datum) (Datum, error)
-	EvalOverlapsArrayOp(*OverlapsArrayOp, Datum, Datum) (Datum, error)
-	EvalOverlapsINetOp(*OverlapsINetOp, Datum, Datum) (Datum, error)
-	EvalPlusDateIntOp(*PlusDateIntOp, Datum, Datum) (Datum, error)
-	EvalPlusDateIntervalOp(*PlusDateIntervalOp, Datum, Datum) (Datum, error)
-	EvalPlusDateTimeOp(*PlusDateTimeOp, Datum, Datum) (Datum, error)
-	EvalPlusDateTimeTZOp(*PlusDateTimeTZOp, Datum, Datum) (Datum, error)
-	EvalPlusDecimalIntOp(*PlusDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalPlusDecimalOp(*PlusDecimalOp, Datum, Datum) (Datum, error)
-	EvalPlusFloatOp(*PlusFloatOp, Datum, Datum) (Datum, error)
-	EvalPlusINetIntOp(*PlusINetIntOp, Datum, Datum) (Datum, error)
-	EvalPlusIntDateOp(*PlusIntDateOp, Datum, Datum) (Datum, error)
-	EvalPlusIntDecimalOp(*PlusIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalPlusIntINetOp(*PlusIntINetOp, Datum, Datum) (Datum, error)
-	EvalPlusIntOp(*PlusIntOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalDateOp(*PlusIntervalDateOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalOp(*PlusIntervalOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalTimeOp(*PlusIntervalTimeOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalTimeTZOp(*PlusIntervalTimeTZOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalTimestampOp(*PlusIntervalTimestampOp, Datum, Datum) (Datum, error)
-	EvalPlusIntervalTimestampTZOp(*PlusIntervalTimestampTZOp, Datum, Datum) (Datum, error)
-	EvalPlusTimeDateOp(*PlusTimeDateOp, Datum, Datum) (Datum, error)
-	EvalPlusTimeIntervalOp(*PlusTimeIntervalOp, Datum, Datum) (Datum, error)
-	EvalPlusTimeTZDateOp(*PlusTimeTZDateOp, Datum, Datum) (Datum, error)
-	EvalPlusTimeTZIntervalOp(*PlusTimeTZIntervalOp, Datum, Datum) (Datum, error)
-	EvalPlusTimestampIntervalOp(*PlusTimestampIntervalOp, Datum, Datum) (Datum, error)
-	EvalPlusTimestampTZIntervalOp(*PlusTimestampTZIntervalOp, Datum, Datum) (Datum, error)
-	EvalPowDecimalIntOp(*PowDecimalIntOp, Datum, Datum) (Datum, error)
-	EvalPowDecimalOp(*PowDecimalOp, Datum, Datum) (Datum, error)
-	EvalPowFloatOp(*PowFloatOp, Datum, Datum) (Datum, error)
-	EvalPowIntDecimalOp(*PowIntDecimalOp, Datum, Datum) (Datum, error)
-	EvalPowIntOp(*PowIntOp, Datum, Datum) (Datum, error)
-	EvalPrependToMaybeNullArrayOp(*PrependToMaybeNullArrayOp, Datum, Datum) (Datum, error)
-	EvalRShiftINetOp(*RShiftINetOp, Datum, Datum) (Datum, error)
-	EvalRShiftIntOp(*RShiftIntOp, Datum, Datum) (Datum, error)
-	EvalRShiftVarBitIntOp(*RShiftVarBitIntOp, Datum, Datum) (Datum, error)
-	EvalSimilarToOp(*SimilarToOp, Datum, Datum) (Datum, error)
+	EvalAppendToMaybeNullArrayOp(context.Context, *AppendToMaybeNullArrayOp, Datum, Datum) (Datum, error)
+	EvalBitAndINetOp(context.Context, *BitAndINetOp, Datum, Datum) (Datum, error)
+	EvalBitAndIntOp(context.Context, *BitAndIntOp, Datum, Datum) (Datum, error)
+	EvalBitAndVarBitOp(context.Context, *BitAndVarBitOp, Datum, Datum) (Datum, error)
+	EvalBitOrINetOp(context.Context, *BitOrINetOp, Datum, Datum) (Datum, error)
+	EvalBitOrIntOp(context.Context, *BitOrIntOp, Datum, Datum) (Datum, error)
+	EvalBitOrVarBitOp(context.Context, *BitOrVarBitOp, Datum, Datum) (Datum, error)
+	EvalBitXorIntOp(context.Context, *BitXorIntOp, Datum, Datum) (Datum, error)
+	EvalBitXorVarBitOp(context.Context, *BitXorVarBitOp, Datum, Datum) (Datum, error)
+	EvalCompareBox2DOp(context.Context, *CompareBox2DOp, Datum, Datum) (Datum, error)
+	EvalCompareScalarOp(context.Context, *CompareScalarOp, Datum, Datum) (Datum, error)
+	EvalCompareTupleOp(context.Context, *CompareTupleOp, Datum, Datum) (Datum, error)
+	EvalConcatArraysOp(context.Context, *ConcatArraysOp, Datum, Datum) (Datum, error)
+	EvalConcatBytesOp(context.Context, *ConcatBytesOp, Datum, Datum) (Datum, error)
+	EvalConcatJsonbOp(context.Context, *ConcatJsonbOp, Datum, Datum) (Datum, error)
+	EvalConcatOp(context.Context, *ConcatOp, Datum, Datum) (Datum, error)
+	EvalConcatStringOp(context.Context, *ConcatStringOp, Datum, Datum) (Datum, error)
+	EvalConcatVarBitOp(context.Context, *ConcatVarBitOp, Datum, Datum) (Datum, error)
+	EvalContainedByArrayOp(context.Context, *ContainedByArrayOp, Datum, Datum) (Datum, error)
+	EvalContainedByJsonbOp(context.Context, *ContainedByJsonbOp, Datum, Datum) (Datum, error)
+	EvalContainsArrayOp(context.Context, *ContainsArrayOp, Datum, Datum) (Datum, error)
+	EvalContainsJsonbOp(context.Context, *ContainsJsonbOp, Datum, Datum) (Datum, error)
+	EvalDivDecimalIntOp(context.Context, *DivDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalDivDecimalOp(context.Context, *DivDecimalOp, Datum, Datum) (Datum, error)
+	EvalDivFloatOp(context.Context, *DivFloatOp, Datum, Datum) (Datum, error)
+	EvalDivIntDecimalOp(context.Context, *DivIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalDivIntOp(context.Context, *DivIntOp, Datum, Datum) (Datum, error)
+	EvalDivIntervalFloatOp(context.Context, *DivIntervalFloatOp, Datum, Datum) (Datum, error)
+	EvalDivIntervalIntOp(context.Context, *DivIntervalIntOp, Datum, Datum) (Datum, error)
+	EvalFloorDivDecimalIntOp(context.Context, *FloorDivDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalFloorDivDecimalOp(context.Context, *FloorDivDecimalOp, Datum, Datum) (Datum, error)
+	EvalFloorDivFloatOp(context.Context, *FloorDivFloatOp, Datum, Datum) (Datum, error)
+	EvalFloorDivIntDecimalOp(context.Context, *FloorDivIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalFloorDivIntOp(context.Context, *FloorDivIntOp, Datum, Datum) (Datum, error)
+	EvalInTupleOp(context.Context, *InTupleOp, Datum, Datum) (Datum, error)
+	EvalJSONAllExistsOp(context.Context, *JSONAllExistsOp, Datum, Datum) (Datum, error)
+	EvalJSONExistsOp(context.Context, *JSONExistsOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchTextIntOp(context.Context, *JSONFetchTextIntOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchTextPathOp(context.Context, *JSONFetchTextPathOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchTextStringOp(context.Context, *JSONFetchTextStringOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchValIntOp(context.Context, *JSONFetchValIntOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchValPathOp(context.Context, *JSONFetchValPathOp, Datum, Datum) (Datum, error)
+	EvalJSONFetchValStringOp(context.Context, *JSONFetchValStringOp, Datum, Datum) (Datum, error)
+	EvalJSONSomeExistsOp(context.Context, *JSONSomeExistsOp, Datum, Datum) (Datum, error)
+	EvalLShiftINetOp(context.Context, *LShiftINetOp, Datum, Datum) (Datum, error)
+	EvalLShiftIntOp(context.Context, *LShiftIntOp, Datum, Datum) (Datum, error)
+	EvalLShiftVarBitIntOp(context.Context, *LShiftVarBitIntOp, Datum, Datum) (Datum, error)
+	EvalMatchLikeOp(context.Context, *MatchLikeOp, Datum, Datum) (Datum, error)
+	EvalMatchRegexpOp(context.Context, *MatchRegexpOp, Datum, Datum) (Datum, error)
+	EvalMinusDateIntOp(context.Context, *MinusDateIntOp, Datum, Datum) (Datum, error)
+	EvalMinusDateIntervalOp(context.Context, *MinusDateIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusDateOp(context.Context, *MinusDateOp, Datum, Datum) (Datum, error)
+	EvalMinusDateTimeOp(context.Context, *MinusDateTimeOp, Datum, Datum) (Datum, error)
+	EvalMinusDecimalIntOp(context.Context, *MinusDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalMinusDecimalOp(context.Context, *MinusDecimalOp, Datum, Datum) (Datum, error)
+	EvalMinusFloatOp(context.Context, *MinusFloatOp, Datum, Datum) (Datum, error)
+	EvalMinusINetIntOp(context.Context, *MinusINetIntOp, Datum, Datum) (Datum, error)
+	EvalMinusINetOp(context.Context, *MinusINetOp, Datum, Datum) (Datum, error)
+	EvalMinusIntDecimalOp(context.Context, *MinusIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalMinusIntOp(context.Context, *MinusIntOp, Datum, Datum) (Datum, error)
+	EvalMinusIntervalOp(context.Context, *MinusIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusJsonbIntOp(context.Context, *MinusJsonbIntOp, Datum, Datum) (Datum, error)
+	EvalMinusJsonbStringArrayOp(context.Context, *MinusJsonbStringArrayOp, Datum, Datum) (Datum, error)
+	EvalMinusJsonbStringOp(context.Context, *MinusJsonbStringOp, Datum, Datum) (Datum, error)
+	EvalMinusTimeIntervalOp(context.Context, *MinusTimeIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusTimeOp(context.Context, *MinusTimeOp, Datum, Datum) (Datum, error)
+	EvalMinusTimeTZIntervalOp(context.Context, *MinusTimeTZIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampIntervalOp(context.Context, *MinusTimestampIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampOp(context.Context, *MinusTimestampOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampTZIntervalOp(context.Context, *MinusTimestampTZIntervalOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampTZOp(context.Context, *MinusTimestampTZOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampTZTimestampOp(context.Context, *MinusTimestampTZTimestampOp, Datum, Datum) (Datum, error)
+	EvalMinusTimestampTimestampTZOp(context.Context, *MinusTimestampTimestampTZOp, Datum, Datum) (Datum, error)
+	EvalModDecimalIntOp(context.Context, *ModDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalModDecimalOp(context.Context, *ModDecimalOp, Datum, Datum) (Datum, error)
+	EvalModFloatOp(context.Context, *ModFloatOp, Datum, Datum) (Datum, error)
+	EvalModIntDecimalOp(context.Context, *ModIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalModIntOp(context.Context, *ModIntOp, Datum, Datum) (Datum, error)
+	EvalModStringOp(context.Context, *ModStringOp, Datum, Datum) (Datum, error)
+	EvalMultDecimalIntOp(context.Context, *MultDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalMultDecimalIntervalOp(context.Context, *MultDecimalIntervalOp, Datum, Datum) (Datum, error)
+	EvalMultDecimalOp(context.Context, *MultDecimalOp, Datum, Datum) (Datum, error)
+	EvalMultFloatIntervalOp(context.Context, *MultFloatIntervalOp, Datum, Datum) (Datum, error)
+	EvalMultFloatOp(context.Context, *MultFloatOp, Datum, Datum) (Datum, error)
+	EvalMultIntDecimalOp(context.Context, *MultIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalMultIntIntervalOp(context.Context, *MultIntIntervalOp, Datum, Datum) (Datum, error)
+	EvalMultIntOp(context.Context, *MultIntOp, Datum, Datum) (Datum, error)
+	EvalMultIntervalDecimalOp(context.Context, *MultIntervalDecimalOp, Datum, Datum) (Datum, error)
+	EvalMultIntervalFloatOp(context.Context, *MultIntervalFloatOp, Datum, Datum) (Datum, error)
+	EvalMultIntervalIntOp(context.Context, *MultIntervalIntOp, Datum, Datum) (Datum, error)
+	EvalOverlapsArrayOp(context.Context, *OverlapsArrayOp, Datum, Datum) (Datum, error)
+	EvalOverlapsINetOp(context.Context, *OverlapsINetOp, Datum, Datum) (Datum, error)
+	EvalPlusDateIntOp(context.Context, *PlusDateIntOp, Datum, Datum) (Datum, error)
+	EvalPlusDateIntervalOp(context.Context, *PlusDateIntervalOp, Datum, Datum) (Datum, error)
+	EvalPlusDateTimeOp(context.Context, *PlusDateTimeOp, Datum, Datum) (Datum, error)
+	EvalPlusDateTimeTZOp(context.Context, *PlusDateTimeTZOp, Datum, Datum) (Datum, error)
+	EvalPlusDecimalIntOp(context.Context, *PlusDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalPlusDecimalOp(context.Context, *PlusDecimalOp, Datum, Datum) (Datum, error)
+	EvalPlusFloatOp(context.Context, *PlusFloatOp, Datum, Datum) (Datum, error)
+	EvalPlusINetIntOp(context.Context, *PlusINetIntOp, Datum, Datum) (Datum, error)
+	EvalPlusIntDateOp(context.Context, *PlusIntDateOp, Datum, Datum) (Datum, error)
+	EvalPlusIntDecimalOp(context.Context, *PlusIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalPlusIntINetOp(context.Context, *PlusIntINetOp, Datum, Datum) (Datum, error)
+	EvalPlusIntOp(context.Context, *PlusIntOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalDateOp(context.Context, *PlusIntervalDateOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalOp(context.Context, *PlusIntervalOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalTimeOp(context.Context, *PlusIntervalTimeOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalTimeTZOp(context.Context, *PlusIntervalTimeTZOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalTimestampOp(context.Context, *PlusIntervalTimestampOp, Datum, Datum) (Datum, error)
+	EvalPlusIntervalTimestampTZOp(context.Context, *PlusIntervalTimestampTZOp, Datum, Datum) (Datum, error)
+	EvalPlusTimeDateOp(context.Context, *PlusTimeDateOp, Datum, Datum) (Datum, error)
+	EvalPlusTimeIntervalOp(context.Context, *PlusTimeIntervalOp, Datum, Datum) (Datum, error)
+	EvalPlusTimeTZDateOp(context.Context, *PlusTimeTZDateOp, Datum, Datum) (Datum, error)
+	EvalPlusTimeTZIntervalOp(context.Context, *PlusTimeTZIntervalOp, Datum, Datum) (Datum, error)
+	EvalPlusTimestampIntervalOp(context.Context, *PlusTimestampIntervalOp, Datum, Datum) (Datum, error)
+	EvalPlusTimestampTZIntervalOp(context.Context, *PlusTimestampTZIntervalOp, Datum, Datum) (Datum, error)
+	EvalPowDecimalIntOp(context.Context, *PowDecimalIntOp, Datum, Datum) (Datum, error)
+	EvalPowDecimalOp(context.Context, *PowDecimalOp, Datum, Datum) (Datum, error)
+	EvalPowFloatOp(context.Context, *PowFloatOp, Datum, Datum) (Datum, error)
+	EvalPowIntDecimalOp(context.Context, *PowIntDecimalOp, Datum, Datum) (Datum, error)
+	EvalPowIntOp(context.Context, *PowIntOp, Datum, Datum) (Datum, error)
+	EvalPrependToMaybeNullArrayOp(context.Context, *PrependToMaybeNullArrayOp, Datum, Datum) (Datum, error)
+	EvalRShiftINetOp(context.Context, *RShiftINetOp, Datum, Datum) (Datum, error)
+	EvalRShiftIntOp(context.Context, *RShiftIntOp, Datum, Datum) (Datum, error)
+	EvalRShiftVarBitIntOp(context.Context, *RShiftVarBitIntOp, Datum, Datum) (Datum, error)
+	EvalSimilarToOp(context.Context, *SimilarToOp, Datum, Datum) (Datum, error)
 }
 
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *CbrtDecimalOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalCbrtDecimalOp(op, v)
+func (op *CbrtDecimalOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalCbrtDecimalOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *CbrtFloatOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalCbrtFloatOp(op, v)
+func (op *CbrtFloatOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalCbrtFloatOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *ComplementINetOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalComplementINetOp(op, v)
+func (op *ComplementINetOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalComplementINetOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *ComplementIntOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalComplementIntOp(op, v)
+func (op *ComplementIntOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalComplementIntOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *ComplementVarBitOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalComplementVarBitOp(op, v)
+func (op *ComplementVarBitOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalComplementVarBitOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *SqrtDecimalOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalSqrtDecimalOp(op, v)
+func (op *SqrtDecimalOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalSqrtDecimalOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *SqrtFloatOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalSqrtFloatOp(op, v)
+func (op *SqrtFloatOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalSqrtFloatOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *UnaryMinusDecimalOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalUnaryMinusDecimalOp(op, v)
+func (op *UnaryMinusDecimalOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalUnaryMinusDecimalOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *UnaryMinusFloatOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalUnaryMinusFloatOp(op, v)
+func (op *UnaryMinusFloatOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalUnaryMinusFloatOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *UnaryMinusIntOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalUnaryMinusIntOp(op, v)
+func (op *UnaryMinusIntOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalUnaryMinusIntOp(ctx, op, v)
 }
 
 // Eval is part of the UnaryEvalOp interface.
-func (op *UnaryMinusIntervalOp) Eval(e OpEvaluator, v Datum) (Datum, error) {
-	return e.EvalUnaryMinusIntervalOp(op, v)
+func (op *UnaryMinusIntervalOp) Eval(ctx context.Context, e OpEvaluator, v Datum) (Datum, error) {
+	return e.EvalUnaryMinusIntervalOp(ctx, op, v)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *AppendToMaybeNullArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalAppendToMaybeNullArrayOp(op, a, b)
+func (op *AppendToMaybeNullArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalAppendToMaybeNullArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitAndINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitAndINetOp(op, a, b)
+func (op *BitAndINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitAndINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitAndIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitAndIntOp(op, a, b)
+func (op *BitAndIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitAndIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitAndVarBitOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitAndVarBitOp(op, a, b)
+func (op *BitAndVarBitOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitAndVarBitOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitOrINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitOrINetOp(op, a, b)
+func (op *BitOrINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitOrINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitOrIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitOrIntOp(op, a, b)
+func (op *BitOrIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitOrIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitOrVarBitOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitOrVarBitOp(op, a, b)
+func (op *BitOrVarBitOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitOrVarBitOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitXorIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitXorIntOp(op, a, b)
+func (op *BitXorIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitXorIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *BitXorVarBitOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalBitXorVarBitOp(op, a, b)
+func (op *BitXorVarBitOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalBitXorVarBitOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *CompareBox2DOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalCompareBox2DOp(op, a, b)
+func (op *CompareBox2DOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalCompareBox2DOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *CompareScalarOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalCompareScalarOp(op, a, b)
+func (op *CompareScalarOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalCompareScalarOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *CompareTupleOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalCompareTupleOp(op, a, b)
+func (op *CompareTupleOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalCompareTupleOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatArraysOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatArraysOp(op, a, b)
+func (op *ConcatArraysOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatArraysOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatBytesOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatBytesOp(op, a, b)
+func (op *ConcatBytesOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatBytesOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatJsonbOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatJsonbOp(op, a, b)
+func (op *ConcatJsonbOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatJsonbOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatOp(op, a, b)
+func (op *ConcatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatStringOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatStringOp(op, a, b)
+func (op *ConcatStringOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatStringOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ConcatVarBitOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalConcatVarBitOp(op, a, b)
+func (op *ConcatVarBitOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalConcatVarBitOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ContainedByArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalContainedByArrayOp(op, a, b)
+func (op *ContainedByArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalContainedByArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ContainedByJsonbOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalContainedByJsonbOp(op, a, b)
+func (op *ContainedByJsonbOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalContainedByJsonbOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ContainsArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalContainsArrayOp(op, a, b)
+func (op *ContainsArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalContainsArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ContainsJsonbOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalContainsJsonbOp(op, a, b)
+func (op *ContainsJsonbOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalContainsJsonbOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivDecimalIntOp(op, a, b)
+func (op *DivDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivDecimalOp(op, a, b)
+func (op *DivDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivFloatOp(op, a, b)
+func (op *DivFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivIntDecimalOp(op, a, b)
+func (op *DivIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivIntOp(op, a, b)
+func (op *DivIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivIntervalFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivIntervalFloatOp(op, a, b)
+func (op *DivIntervalFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivIntervalFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *DivIntervalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalDivIntervalIntOp(op, a, b)
+func (op *DivIntervalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalDivIntervalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *FloorDivDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalFloorDivDecimalIntOp(op, a, b)
+func (op *FloorDivDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalFloorDivDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *FloorDivDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalFloorDivDecimalOp(op, a, b)
+func (op *FloorDivDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalFloorDivDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *FloorDivFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalFloorDivFloatOp(op, a, b)
+func (op *FloorDivFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalFloorDivFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *FloorDivIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalFloorDivIntDecimalOp(op, a, b)
+func (op *FloorDivIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalFloorDivIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *FloorDivIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalFloorDivIntOp(op, a, b)
+func (op *FloorDivIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalFloorDivIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *InTupleOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalInTupleOp(op, a, b)
+func (op *InTupleOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalInTupleOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONAllExistsOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONAllExistsOp(op, a, b)
+func (op *JSONAllExistsOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONAllExistsOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONExistsOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONExistsOp(op, a, b)
+func (op *JSONExistsOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONExistsOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchTextIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchTextIntOp(op, a, b)
+func (op *JSONFetchTextIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchTextIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchTextPathOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchTextPathOp(op, a, b)
+func (op *JSONFetchTextPathOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchTextPathOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchTextStringOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchTextStringOp(op, a, b)
+func (op *JSONFetchTextStringOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchTextStringOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchValIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchValIntOp(op, a, b)
+func (op *JSONFetchValIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchValIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchValPathOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchValPathOp(op, a, b)
+func (op *JSONFetchValPathOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchValPathOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONFetchValStringOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONFetchValStringOp(op, a, b)
+func (op *JSONFetchValStringOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONFetchValStringOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *JSONSomeExistsOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalJSONSomeExistsOp(op, a, b)
+func (op *JSONSomeExistsOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalJSONSomeExistsOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *LShiftINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalLShiftINetOp(op, a, b)
+func (op *LShiftINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalLShiftINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *LShiftIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalLShiftIntOp(op, a, b)
+func (op *LShiftIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalLShiftIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *LShiftVarBitIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalLShiftVarBitIntOp(op, a, b)
+func (op *LShiftVarBitIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalLShiftVarBitIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MatchLikeOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMatchLikeOp(op, a, b)
+func (op *MatchLikeOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMatchLikeOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MatchRegexpOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMatchRegexpOp(op, a, b)
+func (op *MatchRegexpOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMatchRegexpOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDateIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDateIntOp(op, a, b)
+func (op *MinusDateIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDateIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDateIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDateIntervalOp(op, a, b)
+func (op *MinusDateIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDateIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDateOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDateOp(op, a, b)
+func (op *MinusDateOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDateOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDateTimeOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDateTimeOp(op, a, b)
+func (op *MinusDateTimeOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDateTimeOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDecimalIntOp(op, a, b)
+func (op *MinusDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusDecimalOp(op, a, b)
+func (op *MinusDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusFloatOp(op, a, b)
+func (op *MinusFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusINetIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusINetIntOp(op, a, b)
+func (op *MinusINetIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusINetIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusINetOp(op, a, b)
+func (op *MinusINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusIntDecimalOp(op, a, b)
+func (op *MinusIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusIntOp(op, a, b)
+func (op *MinusIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusIntervalOp(op, a, b)
+func (op *MinusIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusJsonbIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusJsonbIntOp(op, a, b)
+func (op *MinusJsonbIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusJsonbIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusJsonbStringArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusJsonbStringArrayOp(op, a, b)
+func (op *MinusJsonbStringArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusJsonbStringArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusJsonbStringOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusJsonbStringOp(op, a, b)
+func (op *MinusJsonbStringOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusJsonbStringOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimeIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimeIntervalOp(op, a, b)
+func (op *MinusTimeIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimeIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimeOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimeOp(op, a, b)
+func (op *MinusTimeOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimeOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimeTZIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimeTZIntervalOp(op, a, b)
+func (op *MinusTimeTZIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimeTZIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampIntervalOp(op, a, b)
+func (op *MinusTimestampIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampOp(op, a, b)
+func (op *MinusTimestampOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampTZIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampTZIntervalOp(op, a, b)
+func (op *MinusTimestampTZIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampTZIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampTZOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampTZOp(op, a, b)
+func (op *MinusTimestampTZOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampTZOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampTZTimestampOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampTZTimestampOp(op, a, b)
+func (op *MinusTimestampTZTimestampOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampTZTimestampOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MinusTimestampTimestampTZOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMinusTimestampTimestampTZOp(op, a, b)
+func (op *MinusTimestampTimestampTZOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMinusTimestampTimestampTZOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModDecimalIntOp(op, a, b)
+func (op *ModDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModDecimalOp(op, a, b)
+func (op *ModDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModFloatOp(op, a, b)
+func (op *ModFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModIntDecimalOp(op, a, b)
+func (op *ModIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModIntOp(op, a, b)
+func (op *ModIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *ModStringOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalModStringOp(op, a, b)
+func (op *ModStringOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalModStringOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultDecimalIntOp(op, a, b)
+func (op *MultDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultDecimalIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultDecimalIntervalOp(op, a, b)
+func (op *MultDecimalIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultDecimalIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultDecimalOp(op, a, b)
+func (op *MultDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultFloatIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultFloatIntervalOp(op, a, b)
+func (op *MultFloatIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultFloatIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultFloatOp(op, a, b)
+func (op *MultFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntDecimalOp(op, a, b)
+func (op *MultIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntIntervalOp(op, a, b)
+func (op *MultIntIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntOp(op, a, b)
+func (op *MultIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntervalDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntervalDecimalOp(op, a, b)
+func (op *MultIntervalDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntervalDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntervalFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntervalFloatOp(op, a, b)
+func (op *MultIntervalFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntervalFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *MultIntervalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalMultIntervalIntOp(op, a, b)
+func (op *MultIntervalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalMultIntervalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *OverlapsArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalOverlapsArrayOp(op, a, b)
+func (op *OverlapsArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalOverlapsArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *OverlapsINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalOverlapsINetOp(op, a, b)
+func (op *OverlapsINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalOverlapsINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDateIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDateIntOp(op, a, b)
+func (op *PlusDateIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDateIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDateIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDateIntervalOp(op, a, b)
+func (op *PlusDateIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDateIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDateTimeOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDateTimeOp(op, a, b)
+func (op *PlusDateTimeOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDateTimeOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDateTimeTZOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDateTimeTZOp(op, a, b)
+func (op *PlusDateTimeTZOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDateTimeTZOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDecimalIntOp(op, a, b)
+func (op *PlusDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusDecimalOp(op, a, b)
+func (op *PlusDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusFloatOp(op, a, b)
+func (op *PlusFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusINetIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusINetIntOp(op, a, b)
+func (op *PlusINetIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusINetIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntDateOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntDateOp(op, a, b)
+func (op *PlusIntDateOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntDateOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntDecimalOp(op, a, b)
+func (op *PlusIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntINetOp(op, a, b)
+func (op *PlusIntINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntOp(op, a, b)
+func (op *PlusIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalDateOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalDateOp(op, a, b)
+func (op *PlusIntervalDateOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalDateOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalOp(op, a, b)
+func (op *PlusIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalTimeOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalTimeOp(op, a, b)
+func (op *PlusIntervalTimeOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalTimeOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalTimeTZOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalTimeTZOp(op, a, b)
+func (op *PlusIntervalTimeTZOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalTimeTZOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalTimestampOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalTimestampOp(op, a, b)
+func (op *PlusIntervalTimestampOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalTimestampOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusIntervalTimestampTZOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusIntervalTimestampTZOp(op, a, b)
+func (op *PlusIntervalTimestampTZOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusIntervalTimestampTZOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimeDateOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimeDateOp(op, a, b)
+func (op *PlusTimeDateOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimeDateOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimeIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimeIntervalOp(op, a, b)
+func (op *PlusTimeIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimeIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimeTZDateOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimeTZDateOp(op, a, b)
+func (op *PlusTimeTZDateOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimeTZDateOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimeTZIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimeTZIntervalOp(op, a, b)
+func (op *PlusTimeTZIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimeTZIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimestampIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimestampIntervalOp(op, a, b)
+func (op *PlusTimestampIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimestampIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PlusTimestampTZIntervalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPlusTimestampTZIntervalOp(op, a, b)
+func (op *PlusTimestampTZIntervalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPlusTimestampTZIntervalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PowDecimalIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPowDecimalIntOp(op, a, b)
+func (op *PowDecimalIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPowDecimalIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PowDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPowDecimalOp(op, a, b)
+func (op *PowDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPowDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PowFloatOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPowFloatOp(op, a, b)
+func (op *PowFloatOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPowFloatOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PowIntDecimalOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPowIntDecimalOp(op, a, b)
+func (op *PowIntDecimalOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPowIntDecimalOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PowIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPowIntOp(op, a, b)
+func (op *PowIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPowIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *PrependToMaybeNullArrayOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalPrependToMaybeNullArrayOp(op, a, b)
+func (op *PrependToMaybeNullArrayOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalPrependToMaybeNullArrayOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *RShiftINetOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalRShiftINetOp(op, a, b)
+func (op *RShiftINetOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalRShiftINetOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *RShiftIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalRShiftIntOp(op, a, b)
+func (op *RShiftIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalRShiftIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *RShiftVarBitIntOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalRShiftVarBitIntOp(op, a, b)
+func (op *RShiftVarBitIntOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalRShiftVarBitIntOp(ctx, op, a, b)
 }
 
 // Eval is part of the BinaryEvalOp interface.
-func (op *SimilarToOp) Eval(e OpEvaluator, a, b Datum) (Datum, error) {
-	return e.EvalSimilarToOp(op, a, b)
+func (op *SimilarToOp) Eval(ctx context.Context, e OpEvaluator, a, b Datum) (Datum, error) {
+	return e.EvalSimilarToOp(ctx, op, a, b)
 }
 

--- a/pkg/sql/sem/tree/eval_unary_ops.go
+++ b/pkg/sql/sem/tree/eval_unary_ops.go
@@ -10,11 +10,13 @@
 
 package tree
 
+import "context"
+
 // UnaryNoop is a UnaryEvalOp.
 type UnaryNoop struct{}
 
 // Eval of UnaryNoop does nothing and returns the passed Datum.
-func (v *UnaryNoop) Eval(evaluator OpEvaluator, d Datum) (Datum, error) {
+func (v *UnaryNoop) Eval(ctx context.Context, evaluator OpEvaluator, d Datum) (Datum, error) {
 	return d, nil
 }
 

--- a/pkg/sql/sem/tree/evalgen/eval_gen.go
+++ b/pkg/sql/sem/tree/evalgen/eval_gen.go
@@ -113,6 +113,8 @@ const header = `// Copyright 2022 The Cockroach Authors.
 // tree.XYZ in a new file, you may get the confusing error: undefined: XYZ.
 // Run './dev generate bazel' to fix this.
 package tree
+
+import "context"
 `
 
 func findTypesWithMethod(ins *inspector.Inspector, filter func(decl *ast.FuncDecl) bool) stringSet {

--- a/pkg/sql/sem/tree/evalgen/expr.go
+++ b/pkg/sql/sem/tree/evalgen/expr.go
@@ -51,14 +51,14 @@ const visitorTemplate = header +
 // ExprEvaluator is used to evaluate TypedExpr expressions.
 type ExprEvaluator interface {
 {{- range . }}{{ if isDatum . }}{{ else }}
-	Eval{{.}}({{ template "name" . }}) (Datum, error)
+	Eval{{.}}(context.Context, {{ template "name" . }}) (Datum, error)
 {{- end}}{{ end }}
 }
 
 {{ range . }}
 // Eval is part of the TypedExpr interface.
-func (node {{ template "name" . }}) Eval(v ExprEvaluator) (Datum, error) {
-	{{ if isDatum . }}return node, nil{{ else }}return v.Eval{{.}}(node){{ end }}
+func (node {{ template "name" . }}) Eval(ctx context.Context, v ExprEvaluator) (Datum, error) {
+	{{ if isDatum . }}return node, nil{{ else }}return v.Eval{{.}}(ctx, node){{ end }}
 }
 {{ end }}
 `

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -66,7 +66,7 @@ type TypedExpr interface {
 	// should be replaced prior to expression evaluation by an
 	// appropriate WalkExpr. For example, Placeholder should be replaced
 	// by the argument passed from the client.
-	Eval(ExprEvaluator) (Datum, error)
+	Eval(context.Context, ExprEvaluator) (Datum, error)
 }
 
 // VariableExpr is an Expr that may change per row. It is used to

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -89,7 +89,7 @@ func TestStringConcat(t *testing.T) {
 			continue
 		}
 		d := randgen.RandDatum(rng, typ, false /* nullOk */)
-		expected, err := eval.PerformCast(&evalCtx, d, types.String)
+		expected, err := eval.PerformCast(ctx, &evalCtx, d, types.String)
 		require.NoError(t, err)
 		concatOp := treebin.MakeBinaryOperator(treebin.Concat)
 		concatExprLeft := tree.NewTypedBinaryExpr(concatOp, tree.NewDString(""), d, types.String)

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -68,7 +68,7 @@ func TestCastFromNull(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	for _, typ := range types.Scalar {
 		castExpr := tree.CastExpr{Expr: tree.DNull, Type: typ}
-		res, err := eval.Expr(nil, &castExpr)
+		res, err := eval.Expr(context.Background(), nil, &castExpr)
 		require.NoError(t, err)
 		require.Equal(t, tree.DNull, res)
 	}
@@ -93,11 +93,11 @@ func TestStringConcat(t *testing.T) {
 		require.NoError(t, err)
 		concatOp := treebin.MakeBinaryOperator(treebin.Concat)
 		concatExprLeft := tree.NewTypedBinaryExpr(concatOp, tree.NewDString(""), d, types.String)
-		resLeft, err := eval.Expr(&evalCtx, concatExprLeft)
+		resLeft, err := eval.Expr(ctx, &evalCtx, concatExprLeft)
 		require.NoError(t, err)
 		require.Equal(t, expected, resLeft)
 		concatExprRight := tree.NewTypedBinaryExpr(concatOp, d, tree.NewDString(""), types.String)
-		resRight, err := eval.Expr(&evalCtx, concatExprRight)
+		resRight, err := eval.Expr(ctx, &evalCtx, concatExprRight)
 		require.NoError(t, err)
 		require.Equal(t, expected, resRight)
 	}

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -174,13 +174,13 @@ func TestExprString(t *testing.T) {
 			t.Errorf("Print/parse/print cycle changes the string: `%s` vs `%s`", str, str2)
 		}
 		// Compare the normalized expressions.
-		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
-		defer ctx.TestingMon.Stop(context.Background())
-		normalized, err := normalize.Expr(ctx, typedExpr)
+		evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+		defer evalCtx.Stop(context.Background())
+		normalized, err := normalize.Expr(context.Background(), evalCtx, typedExpr)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		normalized2, err := normalize.Expr(ctx, typedExpr2)
+		normalized2, err := normalize.Expr(context.Background(), evalCtx, typedExpr2)
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -420,7 +420,7 @@ func TestFormatPgwireText(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			typeChecked, err = normalize.Expr(evalCtx, typeChecked)
+			typeChecked, err = normalize.Expr(ctx, evalCtx, typeChecked)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/indexed_vars.go
+++ b/pkg/sql/sem/tree/indexed_vars.go
@@ -229,11 +229,6 @@ type typeContainer struct {
 
 var _ IndexedVarContainer = &typeContainer{}
 
-// IndexedVarEval is part of the IndexedVarContainer interface.
-func (tc *typeContainer) IndexedVarEval(idx int, e ExprEvaluator) (Datum, error) {
-	return nil, errors.AssertionFailedf("no eval allowed in typeContainer")
-}
-
 // IndexedVarResolvedType is part of the IndexedVarContainer interface.
 func (tc *typeContainer) IndexedVarResolvedType(idx int) *types.T {
 	return tc.types[idx]

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -26,8 +26,12 @@ import (
 
 type testVarContainer []tree.Datum
 
-func (d testVarContainer) IndexedVarEval(idx int, e tree.ExprEvaluator) (tree.Datum, error) {
-	return d[idx].Eval(e)
+var _ eval.IndexedVarContainer = testVarContainer{}
+
+func (d testVarContainer) IndexedVarEval(
+	ctx context.Context, idx int, e tree.ExprEvaluator,
+) (tree.Datum, error) {
+	return d[idx].Eval(ctx, e)
 }
 
 func (d testVarContainer) IndexedVarResolvedType(idx int) *types.T {
@@ -103,7 +107,7 @@ func TestIndexedVars(t *testing.T) {
 	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	defer evalCtx.Stop(context.Background())
 	evalCtx.IVarContainer = c
-	d, err := eval.Expr(evalCtx, typedExpr)
+	d, err := eval.Expr(ctx, evalCtx, typedExpr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -74,7 +74,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 			}
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(context.Background())
-			typedExpr, err := normalize.Expr(evalCtx, typeChecked)
+			typedExpr, err := normalize.Expr(ctx, evalCtx, typeChecked)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -346,7 +346,7 @@ func writeSettingInternal(
 			}
 		} else {
 			// Setting a non-DEFAULT value.
-			value, err := eval.Expr(evalCtx, value)
+			value, err := eval.Expr(ctx, evalCtx, value)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -142,7 +142,7 @@ func (n *setVarNode) startExec(params runParams) error {
 			strVal, err = n.v.GetStringVal(params.ctx, params.extendedEvalCtx, n.typedValues, params.p.Txn())
 		} else {
 			// No string converter defined, use the default one.
-			strVal, err = getStringVal(params.EvalContext(), n.name, n.typedValues)
+			strVal, err = getStringVal(params.ctx, params.EvalContext(), n.name, n.typedValues)
 		}
 		if err != nil {
 			return err
@@ -247,25 +247,31 @@ func (n *resetAllNode) Next(_ runParams) (bool, error) { return false, nil }
 func (n *resetAllNode) Values() tree.Datums            { return nil }
 func (n *resetAllNode) Close(_ context.Context)        {}
 
-func getStringVal(evalCtx *eval.Context, name string, values []tree.TypedExpr) (string, error) {
+func getStringVal(
+	ctx context.Context, evalCtx *eval.Context, name string, values []tree.TypedExpr,
+) (string, error) {
 	if len(values) != 1 {
 		return "", newSingleArgVarError(name)
 	}
-	return paramparse.DatumAsString(evalCtx, name, values[0])
+	return paramparse.DatumAsString(ctx, evalCtx, name, values[0])
 }
 
-func getIntVal(evalCtx *eval.Context, name string, values []tree.TypedExpr) (int64, error) {
+func getIntVal(
+	ctx context.Context, evalCtx *eval.Context, name string, values []tree.TypedExpr,
+) (int64, error) {
 	if len(values) != 1 {
 		return 0, newSingleArgVarError(name)
 	}
-	return paramparse.DatumAsInt(evalCtx, name, values[0])
+	return paramparse.DatumAsInt(ctx, evalCtx, name, values[0])
 }
 
-func getFloatVal(evalCtx *eval.Context, name string, values []tree.TypedExpr) (float64, error) {
+func getFloatVal(
+	ctx context.Context, evalCtx *eval.Context, name string, values []tree.TypedExpr,
+) (float64, error) {
 	if len(values) != 1 {
 		return 0, newSingleArgVarError(name)
 	}
-	return paramparse.DatumAsFloat(evalCtx, name, values[0])
+	return paramparse.DatumAsFloat(ctx, evalCtx, name, values[0])
 }
 
 func timeZoneVarGetStringVal(

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -131,7 +131,7 @@ func (n *setVarNode) startExec(params runParams) error {
 	}
 	if n.typedValues != nil {
 		for i, v := range n.typedValues {
-			d, err := eval.Expr(params.EvalContext(), v)
+			d, err := eval.Expr(params.ctx, params.EvalContext(), v)
 			if err != nil {
 				return err
 			}
@@ -269,12 +269,12 @@ func getFloatVal(evalCtx *eval.Context, name string, values []tree.TypedExpr) (f
 }
 
 func timeZoneVarGetStringVal(
-	_ context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn,
+	ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn,
 ) (string, error) {
 	if len(values) != 1 {
 		return "", newSingleArgVarError("timezone")
 	}
-	d, err := eval.Expr(&evalCtx.Context, values[0])
+	d, err := eval.Expr(ctx, &evalCtx.Context, values[0])
 	if err != nil {
 		return "", err
 	}
@@ -348,7 +348,7 @@ func makeTimeoutVarGetter(
 		if len(values) != 1 {
 			return "", newSingleArgVarError(varName)
 		}
-		d, err := eval.Expr(&evalCtx.Context, values[0])
+		d, err := eval.Expr(ctx, &evalCtx.Context, values[0])
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -345,7 +345,7 @@ func evaluateYAMLConfig(expr tree.TypedExpr, params runParams) (string, bool, er
 	var yamlConfig string
 	deleteZone := false
 	if expr != nil {
-		datum, err := eval.Expr(params.EvalContext(), expr)
+		datum, err := eval.Expr(params.ctx, params.EvalContext(), expr)
 		if err != nil {
 			return "", false, err
 		}
@@ -395,7 +395,7 @@ func evaluateZoneOptions(
 				optionsStr = append(optionsStr, fmt.Sprintf("%s = COPY FROM PARENT", name))
 				continue
 			}
-			datum, err := eval.Expr(params.EvalContext(), expr)
+			datum, err := eval.Expr(params.ctx, params.EvalContext(), expr)
 			if err != nil {
 				return nil, nil, nil, err
 			}

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -109,11 +109,13 @@ func getRowKey(
 
 // parseExpriationTime parses an expression into a hlc.Timestamp representing
 // the expiration time of the split.
-func parseExpirationTime(evalCtx *eval.Context, expireExpr tree.TypedExpr) (hlc.Timestamp, error) {
+func parseExpirationTime(
+	ctx context.Context, evalCtx *eval.Context, expireExpr tree.TypedExpr,
+) (hlc.Timestamp, error) {
 	if !eval.IsConst(evalCtx, expireExpr) {
 		return hlc.Timestamp{}, errors.Errorf("SPLIT AT: only constant expressions are allowed for expiration")
 	}
-	d, err := eval.Expr(evalCtx.Context, evalCtx, expireExpr)
+	d, err := eval.Expr(ctx, evalCtx, expireExpr)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}

--- a/pkg/sql/split.go
+++ b/pkg/sql/split.go
@@ -113,7 +113,7 @@ func parseExpirationTime(evalCtx *eval.Context, expireExpr tree.TypedExpr) (hlc.
 	if !eval.IsConst(evalCtx, expireExpr) {
 		return hlc.Timestamp{}, errors.Errorf("SPLIT AT: only constant expressions are allowed for expiration")
 	}
-	d, err := eval.Expr(evalCtx, expireExpr)
+	d, err := eval.Expr(evalCtx.Context, evalCtx, expireExpr)
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -70,9 +70,10 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				return nil, err
 			}
 			if err := opc.runExecBuilder(
+				ctx,
 				&pt,
 				&stmt,
-				newExecFactory(p),
+				newExecFactory(ctx, p),
 				memo,
 				p.EvalContext(),
 				p.autoCommit,
@@ -85,7 +86,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 					"DECLARE CURSOR must not contain data-modifying statements in WITH")
 			}
 
-			statement := formatWithPlaceholders(s.Select, p.EvalContext())
+			statement := formatWithPlaceholders(ctx, s.Select, p.EvalContext())
 			itCtx := context.Background()
 			rows, err := ie.QueryIterator(itCtx, "sql-cursor", p.txn, statement)
 			if err != nil {

--- a/pkg/sql/stats/json.go
+++ b/pkg/sql/stats/json.go
@@ -147,7 +147,7 @@ func (js *JSONStatistic) GetHistogram(
 	h.Buckets = make([]HistogramData_Bucket, len(js.HistogramBuckets))
 	for i := range h.Buckets {
 		hb := &js.HistogramBuckets[i]
-		upperVal, err := rowenc.ParseDatumStringAs(colType, hb.UpperBound, evalCtx)
+		upperVal, err := rowenc.ParseDatumStringAs(ctx, colType, hb.UpperBound, evalCtx)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -68,7 +68,7 @@ func Set(
 		if typedExpr, err = normalize.Expr(evalCtx, typedExpr); err != nil {
 			return err
 		}
-		datum, err := eval.Expr(evalCtx, typedExpr)
+		datum, err := eval.Expr(ctx, evalCtx, typedExpr)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -31,9 +31,9 @@ import (
 type Setter interface {
 	// Set is called during CREATE [TABLE | INDEX] ... WITH (...) or
 	// ALTER [TABLE | INDEX] ... WITH (...).
-	Set(semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error
+	Set(ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error
 	// Reset is called during ALTER [TABLE | INDEX] ... RESET (...)
-	Reset(evalCtx *eval.Context, key string) error
+	Reset(ctx context.Context, evalCtx *eval.Context, key string) error
 	// RunPostChecks is called after all storage parameters have been set.
 	// This allows checking whether multiple storage parameters together
 	// form a valid configuration.
@@ -65,7 +65,7 @@ func Set(
 		if err != nil {
 			return err
 		}
-		if typedExpr, err = normalize.Expr(evalCtx, typedExpr); err != nil {
+		if typedExpr, err = normalize.Expr(ctx, evalCtx, typedExpr); err != nil {
 			return err
 		}
 		datum, err := eval.Expr(ctx, evalCtx, typedExpr)
@@ -73,7 +73,7 @@ func Set(
 			return err
 		}
 
-		if err := setter.Set(semaCtx, evalCtx, key, datum); err != nil {
+		if err := setter.Set(ctx, semaCtx, evalCtx, key, datum); err != nil {
 			return err
 		}
 	}
@@ -82,10 +82,12 @@ func Set(
 
 // Reset sets the given storage parameters using the
 // given observer.
-func Reset(evalCtx *eval.Context, params tree.NameList, paramObserver Setter) error {
+func Reset(
+	ctx context.Context, evalCtx *eval.Context, params tree.NameList, paramObserver Setter,
+) error {
 	for _, p := range params {
 		telemetry.Inc(sqltelemetry.ResetTableStorageParameter(string(p)))
-		if err := paramObserver.Reset(evalCtx, string(p)); err != nil {
+		if err := paramObserver.Reset(ctx, evalCtx, string(p)); err != nil {
 			return err
 		}
 	}
@@ -94,8 +96,8 @@ func Reset(evalCtx *eval.Context, params tree.NameList, paramObserver Setter) er
 
 // SetFillFactor validates the fill_factor storage param and then issues a
 // notice.
-func SetFillFactor(evalCtx *eval.Context, key string, datum tree.Datum) error {
-	val, err := paramparse.DatumAsFloat(evalCtx, key, datum)
+func SetFillFactor(ctx context.Context, evalCtx *eval.Context, key string, datum tree.Datum) error {
+	val, err := paramparse.DatumAsFloat(ctx, evalCtx, key, datum)
 	if err != nil {
 		return err
 	}
@@ -104,7 +106,7 @@ func SetFillFactor(evalCtx *eval.Context, key string, datum tree.Datum) error {
 	}
 	if evalCtx != nil {
 		evalCtx.ClientNoticeSender.BufferClientNotice(
-			evalCtx.Context,
+			ctx,
 			pgnotice.Newf("storage parameter %q is ignored", key),
 		)
 	}

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -13,6 +13,7 @@
 package tablestorageparam
 
 import (
+	"context"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -64,8 +65,10 @@ func (po *Setter) RunPostChecks() error {
 	return nil
 }
 
-func boolFromDatum(evalCtx *eval.Context, key string, datum tree.Datum) (bool, error) {
-	if stringVal, err := paramparse.DatumAsString(evalCtx, key, datum); err == nil {
+func boolFromDatum(
+	ctx context.Context, evalCtx *eval.Context, key string, datum tree.Datum,
+) (bool, error) {
+	if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 		return paramparse.ParseBoolVar(key, stringVal)
 	}
 	s, err := paramparse.GetSingleBool(key, datum)
@@ -75,28 +78,32 @@ func boolFromDatum(evalCtx *eval.Context, key string, datum tree.Datum) (bool, e
 	return bool(*s), nil
 }
 
-func intFromDatum(evalCtx *eval.Context, key string, datum tree.Datum) (int64, error) {
+func intFromDatum(
+	ctx context.Context, evalCtx *eval.Context, key string, datum tree.Datum,
+) (int64, error) {
 	intDatum := datum
-	if stringVal, err := paramparse.DatumAsString(evalCtx, key, datum); err == nil {
+	if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 		if intDatum, err = tree.ParseDInt(stringVal); err != nil {
 			return 0, errors.Wrapf(err, "invalid integer value for %s", key)
 		}
 	}
-	s, err := paramparse.DatumAsInt(evalCtx, key, intDatum)
+	s, err := paramparse.DatumAsInt(ctx, evalCtx, key, intDatum)
 	if err != nil {
 		return 0, err
 	}
 	return s, nil
 }
 
-func floatFromDatum(evalCtx *eval.Context, key string, datum tree.Datum) (float64, error) {
+func floatFromDatum(
+	ctx context.Context, evalCtx *eval.Context, key string, datum tree.Datum,
+) (float64, error) {
 	floatDatum := datum
-	if stringVal, err := paramparse.DatumAsString(evalCtx, key, datum); err == nil {
+	if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 		if floatDatum, err = tree.ParseDFloat(stringVal); err != nil {
 			return 0, errors.Wrapf(err, "invalid float value for %s", key)
 		}
 	}
-	s, err := paramparse.DatumAsFloat(evalCtx, key, floatDatum)
+	s, err := paramparse.DatumAsFloat(ctx, evalCtx, key, floatDatum)
 	if err != nil {
 		return 0, err
 	}
@@ -117,8 +124,8 @@ func (po *Setter) getOrCreateRowLevelTTL() *catpb.RowLevelTTL {
 }
 
 type tableParam struct {
-	onSet   func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error
-	onReset func(po *Setter, evalCtx *eval.Context, key string) error
+	onSet   func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error
+	onReset func(ctx context.Context, po *Setter, evalCtx *eval.Context, key string) error
 }
 
 var ttlAutomaticColumnNotice = pgnotice.Newf("ttl_automatic_column is no longer used. " +
@@ -127,18 +134,18 @@ var ttlAutomaticColumnNotice = pgnotice.Newf("ttl_automatic_column is no longer 
 
 var tableParams = map[string]tableParam{
 	`fillfactor`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			return storageparam.SetFillFactor(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			return storageparam.SetFillFactor(ctx, evalCtx, key, datum)
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, _ *eval.Context, key string) error {
 			// Operation is a no-op so do nothing.
 			return nil
 		},
 	},
 	`autovacuum_enabled`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
 			var boolVal bool
-			if stringVal, err := paramparse.DatumAsString(evalCtx, key, datum); err == nil {
+			if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 				boolVal, err = paramparse.ParseBoolVar(key, stringVal)
 				if err != nil {
 					return err
@@ -152,20 +159,20 @@ var tableParams = map[string]tableParam{
 			}
 			if !boolVal && evalCtx != nil {
 				evalCtx.ClientNoticeSender.BufferClientNotice(
-					evalCtx.Context,
+					ctx,
 					pgnotice.Newf(`storage parameter "%s = %s" is ignored`, key, datum.String()),
 				)
 			}
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, _ *eval.Context, key string) error {
 			// Operation is a no-op so do nothing.
 			return nil
 		},
 	},
 	`ttl`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			setTrue, err := boolFromDatum(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			setTrue, err := boolFromDatum(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -184,26 +191,26 @@ var tableParams = map[string]tableParam{
 			}
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			po.UpdatedRowLevelTTL = nil
 			return nil
 		},
 	},
 	// todo(wall): remove in 23.1
 	`ttl_automatic_column`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			evalCtx.ClientNoticeSender.BufferClientNotice(evalCtx.Context, ttlAutomaticColumnNotice)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			evalCtx.ClientNoticeSender.BufferClientNotice(ctx, ttlAutomaticColumnNotice)
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
-			evalCtx.ClientNoticeSender.BufferClientNotice(evalCtx.Context, ttlAutomaticColumnNotice)
+		onReset: func(ctx context.Context, po *Setter, evalCtx *eval.Context, key string) error {
+			evalCtx.ClientNoticeSender.BufferClientNotice(ctx, ttlAutomaticColumnNotice)
 			return nil
 		},
 	},
 	`ttl_expire_after`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
 			var d *tree.DInterval
-			if stringVal, err := paramparse.DatumAsString(evalCtx, key, datum); err == nil {
+			if stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum); err == nil {
 				d, err = tree.ParseDInterval(evalCtx.SessionData().GetIntervalStyle(), stringVal)
 				if err != nil {
 					return pgerror.Wrapf(
@@ -243,7 +250,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.DurationExpr = catpb.Expression(tree.Serialize(d))
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.DurationExpr = ""
 			}
@@ -251,8 +258,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_expiration_expression`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			stringVal, err := paramparse.DatumAsString(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			stringVal, err := paramparse.DatumAsString(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -260,7 +267,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.ExpirationExpr = catpb.Expression(stringVal)
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.ExpirationExpr = ""
 			}
@@ -268,8 +275,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_select_batch_size`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			val, err := paramparse.DatumAsInt(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -280,7 +287,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.SelectBatchSize = val
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.SelectBatchSize = 0
 			}
@@ -288,8 +295,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_delete_batch_size`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			val, err := paramparse.DatumAsInt(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -300,7 +307,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.DeleteBatchSize = val
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.DeleteBatchSize = 0
 			}
@@ -308,8 +315,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_range_concurrency`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			val, err := paramparse.DatumAsInt(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -320,7 +327,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.RangeConcurrency = val
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.RangeConcurrency = 0
 			}
@@ -328,8 +335,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_delete_rate_limit`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			val, err := paramparse.DatumAsInt(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			val, err := paramparse.DatumAsInt(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -340,7 +347,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.DeleteRateLimit = val
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.DeleteRateLimit = 0
 			}
@@ -348,8 +355,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_label_metrics`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			val, err := boolFromDatum(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			val, err := boolFromDatum(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -357,7 +364,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.LabelMetrics = val
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.LabelMetrics = false
 			}
@@ -365,8 +372,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_job_cron`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			str, err := paramparse.DatumAsString(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			str, err := paramparse.DatumAsString(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -377,7 +384,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.DeletionCron = str
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.DeletionCron = ""
 			}
@@ -385,8 +392,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_pause`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			b, err := boolFromDatum(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			b, err := boolFromDatum(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -394,7 +401,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.Pause = b
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.Pause = false
 			}
@@ -402,8 +409,8 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`ttl_row_stats_poll_interval`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-			d, err := paramparse.DatumAsDuration(evalCtx, key, datum)
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			d, err := paramparse.DatumAsDuration(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -414,7 +421,7 @@ var tableParams = map[string]tableParam{
 			rowLevelTTL.RowStatsPollInterval = d
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			if po.hasRowLevelTTL() {
 				po.UpdatedRowLevelTTL.RowStatsPollInterval = 0
 			}
@@ -422,7 +429,7 @@ var tableParams = map[string]tableParam{
 		},
 	},
 	`exclude_data_from_backup`: {
-		onSet: func(po *Setter, semaCtx *tree.SemaContext,
+		onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext,
 			evalCtx *eval.Context, key string, datum tree.Datum) error {
 			if po.TableDesc.Temporary {
 				return pgerror.Newf(pgcode.FeatureNotSupported,
@@ -438,7 +445,7 @@ var tableParams = map[string]tableParam{
 				return errors.New("cannot set data in a table with inbound foreign key constraints to be excluded from backup")
 			}
 
-			excludeDataFromBackup, err := boolFromDatum(evalCtx, key, datum)
+			excludeDataFromBackup, err := boolFromDatum(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
@@ -450,7 +457,7 @@ var tableParams = map[string]tableParam{
 			po.TableDesc.ExcludeDataFromBackup = excludeDataFromBackup
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			po.TableDesc.ExcludeDataFromBackup = false
 			return nil
 		},
@@ -469,16 +476,16 @@ var tableParams = map[string]tableParam{
 	},
 	`sql_stats_forecasts_enabled`: {
 		onSet: func(
-			po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
+			ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
 		) error {
-			enabled, err := boolFromDatum(evalCtx, key, datum)
+			enabled, err := boolFromDatum(ctx, evalCtx, key, datum)
 			if err != nil {
 				return err
 			}
 			po.TableDesc.ForecastStats = &enabled
 			return nil
 		},
-		onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+		onReset: func(_ context.Context, po *Setter, evalCtx *eval.Context, key string) error {
 			po.TableDesc.ForecastStats = nil
 			return nil
 		},
@@ -516,10 +523,10 @@ func init() {
 		`user_catalog_table`,
 	} {
 		tableParams[param] = tableParam{
-			onSet: func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+			onSet: func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
 				return unimplemented.NewWithIssuef(43299, "storage parameter %q", key)
 			},
-			onReset: func(po *Setter, evalCtx *eval.Context, key string) error {
+			onReset: func(_ context.Context, po *Setter, _ *eval.Context, key string) error {
 				return nil
 			},
 		}
@@ -527,9 +534,14 @@ func init() {
 }
 
 func autoStatsEnabledSettingFunc(
-	po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
+	ctx context.Context,
+	po *Setter,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	key string,
+	datum tree.Datum,
 ) error {
-	boolVal, err := boolFromDatum(evalCtx, key, datum)
+	boolVal, err := boolFromDatum(ctx, evalCtx, key, datum)
 	if err != nil {
 		return err
 	}
@@ -542,9 +554,9 @@ func autoStatsEnabledSettingFunc(
 
 func autoStatsMinStaleRowsSettingFunc(
 	validateFunc func(v int64) error,
-) func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-	return func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-		intVal, err := intFromDatum(evalCtx, key, datum)
+) func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+	return func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+		intVal, err := intFromDatum(ctx, evalCtx, key, datum)
 		if err != nil {
 			return err
 		}
@@ -561,10 +573,10 @@ func autoStatsMinStaleRowsSettingFunc(
 
 func autoStatsFractionStaleRowsSettingFunc(
 	validateFunc func(v float64) error,
-) func(po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
-	return func(po *Setter, semaCtx *tree.SemaContext,
+) func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum) error {
+	return func(ctx context.Context, po *Setter, semaCtx *tree.SemaContext,
 		evalCtx *eval.Context, key string, datum tree.Datum) error {
-		floatVal, err := floatFromDatum(evalCtx, key, datum)
+		floatVal, err := floatFromDatum(ctx, evalCtx, key, datum)
 		if err != nil {
 			return err
 		}
@@ -579,7 +591,9 @@ func autoStatsFractionStaleRowsSettingFunc(
 	}
 }
 
-func autoStatsTableSettingResetFunc(po *Setter, evalCtx *eval.Context, key string) error {
+func autoStatsTableSettingResetFunc(
+	_ context.Context, po *Setter, evalCtx *eval.Context, key string,
+) error {
 	if po.TableDesc.AutoStatsSettings == nil {
 		return nil
 	}
@@ -600,7 +614,11 @@ func autoStatsTableSettingResetFunc(po *Setter, evalCtx *eval.Context, key strin
 
 // Set implements the Setter interface.
 func (po *Setter) Set(
-	semaCtx *tree.SemaContext, evalCtx *eval.Context, key string, datum tree.Datum,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	key string,
+	datum tree.Datum,
 ) error {
 	if strings.HasPrefix(key, "ttl_") && len(po.TableDesc.AllMutations()) > 0 {
 		return pgerror.Newf(
@@ -609,13 +627,13 @@ func (po *Setter) Set(
 		)
 	}
 	if p, ok := tableParams[key]; ok {
-		return p.onSet(po, semaCtx, evalCtx, key, datum)
+		return p.onSet(ctx, po, semaCtx, evalCtx, key, datum)
 	}
 	return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage parameter %q", key)
 }
 
 // Reset implements the Setter interface.
-func (po *Setter) Reset(evalCtx *eval.Context, key string) error {
+func (po *Setter) Reset(ctx context.Context, evalCtx *eval.Context, key string) error {
 	if strings.HasPrefix(key, "ttl_") && len(po.TableDesc.AllMutations()) > 0 {
 		return pgerror.Newf(
 			pgcode.FeatureNotSupported,
@@ -623,7 +641,7 @@ func (po *Setter) Reset(evalCtx *eval.Context, key string) error {
 		)
 	}
 	if p, ok := tableParams[key]; ok {
-		return p.onReset(po, evalCtx, key)
+		return p.onReset(ctx, po, evalCtx, key)
 	}
 	return pgerror.Newf(pgcode.InvalidParameterValue, "invalid storage parameter %q", key)
 }

--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -119,7 +119,7 @@ func (n *alterTenantSetClusterSettingNode) startExec(params runParams) error {
 		// tenant ID is non zero and refers to a tenant that exists in
 		// system.tenants.
 		var err error
-		tenantIDi, tenantID, err = resolveTenantID(params.p, n.tenantID)
+		tenantIDi, tenantID, err = resolveTenantID(params.ctx, params.p, n.tenantID)
 		if err != nil {
 			return err
 		}
@@ -176,8 +176,10 @@ func (n *alterTenantSetClusterSettingNode) Next(_ runParams) (bool, error) { ret
 func (n *alterTenantSetClusterSettingNode) Values() tree.Datums            { return nil }
 func (n *alterTenantSetClusterSettingNode) Close(_ context.Context)        {}
 
-func resolveTenantID(p *planner, expr tree.TypedExpr) (uint64, tree.Datum, error) {
-	tenantIDd, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), expr)
+func resolveTenantID(
+	ctx context.Context, p *planner, expr tree.TypedExpr,
+) (uint64, tree.Datum, error) {
+	tenantIDd, err := eval.Expr(ctx, p.EvalContext(), expr)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/sql/tenant_settings.go
+++ b/pkg/sql/tenant_settings.go
@@ -142,7 +142,7 @@ func (n *alterTenantSetClusterSettingNode) startExec(params runParams) error {
 		}
 	} else {
 		reportedValue = tree.AsStringWithFlags(n.value, tree.FmtBareStrings)
-		value, err := eval.Expr(params.p.EvalContext(), n.value)
+		value, err := eval.Expr(params.ctx, params.p.EvalContext(), n.value)
 		if err != nil {
 			return err
 		}
@@ -177,7 +177,7 @@ func (n *alterTenantSetClusterSettingNode) Values() tree.Datums            { ret
 func (n *alterTenantSetClusterSettingNode) Close(_ context.Context)        {}
 
 func resolveTenantID(p *planner, expr tree.TypedExpr) (uint64, tree.Datum, error) {
-	tenantIDd, err := eval.Expr(p.EvalContext(), expr)
+	tenantIDd, err := eval.Expr(p.EvalContext().Context, p.EvalContext(), expr)
 	if err != nil {
 		return 0, nil, err
 	}

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -722,7 +722,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
-		datum1, err := eval.Expr(&ec, typed1)
+		datum1, err := eval.Expr(ctx, &ec, typed1)
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
@@ -736,7 +736,7 @@ func TestRandomDatumRoundtrip(t *testing.T) {
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}
-		datum2, err := eval.Expr(&ec, typed2)
+		datum2, err := eval.Expr(ctx, &ec, typed2)
 		if err != nil {
 			return nil //nolint:returnerrcheck
 		}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -264,7 +264,7 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 		// prevent computed columns from depending on other computed columns.
 		params.EvalContext().PushIVarContainer(&u.run.iVarContainerForComputedCols)
 		for i := range u.run.computedCols {
-			d, err := eval.Expr(params.EvalContext(), u.run.computeExprs[i])
+			d, err := eval.Expr(params.ctx, params.EvalContext(), u.run.computeExprs[i])
 			if err != nil {
 				params.EvalContext().IVarContainer = nil
 				name := u.run.computedCols[i].GetName()

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -704,7 +704,7 @@ func MaybeUpgradeStoredPasswordHash(
 	// configuration.
 
 	autoUpgradePasswordHashesBool := security.AutoUpgradePasswordHashes.Get(&execCfg.Settings.SV)
-	hashMethod := security.GetConfiguredPasswordHashMethod(ctx, &execCfg.Settings.SV)
+	hashMethod := security.GetConfiguredPasswordHashMethod(&execCfg.Settings.SV)
 
 	converted, prevHash, newHash, newMethod, err := password.MaybeUpgradePasswordHash(ctx,
 		autoUpgradePasswordHashesBool, hashMethod, cleartext, currentHash,

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -77,7 +77,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	for _, tupleRow := range n.tuples {
 		for i, typedExpr := range tupleRow {
 			var err error
-			row[i], err = eval.Expr(params.EvalContext(), typedExpr)
+			row[i], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1309,10 +1309,10 @@ var varGen = map[string]sessionVar{
 	// their own password hash algorithm.
 	`password_encryption`: {
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			return security.GetConfiguredPasswordHashMethod(evalCtx.Ctx(), &evalCtx.Settings.SV).String(), nil
+			return security.GetConfiguredPasswordHashMethod(&evalCtx.Settings.SV).String(), nil
 		},
 		SetWithPlanner: func(ctx context.Context, p *planner, local bool, val string) error {
-			method := security.GetConfiguredPasswordHashMethod(ctx, &p.ExecCfg().Settings.SV)
+			method := security.GetConfiguredPasswordHashMethod(&p.ExecCfg().Settings.SV)
 			if val != method.String() {
 				return newCannotChangeParameterError("password_encryption")
 			}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2412,7 +2412,7 @@ func makePostgresBoolGetStringValFn(varName string) getStringValFn {
 		if len(values) != 1 {
 			return "", newSingleArgVarError(varName)
 		}
-		val, err := eval.Expr(&evalCtx.Context, values[0])
+		val, err := eval.Expr(ctx, &evalCtx.Context, values[0])
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -280,7 +280,7 @@ var varGen = map[string]sessionVar{
 		GetStringVal: func(
 			ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, txn *kv.Txn,
 		) (string, error) {
-			dbName, err := getStringVal(&evalCtx.Context, `database`, values)
+			dbName, err := getStringVal(ctx, &evalCtx.Context, `database`, values)
 			if err != nil {
 				return "", err
 			}
@@ -1135,12 +1135,12 @@ var varGen = map[string]sessionVar{
 	// https://www.postgresql.org/docs/9.6/static/runtime-config-client.html
 	`search_path`: {
 		GetStringVal: func(
-			_ context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn,
+			ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn,
 		) (string, error) {
 			comma := ""
 			var buf bytes.Buffer
 			for _, v := range values {
-				s, err := paramparse.DatumAsString(&evalCtx.Context, "search_path", v)
+				s, err := paramparse.DatumAsString(ctx, &evalCtx.Context, "search_path", v)
 				if err != nil {
 					return "", err
 				}
@@ -2548,7 +2548,7 @@ func makeBackwardsCompatBoolVar(varName string, displayValue bool) sessionVar {
 // the user to provide plain integer values to a SET variable.
 func makeIntGetStringValFn(name string) getStringValFn {
 	return func(ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, _ *kv.Txn) (string, error) {
-		s, err := getIntVal(&evalCtx.Context, name, values)
+		s, err := getIntVal(ctx, &evalCtx.Context, name, values)
 		if err != nil {
 			return "", err
 		}
@@ -2560,7 +2560,7 @@ func makeIntGetStringValFn(name string) getStringValFn {
 // the user to provide plain float values to a SET variable.
 func makeFloatGetStringValFn(name string) getStringValFn {
 	return func(ctx context.Context, evalCtx *extendedEvalContext, values []tree.TypedExpr, txn *kv.Txn) (string, error) {
-		f, err := getFloatVal(&evalCtx.Context, name, values)
+		f, err := getFloatVal(ctx, &evalCtx.Context, name, values)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -342,9 +342,12 @@ func (v *vTableLookupJoinNode) pushRow(lookedUpRow ...tree.Datum) error {
 		v.run.row = append(v.run.row, lookedUpRow[i-1])
 	}
 	// Run the predicate and exit if we don't match, or if there was an error.
-	if ok, err := v.pred.eval(v.run.params.EvalContext(),
+	if ok, err := v.pred.eval(
+		v.run.params.ctx,
+		v.run.params.EvalContext(),
 		v.run.row[:len(v.inputCols)],
-		v.run.row[len(v.inputCols):]); !ok || err != nil {
+		v.run.row[len(v.inputCols):],
+	); !ok || err != nil {
 		return err
 	}
 	_, err := v.run.rows.AddRow(v.run.params.ctx, v.run.row)

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -108,7 +108,7 @@ func (w *windowFuncHolder) TypeCheck(
 	return w, nil
 }
 
-func (w *windowFuncHolder) Eval(v tree.ExprEvaluator) (tree.Datum, error) {
+func (w *windowFuncHolder) Eval(ctx context.Context, v tree.ExprEvaluator) (tree.Datum, error) {
 	panic("windowFuncHolder should not be evaluated directly")
 }
 

--- a/pkg/streaming/api.go
+++ b/pkg/streaming/api.go
@@ -11,6 +11,8 @@
 package streaming
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/ccl/streamingccl/streampb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -30,11 +32,11 @@ const InvalidStreamID StreamID = 0
 
 // GetReplicationStreamManagerHook is the hook to get access to the producer side replication APIs.
 // Used by builtin functions to trigger streaming replication.
-var GetReplicationStreamManagerHook func(evalCtx *eval.Context) (ReplicationStreamManager, error)
+var GetReplicationStreamManagerHook func(ctx context.Context, evalCtx *eval.Context) (ReplicationStreamManager, error)
 
 // GetStreamIngestManagerHook is the hook to get access to the ingestion side replication APIs.
 // Used by builtin functions to trigger streaming replication.
-var GetStreamIngestManagerHook func(evalCtx *eval.Context) (StreamIngestManager, error)
+var GetStreamIngestManagerHook func(ctx context.Context, evalCtx *eval.Context) (StreamIngestManager, error)
 
 // ReplicationStreamManager represents a collection of APIs that streaming replication supports
 // on the production side.
@@ -100,17 +102,21 @@ type StreamIngestManager interface {
 }
 
 // GetReplicationStreamManager returns a ReplicationStreamManager if a CCL binary is loaded.
-func GetReplicationStreamManager(evalCtx *eval.Context) (ReplicationStreamManager, error) {
+func GetReplicationStreamManager(
+	ctx context.Context, evalCtx *eval.Context,
+) (ReplicationStreamManager, error) {
 	if GetReplicationStreamManagerHook == nil {
 		return nil, errors.New("replication streaming requires a CCL binary")
 	}
-	return GetReplicationStreamManagerHook(evalCtx)
+	return GetReplicationStreamManagerHook(ctx, evalCtx)
 }
 
 // GetStreamIngestManager returns a StreamIngestManager if a CCL binary is loaded.
-func GetStreamIngestManager(evalCtx *eval.Context) (StreamIngestManager, error) {
+func GetStreamIngestManager(
+	ctx context.Context, evalCtx *eval.Context,
+) (StreamIngestManager, error) {
 	if GetReplicationStreamManagerHook == nil {
 		return nil, errors.New("replication streaming requires a CCL binary")
 	}
-	return GetStreamIngestManagerHook(evalCtx)
+	return GetStreamIngestManagerHook(ctx, evalCtx)
 }

--- a/pkg/streaming/api.go
+++ b/pkg/streaming/api.go
@@ -43,6 +43,7 @@ var GetStreamIngestManagerHook func(ctx context.Context, evalCtx *eval.Context) 
 type ReplicationStreamManager interface {
 	// StartReplicationStream starts a stream replication job for the specified tenant on the producer side.
 	StartReplicationStream(
+		ctx context.Context,
 		evalCtx *eval.Context,
 		txn *kv.Txn,
 		tenantID uint64,
@@ -53,6 +54,7 @@ type ReplicationStreamManager interface {
 	// progress and extends its life, and the new producer progress will be returned.
 	// If 'frontier' is hlc.MaxTimestamp, returns the producer progress without updating it.
 	HeartbeatReplicationStream(
+		ctx context.Context,
 		evalCtx *eval.Context,
 		streamID StreamID,
 		frontier hlc.Timestamp,
@@ -69,6 +71,7 @@ type ReplicationStreamManager interface {
 
 	// GetReplicationStreamSpec gets a stream replication spec on the producer side.
 	GetReplicationStreamSpec(
+		ctx context.Context,
 		evalCtx *eval.Context,
 		txn *kv.Txn,
 		streamID StreamID,
@@ -78,7 +81,11 @@ type ReplicationStreamManager interface {
 	// 'successfulIngestion' indicates whether the stream ingestion finished successfully and
 	// determines the fate of the producer job, succeeded or canceled.
 	CompleteReplicationStream(
-		evalCtx *eval.Context, txn *kv.Txn, streamID StreamID, successfulIngestion bool,
+		ctx context.Context,
+		evalCtx *eval.Context,
+		txn *kv.Txn,
+		streamID StreamID,
+		successfulIngestion bool,
 	) error
 }
 
@@ -87,6 +94,7 @@ type ReplicationStreamManager interface {
 type StreamIngestManager interface {
 	// CompleteStreamIngestion signals a running stream ingestion job to complete on the consumer side.
 	CompleteStreamIngestion(
+		ctx context.Context,
 		evalCtx *eval.Context,
 		txn *kv.Txn,
 		ingestionJobID jobspb.JobID,
@@ -95,6 +103,7 @@ type StreamIngestManager interface {
 
 	// GetStreamIngestionStats gets a statistics summary for a stream ingestion job.
 	GetStreamIngestionStats(
+		ctx context.Context,
 		evalCtx *eval.Context,
 		txn *kv.Txn,
 		ingestionJobID jobspb.JobID,

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1780,6 +1780,16 @@ func TestLint(t *testing.T) {
 				stream.GrepNot(`pkg/server/dumpstore.*\.go.*"io/ioutil" has been deprecated since Go 1\.16: As of Go 1\.16`),
 				stream.GrepNot(`pkg/server/heapprofiler/profilestore_test\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
 				stream.GrepNot(`pkg/util/log/file_api\.go.*"io/ioutil" has been deprecated since Go 1\.16`),
+				// TODO(yuzefovich): remove these exclusions.
+				stream.GrepNot(`pkg/sql/conn_executor.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/instrumentation.go:.*SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/planner.go:.*SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/schema_changer.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/distsql/server.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/execinfra/processorsbase.go:.*SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/importer/import_table_creation.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/row/expr_walker_test.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
+				stream.GrepNot(`pkg/sql/schemachanger/scbuild/tree_context_builder.go:.* evalCtx.SetDeprecatedContext is deprecated: .*`),
 			), func(s string) {
 				t.Errorf("\n%s", s)
 			}); err != nil {


### PR DESCRIPTION
This PR contains several commits that take steps towards the removal of the stored `context.Context` from `eval.Context`. The largest change is introducing an explicit `context.Context` argument to the `tree.TypedExpr.Eval` method (this is done in the first commit). The remaining commits remove accesses to the stored context in most cases (via either already available context in scope or small plumbing).

This PR doesn't completely remove the stored context because there were two methods `eval.Context.MustGetPlaceholderValue` and `eval.UnwrapDatum` (when unwrapping a placeholder) that still use it. Performing the plumbing for those turned out to be a daunting task, so it was abandoned.

In order to not introduce any new usages this PR unexports the stored context, provides the setter method, and marks both as deprecated.

Epic: None