### PR TITLE
streamingccl: fix producer stream to properly propagate error

### DIFF
--- a/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
+++ b/pkg/ccl/streamingccl/streamclient/partitioned_stream_client_test.go
@@ -52,6 +52,11 @@ func (f *subscriptionFeedSource) Next() (streamingccl.Event, bool) {
 	return event, hasMore
 }
 
+// Error implements the streamingtest.FeedSource interface.
+func (f *subscriptionFeedSource) Error() error {
+	return f.sub.Err()
+}
+
 // Close implements the streamingtest.FeedSource interface.
 func (f *subscriptionFeedSource) Close(ctx context.Context) {}
 
@@ -201,6 +206,10 @@ INSERT INTO d.t2 VALUES (2);
 	// the subscribe function sees our local context cancellation.
 	err = cg.Wait()
 	require.True(t, errors.Is(err, context.Canceled) || isQueryCanceledError(err))
+
+	rf.ObserveError(ctx, func(err error) bool {
+		return errors.Is(err, context.Canceled) || isQueryCanceledError(err)
+	})
 
 	// Testing client.Complete()
 	err = client.Complete(ctx, streaming.StreamID(999), true)

--- a/pkg/ccl/streamingccl/streamingtest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingtest/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",


### PR DESCRIPTION
Previously when rangefeed returns internal error, the error
didn't get propagated through the producer stream cursor.

The bug is that the SQL receiver's result writer only sends
error after all ValueGenerators close. However, closing eventStream
(i.e., the producer stream ValueGenerator) relies on shutting
down of streamLoop which is not explicitly shut down during Close.

Release justification: bug fixes and low-risk updates to
new functionality

Release note: None