### PR TITLE
sql/schemachanger: Enable adding/dropping path of check constraint

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -51,7 +51,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scbackup"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1579,10 +1578,10 @@ func revalidateIndexes(
 
 	// We don't actually need the 'historical' read the way the schema change does
 	// since our table is offline.
-	var runner sqlutil.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn sqlutil.InternalExecFn) error {
+	var runner descs.HistoricalInternalExecTxnRunner = func(ctx context.Context, fn descs.InternalExecFn) error {
 		return execCfg.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			ie := job.MakeSessionBoundInternalExecutor(sql.NewFakeSessionData(execCfg.SV())).(*sql.InternalExecutor)
-			return fn(ctx, txn, ie)
+			return fn(ctx, txn, ie, nil /* descriptors */)
 		})
 	}
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -974,7 +974,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	jobRegistry.SetInternalExecutorFactory(ieFactory)
 	execCfg.IndexBackfiller = sql.NewIndexBackfiller(execCfg)
 	execCfg.IndexMerger = sql.NewIndexBackfillerMergePlanner(execCfg)
-	execCfg.IndexValidator = scdeps.NewIndexValidator(
+	execCfg.Validator = scdeps.NewValidator(
 		execCfg.DB,
 		execCfg.Codec,
 		execCfg.Settings,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -979,8 +979,10 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		execCfg.Codec,
 		execCfg.Settings,
 		ieFactory,
+		collectionFactory,
 		sql.ValidateForwardIndexes,
 		sql.ValidateInvertedIndexes,
+		sql.ValidateCheckConstraint,
 		sql.NewFakeSessionData,
 	)
 	execCfg.InternalExecutorFactory = ieFactory

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1513,6 +1513,42 @@ func (e InvalidIndexesError) Error() string {
 	return fmt.Sprintf("found %d invalid indexes", len(e.Indexes))
 }
 
+// ValidateCheckConstraint validates the check constraint against all rows
+// in the table.
+func ValidateCheckConstraint(
+	ctx context.Context,
+	tableDesc catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	sessionData *sessiondata.SessionData,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
+	execOverride sessiondata.InternalExecutorOverride,
+) (err error) {
+	if constraint.CheckConstraint == nil {
+		return errors.AssertionFailedf("%v is not a check constraint", constraint.GetConstraintName())
+	}
+
+	tableDesc, err = tableDesc.MakeFirstMutationPublic(catalog.IgnoreConstraints)
+	if err != nil {
+		return err
+	}
+
+	// The check operates at the historical timestamp.
+	return runHistoricalTxn(ctx, func(
+		ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, descriptors *descs.Collection,
+	) error {
+		// Use the DistSQLTypeResolver because we need to resolve types by ID.
+		resolver := descs.NewDistSQLTypeResolver(descriptors, txn)
+		semaCtx := tree.MakeSemaContext()
+		semaCtx.TypeResolver = &resolver
+		defer func() { descriptors.ReleaseAll(ctx) }()
+
+		return ie.WithSyntheticDescriptors([]catalog.Descriptor{tableDesc}, func() error {
+			return validateCheckExpr(ctx, &semaCtx, txn, sessionData, constraint.CheckConstraint.Expr,
+				tableDesc.(*tabledesc.Mutable), ie)
+		})
+	})
+}
+
 // ValidateInvertedIndexes checks that the indexes have entries for
 // all the items of data in rows.
 //
@@ -1613,18 +1649,6 @@ func ValidateInvertedIndexes(
 	if len(invalidErr.Indexes) > 0 {
 		return invalidErr
 	}
-	return nil
-}
-
-func ValidateCheckConstraint(
-	ctx context.Context,
-	tableDesc catalog.TableDescriptor,
-	constraint *descpb.ConstraintDetail,
-	sessionData *sessiondata.SessionData,
-	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
-	execOverride sessiondata.InternalExecutorOverride,
-) (err error) {
-	// TODO (xiang): implement this.
 	return nil
 }
 

--- a/pkg/sql/catalog/descpb/constraint.go
+++ b/pkg/sql/catalog/descpb/constraint.go
@@ -125,3 +125,22 @@ func (c *ConstraintDetail) GetConstraintName() string {
 	}
 	return ""
 }
+
+// SetConstraintName sets correct constraint name base on the constraint
+// type.
+func (c *ConstraintDetail) SetConstraintName(name string) {
+	switch c.Kind {
+	case ConstraintTypePK:
+		c.Index.Name = name
+	case ConstraintTypeUnique:
+		if c.Index != nil {
+			c.Index.Name = name
+		} else {
+			c.UniqueWithoutIndexConstraint.Name = name
+		}
+	case ConstraintTypeFK:
+		c.FK.Name = name
+	case ConstraintTypeCheck:
+		c.CheckConstraint.Name = name
+	}
+}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -447,3 +448,11 @@ func MakeTestCollection(ctx context.Context, leaseManager *lease.Manager) Collec
 		leased:   makeLeasedDescriptors(leaseManager),
 	}
 }
+
+// InternalExecFn is the type of functions that operates using an internalExecutor.
+type InternalExecFn func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor, descriptors *Collection) error
+
+// HistoricalInternalExecTxnRunner is like historicalTxnRunner except it only
+// passes the fn the exported InternalExecutor instead of the whole unexported
+// extendedEvalContenxt, so it can be implemented outside pkg/sql.
+type HistoricalInternalExecTxnRunner func(ctx context.Context, fn InternalExecFn) error

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -655,6 +655,12 @@ func IndexNamePlaceholder(id descpb.IndexID) string {
 	return fmt.Sprintf("crdb_internal_index_%d_name_placeholder", id)
 }
 
+// ConstraintNamePlaceholder constructs a placeholder name for a constraint based
+// on its id.
+func ConstraintNamePlaceholder(id descpb.ConstraintID) string {
+	return fmt.Sprintf("crdb_internal_constraint_%d_name_placeholder", id)
+}
+
 // RenameColumnInTable will rename the column in tableDesc from oldName to
 // newName, including in expressions as well as shard columns.
 // The function is recursive because of this, but there should only be one level

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1271,8 +1271,8 @@ type ExecutorConfig struct {
 	// IndexMerger is also used to backfill indexes and is also rather circular.
 	IndexMerger *IndexBackfillerMergePlanner
 
-	// IndexValidator is used to validate indexes.
-	IndexValidator scexec.IndexValidator
+	// Validator is used to validate indexes and check constraints.
+	Validator scexec.Validator
 
 	// ContentionRegistry is a node-level registry of contention events used for
 	// contention observability.

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -268,7 +268,7 @@ func newSchemaChangerTxnRunDependencies(
 		// nothing to save because nobody will ever try to resume.
 		scdeps.NewNoOpBackfillerTracker(execCfg.Codec),
 		scdeps.NewNoopPeriodicProgressFlusher(),
-		execCfg.IndexValidator,
+		execCfg.Validator,
 		scdeps.NewConstantClock(evalContext.GetTxnTimestamp(time.Microsecond).Time),
 		metaDataUpdater,
 		NewSchemaChangerEventLogger(txn, execCfg, 1),

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -63,7 +63,7 @@ func NewExecutorDependencies(
 	merger scexec.Merger,
 	backfillTracker scexec.BackfillerTracker,
 	backfillFlusher scexec.PeriodicProgressFlusher,
-	indexValidator scexec.IndexValidator,
+	indexValidator scexec.Validator,
 	clock scmutationexec.Clock,
 	metadataUpdater scexec.DescriptorMetadataUpdater,
 	eventLogger scexec.EventLogger,
@@ -105,7 +105,7 @@ type txnDeps struct {
 	descsCollection     *descs.Collection
 	jobRegistry         JobRegistry
 	createdJobs         []jobspb.JobID
-	indexValidator      scexec.IndexValidator
+	indexValidator      scexec.Validator
 	statsRefresher      scexec.StatsRefresher
 	tableStatsToRefresh []descpb.ID
 	eventLogger         scexec.EventLogger
@@ -400,7 +400,7 @@ func (d *execDeps) PeriodicProgressFlusher() scexec.PeriodicProgressFlusher {
 	return d.periodicProgressFlusher
 }
 
-func (d *execDeps) IndexValidator() scexec.IndexValidator {
+func (d *execDeps) Validator() scexec.Validator {
 	return d.indexValidator
 }
 

--- a/pkg/sql/schemachanger/scdeps/index_validator.go
+++ b/pkg/sql/schemachanger/scdeps/index_validator.go
@@ -30,7 +30,7 @@ type ValidateForwardIndexesFn func(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
 	indexes []catalog.Index,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	gatherAllInvalid bool,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -42,7 +42,7 @@ type ValidateInvertedIndexesFn func(
 	codec keys.SQLCodec,
 	tbl catalog.TableDescriptor,
 	indexes []catalog.Index,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	withFirstMutationPublic bool,
 	gatherAllInvalid bool,
 	execOverride sessiondata.InternalExecutorOverride,
@@ -53,11 +53,8 @@ type ValidateCheckConstraintFn func(
 	ctx context.Context,
 	tbl catalog.TableDescriptor,
 	constraint *descpb.ConstraintDetail,
-	ieFactory sqlutil.InternalExecutorFactory,
 	sessionData *sessiondata.SessionData,
-	db *kv.DB,
-	collectionFactory *descs.CollectionFactory,
-	runHistoricalTxn sqlutil.HistoricalInternalExecTxnRunner,
+	runHistoricalTxn descs.HistoricalInternalExecTxnRunner,
 	execOverride sessiondata.InternalExecutorOverride,
 ) error
 
@@ -109,18 +106,30 @@ func (vd validator) ValidateInvertedIndexes(
 	)
 }
 
+func (vd validator) ValidateCheckConstraint(
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	return vd.validateCheckConstraint(ctx, tbl, constraint, vd.newFakeSessionData(&vd.settings.SV),
+		vd.makeHistoricalInternalExecTxnRunner(), override)
+}
+
 // makeHistoricalInternalExecTxnRunner creates a new transaction runner which
 // always runs at the same time and that time is the current time as of when
 // this constructor was called.
-func (vd validator) makeHistoricalInternalExecTxnRunner() sqlutil.HistoricalInternalExecTxnRunner {
+func (vd validator) makeHistoricalInternalExecTxnRunner() descs.HistoricalInternalExecTxnRunner {
 	now := vd.db.Clock().Now()
-	return func(ctx context.Context, fn sqlutil.InternalExecFn) error {
-		validationTxn := vd.db.NewTxn(ctx, "validation")
-		err := validationTxn.SetFixedTimestamp(ctx, now)
-		if err != nil {
-			return err
-		}
-		return fn(ctx, validationTxn, vd.ieFactory.NewInternalExecutor(vd.newFakeSessionData(&vd.settings.SV)))
+	return func(ctx context.Context, fn descs.InternalExecFn) error {
+		return vd.collectionFactory.TxnWithExecutor(ctx, vd.db, vd.newFakeSessionData(&vd.settings.SV), func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor,
+		) error {
+			if err := txn.SetFixedTimestamp(ctx, now); err != nil {
+				return err
+			}
+			return fn(ctx, txn, ie, descriptors)
+		})
 	}
 }
 
@@ -131,8 +140,10 @@ func NewValidator(
 	codec keys.SQLCodec,
 	settings *cluster.Settings,
 	ieFactory sqlutil.InternalExecutorFactory,
+	collectionFactory *descs.CollectionFactory,
 	validateForwardIndexes ValidateForwardIndexesFn,
 	validateInvertedIndexes ValidateInvertedIndexesFn,
+	validateCheckConstraint ValidateCheckConstraintFn,
 	newFakeSessionData NewFakeSessionDataFn,
 ) scexec.Validator {
 	return validator{
@@ -140,8 +151,10 @@ func NewValidator(
 		codec:                   codec,
 		settings:                settings,
 		ieFactory:               ieFactory,
+		collectionFactory:       collectionFactory,
 		validateForwardIndexes:  validateForwardIndexes,
 		validateInvertedIndexes: validateInvertedIndexes,
+		validateCheckConstraint: validateCheckConstraint,
 		newFakeSessionData:      newFakeSessionData,
 	}
 }

--- a/pkg/sql/schemachanger/scdeps/run_deps.go
+++ b/pkg/sql/schemachanger/scdeps/run_deps.go
@@ -44,7 +44,7 @@ func NewJobRunDependencies(
 	job *jobs.Job,
 	codec keys.SQLCodec,
 	settings *cluster.Settings,
-	indexValidator scexec.IndexValidator,
+	indexValidator scexec.Validator,
 	metadataUpdaterFactory MetadataUpdaterFactory,
 	statsRefresher scexec.StatsRefresher,
 	testingKnobs *scexec.TestingKnobs,
@@ -88,7 +88,7 @@ type jobExecutionDeps struct {
 	job                   *jobs.Job
 	kvTrace               bool
 
-	indexValidator scexec.IndexValidator
+	indexValidator scexec.Validator
 
 	codec        keys.SQLCodec
 	settings     *cluster.Settings

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -998,6 +998,17 @@ func (s *TestState) Validator() scexec.Validator {
 	return s
 }
 
+// ValidateCheckConstraint implements the validator interface.
+func (s *TestState) ValidateCheckConstraint(
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	s.LogSideEffectf("validate check constraint %v in table #%d", constraint.GetConstraintName(), tbl.GetID())
+	return nil
+}
+
 // LogEvent implements scexec.EventLogger.
 func (s *TestState) LogEvent(
 	_ context.Context,

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -963,7 +963,7 @@ func (s *TestState) WithTxnInJob(ctx context.Context, fn scrun.JobTxnFunc) (err 
 	return err
 }
 
-// ValidateForwardIndexes implements the index validator interface.
+// ValidateForwardIndexes implements the validator interface.
 func (s *TestState) ValidateForwardIndexes(
 	_ context.Context,
 	tbl catalog.TableDescriptor,
@@ -978,7 +978,7 @@ func (s *TestState) ValidateForwardIndexes(
 	return nil
 }
 
-// ValidateInvertedIndexes implements the index validator interface.
+// ValidateInvertedIndexes implements the validator interface.
 func (s *TestState) ValidateInvertedIndexes(
 	_ context.Context,
 	tbl catalog.TableDescriptor,
@@ -993,8 +993,8 @@ func (s *TestState) ValidateInvertedIndexes(
 	return nil
 }
 
-// IndexValidator implements the scexec.Dependencies interface.
-func (s *TestState) IndexValidator() scexec.IndexValidator {
+// Validator implements the scexec.Dependencies interface.
+func (s *TestState) Validator() scexec.Validator {
 	return s
 }
 

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -211,6 +211,13 @@ type Validator interface {
 		indexes []catalog.Index,
 		override sessiondata.InternalExecutorOverride,
 	) error
+
+	ValidateCheckConstraint(
+		ctx context.Context,
+		tbl catalog.TableDescriptor,
+		constraint *descpb.ConstraintDetail,
+		override sessiondata.InternalExecutorOverride,
+	) error
 }
 
 // IndexSpanSplitter can try to split an index span in the current transaction

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -37,7 +37,7 @@ type Dependencies interface {
 	IndexMerger() Merger
 	BackfillProgressTracker() BackfillerTracker
 	PeriodicProgressFlusher() PeriodicProgressFlusher
-	IndexValidator() IndexValidator
+	Validator() Validator
 	IndexSpanSplitter() IndexSpanSplitter
 	EventLogger() EventLogger
 	DescriptorMetadataUpdater(ctx context.Context) DescriptorMetadataUpdater
@@ -196,8 +196,8 @@ type Merger interface {
 	) error
 }
 
-// IndexValidator provides interfaces that allow indexes to be validated.
-type IndexValidator interface {
+// Validator provides interfaces that allow indexes and check constraints to be validated.
+type Validator interface {
 	ValidateForwardIndexes(
 		ctx context.Context,
 		tbl catalog.TableDescriptor,

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -43,9 +43,9 @@ func executeValidateUniqueIndex(
 		User: username.RootUserName(),
 	}
 	if index.GetType() == descpb.IndexDescriptor_FORWARD {
-		err = deps.IndexValidator().ValidateForwardIndexes(ctx, table, []catalog.Index{index}, execOverride)
+		err = deps.Validator().ValidateForwardIndexes(ctx, table, []catalog.Index{index}, execOverride)
 	} else {
-		err = deps.IndexValidator().ValidateInvertedIndexes(ctx, table, []catalog.Index{index}, execOverride)
+		err = deps.Validator().ValidateInvertedIndexes(ctx, table, []catalog.Index{index}, execOverride)
 	}
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -56,7 +56,34 @@ func executeValidateUniqueIndex(
 func executeValidateCheckConstraint(
 	ctx context.Context, deps Dependencies, op *scop.ValidateCheckConstraint,
 ) error {
-	return errors.Errorf("executeValidateCheckConstraint is not implemented")
+	descs, err := deps.Catalog().MustReadImmutableDescriptors(ctx, op.TableID)
+	if err != nil {
+		return err
+	}
+	desc := descs[0]
+	table, ok := desc.(catalog.TableDescriptor)
+	if !ok {
+		return catalog.WrapTableDescRefErr(desc.GetID(), catalog.NewDescriptorTypeError(desc))
+	}
+	constraint, err := table.FindConstraintWithID(op.ConstraintID)
+	if err != nil {
+		return err
+	}
+	if constraint.CheckConstraint == nil {
+		return errors.Newf("constraint ID %v does not identify a check constraint in table %v.",
+			op.ConstraintID, op.TableID)
+	}
+
+	// Execute the validation operation as a root user.
+	execOverride := sessiondata.InternalExecutorOverride{
+		User: username.RootUserName(),
+	}
+	err = deps.Validator().ValidateCheckConstraint(ctx, table, constraint, execOverride)
+	if err != nil {
+		return scerrors.SchemaChangerUserError(err)
+	}
+	constraint.CheckConstraint.Validity = descpb.ConstraintValidity_Validated
+	return nil
 }
 
 func executeValidationOps(ctx context.Context, deps Dependencies, ops []scop.Op) (err error) {

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -76,7 +76,7 @@ func (ti testInfra) newExecDeps(
 		noopMerger{},
 		scdeps.NewNoOpBackfillerTracker(ti.lm.Codec()),
 		scdeps.NewNoopPeriodicProgressFlusher(),
-		noopIndexValidator{},
+		noopValidator{},
 		scdeps.NewConstantClock(timeutil.Now()),
 		noopMetadataUpdater{},
 		noopEventLogger{},
@@ -462,11 +462,11 @@ func (n noopMerger) MergeIndexes(
 	return nil
 }
 
-type noopIndexValidator struct{}
+type noopValidator struct{}
 
-var _ scexec.IndexValidator = noopIndexValidator{}
+var _ scexec.Validator = noopValidator{}
 
-func (noopIndexValidator) ValidateForwardIndexes(
+func (noopValidator) ValidateForwardIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
@@ -475,7 +475,7 @@ func (noopIndexValidator) ValidateForwardIndexes(
 	return nil
 }
 
-func (noopIndexValidator) ValidateInvertedIndexes(
+func (noopValidator) ValidateInvertedIndexes(
 	ctx context.Context,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
@@ -574,7 +574,7 @@ func (noopMetadataUpdater) UpsertZoneConfig(
 }
 
 var _ scexec.Backfiller = noopBackfiller{}
-var _ scexec.IndexValidator = noopIndexValidator{}
+var _ scexec.Validator = noopValidator{}
 var _ scexec.EventLogger = noopEventLogger{}
 var _ scexec.StatsRefresher = noopStatsReferesher{}
 var _ scexec.DescriptorMetadataUpdater = noopMetadataUpdater{}

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -484,6 +484,15 @@ func (noopValidator) ValidateInvertedIndexes(
 	return nil
 }
 
+func (noopValidator) ValidateCheckConstraint(
+	ctx context.Context,
+	tbl catalog.TableDescriptor,
+	constraint *descpb.ConstraintDetail,
+	override sessiondata.InternalExecutorOverride,
+) error {
+	return nil
+}
+
 type noopEventLogger struct{}
 
 var _ scexec.EventLogger = noopEventLogger{}

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -252,20 +252,6 @@ func (mr *MockDependenciesMockRecorder) IndexSpanSplitter() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexSpanSplitter", reflect.TypeOf((*MockDependencies)(nil).IndexSpanSplitter))
 }
 
-// IndexValidator mocks base method.
-func (m *MockDependencies) IndexValidator() scexec.IndexValidator {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IndexValidator")
-	ret0, _ := ret[0].(scexec.IndexValidator)
-	return ret0
-}
-
-// IndexValidator indicates an expected call of IndexValidator.
-func (mr *MockDependenciesMockRecorder) IndexValidator() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexValidator", reflect.TypeOf((*MockDependencies)(nil).IndexValidator))
-}
-
 // PeriodicProgressFlusher mocks base method.
 func (m *MockDependencies) PeriodicProgressFlusher() scexec.PeriodicProgressFlusher {
 	m.ctrl.T.Helper()
@@ -348,6 +334,20 @@ func (m *MockDependencies) User() username.SQLUsername {
 func (mr *MockDependenciesMockRecorder) User() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockDependencies)(nil).User))
+}
+
+// Validator mocks base method.
+func (m *MockDependencies) Validator() scexec.Validator {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Validator")
+	ret0, _ := ret[0].(scexec.Validator)
+	return ret0
+}
+
+// Validator indicates an expected call of Validator.
+func (mr *MockDependenciesMockRecorder) Validator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validator", reflect.TypeOf((*MockDependencies)(nil).Validator))
 }
 
 // MockBackfiller is a mock of Backfiller interface.

--- a/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/helpers.go
@@ -211,6 +211,22 @@ func enqueueDropColumnMutation(tbl *tabledesc.Mutable, col *descpb.ColumnDescrip
 	return nil
 }
 
+func enqueueAddCheckConstraintMutation(
+	tbl *tabledesc.Mutable, ck *descpb.TableDescriptor_CheckConstraint,
+) error {
+	tbl.AddCheckMutation(ck, descpb.DescriptorMutation_ADD)
+	tbl.NextMutationID--
+	return nil
+}
+
+func enqueueDropCheckConstraintMutation(
+	tbl *tabledesc.Mutable, ck *descpb.TableDescriptor_CheckConstraint,
+) error {
+	tbl.AddCheckMutation(ck, descpb.DescriptorMutation_DROP)
+	tbl.NextMutationID--
+	return nil
+}
+
 func enqueueAddIndexMutation(
 	tbl *tabledesc.Mutable, idx *descpb.IndexDescriptor, state descpb.DescriptorMutation_State,
 ) error {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -344,6 +344,19 @@ func (m *visitor) SetIndexName(ctx context.Context, op scop.SetIndexName) error 
 	return nil
 }
 
+func (m *visitor) SetConstraintName(ctx context.Context, op scop.SetConstraintName) error {
+	tbl, err := m.checkOutTable(ctx, op.TableID)
+	if err != nil {
+		return err
+	}
+	constraint, err := tbl.FindConstraintWithID(op.ConstraintID)
+	if err != nil {
+		return err
+	}
+	constraint.SetConstraintName(op.Name)
+	return nil
+}
+
 func (m *visitor) AddColumnToIndex(ctx context.Context, op scop.AddColumnToIndex) error {
 	tbl, err := m.checkOutTable(ctx, op.TableID)
 	if err != nil {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -15,9 +15,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -75,7 +77,7 @@ func (m *visitor) RemoveCheckConstraint(ctx context.Context, op scop.RemoveCheck
 	}
 	for i, m := range tbl.Mutations {
 		if c := m.GetConstraint(); c != nil &&
-			c.ConstraintType != descpb.ConstraintToUpdate_CHECK &&
+			c.ConstraintType == descpb.ConstraintToUpdate_CHECK &&
 			c.Check.ConstraintID == op.ConstraintID {
 			tbl.Mutations = append(tbl.Mutations[:i], tbl.Mutations[i+1:]...)
 			found = true
@@ -87,6 +89,97 @@ func (m *visitor) RemoveCheckConstraint(ctx context.Context, op scop.RemoveCheck
 			op.ConstraintID, tbl.GetName(), tbl.GetID())
 	}
 	return nil
+}
+
+func (m *visitor) AddCheckConstraint(ctx context.Context, op scop.AddCheckConstraint) error {
+	tbl, err := m.checkOutTable(ctx, op.TableID)
+	if err != nil || tbl.Dropped() {
+		return err
+	}
+	if op.ConstraintID >= tbl.NextConstraintID {
+		tbl.NextConstraintID = op.ConstraintID + 1
+	}
+
+	// We should have already validated that the check constraint
+	// is syntactically valid in the builder, so we just need to
+	// enqueue it to the descriptor's mutation slice.
+	ck := &descpb.TableDescriptor_CheckConstraint{
+		Expr:         string(op.Expr),
+		Name:         tabledesc.ConstraintNamePlaceholder(op.ConstraintID),
+		Validity:     descpb.ConstraintValidity_Validating,
+		ColumnIDs:    op.ColumnIDs,
+		Hidden:       true,
+		ConstraintID: op.ConstraintID,
+	}
+	return enqueueAddCheckConstraintMutation(tbl, ck)
+}
+
+func (m *visitor) MakeAddedCheckConstraintPublic(
+	ctx context.Context, op scop.MakeAddedCheckConstraintPublic,
+) error {
+	tbl, err := m.checkOutTable(ctx, op.TableID)
+	if err != nil || tbl.Dropped() {
+		return err
+	}
+
+	var found bool
+	for idx, mutation := range tbl.Mutations {
+		if c := mutation.GetConstraint(); c != nil &&
+			c.ConstraintType == descpb.ConstraintToUpdate_CHECK &&
+			c.Check.ConstraintID == op.ConstraintID {
+			// Add the check to the public `Checks` slice
+			tbl.Checks = append(tbl.Checks, &c.Check)
+
+			// Remove the mutation from the mutation slice. The `MakeMutationComplete`
+			// call will also mark the above added check as VALIDATED.
+			// If this is a rollback of a drop, we are trying to add the index back,
+			// so swap the direction before making it complete.
+			mutation.Direction = descpb.DescriptorMutation_ADD
+			err = tbl.MakeMutationComplete(mutation)
+			if err != nil {
+				return err
+			}
+			tbl.Mutations = append(tbl.Mutations[:idx], tbl.Mutations[idx+1:]...)
+
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return errors.AssertionFailedf("failed to find check constraint %d in table %q (%d)",
+			op.ConstraintID, tbl.GetName(), tbl.GetID())
+	}
+
+	if len(tbl.Mutations) == 0 {
+		tbl.Mutations = nil
+	}
+
+	return nil
+}
+
+func (m *visitor) MakeDroppedCheckConstraintValidated(
+	ctx context.Context, op scop.MakeDroppedCheckConstraintValidated,
+) error {
+	tbl, err := m.checkOutTable(ctx, op.TableID)
+	if err != nil {
+		return err
+	}
+	for i, ck := range tbl.Checks {
+		if ck.ConstraintID == op.ConstraintID {
+			tbl.Checks = append(tbl.Checks[:i], tbl.Checks[i+1:]...)
+			// TODO (xiang): We ought to check whether the check constraint
+			// is Unvalidated. If so, we can drop it immediately without
+			// enqueuing a mutation. We need modify the next operation accordingly
+			// bc such a change means it's possible we might no longer find
+			// a mutation later.
+			clone := protoutil.Clone(ck).(*descpb.TableDescriptor_CheckConstraint)
+			clone.Validity = descpb.ConstraintValidity_Dropping
+			return enqueueDropCheckConstraintMutation(tbl, clone)
+		}
+	}
+
+	return errors.AssertionFailedf("failed to find check constraint %d in descriptor %v", op.ConstraintID, tbl)
 }
 
 func (m *visitor) RemoveForeignKeyBackReference(

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -81,7 +81,7 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 		n.job,
 		execCfg.Codec,
 		execCfg.Settings,
-		execCfg.IndexValidator,
+		execCfg.Validator,
 		func(ctx context.Context, descriptors *descs.Collection, txn *kv.Txn) scexec.DescriptorMetadataUpdater {
 			return descmetadata.NewMetadataUpdater(ctx,
 				execCfg.InternalExecutorFactory,

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -288,6 +288,31 @@ type RemoveCheckConstraint struct {
 	ConstraintID descpb.ConstraintID
 }
 
+// AddCheckConstraint adds a check constraint to a table.
+type AddCheckConstraint struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+	ColumnIDs    []descpb.ColumnID
+	scpb.Expression
+}
+
+// MakeDroppedCheckConstraintValidated moves a public
+// check constraint to WRITE_AND_DELETE_ONLY.
+type MakeDroppedCheckConstraintValidated struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
+// MakeAddedCheckConstraintPublic moves a new, validated check
+// constraint from mutation to public.
+type MakeAddedCheckConstraintPublic struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+}
+
 // RemoveForeignKeyConstraint removes a foreign key from the origin table.
 type RemoveForeignKeyConstraint struct {
 	mutationOp

--- a/pkg/sql/schemachanger/scop/mutation.go
+++ b/pkg/sql/schemachanger/scop/mutation.go
@@ -434,6 +434,14 @@ type SetIndexName struct {
 	Name    string
 }
 
+// SetConstraintName renames a constraint.
+type SetConstraintName struct {
+	mutationOp
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
+	Name         string
+}
+
 // DeleteDescriptor deletes a descriptor.
 type DeleteDescriptor struct {
 	mutationOp

--- a/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
@@ -74,6 +74,7 @@ type MutationVisitor interface {
 	RemoveViewBackReferencesInRelations(context.Context, RemoveViewBackReferencesInRelations) error
 	SetColumnName(context.Context, SetColumnName) error
 	SetIndexName(context.Context, SetIndexName) error
+	SetConstraintName(context.Context, SetConstraintName) error
 	DeleteDescriptor(context.Context, DeleteDescriptor) error
 	RemoveJobStateFromDescriptor(context.Context, RemoveJobStateFromDescriptor) error
 	SetJobStateOnDescriptor(context.Context, SetJobStateOnDescriptor) error
@@ -358,6 +359,11 @@ func (op SetColumnName) Visit(ctx context.Context, v MutationVisitor) error {
 // Visit is part of the MutationOp interface.
 func (op SetIndexName) Visit(ctx context.Context, v MutationVisitor) error {
 	return v.SetIndexName(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op SetConstraintName) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.SetConstraintName(ctx, op)
 }
 
 // Visit is part of the MutationOp interface.

--- a/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/mutation_visitor_generated.go
@@ -55,6 +55,9 @@ type MutationVisitor interface {
 	RemoveOwnerBackReferenceInSequence(context.Context, RemoveOwnerBackReferenceInSequence) error
 	RemoveSequenceOwner(context.Context, RemoveSequenceOwner) error
 	RemoveCheckConstraint(context.Context, RemoveCheckConstraint) error
+	AddCheckConstraint(context.Context, AddCheckConstraint) error
+	MakeDroppedCheckConstraintValidated(context.Context, MakeDroppedCheckConstraintValidated) error
+	MakeAddedCheckConstraintPublic(context.Context, MakeAddedCheckConstraintPublic) error
 	RemoveForeignKeyConstraint(context.Context, RemoveForeignKeyConstraint) error
 	RemoveForeignKeyBackReference(context.Context, RemoveForeignKeyBackReference) error
 	RemoveSchemaParent(context.Context, RemoveSchemaParent) error
@@ -260,6 +263,21 @@ func (op RemoveSequenceOwner) Visit(ctx context.Context, v MutationVisitor) erro
 // Visit is part of the MutationOp interface.
 func (op RemoveCheckConstraint) Visit(ctx context.Context, v MutationVisitor) error {
 	return v.RemoveCheckConstraint(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op AddCheckConstraint) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.AddCheckConstraint(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op MakeDroppedCheckConstraintValidated) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.MakeDroppedCheckConstraintValidated(ctx, op)
+}
+
+// Visit is part of the MutationOp interface.
+func (op MakeAddedCheckConstraintPublic) Visit(ctx context.Context, v MutationVisitor) error {
+	return v.MakeAddedCheckConstraintPublic(ctx, op)
 }
 
 // Visit is part of the MutationOp interface.

--- a/pkg/sql/schemachanger/scop/validation.go
+++ b/pkg/sql/schemachanger/scop/validation.go
@@ -28,8 +28,8 @@ type ValidateUniqueIndex struct {
 // ValidateCheckConstraint validates a check constraint on a table's columns.
 type ValidateCheckConstraint struct {
 	validationOp
-	TableID descpb.ID
-	Name    string
+	TableID      descpb.ID
+	ConstraintID descpb.ConstraintID
 }
 
 // Make sure baseOp is used for linter.

--- a/pkg/sql/schemachanger/scpb/scpb.proto
+++ b/pkg/sql/schemachanger/scpb/scpb.proto
@@ -44,6 +44,7 @@ enum Status {
   DELETE_ONLY = 7;
 
   // Intermediate states on the index dropping and adding paths.
+  // VALIDATED is also used on check constraint adding and dropping paths.
   VALIDATED = 8;
   MERGED = 9;
   MERGE_ONLY = 10;
@@ -59,6 +60,9 @@ enum Status {
   TRANSIENT_MERGED = 19;
   TRANSIENT_VALIDATED = 20;
   TRANSIENT_PUBLIC = 21;
+
+  // Intermediate states on check constraint adding and dropping paths.
+  VALIDATING = 22;
 }
 
 // TargetMetadata refers to the metadata for individual elements, where

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_check_constraint.go
@@ -19,14 +19,43 @@ func init() {
 	opRegistry.register((*scpb.CheckConstraint)(nil),
 		toPublic(
 			scpb.Status_ABSENT,
+			to(scpb.Status_VALIDATING,
+				emit(func(this *scpb.CheckConstraint) *scop.AddCheckConstraint {
+					return &scop.AddCheckConstraint{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+						ColumnIDs:    this.ColumnIDs,
+						Expression:   this.Expression,
+					}
+				}),
+			),
+			to(scpb.Status_VALIDATED,
+				emit(func(this *scpb.CheckConstraint) *scop.ValidateCheckConstraint {
+					return &scop.ValidateCheckConstraint{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
+				}),
+			),
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.CheckConstraint) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.CheckConstraint) *scop.MakeAddedCheckConstraintPublic {
+					return &scop.MakeAddedCheckConstraintPublic{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
 				}),
 			),
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
+			to(scpb.Status_VALIDATED,
+				emit(func(this *scpb.CheckConstraint) *scop.MakeDroppedCheckConstraintValidated {
+					return &scop.MakeDroppedCheckConstraintValidated{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+					}
+				})),
+			equiv(scpb.Status_VALIDATING),
 			to(scpb.Status_ABSENT,
 				// TODO(postamar): remove revertibility constraint when possible
 				revertible(false),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_constraint_name.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_constraint_name.go
@@ -11,6 +11,7 @@
 package opgen
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 )
@@ -20,18 +21,24 @@ func init() {
 		toPublic(
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
-				emit(func(this *scpb.ConstraintName) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.ConstraintName) *scop.SetConstraintName {
+					return &scop.SetConstraintName{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+						Name:         this.Name,
+					}
 				}),
 			),
 		),
 		toAbsent(
 			scpb.Status_PUBLIC,
 			to(scpb.Status_ABSENT,
-				// TODO(postamar): remove revertibility constraint when possible
-				revertible(false),
-				emit(func(this *scpb.ConstraintName) *scop.NotImplemented {
-					return notImplemented(this)
+				emit(func(this *scpb.ConstraintName) *scop.SetConstraintName {
+					return &scop.SetConstraintName{
+						TableID:      this.TableID,
+						ConstraintID: this.ConstraintID,
+						Name:         tabledesc.ConstraintNamePlaceholder(this.ConstraintID),
+					}
 				}),
 			),
 		),

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "dep_add_index.go",
         "dep_add_index_and_column.go",
         "dep_drop_column.go",
+        "dep_drop_constraint.go",
         "dep_drop_index.go",
         "dep_drop_index_and_column.go",
         "dep_drop_object.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_constraint.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rules
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+func init() {
+	registerDepRuleForDrop(
+		"dependents removed before check constraint becomes non-public",
+		scgraph.Precedence,
+		"dependent", "check-constraint",
+		scpb.Status_ABSENT, scpb.Status_VALIDATED,
+		func(from, to nodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.typeFilter(isConstraintDependent),
+				to.typeFilter(isCheckConstraint),
+				joinOnConstraintID(from, to, "table-id", "constraint-id"),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -261,7 +261,7 @@ func IsDescriptor(e scpb.Element) bool {
 }
 
 func isSubjectTo2VersionInvariant(e scpb.Element) bool {
-	return isIndex(e) || isColumn(e)
+	return isIndex(e) || isColumn(e) || isCheckConstraint(e)
 }
 
 func isIndex(e scpb.Element) bool {
@@ -273,11 +273,13 @@ func isIndex(e scpb.Element) bool {
 }
 
 func isColumn(e scpb.Element) bool {
-	switch e.(type) {
-	case *scpb.Column:
-		return true
-	}
-	return false
+	_, ok := e.(*scpb.Column)
+	return ok
+}
+
+func isCheckConstraint(e scpb.Element) bool {
+	_, ok := e.(*scpb.CheckConstraint)
+	return ok
 }
 
 func isSimpleDependent(e scpb.Element) bool {

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -387,6 +387,14 @@ func isIndexDependent(e scpb.Element) bool {
 	return false
 }
 
+func isConstraintDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ConstraintName, *scpb.ConstraintComment:
+		return true
+	}
+	return false
+}
+
 // registerDepRuleForDrop is a convenience function which calls
 // registerDepRule with the cross-product of (ToAbsent,Transient)^2 target
 // states, which can't easily be composed.

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -338,7 +338,7 @@ deprules
   to: dependent-node
   query:
     - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
+    - $dependent[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
     - joinOnDescID($descriptor, $dependent, $desc-id)
     - toAbsent($descriptor-target, $dependent-target)
     - $descriptor-node[CurrentStatus] = DROPPED
@@ -351,7 +351,7 @@ deprules
   to: referencing-via-attr-node
   query:
     - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
+    - $referencing-via-attr[Type] IN ['*scpb.ColumnFamily', '*scpb.UniqueWithoutIndexConstraint', '*scpb.ForeignKeyConstraint', '*scpb.TableComment', '*scpb.RowLevelTTL', '*scpb.TableLocalityGlobal', '*scpb.TableLocalityPrimaryRegion', '*scpb.TableLocalitySecondaryRegion', '*scpb.TableLocalityRegionalByRow', '*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexName', '*scpb.IndexPartitioning', '*scpb.SecondaryIndexPartial', '*scpb.IndexComment', '*scpb.IndexColumn', '*scpb.ConstraintName', '*scpb.ConstraintComment', '*scpb.Namespace', '*scpb.Owner', '*scpb.UserPrivileges', '*scpb.DatabaseRegionConfig', '*scpb.DatabaseRoleSetting', '*scpb.DatabaseComment', '*scpb.SchemaParent', '*scpb.SchemaComment', '*scpb.ObjectParent', '*scpb.EnumTypeValue']
     - joinReferencedDescID($referencing-via-attr, $referenced-descriptor, $desc-id)
     - toAbsent($referenced-descriptor-target, $referencing-via-attr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
@@ -364,7 +364,7 @@ deprules
   to: referencing-via-expr-node
   query:
     - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $referencing-via-expr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
+    - $referencing-via-expr[Type] IN ['*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-target, $referencing-via-expr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
     - $referencing-via-expr-node[CurrentStatus] = ABSENT
@@ -390,7 +390,7 @@ deprules
   to: idx-or-col-node
   query:
     - $descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - $idx-or-col[Type] IN ['*scpb.Column', '*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.CheckConstraint']
     - joinOnDescID($descriptor, $idx-or-col, $desc-id)
     - toAbsent($descriptor-target, $idx-or-col-target)
     - $descriptor-node[CurrentStatus] = ABSENT

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -151,20 +151,6 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - $column-target[TargetStatus] = ABSENT
-    - $column-node[CurrentStatus] = WRITE_ONLY
-    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
-    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($column, $column-target, $column-node)
-    - joinTargetNode($dependent, $dependent-target, $dependent-node)
-- name: column no longer public before dependents
-  from: column-node
-  kind: Precedence
-  to: dependent-node
-  query:
-    - $column[Type] = '*scpb.Column'
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
-    - joinOnColumnID($column, $dependent, $table-id, $col-id)
     - $column-target[TargetStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = TRANSIENT_WRITE_ONLY
     - $dependent-target[TargetStatus] = ABSENT
@@ -179,8 +165,22 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - transient($column-target, $dependent-target)
-    - $column-node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - toAbsent($column-target, $dependent-target)
+    - $column-node[CurrentStatus] = WRITE_ONLY
+    - $dependent-node[CurrentStatus] = ABSENT
+    - joinTargetNode($column, $column-target, $column-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+- name: column no longer public before dependents
+  from: column-node
+  kind: Precedence
+  to: dependent-node
+  query:
+    - $column[Type] = '*scpb.Column'
+    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - joinOnColumnID($column, $dependent, $table-id, $col-id)
+    - $column-target[TargetStatus] = ABSENT
+    - $column-node[CurrentStatus] = WRITE_ONLY
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
     - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($column, $column-target, $column-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -192,9 +192,9 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - toAbsent($column-target, $dependent-target)
-    - $column-node[CurrentStatus] = WRITE_ONLY
-    - $dependent-node[CurrentStatus] = ABSENT
+    - transient($column-target, $dependent-target)
+    - $column-node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($column, $column-target, $column-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: column type dependents removed right before column type
@@ -224,6 +224,60 @@ deprules
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
     - joinTargetNode($column-type, $column-type-target, $column-type-node)
     - joinTargetNode($column, $column-target, $column-node)
+- name: dependents removed before check constraint becomes non-public
+  from: dependent-node
+  kind: Precedence
+  to: check-constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $check-constraint[Type] = '*scpb.CheckConstraint'
+    - joinOnConstraintID($dependent, $check-constraint, $table-id, $constraint-id)
+    - transient($dependent-target, $check-constraint-target)
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $check-constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($check-constraint, $check-constraint-target, $check-constraint-node)
+- name: dependents removed before check constraint becomes non-public
+  from: dependent-node
+  kind: Precedence
+  to: check-constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $check-constraint[Type] = '*scpb.CheckConstraint'
+    - joinOnConstraintID($dependent, $check-constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $check-constraint-target[TargetStatus] = TRANSIENT_ABSENT
+    - $check-constraint-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($check-constraint, $check-constraint-target, $check-constraint-node)
+- name: dependents removed before check constraint becomes non-public
+  from: dependent-node
+  kind: Precedence
+  to: check-constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $check-constraint[Type] = '*scpb.CheckConstraint'
+    - joinOnConstraintID($dependent, $check-constraint, $table-id, $constraint-id)
+    - toAbsent($dependent-target, $check-constraint-target)
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $check-constraint-node[CurrentStatus] = VALIDATED
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($check-constraint, $check-constraint-target, $check-constraint-node)
+- name: dependents removed before check constraint becomes non-public
+  from: dependent-node
+  kind: Precedence
+  to: check-constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $check-constraint[Type] = '*scpb.CheckConstraint'
+    - joinOnConstraintID($dependent, $check-constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $check-constraint-target[TargetStatus] = ABSENT
+    - $check-constraint-node[CurrentStatus] = VALIDATED
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($check-constraint, $check-constraint-target, $check-constraint-node)
 - name: dependents removed before column
   from: dependent-node
   kind: Precedence
@@ -245,8 +299,9 @@ deprules
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - transient($dependent-target, $column-target)
-    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $column-target[TargetStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($column, $column-target, $column-node)
@@ -258,9 +313,8 @@ deprules
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $dependent-node[CurrentStatus] = ABSENT
-    - $column-target[TargetStatus] = TRANSIENT_ABSENT
+    - transient($dependent-target, $column-target)
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($column, $column-target, $column-node)
@@ -578,10 +632,9 @@ deprules
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - joinOnColumnID($index-column, $column-type, $table-id, $column-id)
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
-    - $index-target[TargetStatus] = TRANSIENT_ABSENT
+    - transient($index-target, $column-target)
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-target[TargetStatus] = ABSENT
-    - $column-node[CurrentStatus] = ABSENT
+    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: indexes containing column reach absent before column
@@ -596,9 +649,10 @@ deprules
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - joinOnColumnID($index-column, $column-type, $table-id, $column-id)
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
-    - transient($index-target, $column-target)
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-target[TargetStatus] = ABSENT
+    - $column-node[CurrentStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: old index absent before new index public when swapping with transient
@@ -630,10 +684,23 @@ deprules
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - $partial-predicate-target[TargetStatus] = TRANSIENT_ABSENT
-    - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-target[TargetStatus] = ABSENT
+    - toAbsent($partial-predicate-target, $index-target)
+    - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
+    - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
+    - joinTargetNode($index, $index-target, $index-node)
+- name: partial predicate removed right before secondary index when not dropping relation
+  from: partial-predicate-node
+  kind: SameStagePrecedence
+  to: index-node
+  query:
+    - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - $index[Type] = '*scpb.SecondaryIndex'
+    - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
+    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
+    - transient($partial-predicate-target, $index-target)
+    - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: partial predicate removed right before secondary index when not dropping relation
@@ -660,23 +727,10 @@ deprules
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - toAbsent($partial-predicate-target, $index-target)
-    - $partial-predicate-node[CurrentStatus] = ABSENT
-    - $index-node[CurrentStatus] = ABSENT
-    - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
-    - joinTargetNode($index, $index-target, $index-node)
-- name: partial predicate removed right before secondary index when not dropping relation
-  from: partial-predicate-node
-  kind: SameStagePrecedence
-  to: index-node
-  query:
-    - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - $index[Type] = '*scpb.SecondaryIndex'
-    - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - transient($partial-predicate-target, $index-target)
+    - $partial-predicate-target[TargetStatus] = TRANSIENT_ABSENT
     - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-target[TargetStatus] = ABSENT
+    - $index-node[CurrentStatus] = ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: primary index swap
@@ -689,8 +743,8 @@ deprules
     - joinOnDescID($old-index, $new-index, $table-id)
     - $old-index[IndexID] = $old-index-id
     - $new-index[SourceIndexID] = $old-index-id
-    - $old-index-target[TargetStatus] = ABSENT
-    - $old-index-node[CurrentStatus] = VALIDATED
+    - $old-index-target[TargetStatus] = TRANSIENT_ABSENT
+    - $old-index-node[CurrentStatus] = TRANSIENT_VALIDATED
     - $new-index-target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $new-index-node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-index, $old-index-target, $old-index-node)
@@ -705,8 +759,8 @@ deprules
     - joinOnDescID($old-index, $new-index, $table-id)
     - $old-index[IndexID] = $old-index-id
     - $new-index[SourceIndexID] = $old-index-id
-    - $old-index-target[TargetStatus] = TRANSIENT_ABSENT
-    - $old-index-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $old-index-target[TargetStatus] = ABSENT
+    - $old-index-node[CurrentStatus] = VALIDATED
     - $new-index-target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $new-index-node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-index, $old-index-target, $old-index-node)
@@ -765,9 +819,9 @@ deprules
     - $index[Type] = '*scpb.IndexColumn'
     - $index-column[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - toAbsent($index-target, $index-column-target)
-    - $index-node[CurrentStatus] = DELETE_ONLY
-    - $index-column-node[CurrentStatus] = ABSENT
+    - transient($index-target, $index-column-target)
+    - $index-node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $index-column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
 - name: remove columns from index right before removing index
@@ -778,9 +832,9 @@ deprules
     - $index[Type] = '*scpb.IndexColumn'
     - $index-column[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - transient($index-target, $index-column-target)
-    - $index-node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - $index-column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - toAbsent($index-target, $index-column-target)
+    - $index-node[CurrentStatus] = DELETE_ONLY
+    - $index-column-node[CurrentStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
 - name: remove columns from index right before removing index

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -319,13 +319,14 @@ DROP INDEX idx2 CASCADE
 ops
 DROP INDEX idx3 CASCADE
 ----
-StatementPhase stage 1 of 1 with 6 MutationType ops
+StatementPhase stage 1 of 1 with 7 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 104, Name: idx3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
+    [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakeDroppedNonPrimaryIndexDeleteAndWriteOnly
       IndexID: 6
@@ -334,8 +335,9 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
       IndexID: 6
       Name: crdb_internal_index_6_name_placeholder
       TableID: 104
-    *scop.MakeDroppedCheckConstraintValidated
+    *scop.SetConstraintName
       ConstraintID: 2
+      Name: crdb_internal_constraint_2_name_placeholder
       TableID: 104
     *scop.MakeDroppedColumnDeleteAndWriteOnly
       ColumnID: 5
@@ -360,6 +362,9 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
       ColumnID: 5
       Name: crdb_internal_column_5_name_placeholder
       TableID: 104
+    *scop.MakeDroppedCheckConstraintValidated
+      ConstraintID: 2
+      TableID: 104
 PreCommitPhase stage 1 of 1 with 2 MutationType ops
   transitions:
   ops:
@@ -373,12 +378,12 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
       - 104
       JobID: 1
       NonCancelable: true
-      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 4 MutationType ops pending
+      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops pending
       Statements:
       - statement: DROP INDEX idx3 CASCADE
         redactedstatement: DROP INDEX ‹defaultdb›.public.‹t1›@‹idx3› CASCADE
         statementtag: DROP INDEX
-PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 5, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
@@ -386,7 +391,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], VALIDATED] -> ABSENT
-    [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakeDroppedColumnDeleteOnly
       ColumnID: 5
@@ -394,8 +398,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
     *scop.RemoveCheckConstraint
       ConstraintID: 2
       TableID: 104
-    *scop.NotImplemented
-      ElementType: scpb.ConstraintName
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 6
       TableID: 104
@@ -480,6 +482,10 @@ DROP INDEX idx3 CASCADE
   to:   [Column:{DescID: 104, ColumnID: 5}, ABSENT]
   kind: SameStagePrecedence
   rules: [dependents removed before column; column type removed right before column when not dropping relation]
+- from: [ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT]
+  to:   [CheckConstraint:{DescID: 104, ConstraintID: 2}, VALIDATED]
+  kind: Precedence
+  rule: dependents removed before check constraint becomes non-public
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -319,12 +319,13 @@ DROP INDEX idx2 CASCADE
 ops
 DROP INDEX idx3 CASCADE
 ----
-StatementPhase stage 1 of 1 with 5 MutationType ops
+StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 5}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 104, Name: crdb_internal_i_shard_16, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 104, Name: idx3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
   ops:
     *scop.MakeDroppedNonPrimaryIndexDeleteAndWriteOnly
       IndexID: 6
@@ -332,6 +333,9 @@ StatementPhase stage 1 of 1 with 5 MutationType ops
     *scop.SetIndexName
       IndexID: 6
       Name: crdb_internal_index_6_name_placeholder
+      TableID: 104
+    *scop.MakeDroppedCheckConstraintValidated
+      ConstraintID: 2
       TableID: 104
     *scop.MakeDroppedColumnDeleteAndWriteOnly
       ColumnID: 5
@@ -381,7 +385,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
-    [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT], VALIDATED] -> ABSENT
     [[ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MakeDroppedColumnDeleteOnly

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -1200,7 +1200,7 @@ CREATE TABLE defaultdb.greeter (
 ops
 DROP TABLE defaultdb.greeter
 ----
-StatementPhase stage 1 of 1 with 2 MutationType ops
+StatementPhase stage 1 of 1 with 1 MutationType op
   transitions:
     [[Table:{DescID: 114}, ABSENT], PUBLIC] -> OFFLINE
     [[Column:{DescID: 114, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -1210,14 +1210,10 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
     [[Column:{DescID: 114, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[PrimaryIndex:{DescID: 114, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
-    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
   ops:
     *scop.MarkDescriptorAsOffline
       DescID: 114
       Reason: DROP TABLE defaultdb.public.greeter
-    *scop.MakeDroppedCheckConstraintValidated
-      ConstraintID: 2
-      TableID: 114
 PreCommitPhase stage 1 of 1 with 4 MutationType ops
   transitions:
   ops:
@@ -1239,13 +1235,13 @@ PreCommitPhase stage 1 of 1 with 4 MutationType ops
       - 114
       JobID: 1
       NonCancelable: true
-      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
+      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 11 MutationType ops
         pending
       Statements:
       - statement: DROP TABLE defaultdb.greeter
         redactedstatement: DROP TABLE ‹defaultdb›.public.‹greeter›
         statementtag: DROP TABLE
-PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 15 MutationType ops
   transitions:
     [[Namespace:{DescID: 114, Name: greeter, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
@@ -1281,6 +1277,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     [[SecondaryIndexPartial:{DescID: 114, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 114, Name: i, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
     [[ConstraintName:{DescID: 114, Name: check, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
@@ -1320,6 +1317,9 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
         DescriptorID: 114
         Name: greeter
         SchemaID: 101
+    *scop.MakeDroppedCheckConstraintValidated
+      ConstraintID: 2
+      TableID: 114
     *scop.SetJobStateOnDescriptor
       DescriptorID: 112
     *scop.SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -1200,7 +1200,7 @@ CREATE TABLE defaultdb.greeter (
 ops
 DROP TABLE defaultdb.greeter
 ----
-StatementPhase stage 1 of 1 with 1 MutationType op
+StatementPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [[Table:{DescID: 114}, ABSENT], PUBLIC] -> OFFLINE
     [[Column:{DescID: 114, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -1210,10 +1210,14 @@ StatementPhase stage 1 of 1 with 1 MutationType op
     [[Column:{DescID: 114, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[PrimaryIndex:{DescID: 114, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], PUBLIC] -> VALIDATED
+    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
   ops:
     *scop.MarkDescriptorAsOffline
       DescID: 114
       Reason: DROP TABLE defaultdb.public.greeter
+    *scop.MakeDroppedCheckConstraintValidated
+      ConstraintID: 2
+      TableID: 114
 PreCommitPhase stage 1 of 1 with 4 MutationType ops
   transitions:
   ops:
@@ -1235,13 +1239,13 @@ PreCommitPhase stage 1 of 1 with 4 MutationType ops
       - 114
       JobID: 1
       NonCancelable: true
-      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 12 MutationType ops
+      RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 10 MutationType ops
         pending
       Statements:
       - statement: DROP TABLE defaultdb.greeter
         redactedstatement: DROP TABLE ‹defaultdb›.public.‹greeter›
         statementtag: DROP TABLE
-PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
   transitions:
     [[Namespace:{DescID: 114, Name: greeter, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 114}, ABSENT], PUBLIC] -> ABSENT
@@ -1277,7 +1281,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
     [[SecondaryIndexPartial:{DescID: 114, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 114, Name: i, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[ConstraintName:{DescID: 114, Name: check, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
@@ -1311,14 +1314,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
       TypeIDs:
       - 112
       - 113
-    *scop.RemoveCheckConstraint
-      ConstraintID: 2
-      TableID: 114
-    *scop.UpdateTableBackReferencesInTypes
-      BackReferencedTableID: 114
-      TypeIDs:
-      - 112
-      - 113
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -1334,7 +1329,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 11 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 2 with 13 MutationType ops
   transitions:
     [[Table:{DescID: 114}, ABSENT], DROPPED] -> ABSENT
     [[Column:{DescID: 114, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
@@ -1344,6 +1339,7 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 11 MutationType ops
     [[Column:{DescID: 114, ColumnID: 4294967294}, ABSENT], DELETE_ONLY] -> ABSENT
     [[PrimaryIndex:{DescID: 114, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], VALIDATED] -> ABSENT
   ops:
     *scop.LogEvent
       Element:
@@ -1417,6 +1413,14 @@ PostCommitNonRevertiblePhase stage 2 of 2 with 11 MutationType ops
           SourceElementID: 1
           SubWorkID: 1
       TableID: 114
+    *scop.RemoveCheckConstraint
+      ConstraintID: 2
+      TableID: 114
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 114
+      TypeIDs:
+      - 112
+      - 113
     *scop.RemoveJobStateFromDescriptor
       DescriptorID: 112
       JobID: 1

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -12,19 +12,21 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: DROP INDEX
 increment telemetry for sql.schema.drop_index
-## StatementPhase stage 1 of 1 with 5 MutationType ops
+## StatementPhase stage 1 of 1 with 6 MutationType ops
 upsert descriptor #104
-  ...
-       - 3
-       constraintId: 2
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    constraintId: 2
   -    expr: crdb_internal_j_shard_16 IN (0:::INT8, 1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8,
   -      5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8,
   -      13:::INT8, 14:::INT8, 15:::INT8)
-  +    expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
-  +      3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
-  +      11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
-       hidden: true
-       name: check_crdb_internal_j_shard_16
+  -    hidden: true
+  -    name: check_crdb_internal_j_shard_16
+  +  checks: []
+     columns:
+     - id: 1
   ...
          oid: 20
          width: 64
@@ -103,6 +105,23 @@ upsert descriptor #104
   +      version: 3
   +    mutationId: 2
   +    state: DELETE_AND_WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        constraintId: 2
+  +        expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
+  +          3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
+  +          11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
+  +        hidden: true
+  +        name: check_crdb_internal_j_shard_16
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: check_crdb_internal_j_shard_16
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 2
+  +    state: DELETE_AND_WRITE_ONLY
   +  - column:
   +      computeExpr: mod(fnv32(crdb_internal.datums_to_bytes(j)), 16:::INT8)
   +      hidden: true
@@ -164,19 +183,6 @@ commit transaction #2
 begin transaction #3
 ## PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
 upsert descriptor #104
-   table:
-  -  checks:
-  -  - columnIds:
-  -    - 3
-  -    constraintId: 2
-  -    expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
-  -      3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
-  -      11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
-  -    hidden: true
-  -    name: check_crdb_internal_j_shard_16
-  +  checks: []
-     columns:
-     - id: 1
   ...
      id: 104
      indexes: []
@@ -188,6 +194,23 @@ upsert descriptor #104
   ...
          version: 3
        mutationId: 2
+  -    state: DELETE_AND_WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        constraintId: 2
+  -        expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
+  -          3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
+  -          11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
+  -        hidden: true
+  -        name: check_crdb_internal_j_shard_16
+  -        validity: Dropping
+  -      foreignKey: {}
+  -      name: check_crdb_internal_j_shard_16
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 2
   -    state: DELETE_AND_WRITE_ONLY
   +    state: DELETE_ONLY
      - column:

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_index_hash_sharded_index
@@ -12,7 +12,7 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: DROP INDEX
 increment telemetry for sql.schema.drop_index
-## StatementPhase stage 1 of 1 with 6 MutationType ops
+## StatementPhase stage 1 of 1 with 7 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -105,23 +105,6 @@ upsert descriptor #104
   +      version: 3
   +    mutationId: 2
   +    state: DELETE_AND_WRITE_ONLY
-  +  - constraint:
-  +      check:
-  +        columnIds:
-  +        - 3
-  +        constraintId: 2
-  +        expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
-  +          3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
-  +          11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
-  +        hidden: true
-  +        name: check_crdb_internal_j_shard_16
-  +        validity: Dropping
-  +      foreignKey: {}
-  +      name: check_crdb_internal_j_shard_16
-  +      uniqueWithoutIndexConstraint: {}
-  +    direction: DROP
-  +    mutationId: 2
-  +    state: DELETE_AND_WRITE_ONLY
   +  - column:
   +      computeExpr: mod(fnv32(crdb_internal.datums_to_bytes(j)), 16:::INT8)
   +      hidden: true
@@ -132,6 +115,23 @@ upsert descriptor #104
   +        oid: 20
   +        width: 64
   +      virtual: true
+  +    direction: DROP
+  +    mutationId: 2
+  +    state: DELETE_AND_WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        constraintId: 2
+  +        expr: crdb_internal_column_3_name_placeholder IN (0:::INT8, 1:::INT8, 2:::INT8,
+  +          3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
+  +          11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
+  +        hidden: true
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        validity: Dropping
+  +      foreignKey: {}
+  +      name: crdb_internal_constraint_2_name_placeholder
+  +      uniqueWithoutIndexConstraint: {}
   +    direction: DROP
   +    mutationId: 2
   +    state: DELETE_AND_WRITE_ONLY
@@ -181,7 +181,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 2 with 5 MutationType ops
 upsert descriptor #104
   ...
      id: 104
@@ -195,6 +195,13 @@ upsert descriptor #104
          version: 3
        mutationId: 2
   -    state: DELETE_AND_WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         computeExpr: mod(fnv32(crdb_internal.datums_to_bytes(j)), 16:::INT8)
+  ...
+       direction: DROP
+       mutationId: 2
+  -    state: DELETE_AND_WRITE_ONLY
   -  - constraint:
   -      check:
   -        columnIds:
@@ -204,20 +211,13 @@ upsert descriptor #104
   -          3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8,
   -          11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8)
   -        hidden: true
-  -        name: check_crdb_internal_j_shard_16
+  -        name: crdb_internal_constraint_2_name_placeholder
   -        validity: Dropping
   -      foreignKey: {}
-  -      name: check_crdb_internal_j_shard_16
+  -      name: crdb_internal_constraint_2_name_placeholder
   -      uniqueWithoutIndexConstraint: {}
   -    direction: DROP
   -    mutationId: 2
-  -    state: DELETE_AND_WRITE_ONLY
-  +    state: DELETE_ONLY
-     - column:
-         computeExpr: mod(fnv32(crdb_internal.datums_to_bytes(j)), 16:::INT8)
-  ...
-       direction: DROP
-       mutationId: 2
   -    state: DELETE_AND_WRITE_ONLY
   +    state: DELETE_ONLY
      name: t

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
@@ -8,14 +8,16 @@ EXPLAIN (ddl) DROP INDEX idx CASCADE;
 Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 4 elements transitioning toward ABSENT
+ │         ├── 5 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
  │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104, Name: crdb_internal_j_shard_16, ColumnID: 3}
  │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → ABSENT     IndexName:{DescID: 104, Name: idx, IndexID: 2}
- │         └── 5 Mutation operations
+ │         │    ├── PUBLIC → ABSENT     IndexName:{DescID: 104, Name: idx, IndexID: 2}
+ │         │    └── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, ConstraintID: 2}
+ │         └── 6 Mutation operations
  │              ├── MakeDroppedNonPrimaryIndexDeleteAndWriteOnly {"IndexID":2,"TableID":104}
  │              ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+ │              ├── MakeDroppedCheckConstraintValidated {"ConstraintID":2,"TableID":104}
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":3,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
  │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
@@ -32,7 +34,7 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── PUBLIC     → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 2}
+      │    │    ├── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 2}
       │    │    └── PUBLIC     → ABSENT      ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
       │    └── 6 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
@@ -8,19 +8,21 @@ EXPLAIN (ddl) DROP INDEX idx CASCADE;
 Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 5 elements transitioning toward ABSENT
+ │         ├── 6 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
  │         │    ├── PUBLIC → ABSENT     ColumnName:{DescID: 104, Name: crdb_internal_j_shard_16, ColumnID: 3}
  │         │    ├── PUBLIC → VALIDATED  SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
  │         │    ├── PUBLIC → ABSENT     IndexName:{DescID: 104, Name: idx, IndexID: 2}
- │         │    └── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, ConstraintID: 2}
- │         └── 6 Mutation operations
+ │         │    ├── PUBLIC → VALIDATED  CheckConstraint:{DescID: 104, ConstraintID: 2}
+ │         │    └── PUBLIC → ABSENT     ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+ │         └── 7 Mutation operations
  │              ├── MakeDroppedNonPrimaryIndexDeleteAndWriteOnly {"IndexID":2,"TableID":104}
  │              ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
- │              ├── MakeDroppedCheckConstraintValidated {"ConstraintID":2,"TableID":104}
+ │              ├── SetConstraintName {"ConstraintID":2,"Name":"crdb_internal_co...","TableID":104}
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":3,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
- │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+ │              └── MakeDroppedCheckConstraintValidated {"ConstraintID":2,"TableID":104}
  ├── PreCommitPhase
  │    └── Stage 1 of 1 in PreCommitPhase
  │         └── 2 Mutation operations
@@ -28,18 +30,16 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
  │              └── CreateSchemaChangerJob {"NonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
+      │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104, ColumnID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── VALIDATED  → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 2}
-      │    │    └── PUBLIC     → ABSENT      ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
-      │    └── 6 Mutation operations
+      │    │    └── VALIDATED  → ABSENT      CheckConstraint:{DescID: 104, ConstraintID: 2}
+      │    └── 5 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
-      │         ├── NotImplemented {"ElementType":"scpb.ConstraintN..."}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -11,7 +11,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 4 elements transitioning toward ABSENT
+│       ├── • 5 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 3}
 │       │   │   │ PUBLIC → WRITE_ONLY
@@ -28,13 +28,16 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │   │     PUBLIC → VALIDATED
 │       │   │
-│       │   └── • IndexName:{DescID: 104, Name: idx, IndexID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │             rule: "index no longer public before dependents"
+│       │   ├── • IndexName:{DescID: 104, Name: idx, IndexID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "index no longer public before dependents"
+│       │   │
+│       │   └── • CheckConstraint:{DescID: 104, ConstraintID: 2}
+│       │         PUBLIC → VALIDATED
 │       │
-│       └── • 5 Mutation operations
+│       └── • 6 Mutation operations
 │           │
 │           ├── • MakeDroppedNonPrimaryIndexDeleteAndWriteOnly
 │           │     IndexID: 2
@@ -43,6 +46,10 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │           ├── • SetIndexName
 │           │     IndexID: 2
 │           │     Name: crdb_internal_index_2_name_placeholder
+│           │     TableID: 104
+│           │
+│           ├── • MakeDroppedCheckConstraintValidated
+│           │     ConstraintID: 2
 │           │     TableID: 104
 │           │
 │           ├── • MakeDroppedColumnDeleteAndWriteOnly
@@ -137,7 +144,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │   │     VALIDATED → DELETE_ONLY
     │   │   │
     │   │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 2}
-    │   │   │     PUBLIC → ABSENT
+    │   │   │     VALIDATED → ABSENT
     │   │   │
     │   │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
     │   │         PUBLIC → ABSENT

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -11,7 +11,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 5 elements transitioning toward ABSENT
+│       ├── • 6 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 3}
 │       │   │   │ PUBLIC → WRITE_ONLY
@@ -34,10 +34,16 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │   │         rule: "index no longer public before dependents"
 │       │   │
-│       │   └── • CheckConstraint:{DescID: 104, ConstraintID: 2}
-│       │         PUBLIC → VALIDATED
+│       │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 2}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • Precedence dependency from ABSENT ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+│       │   │         rule: "dependents removed before check constraint becomes non-public"
+│       │   │
+│       │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+│       │         PUBLIC → ABSENT
 │       │
-│       └── • 6 Mutation operations
+│       └── • 7 Mutation operations
 │           │
 │           ├── • MakeDroppedNonPrimaryIndexDeleteAndWriteOnly
 │           │     IndexID: 2
@@ -48,8 +54,9 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │           │     Name: crdb_internal_index_2_name_placeholder
 │           │     TableID: 104
 │           │
-│           ├── • MakeDroppedCheckConstraintValidated
+│           ├── • SetConstraintName
 │           │     ConstraintID: 2
+│           │     Name: crdb_internal_constraint_2_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • MakeDroppedColumnDeleteAndWriteOnly
@@ -73,9 +80,13 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │           │         SubWorkID: 1
 │           │     TargetStatus: 1
 │           │
-│           └── • SetColumnName
-│                 ColumnID: 3
-│                 Name: crdb_internal_column_3_name_placeholder
+│           ├── • SetColumnName
+│           │     ColumnID: 3
+│           │     Name: crdb_internal_column_3_name_placeholder
+│           │     TableID: 104
+│           │
+│           └── • MakeDroppedCheckConstraintValidated
+│                 ConstraintID: 2
 │                 TableID: 104
 │
 ├── • PreCommitPhase
@@ -95,7 +106,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
 │                 - 104
 │                 JobID: 1
 │                 NonCancelable: true
-│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 4 MutationType ops pending
+│                 RunningStatus: PostCommitNonRevertiblePhase stage 1 of 2 with 3 MutationType ops pending
 │                 Statements:
 │                 - statement: DROP INDEX idx CASCADE
 │                   redactedstatement: DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx› CASCADE
@@ -105,7 +116,7 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 7 elements transitioning toward ABSENT
+    │   ├── • 6 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │     WRITE_ONLY → DELETE_ONLY
@@ -143,13 +154,10 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │   │     VALIDATED → DELETE_ONLY
     │   │   │
-    │   │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 2}
-    │   │   │     VALIDATED → ABSENT
-    │   │   │
-    │   │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
-    │   │         PUBLIC → ABSENT
+    │   │   └── • CheckConstraint:{DescID: 104, ConstraintID: 2}
+    │   │         VALIDATED → ABSENT
     │   │
-    │   └── • 6 Mutation operations
+    │   └── • 5 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
     │       │     ColumnID: 3
@@ -158,9 +166,6 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │       ├── • RemoveCheckConstraint
     │       │     ConstraintID: 2
     │       │     TableID: 104
-    │       │
-    │       ├── • NotImplemented
-    │       │     ElementType: scpb.ConstraintName
     │       │
     │       ├── • MakeDroppedIndexDeleteOnly
     │       │     IndexID: 2


### PR DESCRIPTION
Previously, we emit unimplemented operations on the adding and dropping
path of check constraint and constraint name. This PR enables this feature
as it will unblock certain DDL statement in the declarative schema changer
such as `ALTER PRIMARY KEY USING HASH`.

The last two commits are the "meaty" commits:
1). Implemented the logic to validate a check constraint in `backfill.go` 
     and plumb it in to the Validator used in declarative schema changer
     for unique index and check constraint validation.

2). Introduced a new status -- `VALIDATING`, and now the 
     adding/dropping path of a check constraint is
    ABSENT <--> VALIDATING <--> VALIDATED <--> PUBLIC

Release note: None