### PR TITLE
sql/logictest: create_as fails intermittently

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -463,6 +463,13 @@ func TestTenantLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestTenantLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestTenantLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -382,17 +382,3 @@ query I
 SELECT * FROM tab_from_seq
 ----
 2
-
-# Regression test for #81554, where tried to do gigantic batches for CTAS in
-# explicit transactions. Use a fixed command size, so that an error is decoupled
-# fom the default size.
-statement ok
-SET CLUSTER SETTING kv.raft.command.max_size='5m'
-
-statement ok
-BEGIN;
-CREATE TABLE source_tbl_huge AS SELECT 1::CHAR(256) FROM generate_series(1, 500000);
-COMMIT;
-
-statement ok
-SET CLUSTER SETTING kv.raft.command.max_size to default

--- a/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/create_as_non_metamorphic
@@ -1,0 +1,16 @@
+# LogicTest: !metamorphic
+# Disabled to allow us to validate create as with large batch sizes.
+
+# Regression test for #81554, where tried to do gigantic batches for CTAS in
+# explicit transactions. Use a fixed command size, so that an error is decoupled
+# fom the default size.
+statement ok
+SET CLUSTER SETTING kv.raft.command.max_size='5m'
+
+statement ok
+BEGIN;
+CREATE TABLE source_tbl_huge AS SELECT 1::CHAR(256) FROM generate_series(1, 500000);
+COMMIT;
+
+statement ok
+SET CLUSTER SETTING kv.raft.command.max_size to default

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -436,6 +436,13 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -436,6 +436,13 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -436,6 +436,13 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -436,6 +436,13 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -450,6 +450,13 @@ func TestLogic_create_as(
 	runLogicTest(t, "create_as")
 }
 
+func TestLogic_create_as_non_metamorphic(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_as_non_metamorphic")
+}
+
 func TestLogic_create_index(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Fixes: #85357

Previously, when we added the CTAS test for validating
tables with statements that exceed the raft command size,
we did not take into account that the number of bytes for
flushing can be adjusted in a metamorphic way. This was
inadequate because with metamorphic testing the value
could potentially be larger than the raft command size,
which would cause rows to never get flushed. To address this,
this patch moves the logic test into a non-metamorphic test
for sanity testing.

Release note: None