### PR TITLE
build: enable required release justifications for stability period

### DIFF
--- a/githooks/commit-msg
+++ b/githooks/commit-msg
@@ -52,7 +52,7 @@ IFS='
 notes=($($grep -iE '^release note' "$1"))
 
 # Set this to 1 to require a release justification note.
-require_justification=0
+require_justification=1
 justification=($($grep -iE '^release justification: \S+' "$1"))
 
 IFS=$saveIFS

--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -2,7 +2,7 @@
 #
 # Prepare the commit message by adding a release note.
 
-require_justification=0
+require_justification=1
 set -euo pipefail
 
 if [[ "${2-}" = "message" ]]; then


### PR DESCRIPTION
Addresses RE-235.

To begin stability period for the 22.2 release.

Will merge Sunday night.

Release justification: non-production code change
Release note: None