### PR TITLE
sql/rowexec: check MustBeStreaming on instantiated generators

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -846,7 +846,6 @@ func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
 
 func TestTenantStreamingDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 85630, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// TODO(casper): disabled due to error when setting a cluster setting


### PR DESCRIPTION
In projectSetProcessor, the `gen` array is not populated until
nextInputRow() is called in Next.  But, we expected that these
generators had been populated in MustBeStreaming which is called
before Next() is called.

As a result, rows returned streaming value generators were still
buffered.

I believe this is the main cause of #85630 and other odd behaviour
we've seen in the tenant replication tests.

Release note: None