### PR TITLE
sql: deflake TestRevertingJobsOnDatabasesAndSchemas

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6923,8 +6923,7 @@ func TestRevertingJobsOnDatabasesAndSchemas(t *testing.T) {
 				go func(scStmt string) {
 					// This transaction will not return until the server is shutdown. Therefore,
 					// we run it in a separate goroutine and don't check the returned error.
-					sqlDB.Exec(t, `SET use_declarative_schema_changer = 'off'`)
-					_, _ = db.Exec(scStmt)
+					_, _ = db.Exec(`SET use_declarative_schema_changer = 'off'; ` + scStmt)
 				}(tc.scStmt)
 				// Verify that the job is in retry state while reverting.
 				const query = `SELECT num_runs > 3 FROM crdb_internal.jobs WHERE status = '` + string(jobs.StatusReverting) + `' AND description ~ '%s'`


### PR DESCRIPTION
The setting of the variable was not in the same session we needed it to be in.

Fixes #77048

Release note: None