### PR TITLE
sql: support UDFs with named args, strictness, and volatility

### DIFF
--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -391,7 +391,7 @@ func (ep *DummyEvalPlanner) EvalSubquery(expr *tree.Subquery) (tree.Datum, error
 
 // EvalRoutineExpr is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) EvalRoutineExpr(
-	ctx context.Context, expr *tree.RoutineExpr,
+	ctx context.Context, expr *tree.RoutineExpr, input tree.Datums,
 ) (tree.Datum, error) {
 	return nil, errors.WithStack(errEvalPlanner)
 }

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -858,3 +858,91 @@ query I
 SELECT empty_result()
 ----
 NULL
+
+statement ok
+CREATE FUNCTION int_identity(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT i';
+
+query I
+SELECT int_identity(1)
+----
+1
+
+query I
+SELECT int_identity(10 + int_identity(1))
+----
+11
+
+query II
+SELECT a+b, int_identity(a+b) FROM ab WHERE a = int_identity(a) AND b = int_identity(b)
+----
+2  2
+4  4
+6  6
+5  5
+6  6
+
+# Define some custom arithmetic functions that we can write interesting tests
+# with that use builtin operators as oracles.
+statement ok
+CREATE FUNCTION add(x INT, y INT) RETURNS INT LANGUAGE SQL AS 'SELECT x+y';
+
+statement ok
+CREATE FUNCTION sub(x INT, y INT) RETURNS INT LANGUAGE SQL AS 'SELECT x-y';
+
+statement ok
+CREATE FUNCTION mult(x INT, y INT) RETURNS INT LANGUAGE SQL AS 'SELECT x*y';
+
+query II
+SELECT a + a + a + b + b + b, add(a, add(a, add(a, add(b, add(b, b))))) FROM ab
+----
+6   6
+12  12
+18  18
+15  15
+18  18
+
+query II
+SELECT (a * (a + b)) - b, sub(mult(a, add(a, b)), b) FROM ab
+----
+1   1
+6   6
+15  15
+19  19
+29  29
+
+query II
+SELECT a * (3 + b - a) + a * b * a, add(mult(a, add(3, sub(b, a))), mult(a, mult(b, a))) FROM ab
+----
+4   4
+14  14
+36  36
+16  16
+20  20
+
+statement ok
+CREATE FUNCTION fetch_b(arg_a INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT b FROM ab WHERE a = arg_a
+$$
+
+query II
+SELECT b, fetch_b(a) FROM ab
+----
+1  1
+2  2
+3  3
+1  1
+1  1
+
+query II
+SELECT b + (a * 7) - (a * b), add(fetch_b(a), sub(mult(a, 7), mult(a, fetch_b(a)))) FROM ab
+----
+7   7
+12  12
+15  15
+25  25
+31  31
+
+query I
+SELECT fetch_b(99999999)
+----
+NULL

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -946,3 +946,42 @@ query I
 SELECT fetch_b(99999999)
 ----
 NULL
+
+subtest volatility
+
+statement ok
+CREATE TABLE kv (k INT PRIMARY KEY, v INT);
+INSERT INTO kv VALUES (1, 1), (2, 2), (3, 3);
+CREATE FUNCTION get_l(i INT) RETURNS INT IMMUTABLE LEAKPROOF LANGUAGE SQL AS $$
+  SELECT v FROM kv WHERE k = i;
+$$;
+CREATE FUNCTION get_i(i INT) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$
+  SELECT v FROM kv WHERE k = i;
+$$;
+CREATE FUNCTION get_s(i INT) RETURNS INT STABLE LANGUAGE SQL AS $$
+  SELECT v FROM kv WHERE k = i;
+$$;
+CREATE FUNCTION get_v(i INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT v FROM kv WHERE k = i;
+$$;
+CREATE FUNCTION int_identity_v(i INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$
+  SELECT i;
+$$;
+
+# Only the volatile functions should see the changes made by the UPDATE in the
+# CTE.
+query IIIIIIII colnames
+WITH u AS (
+    UPDATE kv SET v = v + 10 RETURNING k
+)
+SELECT
+  get_l(k) l1, get_l(int_identity_v(k)) l2,
+  get_i(k) i1, get_i(int_identity_v(k)) i2,
+  get_s(k) s1, get_s(int_identity_v(k)) s2,
+  get_v(k) v1, get_v(int_identity_v(k)) v2
+FROM u;
+----
+l1  l2  i1  i2  s1  s2  v1  v2
+1   1   1   1   1   1   11  11
+2   2   2   2   2   2   12  12
+3   3   3   3   3   3   13  13

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -310,73 +310,6 @@ ALTER FUNCTION f() SET SCHEMA test_sc
 statement error pq: unimplemented: alter function depends on extension not supported.*
 ALTER FUNCTION f() DEPENDS ON EXTENSION postgis
 
-subtest execution
-
-statement ok
-INSERT INTO ab VALUES (1, 1), (2, 2), (3, 3), (4, 1), (5, 1)
-
-statement ok
-CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 2-1';
-
-query I
-SELECT one()
-----
-1
-
-query I colnames
-SELECT * FROM one()
-----
-one
-1
-
-query III colnames
-SELECT *, one() FROM ab WHERE a = one()
-----
-a  b  one
-1  1  1
-
-query III colnames
-SELECT *, one() FROM ab WHERE b = one()
-----
-a  b  one
-1  1  1
-4  1  1
-5  1  1
-
-query II colnames
-SELECT * FROM ab WHERE b = one() + 1
-----
-a  b
-2  2
-
-statement ok
-CREATE FUNCTION max_in_values() RETURNS INT LANGUAGE SQL AS $$
-  SELECT i FROM (VALUES (1, 0), (2, 0), (3, 0)) AS v(i, j) ORDER BY i DESC
-$$
-
-query I
-SELECT max_in_values()
-----
-3
-
-statement ok
-CREATE FUNCTION fetch_one_then_two() RETURNS INT LANGUAGE SQL AS $$
-  SELECT b FROM ab WHERE a = 1;
-  SELECT b FROM ab WHERE a = 2;
-$$
-
-query II
-SELECT i, fetch_one_then_two()
-FROM (VALUES (1), (2), (3)) AS v(i)
-WHERE i = fetch_one_then_two()
-----
-2  2
-
-query I colnames
-SELECT * FROM fetch_one_then_two()
-----
-fetch_one_then_two
-2
 
 subtest udf_pg_proc
 
@@ -399,9 +332,9 @@ query TTTTTBBBTITTTTT
 SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 ----
-100124  proc_f    4101115737  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    SELECT 1;
-100125  proc_f    4101115737  1546506610  14  true   true   true   i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
-100128  proc_f_2  131273696   1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
+100121  proc_f    4101115737  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    SELECT 1;
+100122  proc_f    4101115737  1546506610  14  true   true   true   i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
+100125  proc_f_2  131273696   1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
 
 subtest create_function_statements
 
@@ -419,7 +352,7 @@ CREATE FUNCTION public.proc_f(IN INT8)
     LANGUAGE SQL
     AS $$
     SELECT 1;
-$$  104  test  105  public  124  proc_f
+$$  104  test  105  public  121  proc_f
 CREATE FUNCTION public.proc_f(IN STRING, IN b INT8)
     RETURNS SETOF STRING
     IMMUTABLE
@@ -428,7 +361,7 @@ CREATE FUNCTION public.proc_f(IN STRING, IN b INT8)
     LANGUAGE SQL
     AS $$
     SELECT 'hello';
-$$  104  test  105  public  125  proc_f
+$$  104  test  105  public  122  proc_f
 CREATE FUNCTION sc.proc_f_2(IN STRING)
     RETURNS STRING
     VOLATILE
@@ -437,7 +370,7 @@ CREATE FUNCTION sc.proc_f_2(IN STRING)
     LANGUAGE SQL
     AS $$
     SELECT 'hello';
-$$  104  test  127  sc  128  proc_f_2
+$$  104  test  124  sc  125  proc_f_2
 
 statement ok
 CREATE DATABASE test_cross_db;
@@ -459,7 +392,7 @@ CREATE FUNCTION public.proc_f(IN INT8)
     LANGUAGE SQL
     AS $$
     SELECT 1;
-$$  104  test  105  public  124  proc_f
+$$  104  test  105  public  121  proc_f
 CREATE FUNCTION public.proc_f(IN STRING, IN b INT8)
     RETURNS SETOF STRING
     IMMUTABLE
@@ -468,7 +401,7 @@ CREATE FUNCTION public.proc_f(IN STRING, IN b INT8)
     LANGUAGE SQL
     AS $$
     SELECT 'hello';
-$$  104  test  105  public  125  proc_f
+$$  104  test  105  public  122  proc_f
 CREATE FUNCTION sc.proc_f_2(IN STRING)
     RETURNS STRING
     VOLATILE
@@ -477,7 +410,7 @@ CREATE FUNCTION sc.proc_f_2(IN STRING)
     LANGUAGE SQL
     AS $$
     SELECT 'hello';
-$$  104  test  127  sc  128  proc_f_2
+$$  104  test  124  sc  125  proc_f_2
 CREATE FUNCTION public.f_cross_db()
     RETURNS INT8
     VOLATILE
@@ -486,7 +419,7 @@ CREATE FUNCTION public.f_cross_db()
     LANGUAGE SQL
     AS $$
     SELECT 1;
-$$  129  test_cross_db  130  public  131  f_cross_db
+$$  126  test_cross_db  127  public  128  f_cross_db
 
 subtest show_create_function
 
@@ -557,12 +490,12 @@ proc_implicit
 query I
 SELECT 'proc_implicit'::REGPROC::INT;
 ----
-100126
+100123
 
 query T
 SELECT '100126'::REGPROC;
 ----
-proc_implicit
+100126
 
 query T
 SELECT 'sc.proc_f_2'::REGPROC;
@@ -572,7 +505,7 @@ proc_f_2
 query I
 SELECT 'sc.proc_f_2'::REGPROC::INT;
 ----
-100128
+100125
 
 statement error pq: unknown function: no_such_func()
 SELECT 'no_such_func'::REGPROC;
@@ -583,7 +516,7 @@ SELECT 'proc_f'::REGPROC;
 query T
 SELECT 100126::regproc;
 ----
-proc_implicit
+100126
 
 query I
 SELECT 100117::regproc::INT;
@@ -845,3 +778,83 @@ CREATE FUNCTION public.test_vf_f()
     AS $$
     SELECT lower('hello');
 $$
+
+
+subtest execution
+
+statement ok
+INSERT INTO ab VALUES (1, 1), (2, 2), (3, 3), (4, 1), (5, 1)
+
+statement ok
+CREATE FUNCTION one() RETURNS INT LANGUAGE SQL AS 'SELECT 2-1';
+
+query I
+SELECT one()
+----
+1
+
+query I colnames
+SELECT * FROM one()
+----
+one
+1
+
+query III colnames
+SELECT *, one() FROM ab WHERE a = one()
+----
+a  b  one
+1  1  1
+
+query III colnames
+SELECT *, one() FROM ab WHERE b = one()
+----
+a  b  one
+1  1  1
+4  1  1
+5  1  1
+
+query II colnames
+SELECT * FROM ab WHERE b = one() + 1
+----
+a  b
+2  2
+
+statement ok
+CREATE FUNCTION max_in_values() RETURNS INT LANGUAGE SQL AS $$
+  SELECT i FROM (VALUES (1, 0), (2, 0), (3, 0)) AS v(i, j) ORDER BY i DESC
+$$
+
+query I
+SELECT max_in_values()
+----
+3
+
+statement ok
+CREATE FUNCTION fetch_one_then_two() RETURNS INT LANGUAGE SQL AS $$
+  SELECT b FROM ab WHERE a = 1;
+  SELECT b FROM ab WHERE a = 2;
+$$
+
+query II
+SELECT i, fetch_one_then_two()
+FROM (VALUES (1), (2), (3)) AS v(i)
+WHERE i = fetch_one_then_two()
+----
+2  2
+
+query I colnames
+SELECT * FROM fetch_one_then_two()
+----
+fetch_one_then_two
+2
+
+statement ok
+CREATE TABLE empty (e INT);
+CREATE FUNCTION empty_result() RETURNS INT LANGUAGE SQL AS $$
+  SELECT e FROM empty
+$$
+
+query I
+SELECT empty_result()
+----
+NULL

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -654,6 +654,33 @@ func (b *Builder) addSubquery(
 // buildUDF builds a UDF expression into a typed expression that can be
 // evaluated.
 func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.TypedExpr, error) {
+	udf := scalar.(*memo.UDFExpr)
+
+	// Build the input expressions.
+	var err error
+	var inputExprs tree.TypedExprs
+	if len(udf.Input) > 0 {
+		inputExprs = make(tree.TypedExprs, len(udf.Input))
+		for i := range udf.Input {
+			inputExprs[i], err = b.buildScalar(ctx, udf.Input[i])
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// argOrd returns the ordinal of the arguments that the given column ID
+	// represents. If the column does not represent an argument, then ok=false
+	// is returned.
+	argOrd := func(col opt.ColumnID) (ord int, ok bool) {
+		for i, argCol := range udf.ArgCols {
+			if col == argCol {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+
 	// Create a tree.RoutinePlanFn that can plan the statements in the UDF body.
 	// We do this planning in a separate memo. We use an exec.Factory passed to
 	// the closure rather than b.factory to support executing plans that are
@@ -663,17 +690,23 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	// exec.Factory to avoid import cycles.
 	//
 	// Note: we put o outside of the function so we allocate it only once.
-	udf := scalar.(*memo.UDFExpr)
 	var o xform.Optimizer
-	planFn := func(ctx context.Context, ref tree.RoutineExecFactory, stmtIdx int) (tree.RoutinePlan, error) {
+	planFn := func(
+		ctx context.Context, ref tree.RoutineExecFactory, stmtIdx int, input tree.Datums,
+	) (tree.RoutinePlan, error) {
 		o.Init(ctx, b.evalCtx, b.catalog)
 		f := o.Factory()
 		stmt := udf.Body[stmtIdx]
 
-		// Copy the expression into a new memo.
-		// TODO(mgartner): Replace argument references with constant values.
+		// Copy the expression into a new memo. Replace argument references with
+		// input datums.
 		var replaceFn norm.ReplaceFunc
 		replaceFn = func(e opt.Expr) opt.Expr {
+			if v, ok := e.(*memo.VariableExpr); ok {
+				if ord, ok := argOrd(v.Col); ok {
+					return f.ConstructConstVal(input[ord], v.Typ)
+				}
+			}
 			return f.CopyAndReplaceDefault(e, replaceFn)
 		}
 		f.CopyAndReplace(stmt, stmt.PhysProps, replaceFn)
@@ -704,5 +737,5 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		}
 		return plan, nil
 	}
-	return tree.NewTypedRoutineExpr(udf.Name, planFn, len(udf.Body), udf.Typ), nil
+	return tree.NewTypedRoutineExpr(udf.Name, inputExprs, planFn, len(udf.Body), udf.Typ), nil
 }

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -743,6 +743,7 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		planFn,
 		len(udf.Body),
 		udf.Typ,
+		udf.Volatility,
 		udf.CalledOnNullInput,
 	), nil
 }

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -737,5 +737,12 @@ func (b *Builder) buildUDF(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 		}
 		return plan, nil
 	}
-	return tree.NewTypedRoutineExpr(udf.Name, inputExprs, planFn, len(udf.Body), udf.Typ), nil
+	return tree.NewTypedRoutineExpr(
+		udf.Name,
+		inputExprs,
+		planFn,
+		len(udf.Body),
+		udf.Typ,
+		udf.CalledOnNullInput,
+	), nil
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -59,3 +59,39 @@ Scan /Table/106/1/1/0
 Scan /Table/106/1/2/0
 Scan /Table/106/1/1/0
 Scan /Table/106/1/2/0
+
+statement ok
+CREATE FUNCTION fetch_a_of_1(i INT) RETURNS INT CALLED ON NULL INPUT LANGUAGE SQL AS $$
+  SELECT a FROM t WHERE k = 1
+$$
+
+statement ok
+CREATE FUNCTION fetch_a_of_1_strict(i INT) RETURNS INT RETURNS NULL ON NULL INPUT LANGUAGE SQL AS $$
+  SELECT a FROM t WHERE k = 1
+$$
+
+statement ok
+CREATE FUNCTION fetch_a_of_2_strict(i INT, j INT) RETURNS INT STRICT LANGUAGE SQL AS $$
+  SELECT a FROM t WHERE k = 2
+$$
+
+# When the function is CALLED ON NULL INPUT then it should be evaluated
+# regardless of whether or not any of its inputs are NULL. The trace proves that
+# the function is evaluated. It shows the scan performed by the statement in the
+# function body.
+query T kvtrace
+SELECT fetch_a_of_1(NULL::INT)
+----
+Scan /Table/106/1/1/0
+
+# When the function RETURNS NULL ON NULL INPUT or STRICT then it should not be
+# evaluated if any of its inputs are NULL. The empty traces prove that the
+# function is not evaluated. No scan is performed for the statement in the
+# function body.
+query T kvtrace
+SELECT fetch_a_of_1_strict(NULL::INT)
+----
+
+query T kvtrace
+SELECT fetch_a_of_2_strict(1, NULL::INT)
+----

--- a/pkg/sql/opt/memo/testdata/logprops/udf
+++ b/pkg/sql/opt/memo/testdata/logprops/udf
@@ -38,17 +38,18 @@ project
       └── plus [as="?column?":6, type=int, outer=(1), volatile]
            ├── variable: a:1 [type=int]
            └── udf: fn_volatile [type=int]
-                └── project
-                     ├── columns: "?column?":5(int!null)
-                     ├── cardinality: [1 - 1]
-                     ├── key: ()
-                     ├── fd: ()-->(5)
-                     ├── values
-                     │    ├── cardinality: [1 - 1]
-                     │    ├── key: ()
-                     │    └── tuple [type=tuple]
-                     └── projections
-                          └── const: 1 [as="?column?":5, type=int]
+                └── body
+                     └── project
+                          ├── columns: "?column?":5(int!null)
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(5)
+                          ├── values
+                          │    ├── cardinality: [1 - 1]
+                          │    ├── key: ()
+                          │    └── tuple [type=tuple]
+                          └── projections
+                               └── const: 1 [as="?column?":5, type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_immutable()
@@ -76,17 +77,18 @@ project
            └── eq [type=bool, outer=(2), immutable, constraints=(/2: (/NULL - ]), fd=()-->(2)]
                 ├── variable: b:2 [type=int]
                 └── udf: fn_immutable [type=int]
-                     └── project
-                          ├── columns: "?column?":5(int!null)
-                          ├── cardinality: [1 - 1]
-                          ├── key: ()
-                          ├── fd: ()-->(5)
-                          ├── values
-                          │    ├── cardinality: [1 - 1]
-                          │    ├── key: ()
-                          │    └── tuple [type=tuple]
-                          └── projections
-                               └── const: 1 [as="?column?":5, type=int]
+                     └── body
+                          └── project
+                               ├── columns: "?column?":5(int!null)
+                               ├── cardinality: [1 - 1]
+                               ├── key: ()
+                               ├── fd: ()-->(5)
+                               ├── values
+                               │    ├── cardinality: [1 - 1]
+                               │    ├── key: ()
+                               │    └── tuple [type=tuple]
+                               └── projections
+                                    └── const: 1 [as="?column?":5, type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_immutable() + fn_stable()
@@ -115,29 +117,31 @@ project
                 ├── variable: b:2 [type=int]
                 └── plus [type=int]
                      ├── udf: fn_immutable [type=int]
-                     │    └── project
-                     │         ├── columns: "?column?":5(int!null)
-                     │         ├── cardinality: [1 - 1]
-                     │         ├── key: ()
-                     │         ├── fd: ()-->(5)
-                     │         ├── values
-                     │         │    ├── cardinality: [1 - 1]
-                     │         │    ├── key: ()
-                     │         │    └── tuple [type=tuple]
-                     │         └── projections
-                     │              └── const: 1 [as="?column?":5, type=int]
+                     │    └── body
+                     │         └── project
+                     │              ├── columns: "?column?":5(int!null)
+                     │              ├── cardinality: [1 - 1]
+                     │              ├── key: ()
+                     │              ├── fd: ()-->(5)
+                     │              ├── values
+                     │              │    ├── cardinality: [1 - 1]
+                     │              │    ├── key: ()
+                     │              │    └── tuple [type=tuple]
+                     │              └── projections
+                     │                   └── const: 1 [as="?column?":5, type=int]
                      └── udf: fn_stable [type=int]
-                          └── project
-                               ├── columns: "?column?":6(int!null)
-                               ├── cardinality: [1 - 1]
-                               ├── key: ()
-                               ├── fd: ()-->(6)
-                               ├── values
-                               │    ├── cardinality: [1 - 1]
-                               │    ├── key: ()
-                               │    └── tuple [type=tuple]
-                               └── projections
-                                    └── const: 1 [as="?column?":6, type=int]
+                          └── body
+                               └── project
+                                    ├── columns: "?column?":6(int!null)
+                                    ├── cardinality: [1 - 1]
+                                    ├── key: ()
+                                    ├── fd: ()-->(6)
+                                    ├── values
+                                    │    ├── cardinality: [1 - 1]
+                                    │    ├── key: ()
+                                    │    └── tuple [type=tuple]
+                                    └── projections
+                                         └── const: 1 [as="?column?":6, type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_leakproof()
@@ -163,14 +167,15 @@ project
            └── eq [type=bool, outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
                 ├── variable: b:2 [type=int]
                 └── udf: fn_leakproof [type=int]
-                     └── project
-                          ├── columns: "?column?":5(int!null)
-                          ├── cardinality: [1 - 1]
-                          ├── key: ()
-                          ├── fd: ()-->(5)
-                          ├── values
-                          │    ├── cardinality: [1 - 1]
-                          │    ├── key: ()
-                          │    └── tuple [type=tuple]
-                          └── projections
-                               └── const: 1 [as="?column?":5, type=int]
+                     └── body
+                          └── project
+                               ├── columns: "?column?":5(int!null)
+                               ├── cardinality: [1 - 1]
+                               ├── key: ()
+                               ├── fd: ()-->(5)
+                               ├── values
+                               │    ├── cardinality: [1 - 1]
+                               │    ├── key: ()
+                               │    └── tuple [type=tuple]
+                               └── projections
+                                    └── const: 1 [as="?column?":5, type=int]

--- a/pkg/sql/opt/norm/testdata/rules/udf
+++ b/pkg/sql/opt/norm/testdata/rules/udf
@@ -14,10 +14,11 @@ values
  ├── fd: ()-->(2)
  └── tuple
       └── udf: one
-           └── values
-                ├── columns: "?column?":1!null
-                ├── cardinality: [1 - 1]
-                ├── key: ()
-                ├── fd: ()-->(1)
-                └── tuple
-                     └── const: 1
+           └── body
+                └── values
+                     ├── columns: "?column?":1!null
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(1)
+                     └── tuple
+                          └── const: 1

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1244,6 +1244,13 @@ define UDFPrivate {
 
     # Volatility is the user-provided volatility of the function given during
     # CREATE FUNCTION.
+    #
+    # Volatility affects the visibility of mutations made by the statement
+    # calling the function. A volatile function will see these mutations. Also,
+    # statements within a volatile function's body will see changes made by
+    # previous statements in the function body. In contrast, a stable,
+    # immutable, or leakproof function will see a snapshot of the data as of the
+    # start of the statement calling the function.
     Volatility Volatility
 
     # CalledOnNullInput is true if the function should be called when any of its

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1245,6 +1245,11 @@ define UDFPrivate {
     # Volatility is the user-provided volatility of the function given during
     # CREATE FUNCTION.
     Volatility Volatility
+
+    # CalledOnNullInput is true if the function should be called when any of its
+    # inputs are NULL. If false, the function will not be evaluated in the
+    # presence of NULL inputs, and will instead evaluate directly to NULL.
+    CalledOnNullInput bool
 }
 
 # KVOptions is a set of KVOptionItems that specify arbitrary keys and values

--- a/pkg/sql/opt/ops/scalar.opt
+++ b/pkg/sql/opt/ops/scalar.opt
@@ -1219,14 +1219,31 @@ define NthValue {
 # function body, and a pointer to its type.
 [Scalar]
 define UDF {
+    # Input contains the scalar expressions given as input to the UDF.
+    Input ScalarListExpr
     _ UDFPrivate
 }
 
 [Private]
 define UDFPrivate {
+    # Name is the name of the function.
     Name string
+
+    # Body contains a relational expression for each statement in the function
+    # body.
     Body RelListExpr
+
+    # ArgCols is a list of columns that are references to arguments of the
+    # function. The i-th column in the list corresponds to the i-th argument of
+    # the function. During execution of the UDF, these columns are replaced with
+    # the constant value inputs to the function.
+    ArgCols ColList
+
+    # Typ is the return type of the function.
     Typ Type
+
+    # Volatility is the user-provided volatility of the function given during
+    # CREATE FUNCTION.
     Volatility Volatility
 }
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -536,7 +536,7 @@ func (b *Builder) buildFunction(
 	}
 
 	if f.ResolvedOverload().Body != "" {
-		return b.buildUDF(f, def, inScope, outScope, outCol)
+		return b.buildUDF(f, def, inScope, outScope, outCol, colRefs)
 	}
 
 	if f.ResolvedOverload().Class == tree.AggregateClass {
@@ -595,39 +595,88 @@ func (b *Builder) buildFunction(
 
 // buildUDF builds a set of memo groups that represents a user-defined function
 // invocation.
-// TODO(mgartner): Support UDFs with arguments.
 func (b *Builder) buildUDF(
 	f *tree.FuncExpr,
 	def *tree.ResolvedFunctionDefinition,
 	inScope, outScope *scope,
 	outCol *scopeColumn,
+	colRefs *opt.ColSet,
 ) (out opt.ScalarExpr) {
 	o := f.ResolvedOverload()
+
+	// Build the input expressions.
+	var input memo.ScalarListExpr
+	if len(f.Exprs) > 0 {
+		input = make(memo.ScalarListExpr, len(f.Exprs))
+		for i, pexpr := range f.Exprs {
+			input[i] = b.buildScalar(
+				pexpr.(tree.TypedExpr),
+				inScope,
+				nil, /* outScope */
+				nil, /* outCol */
+				colRefs,
+			)
+		}
+	}
+
+	// Create a new scope for building the statements in the function body. We
+	// start with an empty scope because a statement in the function body cannot
+	// refer to anything from the outer expression. If there are function
+	// arguments, we add them as columns to the scope so that references to them
+	// can be resolved.
+	//
+	// TODO(mgartner): Support anonymous arguments and placeholder-like syntax
+	// for referencing arguments, e.g., $1.
+	//
+	// TODO(mgartner): We may need to set bodyScope.atRoot=true to prevent
+	// CTEs that mutate and are not at the top-level.
+	//
+	bodyScope := b.allocScope()
+	var argCols opt.ColList
+	if o.Types.Length() > 0 {
+		args, ok := o.Types.(tree.ArgTypes)
+		if !ok {
+			// TODO(mgartner): Create an issue for this and link it here.
+			panic(unimplemented.New("user-defined functions",
+				"variadiac user-defined functions are not yet supported"))
+		}
+		argCols = make(opt.ColList, len(args))
+		for i := range args {
+			arg := &args[i]
+			id := b.factory.Metadata().AddColumn(arg.Name, arg.Typ)
+			argCols[i] = id
+			bodyScope.appendColumn(&scopeColumn{
+				name: scopeColName(tree.Name(arg.Name)),
+				typ:  arg.Typ,
+				id:   id,
+			})
+		}
+	}
+
+	// Parse the function body.
 	stmts, err := parser.Parse(o.Body)
 	if err != nil {
 		panic(err)
 	}
 
+	// Build an expression for each statement in the function body.
 	rels := make(memo.RelListExpr, len(stmts))
 	for i := range stmts {
-		// A statement inside a UDF body cannot refer to anything from the outer
-		// expression calling the function, so we use an empty scope.
-		// TODO(mgartner): We may need to set bodyScope.atRoot=true to prevent
-		// CTEs that mutate and are not at the top-level.
-		bodyScope := b.allocScope()
-		bodyScope = b.buildStmt(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+		stmtScope := b.buildStmt(stmts[i].AST, nil /* desiredTypes */, bodyScope)
 		rels[i] = memo.RelRequiredPropsExpr{
-			RelExpr:   bodyScope.expr,
-			PhysProps: bodyScope.makePhysicalProps(),
+			RelExpr:   stmtScope.expr,
+			PhysProps: stmtScope.makePhysicalProps(),
 		}
 	}
 
 	out = b.factory.ConstructUDF(
+		input,
 		&memo.UDFPrivate{
 			Name:       def.Name,
 			Body:       rels,
 			Typ:        f.ResolvedType(),
 			Volatility: o.Volatility,
+			ArgCols:    argCols,
 		},
 	)
 	return b.finishBuildScalar(f, out, inScope, outScope, outCol)

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -672,11 +672,12 @@ func (b *Builder) buildUDF(
 	out = b.factory.ConstructUDF(
 		input,
 		&memo.UDFPrivate{
-			Name:       def.Name,
-			Body:       rels,
-			Typ:        f.ResolvedType(),
-			Volatility: o.Volatility,
-			ArgCols:    argCols,
+			Name:              def.Name,
+			ArgCols:           argCols,
+			Body:              rels,
+			Typ:               f.ResolvedType(),
+			Volatility:        o.Volatility,
+			CalledOnNullInput: o.CalledOnNullInput,
 		},
 	)
 	return b.finishBuildScalar(f, out, inScope, outScope, outCol)

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -6,6 +6,10 @@ CREATE TABLE abc (
 )
 ----
 
+# --------------------------------------------------
+# UDFs without arguments.
+# --------------------------------------------------
+
 build
 SELECT foo()
 ----
@@ -31,12 +35,13 @@ project
  │    └── tuple
  └── projections
       └── udf: one [as=one:2]
-           └── project
-                ├── columns: "?column?":1!null
-                ├── values
-                │    └── tuple
-                └── projections
-                     └── const: 1 [as="?column?":1]
+           └── body
+                └── project
+                     ├── columns: "?column?":1!null
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── const: 1 [as="?column?":1]
 
 build format=show-scalars
 SELECT *, one() FROM abc
@@ -47,12 +52,13 @@ project
  │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
  └── projections
       └── udf: one [as=one:7]
-           └── project
-                ├── columns: "?column?":6!null
-                ├── values
-                │    └── tuple
-                └── projections
-                     └── const: 1 [as="?column?":6]
+           └── body
+                └── project
+                     ├── columns: "?column?":6!null
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── const: 1 [as="?column?":6]
 
 build format=show-scalars
 SELECT * FROM abc WHERE one() = c
@@ -66,12 +72,13 @@ project
       └── filters
            └── eq
                 ├── udf: one
-                │    └── project
-                │         ├── columns: "?column?":6!null
-                │         ├── values
-                │         │    └── tuple
-                │         └── projections
-                │              └── const: 1 [as="?column?":6]
+                │    └── body
+                │         └── project
+                │              ├── columns: "?column?":6!null
+                │              ├── values
+                │              │    └── tuple
+                │              └── projections
+                │                   └── const: 1 [as="?column?":6]
                 └── variable: c:3
 
 build format=show-scalars
@@ -87,40 +94,329 @@ project
  │         └── eq
  │              ├── variable: c:3
  │              └── udf: two
- │                   ├── project
- │                   │    ├── columns: "?column?":6!null
- │                   │    ├── values
- │                   │    │    └── tuple
- │                   │    └── projections
- │                   │         └── const: 1 [as="?column?":6]
- │                   └── project
- │                        ├── columns: "?column?":7!null
- │                        ├── values
- │                        │    └── tuple
- │                        └── projections
- │                             └── const: 2 [as="?column?":7]
+ │                   └── body
+ │                        ├── project
+ │                        │    ├── columns: "?column?":6!null
+ │                        │    ├── values
+ │                        │    │    └── tuple
+ │                        │    └── projections
+ │                        │         └── const: 1 [as="?column?":6]
+ │                        └── project
+ │                             ├── columns: "?column?":7!null
+ │                             ├── values
+ │                             │    └── tuple
+ │                             └── projections
+ │                                  └── const: 2 [as="?column?":7]
  └── projections
       ├── plus [as="?column?":9]
       │    ├── variable: a:1
       │    └── udf: one
-      │         └── project
-      │              ├── columns: "?column?":8!null
-      │              ├── values
-      │              │    └── tuple
-      │              └── projections
-      │                   └── const: 1 [as="?column?":8]
+      │         └── body
+      │              └── project
+      │                   ├── columns: "?column?":8!null
+      │                   ├── values
+      │                   │    └── tuple
+      │                   └── projections
+      │                        └── const: 1 [as="?column?":8]
       └── plus [as="?column?":12]
            ├── variable: b:2
            └── udf: two
-                ├── project
-                │    ├── columns: "?column?":10!null
-                │    ├── values
-                │    │    └── tuple
-                │    └── projections
-                │         └── const: 1 [as="?column?":10]
+                └── body
+                     ├── project
+                     │    ├── columns: "?column?":10!null
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── const: 1 [as="?column?":10]
+                     └── project
+                          ├── columns: "?column?":11!null
+                          ├── values
+                          │    └── tuple
+                          └── projections
+                               └── const: 2 [as="?column?":11]
+
+
+# --------------------------------------------------
+# UDFs with named arguments.
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION add(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT x+y;
+$$;
+----
+
+build format=show-scalars
+SELECT add(1, 2)
+----
+project
+ ├── columns: add:4
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add [as=add:4]
+           ├── args: x:1 y:2
+           ├── input
+           │    ├── const: 1
+           │    └── const: 2
+           └── body
                 └── project
-                     ├── columns: "?column?":11!null
+                     ├── columns: "?column?":3
                      ├── values
                      │    └── tuple
                      └── projections
-                          └── const: 2 [as="?column?":11]
+                          └── plus [as="?column?":3]
+                               ├── variable: x:1
+                               └── variable: y:2
+
+build format=show-scalars
+SELECT add(add(1, 2), 3)
+----
+project
+ ├── columns: add:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add [as=add:7]
+           ├── args: x:4 y:5
+           ├── input
+           │    ├── udf: add
+           │    │    ├── args: x:1 y:2
+           │    │    ├── input
+           │    │    │    ├── const: 1
+           │    │    │    └── const: 2
+           │    │    └── body
+           │    │         └── project
+           │    │              ├── columns: "?column?":3
+           │    │              ├── values
+           │    │              │    └── tuple
+           │    │              └── projections
+           │    │                   └── plus [as="?column?":3]
+           │    │                        ├── variable: x:1
+           │    │                        └── variable: y:2
+           │    └── const: 3
+           └── body
+                └── project
+                     ├── columns: "?column?":6
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":6]
+                               ├── variable: x:4
+                               └── variable: y:5
+
+build format=show-scalars
+SELECT add(a, b) FROM abc
+----
+project
+ ├── columns: add:9
+ ├── scan abc
+ │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ └── projections
+      └── udf: add [as=add:9]
+           ├── args: x:6 y:7
+           ├── input
+           │    ├── variable: a:1
+           │    └── variable: b:2
+           └── body
+                └── project
+                     ├── columns: "?column?":8
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":8]
+                               ├── variable: x:6
+                               └── variable: y:7
+
+build format=show-scalars
+SELECT * FROM abc WHERE a = add(b, c)
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── variable: a:1
+                └── udf: add
+                     ├── args: x:6 y:7
+                     ├── input
+                     │    ├── variable: b:2
+                     │    └── variable: c:3
+                     └── body
+                          └── project
+                               ├── columns: "?column?":8
+                               ├── values
+                               │    └── tuple
+                               └── projections
+                                    └── plus [as="?column?":8]
+                                         ├── variable: x:6
+                                         └── variable: y:7
+
+build format=show-scalars
+SELECT * FROM abc WHERE a = add(add(b, c), 3)
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── variable: a:1
+                └── udf: add
+                     ├── args: x:9 y:10
+                     ├── input
+                     │    ├── udf: add
+                     │    │    ├── args: x:6 y:7
+                     │    │    ├── input
+                     │    │    │    ├── variable: b:2
+                     │    │    │    └── variable: c:3
+                     │    │    └── body
+                     │    │         └── project
+                     │    │              ├── columns: "?column?":8
+                     │    │              ├── values
+                     │    │              │    └── tuple
+                     │    │              └── projections
+                     │    │                   └── plus [as="?column?":8]
+                     │    │                        ├── variable: x:6
+                     │    │                        └── variable: y:7
+                     │    └── const: 3
+                     └── body
+                          └── project
+                               ├── columns: "?column?":11
+                               ├── values
+                               │    └── tuple
+                               └── projections
+                                    └── plus [as="?column?":11]
+                                         ├── variable: x:9
+                                         └── variable: y:10
+
+exec-ddl
+CREATE FUNCTION fetch_b(a_arg INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT b FROM abc WHERE a = a_arg
+$$;
+----
+
+build format=show-scalars
+SELECT fetch_b(1)
+----
+project
+ ├── columns: fetch_b:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: fetch_b [as=fetch_b:7]
+           ├── args: a_arg:1
+           ├── input
+           │    └── const: 1
+           └── body
+                └── project
+                     ├── columns: b:3
+                     └── select
+                          ├── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                          ├── scan abc
+                          │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                          └── filters
+                               └── eq
+                                    ├── variable: a:2
+                                    └── variable: a_arg:1
+
+build format=show-scalars
+SELECT fetch_b(add(1, 2))
+----
+project
+ ├── columns: fetch_b:10
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: fetch_b [as=fetch_b:10]
+           ├── args: a_arg:4
+           ├── input
+           │    └── udf: add
+           │         ├── args: x:1 y:2
+           │         ├── input
+           │         │    ├── const: 1
+           │         │    └── const: 2
+           │         └── body
+           │              └── project
+           │                   ├── columns: "?column?":3
+           │                   ├── values
+           │                   │    └── tuple
+           │                   └── projections
+           │                        └── plus [as="?column?":3]
+           │                             ├── variable: x:1
+           │                             └── variable: y:2
+           └── body
+                └── project
+                     ├── columns: b:6
+                     └── select
+                          ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+                          ├── scan abc
+                          │    └── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+                          └── filters
+                               └── eq
+                                    ├── variable: a:5
+                                    └── variable: a_arg:4
+
+build format=show-scalars
+SELECT * FROM abc WHERE b = fetch_b(a)
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ └── select
+      ├── columns: a:1!null b:2!null c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── variable: b:2
+                └── udf: fetch_b
+                     ├── args: a_arg:6
+                     ├── input
+                     │    └── variable: a:1
+                     └── body
+                          └── project
+                               ├── columns: b:8
+                               └── select
+                                    ├── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+                                    ├── scan abc
+                                    │    └── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+                                    └── filters
+                                         └── eq
+                                              ├── variable: a:7
+                                              └── variable: a_arg:6
+
+exec-ddl
+CREATE FUNCTION shadowed_a(a INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT c FROM abc WHERE abc.b = a
+$$;
+----
+
+# The column "a" from the table takes precedence over the argument "a".
+build format=show-scalars
+SELECT shadowed_a(1)
+----
+project
+ ├── columns: shadowed_a:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: shadowed_a [as=shadowed_a:7]
+           ├── args: a:1
+           ├── input
+           │    └── const: 1
+           └── body
+                └── project
+                     ├── columns: c:4
+                     └── select
+                          ├── columns: abc.a:2!null b:3!null c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                          ├── scan abc
+                          │    └── columns: abc.a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                          └── filters
+                               └── eq
+                                    ├── variable: b:3
+                                    └── variable: abc.a:2

--- a/pkg/sql/opt/testutils/testcat/testdata/udf
+++ b/pkg/sql/opt/testutils/testcat/testdata/udf
@@ -55,3 +55,13 @@ SHOW CREATE FUNCTION e
 ----
 FUNCTION e(i: int) -> int [immutable, called-on-null-input=false]
  └── SELECT i
+
+exec-ddl
+CREATE FUNCTION f() RETURNS INT RETURNS NULL ON NULL INPUT LANGUAGE SQL AS 'SELECT 1'
+----
+
+exec-ddl
+SHOW CREATE FUNCTION f
+----
+FUNCTION f() -> int [volatile, called-on-null-input=false]
+ └── SELECT 1

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -75,6 +75,10 @@ func (p *planner) EvalRoutineExpr(
 	if err != nil {
 		return nil, err
 	}
+	if res == nil {
+		// Return NULL if there are no results.
+		return tree.DNull, nil
+	}
 	return res[0], nil
 }
 

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -24,6 +24,16 @@ import (
 func (p *planner) EvalRoutineExpr(
 	ctx context.Context, expr *tree.RoutineExpr, input tree.Datums,
 ) (result tree.Datum, err error) {
+	// If the routine should not be called on null input, then directly return
+	// NULL if any of the datums in the input are NULL.
+	if !expr.CalledOnNullInput {
+		for i := range input {
+			if input[i] == tree.DNull {
+				return tree.DNull, nil
+			}
+		}
+	}
+
 	retTypes := []*types.T{expr.ResolvedType()}
 
 	// The result of the routine is the result of the last statement. The result

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -203,8 +203,11 @@ type Planner interface {
 	// EvalSubquery returns the Datum for the given subquery node.
 	EvalSubquery(expr *tree.Subquery) (tree.Datum, error)
 
-	// EvalRoutineExpr evaluates a routine and returns the resulting datum.
-	EvalRoutineExpr(ctx context.Context, expr *tree.RoutineExpr) (tree.Datum, error)
+	// EvalRoutineExpr evaluates a routine with the given input datums and
+	// returns the resulting datum.
+	EvalRoutineExpr(
+		ctx context.Context, expr *tree.RoutineExpr, input tree.Datums,
+	) (tree.Datum, error)
 
 	// UnsafeUpsertDescriptor is used to repair descriptors in dire
 	// circumstances. See the comment on the planner implementation.

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -50,19 +50,30 @@ type RoutineExpr struct {
 	// Typ is the type of the routine's result.
 	Typ *types.T
 
+	// CalledOnNullInput is true if the function should be called when any of
+	// its inputs are NULL. If false, the function will not be evaluated in the
+	// presence of null inputs, and will instead evaluate directly to NULL.
+	CalledOnNullInput bool
+
 	name string
 }
 
 // NewTypedRoutineExpr returns a new RoutineExpr that is well-typed.
 func NewTypedRoutineExpr(
-	name string, input TypedExprs, planFn RoutinePlanFn, numStmts int, typ *types.T,
+	name string,
+	input TypedExprs,
+	planFn RoutinePlanFn,
+	numStmts int,
+	typ *types.T,
+	calledOnNullInput bool,
 ) *RoutineExpr {
 	return &RoutineExpr{
-		Input:    input,
-		PlanFn:   planFn,
-		NumStmts: numStmts,
-		Typ:      typ,
-		name:     name,
+		Input:             input,
+		PlanFn:            planFn,
+		NumStmts:          numStmts,
+		Typ:               typ,
+		CalledOnNullInput: calledOnNullInput,
+		name:              name,
 	}
 }
 

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -18,7 +18,9 @@ import (
 
 // RoutinePlanFn creates a plan for the execution of one statement within a
 // routine.
-type RoutinePlanFn func(_ context.Context, _ RoutineExecFactory, stmtIdx int) (RoutinePlan, error)
+type RoutinePlanFn func(
+	_ context.Context, _ RoutineExecFactory, stmtIdx int, input Datums,
+) (RoutinePlan, error)
 
 // RoutinePlan represents a plan for a statement in a routine. It currently maps
 // to exec.Plan. We use the empty interface here rather then exec.Plan to avoid
@@ -36,18 +38,27 @@ type RoutineExecFactory interface{}
 // function. It is only created by execbuilder - it is never constructed during
 // parsing.
 type RoutineExpr struct {
-	PlanFn   RoutinePlanFn
+	// Input contains the input expressions to the routine.
+	Input TypedExprs
+
+	// PlanFn returns an exec plan for a given statement in the routine.
+	PlanFn RoutinePlanFn
+
+	// NumStmts is the number of statements in the routine.
 	NumStmts int
-	Typ      *types.T
+
+	// Typ is the type of the routine's result.
+	Typ *types.T
 
 	name string
 }
 
 // NewTypedRoutineExpr returns a new RoutineExpr that is well-typed.
 func NewTypedRoutineExpr(
-	name string, planFn RoutinePlanFn, numStmts int, typ *types.T,
+	name string, input TypedExprs, planFn RoutinePlanFn, numStmts int, typ *types.T,
 ) *RoutineExpr {
 	return &RoutineExpr{
+		Input:    input,
 		PlanFn:   planFn,
 		NumStmts: numStmts,
 		Typ:      typ,
@@ -69,7 +80,14 @@ func (node *RoutineExpr) ResolvedType() *types.T {
 
 // Format is part of the Expr interface.
 func (node *RoutineExpr) Format(ctx *FmtCtx) {
-	ctx.Printf("%s()", node.name)
+	ctx.Printf("%s(", node.name)
+	for i := range node.Input {
+		node.Input[i].Format(ctx)
+		if i > 0 {
+			ctx.WriteString(", ")
+		}
+	}
+	ctx.WriteByte(')')
 }
 
 // Walk is part of the Expr interface.

--- a/pkg/sql/sem/tree/routine.go
+++ b/pkg/sql/sem/tree/routine.go
@@ -13,6 +13,7 @@ package tree
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -50,6 +51,14 @@ type RoutineExpr struct {
 	// Typ is the type of the routine's result.
 	Typ *types.T
 
+	// Volatility affects the visibility of mutations made by the statement
+	// invoking the routine. A volatile routine will see these mutations. Also,
+	// statements within a volatile function's body will see changes made by
+	// previous statements in the routine. In contrast, a stable, immutable,
+	// or leakproof function will see a snapshot of the data as of the start of
+	// the statement calling the function.
+	Volatility volatility.V
+
 	// CalledOnNullInput is true if the function should be called when any of
 	// its inputs are NULL. If false, the function will not be evaluated in the
 	// presence of null inputs, and will instead evaluate directly to NULL.
@@ -65,6 +74,7 @@ func NewTypedRoutineExpr(
 	planFn RoutinePlanFn,
 	numStmts int,
 	typ *types.T,
+	v volatility.V,
 	calledOnNullInput bool,
 ) *RoutineExpr {
 	return &RoutineExpr{
@@ -72,6 +82,7 @@ func NewTypedRoutineExpr(
 		PlanFn:            planFn,
 		NumStmts:          numStmts,
 		Typ:               typ,
+		Volatility:        v,
 		CalledOnNullInput: calledOnNullInput,
 		name:              name,
 	}


### PR DESCRIPTION
#### sql: UDF with empty result should evaluate to NULL

If the last statement in a UDF returns no rows, the UDF will evaluate to
NULL. Prior to this commit the evaluation of the UDF would panic.

Release note: None

#### sql: support UDFs with named arguments

UDFs with named arguments can now be evaluated.

During query planning, statements in the function body are built with a
scope that includes the named arguments for the function as columns.
This allows references to arguments to be resolved as variables.

During evaluation, the input expressions are first evaluated into
datums. When a plan is built for each statement in the UDF, the argument
columns in the expression are replaced with the input datums before the
expression is optimized.

Note that anonymous arguments and integer references to arguments (e.g.,
`$1`) are not yet supported.

Also, the formatting of `UDFExpr`s has been improved to show argument
columns and input expressions.

Release note: None

#### sql: do not evaluate strict UDFs if any input values are NULL

A UDF can have one of two behaviors when it is invoked with NULL inputs:

  1. If the UDF is `CALLED ON NULL INPUT` (the default) then the
     function is evaluated regardless of whether or not any of the input
     values are NULL.
  2. If the UDF `RETURNS NULL ON NULL INPUT` or is `STRICT` then the
     function is not evaluated if any of the input values are NULL.
     Instead, the function directly results in NULL.

This commit implements these two behaviors.

In the future, we can add a normalization rule that folds a strict UDF
if any of its inputs are constant NULL values.

Release note: None

#### sql: make mutations visible to volatile UDFs

The volatility of a UDF affects the visibility of mutations made by the
statement calling the function. A volatile function will see these
mutations. Also, statements within a volatile function's body will see
changes made by previous statements the function body (note that this is
left untested in this commit because we do not currently support
mutations within UDF bodies). In contrast, a stable, immutable, or
leakproof function will see a snapshot of the data as of the start of
the statement calling the function.

Release note: None
