### PR TITLE
scripts/bench: stream output during run

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -46,7 +46,7 @@ for (( i=0; i<${#shas[@]}; i+=1 )); do
   sha=${shas[i]}
   echo "Switching to $name"
   git checkout -q "$sha"
-  (set -x; ./dev bench ${PKG} --timeout=${BENCHTIMEOUT:-5m} --filter=${BENCHES} --count=10 --bench-mem -v --ignore-cache > "${dest}/bench.${name}" 2> "${dest}/log.txt")
+  (set -x; ./dev bench ${PKG} --timeout=${BENCHTIMEOUT:-5m} --filter=${BENCHES} --count=10 --bench-mem -v --stream-output --ignore-cache > "${dest}/bench.${name}" 2> "${dest}/log.txt")
 done
 
 benchstat "${dest}/bench.$OLDNAME" "${dest}/bench.$NEWNAME"


### PR DESCRIPTION
Makes it easier to `tail -f` the output files during: https://github.com/cockroachdb/cockroach/pull/85724#issuecomment-1208843814.

Release note: None