### PR TITLE
streamingccl, rowexec: correctly mark eventStream as "streaming"

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/event_stream.go
+++ b/pkg/ccl/streamingccl/streamproducer/event_stream.go
@@ -532,11 +532,11 @@ func streamPartition(
 	for _, sp := range spec.Spans {
 		subscribedSpans.Add(sp)
 	}
-	return eval.MakeStreamingValueGenerator(&eventStream{
+	return &eventStream{
 		streamID:        streamID,
 		spec:            spec,
 		subscribedSpans: subscribedSpans,
 		execCfg:         execCfg,
 		mon:             evalCtx.Mon,
-	}), nil
+	}, nil
 }

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -227,9 +227,10 @@ var replicationBuiltins = map[string]builtinDefinition{
 	),
 	"crdb_internal.stream_partition": makeBuiltin(
 		tree.FunctionProperties{
-			Category:         builtinconstants.CategoryStreamIngestion,
-			DistsqlBlocklist: false,
-			Class:            tree.GeneratorClass,
+			Category:           builtinconstants.CategoryStreamIngestion,
+			DistsqlBlocklist:   false,
+			Class:              tree.GeneratorClass,
+			VectorizeStreaming: true,
 		},
 		makeGeneratorOverload(
 			tree.ArgTypes{

--- a/pkg/sql/sem/eval/generators.go
+++ b/pkg/sql/sem/eval/generators.go
@@ -83,25 +83,6 @@ type ValueGenerator interface {
 	Close(ctx context.Context)
 }
 
-// streamingValueGenerator is a marker-type indicating that the wrapped
-// generator is of "streaming" nature, thus, projectSet processor must be
-// streaming too.
-type streamingValueGenerator struct {
-	ValueGenerator
-}
-
-// MakeStreamingValueGenerator marks the generator as "streaming".
-func MakeStreamingValueGenerator(gen ValueGenerator) ValueGenerator {
-	return streamingValueGenerator{ValueGenerator: gen}
-}
-
-// IsStreamingValueGenerator returns whether the generator is of the "streaming"
-// nature.
-func IsStreamingValueGenerator(gen ValueGenerator) bool {
-	_, ok := gen.(streamingValueGenerator)
-	return ok
-}
-
 // CallbackValueGenerator is a ValueGenerator that calls a supplied callback for
 // producing the values. To be used with
 // eval.TestingKnobs.CallbackGenerators.

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1295,6 +1295,12 @@ func (node *FuncExpr) IsDistSQLBlocklist() bool {
 	return (node.fn != nil && node.fn.DistsqlBlocklist) || (node.fnProps != nil && node.fnProps.DistsqlBlocklist)
 }
 
+// IsVectorizeStreaming returns whether the function is of "streaming" nature
+// from the perspective of the vectorized execution engine.
+func (node *FuncExpr) IsVectorizeStreaming() bool {
+	return node.fnProps != nil && node.fnProps.VectorizeStreaming
+}
+
 type funcType int
 
 // FuncExpr.Type

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -124,6 +124,10 @@ type FunctionProperties struct {
 	//
 	// See memo.CanBeCompositeSensitive.
 	CompositeInsensitive bool
+
+	// VectorizeStreaming indicates that the function is of "streaming" nature
+	// from the perspective of the vectorized execution engine.
+	VectorizeStreaming bool
 }
 
 // ShouldDocument returns whether the built-in function should be included in


### PR DESCRIPTION
This commit fixes an incomplete solution of
9bb5d30d280f53d5efe806525076bf419fb44882 which attempted to mark
`eventStream` generator builtin as "streaming" so that the columnarizer
on top of the `projectSetProcessor` would not buffer anything. As found
by Steven, the solution in that commit was incomplete since the
generators array is not populated at the time where `MustBeStreaming`
check is performed. This commit fixes that oversight by using
a different way of propagating the property - via the function
properties.

Release note: None