### PR TITLE
ui: fix time window selection with mouse on Metrics charts

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/components/linegraph/index.tsx
@@ -207,9 +207,11 @@ export class LineGraph extends React.Component<LineGraphProps, {}> {
       start: moment.unix(start),
       end: moment.unix(end),
     };
+    const seconds = moment.duration(moment.utc(end).diff(start)).asSeconds();
     let newTimeScale: TimeScale = {
-      ...findClosestTimeScale(defaultTimeScaleOptions, end - start, start),
+      ...findClosestTimeScale(defaultTimeScaleOptions, seconds),
       key: "Custom",
+      windowSize: moment.duration(moment.unix(end).diff(moment.unix(start))),
       fixedWindowEnd: moment.unix(end),
     };
     if (this.props.adjustTimeScaleOnChange) {


### PR DESCRIPTION
This patch fixes an issue that prevents proper time selection
with mouse on Metrics charts. The root cause of it is
updated time scale object didn't include correct value
of `windowSize` that's used to calculate `start` position
of time range.

Release note (ui change): fix issue with incorrect start time
position of selected time range on Metrics page.

Resolves: #84001