### PR TITLE
sql: cluster setting for early/late binding in udf body

### DIFF
--- a/pkg/sql/create_function_test.go
+++ b/pkg/sql/create_function_test.go
@@ -182,3 +182,95 @@ $$`,
 	})
 	require.NoError(t, err)
 }
+
+func TestCreateFunctionLateBinding(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	tDB := sqlutils.MakeSQLRunner(sqlDB)
+
+	tDB.Exec(t, "SET user_defined_function_early_binding = false")
+
+	tDB.Exec(t, `
+CREATE TABLE t(
+  a INT PRIMARY KEY,
+  b INT,
+  C INT,
+  INDEX t_idx_b(b),
+  INDEX t_idx_c(c)
+);
+CREATE TABLE t_implicit_type(a int, b int);
+CREATE SEQUENCE sq1;
+CREATE VIEW v AS SELECT 1;
+CREATE TYPE notmyworkday AS ENUM ('Monday', 'Tuesday');
+CREATE FUNCTION f(a notmyworkday) RETURNS t_implicit_type IMMUTABLE LANGUAGE SQL AS $$
+  SELECT a FROM public.t;
+  SELECT b FROM t@t_idx_b;
+  SELECT c FROM t@t_idx_c;
+  SELECT a FROM defaultdb.public.v;
+  SELECT nextval('sq1');
+  SELECT * FROM t_implicit_type;
+$$;
+`,
+	)
+
+	err := sql.TestingDescsTxn(ctx, s, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		// Make sure function only has reference to enum type and the implicit type table.
+		funcDesc, err := col.GetImmutableFunctionByID(ctx, txn, 110, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, funcDesc.GetName(), "f")
+		require.Equal(t, []descpb.ID{105}, funcDesc.GetDependsOn())
+		require.Equal(t, []descpb.ID{108, 109}, funcDesc.GetDependsOnTypes())
+		// Make sure function body stays the same (not qualified if user didn't
+		// qualify the names).
+		require.Equal(t,
+			`SELECT a FROM public.t;
+SELECT b FROM t@t_idx_b;
+SELECT c FROM t@t_idx_c;
+SELECT a FROM defaultdb.public.v;
+SELECT nextval(106:::REGCLASS);
+SELECT * FROM t_implicit_type;`,
+			funcDesc.GetFunctionBody())
+
+		// Make sure table has no back references.
+		tn := tree.MakeTableNameWithSchema("defaultdb", "public", "t")
+		_, tbl, err := col.GetImmutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, "t", tbl.GetName())
+		require.Nil(t, tbl.GetDependedOnBy())
+
+		// Make sure sequence has no back references.
+		sqn := tree.MakeTableNameWithSchema("defaultdb", "public", "sq1")
+		_, seq, err := col.GetImmutableTableByName(ctx, txn, &sqn, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, "sq1", seq.GetName())
+		require.Nil(t, seq.GetDependedOnBy())
+
+		// Make sure view has no back references.
+		vn := tree.MakeTableNameWithSchema("defaultdb", "public", "v")
+		_, view, err := col.GetImmutableTableByName(ctx, txn, &vn, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, "v", view.GetName())
+		require.Nil(t, view.GetDependedOnBy())
+
+		// Make sure enum type has correct back references.
+		typn := tree.MakeQualifiedTypeName("defaultdb", "public", "notmyworkday")
+		_, typ, err := col.GetImmutableTypeByName(ctx, txn, &typn, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, "notmyworkday", typ.GetName())
+		require.Equal(t, []descpb.ID{110}, typ.GetReferencingDescriptorIDs())
+
+		// Make sure implicit type has correct back references.
+		tn = tree.MakeTableNameWithSchema("defaultdb", "public", "t_implicit_type")
+		_, tbl, err = col.GetImmutableTableByName(ctx, txn, &tn, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, "t_implicit_type", tbl.GetName())
+		require.Equal(t, []descpb.TableDescriptor_Reference{{ID: 110}}, tbl.GetDependedOnBy())
+
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3296,6 +3296,10 @@ func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }
 
+func (m *sessionDataMutator) SetUserDefinedFunctionEarlyBinding(val bool) {
+	m.data.UserDefinedFunctionEarlyBinding = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4781,8 +4781,9 @@ transaction_rows_read_log                             0
 transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
-troubleshooting_mode                          off
+troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
+user_defined_function_early_binding                   on
 xmloption                                             content
 
 # information_schema can be used with the anonymous database.

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4263,6 +4263,7 @@ transaction_status                                    NoTxn               NULL  
 troubleshooting_mode                                  off                 NULL      NULL        NULL        string
 unconstrained_non_covering_index_scan_enabled         off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                        on                  NULL      NULL        NULL        string
+user_defined_function_early_binding                   on                  NULL      NULL        NULL        string
 vectorize                                             on                  NULL      NULL        NULL        string
 xmloption                                             content             NULL      NULL        NULL        string
 
@@ -4388,6 +4389,7 @@ transaction_status                                    NoTxn               NULL  
 troubleshooting_mode                                  off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled         off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                        on                  NULL  user     NULL      on                  on
+user_defined_function_early_binding                   on                  NULL  user     NULL      on                  on
 vectorize                                             on                  NULL  user     NULL      on                  on
 xmloption                                             content             NULL  user     NULL      content             content
 
@@ -4511,6 +4513,7 @@ transaction_status                                    NULL    NULL     NULL     
 troubleshooting_mode                                  NULL    NULL     NULL     NULL        NULL
 unconstrained_non_covering_index_scan_enabled         NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                        NULL    NULL     NULL     NULL        NULL
+user_defined_function_early_binding                   NULL    NULL     NULL     NULL        NULL
 vectorize                                             NULL    NULL     NULL     NULL        NULL
 xmloption                                             NULL    NULL     NULL     NULL        NULL
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -135,9 +135,10 @@ transaction_rows_read_log                             0
 transaction_rows_written_err                          0
 transaction_rows_written_log                          0
 transaction_status                                    NoTxn
-troubleshooting_mode                        off
+troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
 use_declarative_schema_changer                        on
+user_defined_function_early_binding                   on
 vectorize                                             on
 xmloption                                             content
 

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -42,10 +42,15 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 	preFuncResolver := b.semaCtx.FunctionResolver
 	b.semaCtx.FunctionResolver = nil
 
+	// By default, we do early-binding to track cross references. User is allowed
+	// to set the "user_defined_function_early_binding" session data to false to
+	// have late-binding. Note that references of user-defined types, including
+	// table implicit types, used in function signature will still be tracked when
+	// early binding is off
 	b.insideFuncDef = true
-	b.trackSchemaDeps = true
+	b.trackSchemaDeps = b.evalCtx.SessionData().UserDefinedFunctionEarlyBinding
 	// Make sure datasource names are qualified.
-	b.qualifyDataSourceNamesInAST = true
+	b.qualifyDataSourceNamesInAST = b.evalCtx.SessionData().UserDefinedFunctionEarlyBinding
 	defer func() {
 		b.insideFuncDef = false
 		b.trackSchemaDeps = false

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -294,6 +294,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().LocalityOptimizedSearch = true
 	ot.evalCtx.SessionData().ReorderJoinsLimit = opt.DefaultJoinOrderLimit
 	ot.evalCtx.SessionData().InsertFastPath = true
+	ot.evalCtx.SessionData().UserDefinedFunctionEarlyBinding = true
 
 	return ot
 }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -271,6 +271,17 @@ message LocalOnlySessionData {
   // given probability. This should only be used in test scenarios and is very
   // much a non-production setting.
   double testing_optimizer_disable_rule_probability = 73;
+  // UserDefinedFunctionEarlyBinding is used to turn on/off early binding of
+  // referenced objects within a user-defined function body when a CREATE
+  // FUNCTION statement is run. With early binding on, cross-references are
+  // tracked at function definition time to prevent unexpected schema changes
+  // like dropping a table used by the function. Turning this switch off means
+  // we will have late binding with which references are not tracked. In that
+  // scene, schema changes to referenced objects could potentially break the
+  // function.
+  // Note that references of user-defined types, including table implicit types,
+  // used in function signature will still be tracked when early binding is off.
+  bool user_defined_function_early_binding = 74;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2120,6 +2120,23 @@ var varGen = map[string]sessionVar{
 			return formatFloatAsPostgresSetting(0)
 		},
 	},
+
+	// CockroachDB extension.
+	`user_defined_function_early_binding`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`user_defined_function_early_binding`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("user_defined_function_early_binding", s)
+			if err != nil {
+				return err
+			}
+			m.SetUserDefinedFunctionEarlyBinding(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, kv *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UserDefinedFunctionEarlyBinding), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."


### PR DESCRIPTION
This commit adds a cluster setting to allow users to turn off
early binding of referenced objects in function body at definition
time.

Release note: None