### PR TITLE
lease: fix test flake

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1140,7 +1140,6 @@ INSERT INTO t.kv VALUES ('a', 'b');
 	}
 
 	tableSpan := tableDesc.TableSpan(keys.SystemSQLCodec)
-	tests.CheckKeyCount(t, kvDB, tableSpan, 4)
 
 	// Allow async schema change waiting for GC to complete (when dropping an
 	// index) and clear the index keys.


### PR DESCRIPTION
We were asserting a transient, intermediate state. There was no need to assert it.

Fixes #85513

Release note: None