### PR TITLE
server,ui: idx recommendations on UI

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4207,6 +4207,7 @@ StatementDetailsRequest requests the details of a Statement, based on its keys.
 | aggregation_interval | [google.protobuf.Duration](#cockroach.server.serverpb.StatementDetailsResponse-google.protobuf.Duration) |  |  | [reserved](#support-status) |
 | explain_plan | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) |  |  | [reserved](#support-status) |
 | plan_hash | [uint64](#cockroach.server.serverpb.StatementDetailsResponse-uint64) |  |  | [reserved](#support-status) |
+| index_recommendations | [string](#cockroach.server.serverpb.StatementDetailsResponse-string) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1580,6 +1580,7 @@ message StatementDetailsResponse {
       (gogoproto.stdduration) = true];
     string explain_plan = 4;
     uint64 plan_hash = 5;
+    repeated string index_recommendations = 6;
   }
 
   // statement returns the total statistics for the statement.

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -11,3 +11,7 @@
   line-height: $line-height--x-small;
   color: $colors--neutral-7;
 }
+
+.description-item {
+  margin-bottom: 5px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -13,6 +13,7 @@ import React from "react";
 import { ColumnDescriptor, SortedTable } from "../sortedtable";
 import classNames from "classnames/bind";
 import styles from "./insightsTable.module.scss";
+import { StatementLink } from "../statementsTable";
 
 const cx = classNames.bind(styles);
 
@@ -24,8 +25,14 @@ export interface InsightRecommendation {
   table: string;
   index_id: number;
   query: string;
-  exec_stmt: string;
-  exec_id: string;
+  execution: executionDetails;
+}
+
+export interface executionDetails {
+  statement: string;
+  summary: string;
+  fingerprintID: string;
+  implicit: boolean;
 }
 
 export class InsightsSortedTable extends SortedTable<InsightRecommendation> {}
@@ -90,11 +97,17 @@ function descriptionCell(
     case "REPLACE_INDEX":
       return (
         <>
-          <div>
-            <span className={cx("label-bold")}>Statement Execution: </span>{" "}
-            {insightRec.exec_stmt}
+          <div className={cx("description-item")}>
+            <span className={cx("label-bold")}>Statement Fingerprint: </span>{" "}
+            <StatementLink
+              statementFingerprintID={insightRec.execution.fingerprintID}
+              statement={insightRec.execution.statement}
+              statementSummary={insightRec.execution.summary}
+              implicitTxn={insightRec.execution.implicit}
+              className={"inline"}
+            />
           </div>
-          <div>
+          <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Recommendation: </span>{" "}
             {insightRec.query}
           </div>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -41,10 +41,7 @@ import { Button } from "../button";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { Text, TextTypes } from "../text";
 import { SqlBox } from "src/sql/box";
-import {
-  NodeLink,
-  StatementLinkTarget,
-} from "src/statementsTable/statementsTableContent";
+import { NodeLink } from "src/statementsTable/statementsTableContent";
 
 import {
   ICancelQueryRequest,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -26,13 +26,14 @@ export type PlanHashStats =
 export class PlansSortedTable extends SortedTable<PlanHashStats> {}
 
 const planDetailsColumnLabels = {
-  planID: "Plan ID",
-  lastExecTime: "Last Execution Time",
   avgExecTime: "Average Execution Time",
-  execCount: "Execution Count",
   avgRowsRead: "Average Rows Read",
-  fullScan: "Full Scan",
   distSQL: "Distributed",
+  execCount: "Execution Count",
+  fullScan: "Full Scan",
+  insights: "Insights",
+  lastExecTime: "Last Execution Time",
+  planID: "Plan ID",
   vectorized: "Vectorized",
 };
 export type PlanDetailsTableColumnKeys = keyof typeof planDetailsColumnLabels;
@@ -130,7 +131,28 @@ export const planDetailsTableTitles: PlanDetailsTableTitleType = {
       </Tooltip>
     );
   },
+  insights: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"The amount of insights for the plan."}
+      >
+        {planDetailsColumnLabels.insights}
+      </Tooltip>
+    );
+  },
 };
+
+function formatInsights(recommendations: string[]): string {
+  if (!recommendations || recommendations.length == 0) {
+    return "None";
+  }
+  if (recommendations.length == 1) {
+    return "1 Insight";
+  }
+  return `${recommendations.length} Insights`;
+}
 
 export function makeExplainPlanColumns(
   handleDetails: (plan: PlanHashStats) => void,
@@ -146,6 +168,13 @@ export function makeExplainPlanColumns(
       ),
       sort: (item: PlanHashStats) => longToInt(item.plan_hash),
       alwaysShow: true,
+    },
+    {
+      name: "insights",
+      title: planDetailsTableTitles.insights(),
+      cell: (item: PlanHashStats) =>
+        formatInsights(item.stats.index_recommendations),
+      sort: (item: PlanHashStats) => item.stats.index_recommendations?.length,
     },
     {
       name: "lastExecTime",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.module.scss
@@ -136,3 +136,7 @@
 .no-margin-bottom {
   margin-bottom: 0px;
 }
+
+.margin-bottom {
+  margin-bottom: 20px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -40,7 +40,6 @@ import {
 import { Loading } from "src/loading";
 import { Button } from "src/button";
 import { SqlBox, SqlBoxSize } from "src/sql";
-import { SortSetting } from "src/sortedtable";
 import { PlanDetails } from "./planDetails";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { DiagnosticsView } from "./diagnostics/diagnosticsView";
@@ -88,7 +87,6 @@ export type StatementDetailsProps = StatementDetailsOwnProps &
   RouteComponentProps<{ implicitTxn: string; statement: string }>;
 
 export interface StatementDetailsState {
-  plansSortSetting: SortSetting;
   currentTab?: string;
 }
 
@@ -210,10 +208,6 @@ export class StatementDetails extends React.Component<
     super(props);
     const searchParams = new URLSearchParams(props.history.location.search);
     this.state = {
-      plansSortSetting: {
-        ascending: false,
-        columnTitle: "lastExecTime",
-      },
       currentTab: searchParams.get("tab") || "overview",
     };
     this.activateDiagnosticsRef = React.createRef();
@@ -344,12 +338,6 @@ export class StatementDetails extends React.Component<
     if (this.props.onBackToStatementsClick) {
       this.props.onBackToStatementsClick();
     }
-  };
-
-  onChangePlansSortSetting = (ss: SortSetting): void => {
-    this.setState({
-      plansSortSetting: ss,
-    });
   };
 
   render(): React.ReactElement {
@@ -729,9 +717,8 @@ export class StatementDetails extends React.Component<
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />
           <PlanDetails
+            statementFingerprintID={this.props.statementFingerprintID}
             plans={statement_statistics_per_plan_hash}
-            sortSetting={this.state.plansSortSetting}
-            onChangeSortSetting={this.onChangePlansSortSetting}
           />
         </section>
       </>

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.module.scss
@@ -73,3 +73,7 @@
     text-decoration: underline;
   }
 }
+
+.inline {
+  display: inline-flex;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTableContent.tsx
@@ -197,9 +197,10 @@ interface StatementLinkProps {
   implicitTxn: boolean;
   statement: string;
   statementSummary: string;
-  search: string;
+  search?: string;
   statementQuery?: string;
   onClick?: (statement: string) => void;
+  className?: string;
 }
 
 export const StatementLink = ({
@@ -211,6 +212,7 @@ export const StatementLink = ({
   statementSummary,
   search,
   onClick,
+  className,
 }: StatementLinkProps): React.ReactElement => {
   const onStatementClick = React.useCallback(() => {
     if (onClick) {
@@ -228,7 +230,11 @@ export const StatementLink = ({
   const summary = computeOrUseStmtSummary(statement, statementSummary);
 
   return (
-    <Link to={StatementLinkTarget(linkProps)} onClick={onStatementClick}>
+    <Link
+      to={StatementLinkTarget(linkProps)}
+      onClick={onStatementClick}
+      className={`${cx(className)}`}
+    >
       <div>
         <Tooltip
           placement="bottom"


### PR DESCRIPTION
Returning index recommendations to the statement
details endpoint.
Showing the recommendations per plans on the
statement details page, under explain tab.

Fixes https://github.com/cockroachdb/cockroach/issues/83783
Fixes https://github.com/cockroachdb/cockroach/issues/81861

<img width="1735" alt="Screen Shot 2022-08-10 at 7 50 55 PM" src="https://user-images.githubusercontent.com/1017486/184042415-e97edc82-1bfd-47db-9695-1ad563d3a8a3.png">

<img width="1335" alt="Screen Shot 2022-08-10 at 7 50 11 PM" src="https://user-images.githubusercontent.com/1017486/184042422-2c935fa0-2fd1-4f23-aae5-f9f8fb9d4d85.png">


https://www.loom.com/share/4d83b94ed4bf48ff9bf7007ab3e38242

Release note (api change): Returning index
recommendations on the statement details api.
Release note (ui change): Displaying insights of
index recommendations on the Explain Plans tab on
Statement Details page.