### PR TITLE
sql: don't show hard limit values, just show a 0 or 1

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -170,4 +170,4 @@ SELECT crdb_internal.decode_plan_gist('AgGSARIAAwlAsJ8BE5IBAhcGFg==')
     └── • scan
           table: ?@?
           spans: 32 spans
-          limit: 10200
+          limit

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -512,6 +512,8 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 
 		if a.Params.HardLimit > 0 {
 			ob.Attr("limit", a.Params.HardLimit)
+		} else if a.Params.HardLimit == -1 {
+			ob.Attr("limit", "")
 		}
 
 		if a.Params.Parallelize {
@@ -924,7 +926,8 @@ func (e *emitter) emitSpans(
 
 func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.ScanParams) string {
 	if scanParams.InvertedConstraint == nil && scanParams.IndexConstraint == nil {
-		if scanParams.HardLimit > 0 {
+		// HardLimit can be -1 to signal unknown limit (for gists).
+		if scanParams.HardLimit != 0 {
 			return "LIMITED SCAN"
 		}
 		if scanParams.SoftLimit > 0 {

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -400,7 +400,11 @@ func (f *PlanGistFactory) encodeScanParams(params exec.ScanParams) {
 		f.encodeInt(0)
 	}
 
-	f.encodeInt(int(params.HardLimit))
+	if params.HardLimit > 0 {
+		f.encodeInt(1)
+	} else {
+		f.encodeInt(0)
+	}
 }
 
 func (f *PlanGistFactory) decodeScanParams() exec.ScanParams {
@@ -428,6 +432,12 @@ func (f *PlanGistFactory) decodeScanParams() exec.ScanParams {
 	}
 
 	hardLimit := f.decodeInt()
+
+	// Since we no longer record the limit value and its just a bool tell the emit code
+	// to just print "limit", instead the misleading "limit: 1".
+	if hardLimit > 0 {
+		hardLimit = -1
+	}
 
 	return exec.ScanParams{NeededCols: neededCols, IndexConstraint: idxConstraint, InvertedConstraint: invertedConstraint, HardLimit: int64(hardLimit)}
 }

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -17,7 +17,7 @@ CREATE TABLE xyz (x INT PRIMARY KEY, y INT, z INT)
 
 # ConstructScan/ConstructSerializingProject
 gist-explain-roundtrip
-SELECT * from foo LIMIT 1
+SELECT * from foo LIMIT 10
 ----
 hash: 12007264394566425707
 plan-gist: AgFqAgAHAAACBgY=
@@ -26,12 +26,12 @@ explain(shape):
   missing stats
   table: foo@foo_pkey
   spans: LIMITED SCAN
-  limit: 1
+  limit: 10
 explain(gist):
 • scan
   table: foo@foo_pkey
   spans: LIMITED SCAN
-  limit: 1
+  limit
 
 # ConstructFilter
 gist-explain-roundtrip


### PR DESCRIPTION
From user experience with 22.1 a gist that varies from a hard limit of
various positive values is not valuable. Really we only care if its
zero or not.

Fixes: #84842

Release note: None
