### PR TITLE
kvevent: refactor blocking buffer to use chunked linked list

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "alloc.go",
         "blocking_buffer.go",
         "chan_buffer.go",
+        "chunked_event_queue.go",
         "err_buffer.go",
         "event.go",
         "metrics.go",
@@ -38,6 +39,7 @@ go_test(
         "alloc_test.go",
         "bench_test.go",
         "blocking_buffer_test.go",
+        "chunked_event_queue_test.go",
     ],
     embed = [":kvevent"],
     deps = [
@@ -58,6 +60,7 @@ go_test(
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvevent/chunked_event_queue.go
+++ b/pkg/ccl/changefeedccl/kvevent/chunked_event_queue.go
@@ -1,0 +1,121 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import "sync"
+
+const bufferEventChunkArrSize = 128
+
+// bufferEventChunkQueue is a queue implemented as a linked-list of bufferEntry.
+type bufferEventChunkQueue struct {
+	head, tail *bufferEventChunk
+}
+
+func (l *bufferEventChunkQueue) enqueue(e Event) {
+	if l.tail == nil {
+		chunk := newBufferEntryChunk()
+		l.head, l.tail = chunk, chunk
+		l.head.push(e) // guaranteed to insert into new chunk
+		return
+	}
+
+	if !l.tail.push(e) {
+		chunk := newBufferEntryChunk()
+		l.tail.next = chunk
+		l.tail = chunk
+		l.tail.push(e) // guaranteed to insert into new chunk
+	}
+}
+
+func (l *bufferEventChunkQueue) empty() bool {
+	return l.head == nil || l.head.empty()
+}
+
+func (l *bufferEventChunkQueue) dequeue() (e Event, ok bool) {
+	if l.head == nil {
+		return Event{}, false
+	}
+
+	e, ok, consumedAllFromChunk := l.head.pop()
+
+	if consumedAllFromChunk {
+		toFree := l.head
+		if l.tail == l.head {
+			l.tail = l.head.next
+		}
+		l.head = l.head.next
+		freeBufferEventChunk(toFree)
+		return l.dequeue()
+	}
+
+	if !ok {
+		return Event{}, false
+	}
+
+	return e, true
+
+}
+
+func (l *bufferEventChunkQueue) purge() {
+	for l.head != nil {
+		chunkToFree := l.head
+		l.head = l.head.next
+		freeBufferEventChunk(chunkToFree)
+	}
+	l.tail = l.head
+}
+
+type bufferEventChunk struct {
+	events     [bufferEventChunkArrSize]Event
+	head, tail int32
+	next       *bufferEventChunk // linked-list element
+}
+
+var bufferEntryChunkPool = sync.Pool{
+	New: func() interface{} {
+		return new(bufferEventChunk)
+	},
+}
+
+func newBufferEntryChunk() *bufferEventChunk {
+	return bufferEntryChunkPool.Get().(*bufferEventChunk)
+}
+
+func freeBufferEventChunk(c *bufferEventChunk) {
+	*c = bufferEventChunk{}
+	bufferEntryChunkPool.Put(c)
+}
+
+func (bec *bufferEventChunk) push(e Event) (inserted bool) {
+	if bec.tail == bufferEventChunkArrSize {
+		return false
+	}
+
+	bec.events[bec.tail] = e
+	bec.tail++
+	return true
+}
+
+func (bec *bufferEventChunk) pop() (e Event, ok bool, consumedAll bool) {
+	if bec.head == bufferEventChunkArrSize {
+		return Event{}, false, true
+	}
+
+	if bec.head == bec.tail {
+		return Event{}, false, false
+	}
+
+	e = bec.events[bec.head]
+	bec.head++
+	return e, true, false
+}
+
+func (bec *bufferEventChunk) empty() bool {
+	return bec.tail == bec.head
+}

--- a/pkg/ccl/changefeedccl/kvevent/chunked_event_queue_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/chunked_event_queue_test.go
@@ -1,0 +1,62 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferEntryQueue(t *testing.T) {
+	rand, _ := randutil.NewTestRand()
+
+	q := bufferEventChunkQueue{}
+
+	// Add one event and remove it
+	assert.True(t, q.empty())
+	q.enqueue(Event{})
+	assert.False(t, q.empty())
+	_, ok := q.dequeue()
+	assert.True(t, ok)
+	assert.True(t, q.empty())
+
+	// Add events to fill 5 chunks and assume they are consumed in fifo order.
+	eventCount := bufferEventChunkArrSize * 5
+	lastPop := -1
+	lastPush := -1
+
+	for eventCount > 0 {
+		op := rand.Intn(2)
+		if op == 0 {
+			q.enqueue(Event{approxSize: lastPush + 1})
+			lastPush++
+		} else {
+			e, ok := q.dequeue()
+			if !ok {
+				assert.Equal(t, lastPop, lastPush)
+				assert.True(t, q.empty())
+			} else {
+				assert.Equal(t, e.approxSize, lastPop+1)
+				lastPop++
+				eventCount--
+			}
+		}
+	}
+
+	// Verify that purging works.
+	eventCount = bufferEventChunkArrSize * 2.5
+	for eventCount > 0 {
+		q.enqueue(Event{approxSize: lastPush + 1})
+		eventCount--
+	}
+	q.purge()
+	assert.True(t, q.empty())
+}


### PR DESCRIPTION
This change updates `kvevent.blockingBuffer` to use a chunked linked list instead of a regular linked list. It also updates the benchmark we use to measure performance for this struct. Please see the commit messages for more info.

Results:
```
name          old time/op    new time/op    delta
MemBuffer-10     377ms ± 1%     511ms ± 0%  +35.54%  (p=0.000 n=8+9)

name          old alloc/op   new alloc/op   delta
MemBuffer-10    33.6MB ± 0%     0.4MB ± 3%  -98.93%  (p=0.000 n=9+10)

name          old allocs/op  new allocs/op  delta
MemBuffer-10       120 ±10%       111 ±11%   -6.86%  (p=0.030 n=10+10)

```

The chunked implementation writes exactly the same # of events as the old implementation, which is about ~1179330 events.

Fixes: https://github.com/cockroachdb/cockroach/issues/84709
Fixes: https://github.com/cockroachdb/cockroach/issues/84582
(for now...)