### PR TITLE
bazel: bump size of `serverccl_test`

### DIFF
--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
 
 go_test(
     name = "serverccl_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "admin_test.go",
         "chart_catalog_test.go",


### PR DESCRIPTION
This has timed out in CI.

Release note: None