### PR TITLE
sql/schemachanger/scexec/scmutationexec: bug fix in addNewIndexMutation

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
@@ -24,7 +24,6 @@ upsert descriptor #104
   +  mutations:
   +  - direction: ADD
   +    index:
-  +      constraintId: 2
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -57,7 +56,6 @@ upsert descriptor #104
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 3
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -91,8 +89,7 @@ upsert descriptor #104
   +    state: DELETE_ONLY
      name: t1
      nextColumnId: 4
-  -  nextConstraintId: 2
-  +  nextConstraintId: 4
+     nextConstraintId: 2
      nextFamilyId: 1
   -  nextIndexId: 2
   +  nextIndexId: 4
@@ -272,8 +269,7 @@ upsert descriptor #104
   -  modificationTime:
   -    wallTime: "1640995200000000008"
   +  indexes:
-  +  - constraintId: 2
-  +    createdExplicitly: true
+  +  - createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
   +    id: 2
@@ -306,10 +302,9 @@ upsert descriptor #104
   -  - direction: ADD
   +  - direction: DROP
        index:
-  -      constraintId: 2
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
   -      id: 2
   -      interleave: {}
   -      keyColumnDirections:
@@ -339,8 +334,11 @@ upsert descriptor #104
   -    state: DELETE_AND_WRITE_ONLY
   -  - direction: ADD
   -    index:
-         constraintId: 3
-         createdExplicitly: true
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+         id: 3
+         interleave: {}
   ...
          version: 4
        mutationId: 1
@@ -387,7 +385,6 @@ upsert descriptor #104
   -  mutations:
   -  - direction: DROP
   -    index:
-  -      constraintId: 3
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index
@@ -21,7 +21,7 @@ Schema change plan for CREATE INDEX ‹id1› ON ‹defaultdb›.‹public›.�
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexPartitioning:{DescID: 104, IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
  │         └── 10 Mutation operations
  │              ├── MakeAddedIndexBackfilling {"IsSecondaryIndex":true}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":104}}
@@ -41,7 +41,7 @@ Schema change plan for CREATE INDEX ‹id1› ON ‹defaultdb›.‹public›.�
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -88,7 +88,7 @@ Schema change plan for CREATE INDEX ‹id1› ON ‹defaultdb›.‹public›.�
       │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: id1, IndexID: 2}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    └── 5 Mutation operations
       │         ├── SetIndexName {"IndexID":2,"Name":"id1","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
@@ -97,7 +97,7 @@ Schema change plan for CREATE INDEX ‹id1› ON ‹defaultdb›.‹public›.�
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_1_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_1_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexPartitioning:{DescID: 104, IndexID: 2}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_2_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_2_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -37,7 +37,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_3_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_3_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -37,7 +37,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_4_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_4_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -37,7 +37,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_5_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_5_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -36,7 +36,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_6_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_6_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -36,7 +36,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_7_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain/create_index.rollback_7_of_7
@@ -17,7 +17,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexPartitioning:{DescID: 104, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -36,7 +36,7 @@ Schema change plan for rolling back CREATE INDEX ‹id1› ON ‹defaultdb›.pu
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index
@@ -42,33 +42,33 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   └── • IndexPartitioning:{DescID: 104, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 10 Mutation operations
@@ -186,7 +186,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -227,7 +227,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -344,7 +344,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 5 Mutation operations
@@ -374,7 +374,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX id1
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 4 Mutation operations

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -155,7 +155,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -155,7 +155,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -155,7 +155,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexPartitioning:{DescID: 104, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexPartitioning:{DescID: 104, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • IndexPartitioning:{DescID: 104, IndexID: 2}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexPartitioning:{DescID: 104, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -230,10 +230,10 @@ func (b *builderState) NextViewIndexID(view *scpb.View) (ret catid.IndexID) {
 }
 
 // NextTableConstraintID implements the scbuildstmt.TableHelpers interface.
-func (b *builderState) NextTableConstraintID(table *scpb.Table) (ret catid.ConstraintID) {
+func (b *builderState) NextTableConstraintID(id catid.DescID) (ret catid.ConstraintID) {
 	{
-		b.ensureDescriptor(table.TableID)
-		desc := b.descCache[table.TableID].desc
+		b.ensureDescriptor(id)
+		desc := b.descCache[id].desc
 		tbl, ok := desc.(catalog.TableDescriptor)
 		if !ok {
 			panic(errors.AssertionFailedf("Expected table descriptor for ID %d, instead got %s",
@@ -245,7 +245,7 @@ func (b *builderState) NextTableConstraintID(table *scpb.Table) (ret catid.Const
 		}
 	}
 
-	b.QueryByID(table.TableID).ForEachElementStatus(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
+	b.QueryByID(id).ForEachElementStatus(func(_ scpb.Status, _ scpb.TargetStatus, e scpb.Element) {
 		v, _ := screl.Schema.GetAttribute(screl.ConstraintID, e)
 		if id, ok := v.(catid.ConstraintID); ok && id >= ret {
 			ret = id + 1

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -456,7 +456,7 @@ func createNewPrimaryIndex(
 	replacement.SourceIndexID = existing.IndexID
 	replacementColumns := makeColumnsFn(b, replacement, existingColumns)
 	replacement.TemporaryIndexID = replacement.IndexID + 1
-	replacement.ConstraintID = b.NextTableConstraintID(tbl)
+	replacement.ConstraintID = b.NextTableConstraintID(tbl.TableID)
 	b.Add(replacement)
 	if existingName != nil {
 		updatedName := protoutil.Clone(existingName).(*scpb.IndexName)
@@ -474,7 +474,7 @@ func createNewPrimaryIndex(
 	}
 	temp.TemporaryIndexID = 0
 	temp.IndexID = b.NextTableIndexID(tbl)
-	temp.ConstraintID = b.NextTableConstraintID(tbl)
+	temp.ConstraintID = b.NextTableConstraintID(tbl.TableID)
 	b.AddTransient(temp)
 	if existingPartitioning != nil {
 		updatedPartitioning := protoutil.Clone(existingPartitioning).(*scpb.IndexPartitioning)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -658,6 +658,11 @@ func addSecondaryIndexTargetsForAddColumn(
 	if desc.Sharded.IsSharded {
 		index.Sharding = &desc.Sharded
 	}
+
+	if desc.Unique {
+		index.ConstraintID = b.NextTableConstraintID(tbl.TableID)
+	}
+
 	// If necessary add suffix columns, this would normally be done inside
 	// allocateIndexIDs, but we are going to do it explicitly for the declarative
 	// schema changer.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -490,7 +490,7 @@ func addNewUniqueSecondaryIndexAndTempIndex(
 		IsInverted:          oldPrimaryIndexElem.IsInverted,
 		Sharding:            oldPrimaryIndexElem.Sharding,
 		IsCreatedExplicitly: false,
-		ConstraintID:        b.NextTableConstraintID(tbl),
+		ConstraintID:        b.NextTableConstraintID(tbl.TableID),
 		SourceIndexID:       oldPrimaryIndexElem.IndexID,
 		TemporaryIndexID:    0,
 	}}
@@ -500,7 +500,7 @@ func addNewUniqueSecondaryIndexAndTempIndex(
 		Index:                    protoutil.Clone(newSecondaryIndexElem).(*scpb.SecondaryIndex).Index,
 		IsUsingSecondaryEncoding: true,
 	}
-	temporaryIndexElemForNewSecondaryIndex.ConstraintID = b.NextTableConstraintID(tbl)
+	temporaryIndexElemForNewSecondaryIndex.ConstraintID = b.NextTableConstraintID(tbl.TableID)
 	b.AddTransient(temporaryIndexElemForNewSecondaryIndex)
 
 	temporaryIndexElemForNewSecondaryIndex.IndexID = nextRelationIndexID(b, tbl)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -102,6 +102,11 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 			}
 		}
 	})
+
+	if n.Unique {
+		index.ConstraintID = b.NextTableConstraintID(index.TableID)
+	}
+
 	if index.TableID == catid.InvalidDescID || source == nil {
 		panic(pgerror.Newf(pgcode.WrongObjectType,
 			"%q is not an indexable table or a materialized view", n.Table.ObjectName))

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -198,7 +198,7 @@ type TableHelpers interface {
 
 	// NextTableConstraintID returns the ID that should be used for any new constraint
 	// added to this table.
-	NextTableConstraintID(table *scpb.Table) catid.ConstraintID
+	NextTableConstraintID(id catid.DescID) catid.ConstraintID
 
 	// IndexPartitioningDescriptor creates a new partitioning descriptor
 	// for the secondary index element, or panics.

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
@@ -39,7 +39,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN j INT NOT NULL DEFAULT 123
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: foo_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -72,7 +72,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN k INT DEFAULT 456;
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: foo_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -114,7 +114,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: foo_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -169,16 +169,16 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 3}
 - [[IndexName:{DescID: 106, Name: t_pkey, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: t_pkey, tableId: 106}
-- [[TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 106}
 - [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 2, indexId: 3, tableId: 106}
 - [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, kind: STORED, tableId: 106}
-- [[SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT]
-  {constraintId: 3, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 5}
-- [[TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
-  {constraintId: 4, indexId: 5, isUnique: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 106}
+- [[SecondaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT]
+  {constraintId: 4, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 5}
+- [[TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 5, indexId: 5, isUnique: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 106}
 - [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 4, tableId: 106}
 - [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
@@ -61,7 +61,7 @@ ALTER TABLE defaultdb.t DROP COLUMN j
   {constraintId: 2, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 5}
 - [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT]
   {indexId: 4, name: t_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 5, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 5, tableId: 104}
@@ -111,7 +111,7 @@ ALTER TABLE defaultdb.t DROP COLUMN k
   {constraintId: 2, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 5}
 - [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT]
   {indexId: 4, name: t_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 5, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 5, tableId: 104}
@@ -167,7 +167,7 @@ ALTER TABLE defaultdb.t DROP COLUMN l
   {constraintId: 2, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 5}
 - [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT]
   {indexId: 4, name: t_pkey, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 5, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 5, tableId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -15,7 +15,7 @@ CREATE INDEX id1 ON defaultdb.t1(id, name) STORING (money)
   {indexId: 2, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: id1, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 3, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -38,7 +38,7 @@ CREATE INVERTED INDEX CONCURRENTLY id2
   {indexId: 2, isConcurrently: true, isInverted: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: id2, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: id2, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 3, isConcurrently: true, isInverted: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -65,7 +65,7 @@ CREATE INDEX id3
   {indexId: 2, name: id3, tableId: 104}
 - [[IndexPartitioning:{DescID: 104, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, partitioning: {numColumns: 1}, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 3, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
@@ -96,7 +96,7 @@ CREATE INDEX id4
   {indexId: 2, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: id4, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: id4, tableId: 104}
-- [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+- [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {indexId: 3, isUsingSecondaryEncoding: true, sharding: {columnNames: [id, name], isSharded: true, name: crdb_internal_id_name_shard_8, shardBuckets: 8}, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -213,8 +213,9 @@ CREATE TABLE db.t (
 				return []scop.Op{
 					&scop.MakeAddedTempIndexDeleteOnly{
 						Index: scpb.Index{
-							TableID: table.ID,
-							IndexID: indexToAdd.ID,
+							TableID:      table.ID,
+							IndexID:      indexToAdd.ID,
+							ConstraintID: indexToAdd.ConstraintID,
 						},
 						IsSecondaryIndex: true,
 					},

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -62,6 +62,9 @@ func addNewIndexMutation(
 	if opIndex.IndexID >= tbl.NextIndexID {
 		tbl.NextIndexID = opIndex.IndexID + 1
 	}
+	if opIndex.ConstraintID >= tbl.NextConstraintID {
+		tbl.NextConstraintID = opIndex.ConstraintID + 1
+	}
 
 	// Set up the index descriptor type.
 	indexType := descpb.IndexDescriptor_FORWARD
@@ -84,14 +87,13 @@ func addNewIndexMutation(
 		Type:                        indexType,
 		CreatedExplicitly:           true,
 		EncodingType:                encodingType,
-		ConstraintID:                tbl.GetNextConstraintID(),
+		ConstraintID:                opIndex.ConstraintID,
 		UseDeletePreservingEncoding: isDeletePreserving,
 		StoreColumnNames:            []string{},
 	}
 	if opIndex.Sharding != nil {
 		idx.Sharded = *opIndex.Sharding
 	}
-	tbl.NextConstraintID++
 	return enqueueAddIndexMutation(tbl, idx, state)
 }
 

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -143,7 +143,7 @@ StatementPhase stage 1 of 1 with 11 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
   ops:
@@ -241,7 +241,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
 PostCommitPhase stage 1 of 7 with 4 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
@@ -317,7 +317,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 10 MutationType ops
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], WRITE_ONLY] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -383,7 +383,7 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
 PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3
@@ -428,7 +428,7 @@ StatementPhase stage 1 of 1 with 18 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[Column:{DescID: 104, ColumnID: 3}, PUBLIC], ABSENT] -> DELETE_ONLY
@@ -589,7 +589,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
 PostCommitPhase stage 1 of 7 with 5 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
     [[Column:{DescID: 104, ColumnID: 3}, PUBLIC], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedColumnDeleteAndWriteOnly
@@ -669,7 +669,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], WRITE_ONLY] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
     [[Column:{DescID: 104, ColumnID: 3}, PUBLIC], WRITE_ONLY] -> PUBLIC
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
@@ -748,7 +748,7 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
 PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3
@@ -790,7 +790,7 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
   ops:
@@ -885,7 +885,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
 PostCommitPhase stage 1 of 7 with 4 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], DELETE_ONLY] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedColumnDeleteAndWriteOnly
       ColumnID: 2
@@ -961,7 +961,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 10 MutationType ops
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], WRITE_ONLY] -> PUBLIC
     [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
       IndexID: 1
@@ -1027,7 +1027,7 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
 PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3
@@ -1254,11 +1254,11 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
@@ -1290,7 +1290,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
       TableID: 108
     *scop.MakeAddedIndexBackfilling
       Index:
-        ConstraintID: 3
+        ConstraintID: 4
         IndexID: 4
         IsUnique: true
         SourceIndexID: 1
@@ -1299,7 +1299,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
       IsSecondaryIndex: true
     *scop.MakeAddedTempIndexDeleteOnly
       Index:
-        ConstraintID: 4
+        ConstraintID: 5
         IndexID: 5
         IsUnique: true
         SourceIndexID: 1
@@ -1352,8 +1352,8 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
         statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 7 with 4 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
-    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 3
@@ -1368,7 +1368,7 @@ PostCommitPhase stage 1 of 7 with 4 MutationType ops
 PostCommitPhase stage 2 of 7 with 2 BackfillType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
   ops:
     *scop.BackfillIndex
       IndexID: 2
@@ -1381,7 +1381,7 @@ PostCommitPhase stage 2 of 7 with 2 BackfillType ops
 PostCommitPhase stage 3 of 7 with 4 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], BACKFILLED] -> DELETE_ONLY
   ops:
     *scop.MakeBackfillingIndexDeleteOnly
       IndexID: 2
@@ -1396,7 +1396,7 @@ PostCommitPhase stage 3 of 7 with 4 MutationType ops
 PostCommitPhase stage 4 of 7 with 4 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
   ops:
     *scop.MakeBackfilledIndexMerging
       IndexID: 2
@@ -1411,7 +1411,7 @@ PostCommitPhase stage 4 of 7 with 4 MutationType ops
 PostCommitPhase stage 5 of 7 with 2 BackfillType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGE_ONLY] -> MERGED
   ops:
     *scop.MergeIndex
       BackfilledIndexID: 2
@@ -1424,7 +1424,7 @@ PostCommitPhase stage 5 of 7 with 2 BackfillType ops
 PostCommitPhase stage 6 of 7 with 4 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], MERGED] -> WRITE_ONLY
   ops:
     *scop.MakeMergedIndexWriteOnly
       IndexID: 2
@@ -1439,7 +1439,7 @@ PostCommitPhase stage 6 of 7 with 4 MutationType ops
 PostCommitPhase stage 7 of 7 with 2 ValidationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], WRITE_ONLY] -> VALIDATED
   ops:
     *scop.ValidateUniqueIndex
       IndexID: 2
@@ -1455,9 +1455,9 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 12 MutationType ops
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
-    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[SecondaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
     [[IndexName:{DescID: 108, Name: t_i_key, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.MakeDroppedPrimaryIndexDeleteAndWriteOnly
@@ -1524,8 +1524,8 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops
 PostCommitNonRevertiblePhase stage 3 of 3 with 8 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 108, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
-    [[TemporaryIndex:{DescID: 108, IndexID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -29,7 +29,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
   ops:
@@ -129,7 +129,7 @@ PreCommitPhase stage 1 of 1 with 5 MutationType ops
         statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 7 with 6 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 4
@@ -253,7 +253,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 25 MutationType ops
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 107, Name: foo_pkey, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeDroppedColumnDeleteOnly
       ColumnID: 2
@@ -462,7 +462,7 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 14 MutationType ops
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 4
@@ -654,7 +654,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
@@ -678,7 +678,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexName:{DescID: 107, Name: foo_pkey, IndexID: 1}, ABSENT]
@@ -761,23 +761,23 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents removed
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: SameStagePrecedence
   rule: temp indexes reach absent at the same time as other indexes
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT]
   kind: SameStagePrecedence
   rule: temp indexes reach absent at the same time as other indexes
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill
@@ -880,7 +880,7 @@ StatementPhase stage 1 of 1 with 12 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
   ops:
@@ -984,7 +984,7 @@ PreCommitPhase stage 1 of 1 with 6 MutationType ops
         statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 7 with 7 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 4
@@ -1116,7 +1116,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 26 MutationType ops
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 107, Name: foo_pkey, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeDroppedColumnDeleteOnly
       ColumnID: 3
@@ -1330,7 +1330,7 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 15 MutationType ops
     [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 4
@@ -1529,7 +1529,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT]
@@ -1545,7 +1545,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 1}, ABSENT]
@@ -1636,23 +1636,23 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [IndexName:{DescID: 107, Name: foo_v2_key, IndexID: 2}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents removed
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 4}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: SameStagePrecedence
   rule: temp indexes reach absent at the same time as other indexes
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 1}, ABSENT]
   kind: SameStagePrecedence
   rule: temp indexes reach absent at the same time as other indexes
-- from: [TemporaryIndex:{DescID: 107, IndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -11,7 +11,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
@@ -77,7 +77,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
         statementtag: CREATE INDEX
 PostCommitPhase stage 1 of 7 with 3 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 3
@@ -146,7 +146,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.SetIndexName
       IndexID: 2
@@ -165,7 +165,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
       JobID: 1
 PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3
@@ -188,7 +188,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
@@ -196,7 +196,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
@@ -204,7 +204,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
@@ -227,19 +227,19 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index name and comment
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill
@@ -253,7 +253,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC], ABSENT] -> PUBLIC
@@ -324,7 +324,7 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
         statementtag: CREATE INDEX
 PostCommitPhase stage 1 of 7 with 3 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeAddedIndexDeleteAndWriteOnly
       IndexID: 3
@@ -393,7 +393,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
   transitions:
     [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
     [[IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.SetIndexName
       IndexID: 2
@@ -412,7 +412,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
       JobID: 1
 PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGcJobForIndex
       IndexID: 3
@@ -435,7 +435,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
@@ -443,7 +443,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
@@ -451,7 +451,7 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   kind: Precedence
   rule: index-column added to index before index is backfilled
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
 - from: [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
@@ -474,19 +474,19 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [IndexName:{DescID: 104, Name: id1, IndexID: 2}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index name and comment
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, DELETE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
   kind: Precedence
   rules: [temp index exists before columns, partitioning, and partial; index-column added to index after temp index exists]
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}, WRITE_ONLY]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -151,6 +151,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.TemporaryIndex)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(IndexID, "IndexID"),
+		rel.EntityAttr(ConstraintID, "ConstraintID"),
 		rel.EntityAttr(SourceIndexID, "SourceIndexID"),
 	),
 	rel.EntityMapping(t((*scpb.UniqueWithoutIndexConstraint)(nil)),

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -24,7 +24,6 @@ upsert descriptor #106
   +  mutations:
   +  - direction: ADD
   +    index:
-  +      constraintId: 2
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -47,7 +46,6 @@ upsert descriptor #106
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 3
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -71,8 +69,7 @@ upsert descriptor #106
   +    state: DELETE_ONLY
      name: t
      nextColumnId: 3
-  -  nextConstraintId: 2
-  +  nextConstraintId: 4
+     nextConstraintId: 2
      nextFamilyId: 1
   -  nextIndexId: 2
   +  nextIndexId: 4
@@ -250,8 +247,7 @@ upsert descriptor #106
   -  modificationTime:
   -    wallTime: "1640995200000000008"
   +  indexes:
-  +  - constraintId: 2
-  +    createdExplicitly: true
+  +  - createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
   +    id: 2
@@ -274,10 +270,9 @@ upsert descriptor #106
   -  - direction: ADD
   +  - direction: DROP
        index:
-  -      constraintId: 2
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
   -      id: 2
   -      interleave: {}
   -      keyColumnDirections:
@@ -297,8 +292,11 @@ upsert descriptor #106
   -    state: DELETE_AND_WRITE_ONLY
   -  - direction: ADD
   -    index:
-         constraintId: 3
-         createdExplicitly: true
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+         id: 3
+         interleave: {}
   ...
          version: 4
        mutationId: 1
@@ -343,7 +341,6 @@ upsert descriptor #106
   -  mutations:
   -  - direction: DROP
   -    index:
-  -      constraintId: 3
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
@@ -454,7 +454,7 @@ upsert descriptor #104
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 5
+  +      constraintId: 4
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -480,7 +480,7 @@ upsert descriptor #104
      name: t
      nextColumnId: 5
   -  nextConstraintId: 4
-  +  nextConstraintId: 6
+  +  nextConstraintId: 5
      nextFamilyId: 1
   -  nextIndexId: 5
   +  nextIndexId: 7
@@ -703,10 +703,10 @@ upsert descriptor #104
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-  -      constraintId: 4
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
+         constraintId: 4
+  ...
+         foreignKey: {}
+         geoConfig: {}
   -      id: 5
   -      interleave: {}
   -      keyColumnDirections:
@@ -727,8 +727,12 @@ upsert descriptor #104
   -    state: DELETE_AND_WRITE_ONLY
   -  - direction: ADD
   -    index:
-         constraintId: 5
-         createdExplicitly: true
+  -      constraintId: 4
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+         id: 6
+         interleave: {}
   ...
          version: 4
        mutationId: 1
@@ -889,7 +893,7 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 5
+  -      constraintId: 4
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}

--- a/pkg/sql/schemachanger/testdata/explain/add_column
+++ b/pkg/sql/schemachanger/testdata/explain/add_column
@@ -20,7 +20,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         └── 11 Mutation operations
  │              ├── MakeAddedColumnDeleteOnly {"Column":{"ColumnID":2,"PgAttributeNum":2,"TableID":106}}
  │              ├── LogEvent {"TargetStatus":2}
@@ -43,7 +43,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeAddedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":106}
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":106}
@@ -96,7 +96,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
@@ -119,7 +119,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
            ├── 1 element transitioning toward ABSENT
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_1_of_7
@@ -18,7 +18,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            └── 13 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_2_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_3_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_4_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_5_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 10 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_6_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 10 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column.rollback_7_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 10 Mutation operations
@@ -36,7 +36,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
@@ -20,7 +20,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         └── 12 Mutation operations
  │              ├── MakeAddedColumnDeleteOnly {"Column":{"ColumnID":2,"PgAttributeNum":2,"TableID":106}}
  │              ├── LogEvent {"TargetStatus":2}
@@ -45,7 +45,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 5 Mutation operations
  │    │         ├── MakeAddedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":106}
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":106}
@@ -102,7 +102,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    └── 11 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
@@ -127,7 +127,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
            ├── 1 element transitioning toward ABSENT
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
@@ -18,7 +18,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            └── 15 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 12 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 12 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 12 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── UpdateBackReferencesInSequences {"BackReferencedColumnID":2,"BackReferencedTableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    └── 11 Mutation operations
@@ -37,7 +37,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
@@ -13,14 +13,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
- │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │         │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
  │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
  │         └── 12 Mutation operations
  │              ├── MakeAddedIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
  │              ├── MakeAddedTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
@@ -42,8 +42,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":104}
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":5,"TableID":104}
@@ -52,14 +52,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 2 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │    │    └── 2 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
  │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":1,"TableID":104}
  │    ├── Stage 3 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
@@ -68,7 +68,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 4 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
@@ -77,14 +77,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    ├── Stage 5 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
  │    ├── Stage 6 of 7 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
  │    │    │    ├── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
@@ -93,7 +93,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    └── Stage 7 of 7 in PostCommitPhase
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
  │         └── 2 Validation operations
  │              ├── ValidateUniqueIndex {"IndexID":2,"TableID":104}
  │              └── ValidateUniqueIndex {"IndexID":4,"TableID":104}
@@ -107,11 +107,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -136,8 +136,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
            ├── 1 element transitioning toward ABSENT
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -41,8 +41,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -41,8 +41,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -41,8 +41,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -39,9 +39,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -39,9 +39,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -12,11 +12,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
@@ -39,9 +39,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/create_index
+++ b/pkg/sql/schemachanger/testdata/explain/create_index
@@ -15,7 +15,7 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
  │         └── 6 Mutation operations
  │              ├── MakeAddedIndexBackfilling {"IsSecondaryIndex":true}
  │              ├── MakeAddedTempIndexDeleteOnly {"IsSecondaryIndex":true}
@@ -31,7 +31,7 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":106}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
@@ -78,7 +78,7 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
       │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: idx1, IndexID: 2}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    └── 5 Mutation operations
       │         ├── SetIndexName {"IndexID":2,"Name":"idx1","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":106}
@@ -87,7 +87,7 @@ Schema change plan for CREATE INDEX ‹idx1› ON ‹defaultdb›.‹public›.�
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_1_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
            └── 11 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_2_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 10 Mutation operations
@@ -29,7 +29,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_3_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 10 Mutation operations
@@ -29,7 +29,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_4_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 10 Mutation operations
@@ -29,7 +29,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_5_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 8 Mutation operations
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_6_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 8 Mutation operations
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/create_index.rollback_7_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    └── 8 Mutation operations
@@ -28,7 +28,7 @@ Schema change plan for rolling back CREATE INDEX ‹idx1› ON ‹defaultdb›.p
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── LogEvent {"TargetStatus":1}
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic
@@ -15,7 +15,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         └── 7 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -32,7 +32,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":3,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -85,7 +85,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
@@ -110,7 +110,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 7 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            ├── 4 elements transitioning toward ABSENT
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
            ├── 2 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -29,7 +29,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
@@ -19,7 +19,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         └── 12 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -41,7 +41,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -98,7 +98,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 14 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -130,7 +130,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_1_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            ├── 4 elements transitioning toward ABSENT
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            ├── 6 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_2_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_3_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_4_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_5_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_6_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_7_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -38,7 +38,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -63,8 +63,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -63,8 +63,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC      → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -63,8 +63,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -61,9 +61,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -62,8 +62,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -61,9 +61,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -62,8 +62,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -62,8 +62,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -61,9 +61,9 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            ├── 6 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 4}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -15,7 +15,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -43,7 +43,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -19,8 +19,8 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -16,11 +16,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
       │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
       │    ├── 8 elements transitioning toward PUBLIC
@@ -64,7 +64,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 5 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
@@ -21,7 +21,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         └── 14 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -45,7 +45,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -104,7 +104,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 16 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -138,7 +138,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
@@ -14,7 +14,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -68,7 +68,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+ │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
  │    │    └── 12 Mutation operations
  │    │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -84,7 +84,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -142,8 +142,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: idx, IndexID: 5}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
       │    └── 16 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -170,8 +170,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
            └── 13 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
@@ -64,11 +64,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
- │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+ │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
  │    │    └── 12 Mutation operations
  │    │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -84,45 +84,45 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 10 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    └── 1 Backfill operation
  │    │         └── BackfillIndex {"IndexID":5,"SourceIndexID":3,"TableID":104}
  │    ├── Stage 11 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 12 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 13 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    └── 1 Backfill operation
  │    │         └── MergeIndex {"BackfilledIndexID":5,"TableID":104,"TemporaryIndexID":6}
  │    ├── Stage 14 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    └── Stage 15 of 15 in PostCommitPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
  │         └── 1 Validation operation
  │              └── ValidateUniqueIndex {"IndexID":5,"TableID":104}
  └── PostCommitNonRevertiblePhase
@@ -139,11 +139,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: idx, IndexID: 5}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 16 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -171,7 +171,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
            │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
            └── 13 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
@@ -22,7 +22,7 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
  │         └── 11 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":3,"TableID":106}
  │              ├── LogEvent {"TargetStatus":1}
@@ -43,7 +43,7 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":5,"TableID":106}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
@@ -98,7 +98,7 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
@@ -126,7 +126,7 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
            │    ├── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
            │    └── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":5,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_1_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_2_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":5,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_3_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":5,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_4_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":5,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_5_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_6_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_7_of_7
@@ -16,7 +16,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
@@ -40,7 +40,7 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index
@@ -17,7 +17,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         └── 9 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -36,7 +36,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -92,7 +92,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 13 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
@@ -121,7 +121,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_1_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            ├── 4 elements transitioning toward ABSENT
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            ├── 4 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_2_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_3_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_4_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_5_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_6_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_7_of_7
@@ -11,7 +11,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
@@ -33,7 +33,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            ├── 8 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 3}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: k, ColumnID: 3}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 4 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -13,7 +13,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -44,7 +44,7 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -21,7 +21,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
  │         ├── 1 element transitioning toward TRANSIENT_ABSENT
- │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │         │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         └── 14 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -45,7 +45,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -104,7 +104,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 16 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -138,7 +138,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 11 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -23,7 +23,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  ├── PostCommitPhase
  │    ├── Stage 1 of 7 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeAddedIndexDeleteAndWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
@@ -85,7 +85,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 19 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -126,7 +126,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 14 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":4,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column
@@ -66,7 +66,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
@@ -82,13 +82,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │       │       ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
 │       │       │     rule: "column name and type to public after all index column to public"
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │       │ ABSENT → DELETE_ONLY
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -217,7 +217,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -259,7 +259,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -402,7 +402,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 10 Mutation operations
@@ -501,12 +501,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 6 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_1_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_2_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -144,7 +144,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_3_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -144,7 +144,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_4_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -144,7 +144,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_5_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_6_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column.rollback_7_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -132,7 +132,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -66,7 +66,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
@@ -82,13 +82,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │       │       ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
 │       │       │     rule: "column name and type to public after all index column to public"
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │       │ ABSENT → DELETE_ONLY
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -230,7 +230,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -275,7 +275,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -427,7 +427,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 11 Mutation operations
@@ -532,12 +532,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 7 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -58,7 +58,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -147,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -147,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
@@ -42,7 +42,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -147,7 +147,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
         │   │     PUBLIC → ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -135,7 +135,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -135,7 +135,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -33,7 +33,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
@@ -135,7 +135,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
@@ -30,52 +30,52 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
-│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │       │   │     ABSENT → BACKFILL_ONLY
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │       │   │         rule: "index-column added to index after index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │       │   │         rule: "index-column added to index after index exists"
 │       │   │
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │   │     ABSENT → DELETE_ONLY
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 12 Mutation operations
@@ -110,7 +110,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │           │
 │           ├── • MakeAddedIndexBackfilling
 │           │     Index:
-│           │       ConstraintID: 3
+│           │       ConstraintID: 4
 │           │       IndexID: 4
 │           │       IsUnique: true
 │           │       SourceIndexID: 1
@@ -120,7 +120,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │           │
 │           ├── • MakeAddedTempIndexDeleteOnly
 │           │     Index:
-│           │       ConstraintID: 4
+│           │       ConstraintID: 5
 │           │       IndexID: 5
 │           │       IsUnique: true
 │           │       SourceIndexID: 1
@@ -189,7 +189,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │
 │   │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │   │ DELETE_ONLY → WRITE_ONLY
 │   │   │   │   │
 │   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -198,7 +198,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │   │   │   │         rule: "index-column added to index before temp index receives writes"
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -237,13 +237,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
 │   │   │   │   │     rule: "index-column added to index before index is backfilled"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   │   └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │   │         rule: "temp index is WRITE_ONLY before backfill"
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │   │   │       │ BACKFILL_ONLY → BACKFILLED
 │   │   │       │
-│   │   │       ├── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+│   │   │       ├── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
 │   │   │       │     rule: "temp index is WRITE_ONLY before backfill"
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -271,7 +271,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │   │     BACKFILLED → DELETE_ONLY
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │   │   │         BACKFILLED → DELETE_ONLY
 │   │   │
 │   │   └── • 4 Mutation operations
@@ -298,7 +298,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │   │     DELETE_ONLY → MERGE_ONLY
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │   │   │         DELETE_ONLY → MERGE_ONLY
 │   │   │
 │   │   └── • 4 Mutation operations
@@ -325,7 +325,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │   │     MERGE_ONLY → MERGED
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │   │   │         MERGE_ONLY → MERGED
 │   │   │
 │   │   └── • 2 Backfill operations
@@ -347,7 +347,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │   │   │   │     MERGED → WRITE_ONLY
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │   │   │         MERGED → WRITE_ONLY
 │   │   │
 │   │   └── • 4 Mutation operations
@@ -374,7 +374,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
 │       │   │     WRITE_ONLY → VALIDATED
 │       │   │
-│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
 │       │         WRITE_ONLY → VALIDATED
 │       │
 │       └── • 2 Validation operations
@@ -431,7 +431,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │   │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │         rule: "index existence precedes index name and comment"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
     │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
@@ -440,15 +440,15 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │   │   └── • IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
     │   │       │ ABSENT → PUBLIC
     │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │             rule: "index existence precedes index name and comment"
     │   │
     │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
@@ -553,18 +553,18 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │     rule: "temp indexes reach absent at the same time as other indexes"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 2 elements transitioning toward TRANSIENT_ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │     TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 8 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_1_of_7
@@ -31,7 +31,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -46,7 +46,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │     PUBLIC → ABSENT
         │   │
-        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │   │ BACKFILL_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -60,7 +60,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -72,7 +72,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │         rule: "secondary index in DELETE_ONLY before removing columns"
         │   │
         │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -81,7 +81,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │         rule: "secondary index in DELETE_ONLY before removing columns"
         │   │
         │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -163,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
             ├── • LogEvent
             │     Element:
             │       SecondaryIndex:
-            │         constraintId: 3
+            │         constraintId: 4
             │         indexId: 4
             │         isUnique: true
             │         sourceIndexId: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_2_of_7
@@ -31,7 +31,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -54,13 +54,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -69,7 +69,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -151,7 +151,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
-    │       │         constraintId: 3
+    │       │         constraintId: 4
     │       │         indexId: 4
     │       │         isUnique: true
     │       │         sourceIndexId: 1
@@ -190,7 +190,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -199,7 +199,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_3_of_7
@@ -31,7 +31,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -54,13 +54,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -69,7 +69,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -151,7 +151,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
-    │       │         constraintId: 3
+    │       │         constraintId: 4
     │       │         indexId: 4
     │       │         isUnique: true
     │       │         sourceIndexId: 1
@@ -190,7 +190,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -199,7 +199,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_4_of_7
@@ -31,7 +31,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -54,13 +54,13 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -69,7 +69,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -151,7 +151,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
-    │       │         constraintId: 3
+    │       │         constraintId: 4
     │       │         indexId: 4
     │       │         isUnique: true
     │       │         sourceIndexId: 1
@@ -190,7 +190,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -199,7 +199,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_5_of_7
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -31,16 +31,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -49,7 +49,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -150,7 +150,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -164,7 +164,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -205,7 +205,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
             ├── • LogEvent
             │     Element:
             │       SecondaryIndex:
-            │         constraintId: 3
+            │         constraintId: 4
             │         indexId: 4
             │         isUnique: true
             │         sourceIndexId: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_6_of_7
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -31,16 +31,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -49,7 +49,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -150,7 +150,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -164,7 +164,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -205,7 +205,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
             ├── • LogEvent
             │     Element:
             │       SecondaryIndex:
-            │         constraintId: 3
+            │         constraintId: 4
             │         indexId: 4
             │         isUnique: true
             │         sourceIndexId: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla.rollback_7_of_7
@@ -22,7 +22,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -31,16 +31,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │   │     PUBLIC → ABSENT
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -49,7 +49,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
@@ -150,7 +150,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 1}
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -164,7 +164,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_i_key, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
@@ -205,7 +205,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
             ├── • LogEvent
             │     Element:
             │       SecondaryIndex:
-            │         constraintId: 3
+            │         constraintId: 4
             │         indexId: 4
             │         isUnique: true
             │         sourceIndexId: 1

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index
@@ -31,20 +31,20 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   └── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 6 Mutation operations
@@ -115,7 +115,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -150,7 +150,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -267,7 +267,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 5 Mutation operations
@@ -297,7 +297,7 @@ EXPLAIN (ddl, verbose) CREATE INDEX idx1 ON t (v) WHERE (v = 'a');
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 4 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_1_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_2_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -117,7 +117,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_3_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -117,7 +117,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_4_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -117,7 +117,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_5_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -96,7 +96,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_6_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -96,7 +96,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/create_index.rollback_7_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
@@ -96,7 +96,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: idx1, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 0, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
@@ -35,13 +35,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 7 Mutation operations
@@ -126,7 +126,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -155,7 +155,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -301,7 +301,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 10 Mutation operations
@@ -415,12 +415,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 7 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -106,7 +106,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -106,7 +106,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -106,7 +106,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,7 +94,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,7 +94,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,7 +94,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
@@ -53,13 +53,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 12 Mutation operations
@@ -179,7 +179,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -208,7 +208,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -378,7 +378,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 14 Mutation operations
@@ -530,7 +530,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -547,12 +547,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 11 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -47,16 +47,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -249,6 +249,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3
@@ -301,7 +302,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -292,7 +292,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -301,7 +301,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -47,16 +47,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -249,6 +249,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3
@@ -301,7 +302,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -292,7 +292,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -301,7 +301,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -292,7 +292,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -301,7 +301,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -47,16 +47,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -207,6 +207,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3
@@ -301,7 +302,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -47,19 +47,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -263,7 +263,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -303,6 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -59,7 +59,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -254,7 +254,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -59,7 +59,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -254,7 +254,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -47,19 +47,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -263,7 +263,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -303,6 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -59,7 +59,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -254,7 +254,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -47,19 +47,19 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -263,7 +263,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -277,7 +277,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -303,6 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -38,7 +38,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -38,7 +38,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -38,7 +38,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -38,7 +38,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -163,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -163,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -163,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 6 elements transitioning toward PUBLIC
@@ -163,7 +163,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -41,7 +41,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents removed"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -302,7 +302,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
     │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -47,16 +47,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   └── • Precedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │         rule: "secondary index in DELETE_ONLY before removing columns"
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -70,7 +70,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
     │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -251,6 +251,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       ├── • LogEvent
     │       │     Element:
     │       │       SecondaryIndex:
+    │       │         constraintId: 4
     │       │         indexId: 5
     │       │         isUnique: true
     │       │         sourceIndexId: 3

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
@@ -59,20 +59,20 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 14 Mutation operations
@@ -204,7 +204,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -239,7 +239,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -424,7 +424,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
@@ -592,7 +592,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -613,12 +613,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 11 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
@@ -203,16 +203,16 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
 │   │   │   │   │ ABSENT → PUBLIC
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │   │         rule: "index-column added to index after index exists"
 │   │   │   │
 │   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │   │   │   │   │ ABSENT → PUBLIC
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │   │         rule: "index-column added to index after index exists"
 │   │   │   │
-│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │   │   │ ABSENT → BACKFILL_ONLY
 │   │   │   │   │
 │   │   │   │   └── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -221,20 +221,20 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
 │   │   │   │   │ ABSENT → PUBLIC
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
 │   │   │   │         rule: "temp index exists before columns, partitioning, and partial"
 │   │   │   │         rule: "index-column added to index after temp index exists"
 │   │   │   │
 │   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
 │   │   │       │ ABSENT → PUBLIC
 │   │   │       │
-│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
 │   │   │             rule: "temp index exists before columns, partitioning, and partial"
 │   │   │             rule: "index-column added to index after temp index exists"
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
 │   │   │       │ ABSENT → DELETE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -270,6 +270,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │       │
 │   │       ├── • MakeAddedIndexBackfilling
 │   │       │     Index:
+│   │       │       ConstraintID: 4
 │   │       │       IndexID: 5
 │   │       │       IsUnique: true
 │   │       │       SourceIndexID: 3
@@ -279,6 +280,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │       │
 │   │       ├── • MakeAddedTempIndexDeleteOnly
 │   │       │     Index:
+│   │       │       ConstraintID: 4
 │   │       │       IndexID: 6
 │   │       │       IsUnique: true
 │   │       │       SourceIndexID: 3
@@ -318,7 +320,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -344,7 +346,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │       │ BACKFILL_ONLY → BACKFILLED
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
@@ -353,7 +355,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -367,7 +369,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │         BACKFILLED → DELETE_ONLY
 │   │   │
 │   │   └── • 3 Mutation operations
@@ -387,7 +389,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │         DELETE_ONLY → MERGE_ONLY
 │   │   │
 │   │   └── • 3 Mutation operations
@@ -407,7 +409,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │         MERGE_ONLY → MERGED
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -421,7 +423,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │   │   │         MERGED → WRITE_ONLY
 │   │   │
 │   │   └── • 3 Mutation operations
@@ -441,7 +443,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │       │
 │       ├── • 1 element transitioning toward PUBLIC
 │       │   │
-│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
 │       │         WRITE_ONLY → VALIDATED
 │       │
 │       └── • 1 Validation operation
@@ -515,7 +517,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │   │
     │   ├── • 2 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
     │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx, IndexID: 5}
@@ -524,7 +526,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │   │   └── • IndexName:{DescID: 104, Name: idx, IndexID: 5}
     │   │       │ ABSENT → PUBLIC
     │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 0, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
     │   │             rule: "index existence precedes index name and comment"
     │   │
     │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
@@ -532,7 +534,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
@@ -674,7 +676,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │   │   ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "temp indexes reach absent at the same time as other indexes"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -698,7 +700,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │     rule: "temp indexes reach absent at the same time as other indexes"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 2 elements transitioning toward TRANSIENT_ABSENT
@@ -706,7 +708,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │     TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 13 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
@@ -38,7 +38,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -73,7 +73,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -221,20 +221,20 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
 │   │   │   │   │ ABSENT → PUBLIC
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
 │   │   │   │         rule: "temp index exists before columns, partitioning, and partial"
 │   │   │   │         rule: "index-column added to index after temp index exists"
 │   │   │   │
 │   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
 │   │   │       │ ABSENT → PUBLIC
 │   │   │       │
-│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
 │   │   │             rule: "temp index exists before columns, partitioning, and partial"
 │   │   │             rule: "index-column added to index after temp index exists"
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
 │   │   │       │ ABSENT → DELETE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -318,7 +318,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
@@ -353,7 +353,7 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -529,10 +529,10 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │   │
     │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
@@ -671,10 +671,10 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │   │     rule: "temp indexes reach absent at the same time as other indexes"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -695,18 +695,18 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       ├── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │     rule: "temp indexes reach absent at the same time as other indexes"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 2 elements transitioning toward TRANSIENT_ABSENT
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │     TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, SourceIndexID: 3}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0, SourceIndexID: 3}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 13 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
@@ -50,27 +50,27 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   └── • IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 11 Mutation operations
@@ -181,7 +181,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -222,7 +222,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -380,7 +380,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
@@ -520,12 +520,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 1}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 8 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
@@ -40,7 +40,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -153,7 +153,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
@@ -141,7 +141,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
@@ -44,13 +44,13 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 9 Mutation operations
@@ -144,7 +144,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -173,7 +173,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -340,7 +340,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 13 Mutation operations
@@ -472,7 +472,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -489,12 +489,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
@@ -25,7 +25,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -124,7 +124,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -112,7 +112,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -112,7 +112,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
@@ -19,7 +19,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
     │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -112,7 +112,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -187,7 +187,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -187,7 +187,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -29,7 +29,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -187,7 +187,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     MERGE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -23,7 +23,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
     │   │   │     WRITE_ONLY → DELETE_ONLY
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   ├── • 8 elements transitioning toward PUBLIC
@@ -175,7 +175,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
         │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -59,20 +59,20 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │   │         rule: "temp index exists before columns, partitioning, and partial"
 │       │   │         rule: "index-column added to index after temp index exists"
 │       │   │
 │       │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index exists before columns, partitioning, and partial"
 │       │             rule: "index-column added to index after temp index exists"
 │       │
 │       ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│       │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │         ABSENT → DELETE_ONLY
 │       │
 │       └── • 14 Mutation operations
@@ -204,7 +204,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -239,7 +239,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -424,7 +424,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
@@ -592,7 +592,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -613,12 +613,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 11 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -81,7 +81,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -110,7 +110,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
 │   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
@@ -304,7 +304,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
     │   └── • 19 Mutation operations
@@ -523,7 +523,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
         │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   │   └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │   │         rule: "temp indexes reach absent at the same time as other indexes"
         │   │
         │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
@@ -544,12 +544,12 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
         │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │       └── • SameStagePrecedence dependency from TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │             rule: "temp indexes reach absent at the same time as other indexes"
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
         │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 14 Mutation operations


### PR DESCRIPTION
The first two commits are some small changes and the third commit is the main commit.

Commit 1: Change the signature of an existing function
Commit 2: Add `ConstraintID` as an attribute to `TemporaryIndex` element 
in `screl`.
Commit 3 (the main commit): See below for a detailed description.

Previously, we call `addNewIndexMutation` to enqueue an index mutation
    to the mutation slice. However, that function is buggy in that it
    ignored the `constraintID` field of the input `opIndex` and instead
    called `tbl.NextConstraintID()` and assign it to the index descriptor.
    This is problematic because in the declarative schema changer world, we
    strive to uphold a rule that we shall manage column/index/constraint
    ID allocation in the builder, where we have access to the builder state
    information, so we know what the right next column/index/constraint ID
    in a table is.

To accompany that rule, in the mutation operation (such as this function
    `addNewIndexMutation`), we ought to check for column/index/constraint
    ID of the input element and update the table's
    `nextColumn/Index/ConstraintID` accordingly.

Such a change alo discovered and fixed two other existing issues:
       1. In `CREATE INDEX` and `ADD COLUMN`, we did not allocate
       constraintID to the new primary index or new unique secondary
       index that are created in the builder.
       2. We `--rewrite`'ed a bunch of test output pertaining to
       constraintID of indexes.

Release note: None