### PR TITLE
release-22.1: xform: hoist projection from join only for canonical scans/selects

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3235,6 +3235,10 @@ func (m *sessionDataMutator) SetShowPrimaryKeyConstraintOnNotVisibleColumns(val 
 	m.data.ShowPrimaryKeyConstraintOnNotVisibleColumns = val
 }
 
+func (m *sessionDataMutator) SetDisableHoistProjectionInJoinLimitation(val bool) {
+	m.data.DisableHoistProjectionInJoinLimitation = val
+}
+
 func (m *sessionDataMutator) SetTroubleshootingModeEnabled(val bool) {
 	m.data.TroubleshootingMode = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4716,6 +4716,7 @@ default_transaction_quality_of_service                regular
 default_transaction_read_only                         off
 default_transaction_use_follower_reads                off
 default_with_oids                                     off
+disable_hoist_projection_in_join_limitation           off
 disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4144,6 +4144,7 @@ default_transaction_quality_of_service                regular             NULL  
 default_transaction_read_only                         off                 NULL      NULL        NULL        string
 default_transaction_use_follower_reads                off                 NULL      NULL        NULL        string
 default_with_oids                                     off                 NULL      NULL        NULL        string
+disable_hoist_projection_in_join_limitation           off                 NULL      NULL        NULL        string
 disable_partially_distributed_plans                   off                 NULL      NULL        NULL        string
 disable_plan_gists                                    off                 NULL      NULL        NULL        string
 disallow_full_table_scans                             off                 NULL      NULL        NULL        string
@@ -4267,6 +4268,7 @@ default_transaction_quality_of_service                regular             NULL  
 default_transaction_read_only                         off                 NULL  user     NULL      off                 off
 default_transaction_use_follower_reads                off                 NULL  user     NULL      off                 off
 default_with_oids                                     off                 NULL  user     NULL      off                 off
+disable_hoist_projection_in_join_limitation           off                 NULL  user     NULL      off                 off
 disable_partially_distributed_plans                   off                 NULL  user     NULL      off                 off
 disable_plan_gists                                    off                 NULL  user     NULL      off                 off
 disallow_full_table_scans                             off                 NULL  user     NULL      off                 off
@@ -4385,6 +4387,7 @@ default_transaction_quality_of_service                NULL    NULL     NULL     
 default_transaction_read_only                         NULL    NULL     NULL     NULL        NULL
 default_transaction_use_follower_reads                NULL    NULL     NULL     NULL        NULL
 default_with_oids                                     NULL    NULL     NULL     NULL        NULL
+disable_hoist_projection_in_join_limitation           NULL    NULL     NULL     NULL        NULL
 disable_partially_distributed_plans                   NULL    NULL     NULL     NULL        NULL
 disable_plan_gists                                    NULL    NULL     NULL     NULL        NULL
 disallow_full_table_scans                             NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -47,6 +47,7 @@ default_transaction_quality_of_service                regular
 default_transaction_read_only                         off
 default_transaction_use_follower_reads                off
 default_with_oids                                     off
+disable_hoist_projection_in_join_limitation           off
 disable_partially_distributed_plans                   off
 disable_plan_gists                                    off
 disallow_full_table_scans                             off

--- a/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tpch_vec
@@ -957,18 +957,18 @@ EXPLAIN (VEC) SELECT s_name, s_address FROM supplier, nation WHERE s_suppkey IN 
 └ Node 1
   └ *colexec.sortOp
     └ *colexecjoin.hashJoiner
-      ├ *colexecsel.selEQBytesBytesConstOp
-      │ └ *colfetcher.ColBatchScan
-      └ *rowexec.joinReader
-        └ *colexec.unorderedDistinct
-          └ *rowexec.joinReader
-            └ *colexecsel.selGTInt64Float64Op
-              └ *colexecproj.projMultFloat64Float64ConstOp
-                └ *colexec.hashAggregator
-                  └ *colexecjoin.hashJoiner
-                    ├ *colfetcher.ColIndexJoin
-                    │ └ *colfetcher.ColBatchScan
-                    └ *colfetcher.ColBatchScan
+      ├ *rowexec.joinReader
+      │ └ *colexec.unorderedDistinct
+      │   └ *rowexec.joinReader
+      │     └ *colexecsel.selGTInt64Float64Op
+      │       └ *colexecproj.projMultFloat64Float64ConstOp
+      │         └ *colexec.hashAggregator
+      │           └ *colexecjoin.hashJoiner
+      │             ├ *colfetcher.ColIndexJoin
+      │             │ └ *colfetcher.ColBatchScan
+      │             └ *colfetcher.ColBatchScan
+      └ *colexecsel.selEQBytesBytesConstOp
+        └ *colfetcher.ColBatchScan
 
 # Query 21
 query T

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security",
         "//pkg/settings/cluster",
+        "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -129,6 +130,10 @@ type OptTester struct {
 // Flags are control knobs for tests. Note that specific testcases can
 // override these defaults.
 type Flags struct {
+	ctx context.Context
+
+	evalCtx tree.EvalContext
+
 	// ExprFormat controls the output detail of build / opt/ optsteps command
 	// directives.
 	ExprFormat memo.ExprFmtFlags
@@ -243,12 +248,22 @@ type Flags struct {
 	// more than MemoGroupLimit memo groups are constructed during optimization.
 	MemoGroupLimit int64
 
+	// SuppressSizeCheckReport is used by the check-size command to disable
+	// printing of the number of rules applied or memo groups constructed so that
+	// it can be used as an upper-bound sanity check and not a requirement for an
+	// exact number of rules or memo groups.
+	SuppressSizeCheckReport bool
+
 	// QueryArgs are values for placeholders, used for assign-placeholders-*.
 	QueryArgs []string
 
 	// UseMultiColStats is the value for SessionData.OptimizerUseMultiColStats.
 	// It defaults to true in New.
 	UseMultiColStats bool
+
+	// SkipRace indicates that a test should be skipped if the race detector is
+	// enabled.
+	SkipRace bool
 }
 
 // New constructs a new instance of the OptTester for the given SQL statement.
@@ -263,6 +278,10 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 		semaCtx: tree.MakeSemaContext(),
 		evalCtx: tree.MakeTestingEvalContext(cluster.MakeTestingClusterSettings()),
 	}
+
+	ot.Flags.ctx = ot.ctx
+	ot.Flags.evalCtx = ot.evalCtx
+
 	// To allow opttester tests to use now(), we hardcode a preset transaction
 	// time. May 10, 2017 is a historic day: the release date of CockroachDB 1.0.
 	ot.evalCtx.TxnTimestamp = time.Date(2017, 05, 10, 13, 0, 0, 0, time.UTC)
@@ -402,12 +421,14 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //
 //    Injects table statistics from a json file.
 //
-//  - check-size [rule-limit=...] [group-limit=...]
+//  - check-size [rule-limit=...] [group-limit=...] [suppress-report]
 //
 //    Fully optimizes the given query and outputs the number of rules applied
 //    and memo groups created. If the rule-limit or group-limit flags are set,
 //    check-size will result in a test error if the rule application or memo
-//    group count exceeds the corresponding limit.
+//    group count exceeds the corresponding limit. If either the rule-limit or
+//    group-limit options are used the suppress-report option suppresses
+//    printing of the number of rules and groups explored.
 //
 //  - index-candidates
 //
@@ -504,6 +525,11 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 //
 //  - group-limit: used with check-size to set a max limit on the number of
 //    groups that can be added to the memo before a testing error is returned.
+//
+//  - set: sets the session setting for the given SQL statement, for example:
+//         build set=prefer_lookup_joins_for_fks=true
+//         DELETE FROM parent WHERE p = 3
+//         ----
 //
 func (ot *OptTester) RunCommand(tb testing.TB, d *datadriven.TestData) string {
 	// Allow testcases to override the flags.
@@ -848,6 +874,18 @@ func ruleNamesToRuleSet(args []string) (RuleSet, error) {
 // See OptTester.RunCommand for supported flags.
 func (f *Flags) Set(arg datadriven.CmdArg) error {
 	switch arg.Key {
+	case "set":
+		for _, val := range arg.Vals {
+			s := strings.Split(val, "=")
+			if len(s) != 2 {
+				return errors.Errorf("Expected both session variable name and value for set flag")
+			}
+			err := sql.SetSessionVariable(f.ctx, f.evalCtx, s[0], s[1])
+			if err != nil {
+				return err
+			}
+		}
+
 	case "format":
 		if len(arg.Vals) == 0 {
 			return fmt.Errorf("format flag requires value(s)")
@@ -1041,6 +1079,9 @@ func (f *Flags) Set(arg datadriven.CmdArg) error {
 
 	case "split-diff":
 		f.OptStepsSplitDiff = true
+
+	case "suppress-report":
+		f.SuppressSizeCheckReport = true
 
 	case "rule-limit":
 		if len(arg.Vals) != 1 {
@@ -2074,7 +2115,11 @@ func (ot *OptTester) CheckSize() (string, error) {
 	if ot.Flags.MemoGroupLimit > 0 && groups > ot.Flags.MemoGroupLimit {
 		return "", fmt.Errorf("memo groups exceeded limit: %d groups", groups)
 	}
-	return fmt.Sprintf("Rules Applied: %d\nGroups Added: %d\n", ruleApplications, groups), nil
+	var message string
+	if !ot.Flags.SuppressSizeCheckReport {
+		message = fmt.Sprintf("Rules Applied: %d\nGroups Added: %d\n", ruleApplications, groups)
+	}
+	return message, nil
 }
 
 // IndexCandidates is used with the index-candidates option. It finds index

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1818,3 +1818,40 @@ func (c *CustomFuncs) splitValues(
 	}
 	return localVals, remoteVals
 }
+
+// getfilteredCanonicalScan looks at a *ScanExpr or *SelectExpr "relation" and
+// returns the input *ScanExpr and FiltersExpr, along with ok=true, if the Scan
+// is a canonical scan. If "relation" is a different type, or if it's a
+// *SelectExpr with an Input other than a *ScanExpr, ok=false is returned. Scans
+// or Selects with no filters may return filters as nil.
+func (c *CustomFuncs) getfilteredCanonicalScan(
+	relation memo.RelExpr,
+) (scanExpr *memo.ScanExpr, filters memo.FiltersExpr, ok bool) {
+	var selectExpr *memo.SelectExpr
+	if selectExpr, ok = relation.(*memo.SelectExpr); ok {
+		if scanExpr, ok = selectExpr.Input.(*memo.ScanExpr); !ok {
+			return nil, nil, false
+		}
+		filters = selectExpr.Filters
+	} else if scanExpr, ok = relation.(*memo.ScanExpr); !ok {
+		return nil, nil, false
+	}
+	scanPrivate := &scanExpr.ScanPrivate
+	if !c.IsCanonicalScan(scanPrivate) {
+		return nil, nil, false
+	}
+	return scanExpr, filters, true
+}
+
+// CanHoistProjectInput returns true if a projection of an expression on
+// `relation` is allowed to be hoisted above a parent Join. The preconditions
+// for this are if `relation` is a canonical scan or a select from a canonical
+// scan, or the disable_hoist_projection_in_join_limitation session flag is
+// true.
+func (c *CustomFuncs) CanHoistProjectInput(relation memo.RelExpr) (ok bool) {
+	if c.e.evalCtx.SessionData().DisableHoistProjectionInJoinLimitation {
+		return true
+	}
+	_, _, ok = c.getfilteredCanonicalScan(relation)
+	return ok
+}

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -324,9 +324,9 @@
     )
 )
 
-# HoistProjectFromInnerJoin lifts a Project from under an InnerJoin; the join
-# can then be subject to other rules, most importantly allowing it to become a
-# lookup join.
+# HoistProjectFromInnerJoin lifts a Project of a canonical scan or of a select
+# from a canonical scan from under an InnerJoin; the join can then be subject to
+# other rules, most importantly allowing it to become a lookup join.
 #
 # As long as the projections are non-volatile, it is equivalent to calculate
 # them on every output row.
@@ -341,7 +341,7 @@
 (InnerJoin
     $left:*
     $proj:(Project
-        $right:*
+        $right:* & (CanHoistProjectInput $right)
         $projections:* & ^(HasVolatileProjection $projections)
         $passthrough:*
     )
@@ -359,9 +359,9 @@
     (UnionCols $passthrough (OutputCols $left))
 )
 
-# HoistProjectFromLeftJoin pulls a project from under an LeftJoin; the join can
-# then be subject to other rules, most importantly allowing it to become a
-# lookup join.
+# HoistProjectFromLeftJoin pulls a project of a canonical scan or of a select
+# from a canonical scan from under an LeftJoin; the join can then be subject to
+# other rules, most importantly allowing it to become a lookup join.
 #
 # This rule is similar to HoistProjectFromInnerJoin, except that we have to
 # handle "outer" rows correctly and make sure we project NULLs, regardless of
@@ -383,7 +383,7 @@
 (LeftJoin
     $left:*
     (Project
-        $right:*
+        $right:* & (CanHoistProjectInput $right)
         $projections:* & ^(HasVolatileProjection $projections)
         $passthrough:*
     )

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -2005,14 +2005,13 @@ project
  │    ├── immutable
  │    ├── key: (8)
  │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
- │    ├── project
- │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
+ │    ├── right-join (hash)
+ │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 column24:24
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    ├── right-join (hash)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
- │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    ├── project
+ │    │    │    ├── columns: column24:24 li.customerid:12!null li.ordernumber:13!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2028,29 +2027,29 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (merge)
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── left ordering: +1,+2
- │    │    │    │    ├── right ordering: +6,+7
+ │    │    │    └── projections
+ │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
+ │    │    │    ├── left ordering: +1,+2
+ │    │    │    ├── right ordering: +6,+7
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
+ │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
- │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
- │    │    │    │    └── filters (true)
- │    │    │    └── filters
- │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
- │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
- │    │    └── projections
- │    │         └── CASE li.customerid:12 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:15::INT8 * cost:20::DECIMAL END [as=column24:24, outer=(12,15,20), immutable]
+ │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+ │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
  │    └── aggregations
  │         ├── sum [as=sum:25, outer=(24)]
  │         │    └── column24:24
@@ -2301,14 +2300,13 @@ project
  │    ├── immutable
  │    ├── key: (8)
  │    ├── fd: ()-->(1-3,6,7), (8)-->(1-3,6,7,9,25)
- │    ├── project
- │    │    ├── columns: column24:24 order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13
+ │    ├── right-join (hash)
+ │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 column24:24
  │    │    ├── immutable
  │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    ├── right-join (hash)
- │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9 li.customerid:12 li.ordernumber:13 li.productid:14 li.quantity:15 p.productid:18 cost:20
- │    │    │    ├── key: (8,12,13,18)
- │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9), (12-14)-->(15), (18)-->(20), (14)==(18), (18)==(14)
+ │    │    ├── project
+ │    │    │    ├── columns: column24:24 li.customerid:12!null li.ordernumber:13!null
+ │    │    │    ├── immutable
  │    │    │    ├── inner-join (hash)
  │    │    │    │    ├── columns: li.customerid:12!null li.ordernumber:13!null li.productid:14!null li.quantity:15 p.productid:18!null cost:20
  │    │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
@@ -2324,29 +2322,29 @@ project
  │    │    │    │    │    └── fd: (18)-->(20)
  │    │    │    │    └── filters
  │    │    │    │         └── li.productid:14 = p.productid:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
- │    │    │    ├── left-join (merge)
- │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
- │    │    │    │    ├── left ordering: +1,+2
- │    │    │    │    ├── right ordering: +6,+7
+ │    │    │    └── projections
+ │    │    │         └── li.quantity:15::INT8 * cost:20::DECIMAL [as=column24:24, outer=(15,20), immutable]
+ │    │    ├── left-join (merge)
+ │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null lineitems1_.customerid:6 lineitems1_.ordernumber:7 lineitems1_.productid:8 lineitems1_.quantity:9
+ │    │    │    ├── left ordering: +1,+2
+ │    │    │    ├── right ordering: +6,+7
+ │    │    │    ├── key: (8)
+ │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
+ │    │    │    ├── scan customerorder [as=order0_]
+ │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
+ │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    └── fd: ()-->(1-3)
+ │    │    │    ├── scan lineitem [as=lineitems1_]
+ │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
+ │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
  │    │    │    │    ├── key: (8)
- │    │    │    │    ├── fd: ()-->(1-3,6,7), (8)-->(9)
- │    │    │    │    ├── scan customerorder [as=order0_]
- │    │    │    │    │    ├── columns: order0_.customerid:1!null order0_.ordernumber:2!null orderdate:3!null
- │    │    │    │    │    ├── constraint: /1/2: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── cardinality: [0 - 1]
- │    │    │    │    │    ├── key: ()
- │    │    │    │    │    └── fd: ()-->(1-3)
- │    │    │    │    ├── scan lineitem [as=lineitems1_]
- │    │    │    │    │    ├── columns: lineitems1_.customerid:6!null lineitems1_.ordernumber:7!null lineitems1_.productid:8!null lineitems1_.quantity:9
- │    │    │    │    │    ├── constraint: /6/7/8: [/'c111'/0 - /'c111'/0]
- │    │    │    │    │    ├── key: (8)
- │    │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
- │    │    │    │    └── filters (true)
- │    │    │    └── filters
- │    │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
- │    │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
- │    │    └── projections
- │    │         └── CASE li.customerid:12 IS NULL WHEN true THEN CAST(NULL AS DECIMAL) ELSE li.quantity:15::INT8 * cost:20::DECIMAL END [as=column24:24, outer=(12,15,20), immutable]
+ │    │    │    │    └── fd: ()-->(6,7), (8)-->(9)
+ │    │    │    └── filters (true)
+ │    │    └── filters
+ │    │         ├── li.customerid:12 = order0_.customerid:1 [outer=(1,12), constraints=(/1: (/NULL - ]; /12: (/NULL - ]), fd=(1)==(12), (12)==(1)]
+ │    │         └── li.ordernumber:13 = order0_.ordernumber:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
  │    └── aggregations
  │         ├── sum [as=sum:25, outer=(24)]
  │         │    └── column24:24

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -10133,6 +10133,127 @@ inner-join (merge)
  │         └── columns: m:1 n:2
  └── filters (true)
 
+# The rule should be allowed to fire when the projection is from a join if the
+# session flag disable_hoist_projection_in_join_limitation is true.
+opt expect=HoistProjectFromInnerJoin set=disable_hoist_projection_in_join_limitation=true
+SELECT * FROM (SELECT a, a+b FROM (SELECT tab1.* from abcd tab1, abcd tab2)) JOIN small ON a=m;
+----
+project
+ ├── columns: a:1!null "?column?":13 m:14!null n:15
+ ├── immutable
+ ├── fd: (1)==(14), (14)==(1)
+ ├── inner-join (cross)
+ │    ├── columns: tab1.a:1!null tab1.b:2 m:14!null n:15
+ │    ├── fd: (1)==(14), (14)==(1)
+ │    ├── scan abcd@abcd_a_b_idx [as=tab2]
+ │    ├── inner-join (lookup abcd@abcd_a_b_idx [as=tab1])
+ │    │    ├── columns: tab1.a:1!null tab1.b:2 m:14!null n:15
+ │    │    ├── key columns: [14] = [1]
+ │    │    ├── fd: (1)==(14), (14)==(1)
+ │    │    ├── scan small
+ │    │    │    └── columns: m:14 n:15
+ │    │    └── filters (true)
+ │    └── filters (true)
+ └── projections
+      └── tab1.a:1 + tab1.b:2 [as="?column?":13, outer=(1,2), immutable]
+
+# The rule should not fire when the projection is from a join.
+opt expect-not=HoistProjectFromInnerJoin set=disable_hoist_projection_in_join_limitation=false
+SELECT * FROM (SELECT a, a+b FROM (SELECT tab1.* from abcd tab1, abcd tab2)) JOIN small ON a=m
+----
+inner-join (hash)
+ ├── columns: a:1!null "?column?":13 m:14!null n:15
+ ├── immutable
+ ├── fd: (1)==(14), (14)==(1)
+ ├── project
+ │    ├── columns: "?column?":13 tab1.a:1
+ │    ├── immutable
+ │    ├── inner-join (cross)
+ │    │    ├── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab1]
+ │    │    │    └── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab2]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── tab1.a:1 + tab1.b:2 [as="?column?":13, outer=(1,2), immutable]
+ ├── scan small
+ │    └── columns: m:14 n:15
+ └── filters
+      └── tab1.a:1 = m:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
+
+# Regression test for #79943.
+exec-ddl
+CREATE TABLE table1 (
+col1_0 GEOGRAPHY NULL,
+col1_1 TIMETZ NOT NULL,
+col1_2 INTERVAL[],
+col1_3 REGCLASS NULL,
+col1_4 REGPROCEDURE,
+col1_5 STRING AS (CASE WHEN col1_2 IS NULL THEN 'abc' ELSE 'def' END) VIRTUAL,
+col1_6 STRING NULL AS (lower(CAST(col1_0 AS STRING))) VIRTUAL,
+col1_7 STRING AS (CASE WHEN col1_4 IS NULL THEN 'foo' ELSE 'bar' END) VIRTUAL,
+INDEX (col1_5 DESC, col1_3, col1_6 DESC, col1_4 ASC) STORING (col1_0, col1_2),
+UNIQUE (col1_1 ASC, lower(CAST(col1_0 AS STRING)) DESC))
+----
+
+exec-ddl
+CREATE TABLE table2 (
+col2_0 FLOAT4,
+col2_1 INT8[] NULL,
+col2_2 OID NULL,
+col2_3 FLOAT4 NOT NULL,
+col2_4 DECIMAL NULL,
+col2_5 INT2,
+col2_6 BYTES,
+col2_7 TIME,
+col2_8 INT8 NULL,
+col2_9 REGPROC,
+col2_10 NAME,
+col2_11 FLOAT4 AS (col2_3 + col2_0) STORED,
+col2_12 INT8 NULL AS (col2_8 + col2_5) VIRTUAL,
+col2_13 INT8 NULL AS (col2_8 + col2_5) VIRTUAL,
+col2_14 INT2 AS (col2_5 + col2_8) VIRTUAL,
+col2_15 INT2 AS (col2_5 + col2_8) VIRTUAL,
+col2_16 FLOAT4 AS (col2_3 + col2_0) VIRTUAL,
+col2_17 INT2 AS (col2_5 + col2_8) VIRTUAL)
+----
+
+# Regression test for #79943.
+# HoistProjectFromInnerJoin should fire, but not fire in so many cases that
+# query optimization never finishes.
+check-size rule-limit=100000 group-limit=10000 suppress-report expect=HoistProjectFromInnerJoin
+SELECT *
+FROM
+    table2 tab_69833
+    JOIN table1@[0] AS tab_69836
+        JOIN table1 AS tab_69837 ON (tab_69836.col1_5) = (tab_69837.col1_5)
+        JOIN table1@[0] AS tab_69838 ON
+                (tab_69836.col1_5) = (tab_69838.col1_6)
+                AND (tab_69837.col1_6) = (tab_69838.col1_7)
+                AND (tab_69837.col1_5) = (tab_69838.col1_7)
+        JOIN table2@[0] AS tab_69839
+            JOIN table2@[0] AS tab_69840 ON
+                    (tab_69839.col2_13) = (tab_69840.col2_8) AND
+                    (tab_69839.col2_13) = (tab_69840.col2_12) ON
+                (tab_69837.tableoid) = (tab_69840.col2_2)
+                AND (tab_69838.crdb_internal_mvcc_timestamp) = (tab_69839.col2_4)
+        JOIN table2@[0] AS tab_69841 ON (tab_69839.tableoid) = (tab_69841.col2_2)
+        JOIN table1 AS tab_69842
+            JOIN table1 AS tab_69843 ON (tab_69842.col1_5) = (tab_69843.col1_5) ON
+                (tab_69838.col1_6) = (tab_69842.col1_5) AND (tab_69837.col1_6) = (tab_69843.col1_5)
+        JOIN table1 AS tab_69844 ON
+                (tab_69838.col1_6) = (tab_69844.col1_5) ON
+            (tab_69833.col2_2) = (tab_69838.tableoid)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69839.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69840.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.col2_4) = (tab_69838.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69838.crdb_internal_mvcc_timestamp)
+ORDER BY
+    tab_69844.col1_6 DESC, tab_69833.crdb_internal_mvcc_timestamp
+LIMIT
+    51:::INT8
+----
+
 # --------------------------------------------------
 # HoistProjectFromLeftJoin
 # --------------------------------------------------
@@ -10256,6 +10377,65 @@ right-join (hash)
  │    └── columns: m:1 n:2
  └── filters
       └── p:6 = m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+# The rule should not fire when the projection is from a join.
+opt expect-not=HoistProjectFromLeftJoin
+SELECT * FROM (SELECT a, a+b FROM (SELECT tab1.* from abcd tab1, abcd tab2)) LEFT OUTER JOIN small ON a=m
+----
+left-join (hash)
+ ├── columns: a:1 "?column?":13 m:14 n:15
+ ├── immutable
+ ├── project
+ │    ├── columns: "?column?":13 tab1.a:1
+ │    ├── immutable
+ │    ├── inner-join (cross)
+ │    │    ├── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab1]
+ │    │    │    └── columns: tab1.a:1 tab1.b:2
+ │    │    ├── scan abcd@abcd_a_b_idx [as=tab2]
+ │    │    └── filters (true)
+ │    └── projections
+ │         └── tab1.a:1 + tab1.b:2 [as="?column?":13, outer=(1,2), immutable]
+ ├── scan small
+ │    └── columns: m:14 n:15
+ └── filters
+      └── tab1.a:1 = m:14 [outer=(1,14), constraints=(/1: (/NULL - ]; /14: (/NULL - ]), fd=(1)==(14), (14)==(1)]
+
+# Regression test for #79943.
+# HoistProjectFromLeftJoin should fire, but not fire in so many cases that
+# query optimization never finishes.
+check-size rule-limit=100000 group-limit=10000 suppress-report expect=HoistProjectFromLeftJoin
+SELECT *
+FROM
+    table2 tab_69833
+    LEFT OUTER JOIN table1@[0] AS tab_69836
+        LEFT OUTER JOIN table1 AS tab_69837 ON (tab_69836.col1_5) = (tab_69837.col1_5)
+        LEFT OUTER JOIN table1@[0] AS tab_69838 ON
+                (tab_69836.col1_5) = (tab_69838.col1_6)
+                AND (tab_69837.col1_6) = (tab_69838.col1_7)
+                AND (tab_69837.col1_5) = (tab_69838.col1_7)
+        LEFT OUTER JOIN table2@[0] AS tab_69839
+            LEFT OUTER JOIN table2@[0] AS tab_69840 ON
+                    (tab_69839.col2_13) = (tab_69840.col2_8) AND
+                    (tab_69839.col2_13) = (tab_69840.col2_12) ON
+                (tab_69837.tableoid) = (tab_69840.col2_2)
+                AND (tab_69838.crdb_internal_mvcc_timestamp) = (tab_69839.col2_4)
+        LEFT OUTER JOIN table2@[0] AS tab_69841 ON (tab_69839.tableoid) = (tab_69841.col2_2)
+        LEFT OUTER JOIN table1 AS tab_69842
+            LEFT OUTER JOIN table1 AS tab_69843 ON (tab_69842.col1_5) = (tab_69843.col1_5) ON
+                (tab_69838.col1_6) = (tab_69842.col1_5) AND (tab_69837.col1_6) = (tab_69843.col1_5)
+        LEFT OUTER JOIN table1 AS tab_69844 ON
+                (tab_69838.col1_6) = (tab_69844.col1_5) ON
+            (tab_69833.col2_2) = (tab_69838.tableoid)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69839.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69840.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.col2_4) = (tab_69838.crdb_internal_mvcc_timestamp)
+            AND (tab_69833.crdb_internal_mvcc_timestamp) = (tab_69838.crdb_internal_mvcc_timestamp)
+ORDER BY
+    tab_69844.col1_6 DESC, tab_69833.crdb_internal_mvcc_timestamp
+LIMIT
+    51:::INT8
+----
 
 # --------------------------------------------------
 # GenerateLocalityOptimizedAntiJoin

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -2061,42 +2061,6 @@ Joins Considered: 6
 Join Tree #4
 --------------------------------------------------------------------------------
   inner-join (hash)
-   ├── scan abc [as=a1]
-   ├── inner-join (hash)
-   │    ├── scan abc [as=a2]
-   │    ├── distinct-on
-   │    │    └── scan abc [as=a5]
-   │    └── filters
-   │         └── a2.c = a5.c
-   └── filters
-        └── a1.a = a2.a
-Vertexes
-  C:
-    scan abc [as=a1]
-  A:
-    scan abc [as=a2]
-  B:
-    distinct-on
-     └── scan abc [as=a5]
-Edges
-  a2.c = a5.c [inner, ses=AB, tes=AB, rules=()]
-  a1.a = a2.a [inner, ses=CA, tes=CA, rules=()]
-Joining CA
-  C A [inner, refs=CA]
-  A C [inner, refs=CA]
-Joining AB
-  A B [inner, refs=AB]
-  B A [inner, refs=AB]
-Joining CAB
-  C AB [inner, refs=CA]
-  AB C [inner, refs=CA]
-  CA B [inner, refs=AB]
-  B CA [inner, refs=AB]
-Joins Considered: 8
---------------------------------------------------------------------------------
-Join Tree #5
---------------------------------------------------------------------------------
-  inner-join (hash)
    ├── inner-join (hash)
    │    ├── scan abc [as=a1]
    │    ├── semi-join (hash)
@@ -2136,7 +2100,7 @@ Joining CAD
   D CA [inner, refs=AD]
 Joins Considered: 8
 --------------------------------------------------------------------------------
-Join Tree #6
+Join Tree #5
 --------------------------------------------------------------------------------
   inner-join (hash)
    ├── inner-join (hash)
@@ -2456,8 +2420,8 @@ WHERE EXISTS (SELECT 1 FROM dz WHERE z = y)
 AND EXISTS (SELECT 1 FROM bx WHERE x = y)
 AND EXISTS (SELECT 1 FROM abc WHERE a = y)
 ----
-Rules Applied: 148
-Groups Added: 80
+Rules Applied: 134
+Groups Added: 73
 
 
 # Regression test for #76522. Do not produce query plans where some of the

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -255,6 +255,10 @@ message LocalOnlySessionData {
   // constraints that only include hidden columns.
   bool show_primary_key_constraint_on_not_visible_columns = 69;
 
+  // disable_hoist_projection_in_join_limitation disables the restrictions
+  // placed on projection hoisting during query planning in the optimizer.
+  bool disable_hoist_projection_in_join_limitation = 76;
+
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2101,6 +2101,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`disable_hoist_projection_in_join_limitation`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`disable_hoist_projection_in_join_limitation`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("disable_hoist_projection_in_join_limitation", s)
+			if err != nil {
+				return err
+			}
+			m.SetDisableHoistProjectionInJoinLimitation(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().DisableHoistProjectionInJoinLimitation), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 const compatErrMsg = "this parameter is currently recognized only for compatibility and has no effect in CockroachDB."
@@ -2151,6 +2168,34 @@ func init() {
 		sort.Strings(res)
 		return res
 	}()
+}
+
+// SetSessionVariable sets a new value for session setting `varName` in the
+// session settings owned by `evalCtx`, returning an error if not successful.
+// This function should only be used for testing. For general-purpose code,
+// please use SessionAccessor.SetSessionVar instead.
+func SetSessionVariable(
+	ctx context.Context, evalCtx tree.EvalContext, varName, varValue string,
+) (err error) {
+	err = CheckSessionVariableValueValid(ctx, evalCtx.Settings, varName, varValue)
+	if err != nil {
+		return err
+	}
+	sdMutatorBase := sessionDataMutatorBase{
+		defaults: make(map[string]string),
+		settings: evalCtx.Settings,
+	}
+	sdMutator := sessionDataMutator{
+		data:                        evalCtx.SessionData(),
+		sessionDataMutatorBase:      sdMutatorBase,
+		sessionDataMutatorCallbacks: sessionDataMutatorCallbacks{},
+	}
+	_, sVar, err := getSessionVar(varName, false)
+	if err != nil {
+		return err
+	}
+
+	return sVar.Set(ctx, sdMutator, varValue)
 }
 
 // makePostgresBoolGetStringValFn returns a function that evaluates and returns


### PR DESCRIPTION
Backport 1/1 commits from #80212.

/cc @cockroachdb/release

---

Fixes #79943

Previously, HoistProjectFromInnerJoin would explore joins with the right
input projection pulled up to the parent of the join, no matter the type
of relation underneath the projection.

This was inadequate because queries involving many joins may invoke the
ReorderJoins rule many times, which creates many new join expressions
(orders of magnitude greater than the number of joins in the query),
which need to be explored. Each of those may trigger projection pull-up,
adding a new join expression to a memo group, further increasing the
search space. Each of those added join expressions may themselves have a
subtree of joins below them involving projections which may fire the
rule again, leading to an explosion of rule firings and a query which
never completes optimization (hangs).

To address this, this patch alters the conditions required to fire
HoistProjectFromInnerJoin so that when the right input of the join is a
projection, the input to the projection must be a canonical scan or a
select from a canonical scan.

HoistProjectFromInnerJoin, added through #59780, is meant to enable more
lookup joins because converting a projection on the right side of a join
into a canonical scan allows GenerateLookupJoins to fire. Likewise,
other join transformations such as SplitDisjunctionOfJoinTerms may
require either a canonical scan or a select from a canonical scan as
join inputs in order to fire.  Other cases are unlikely to cause any new
join transformations to fire since those rules check for canonical scans
as input, so skipping their exploration will not result in any missed
optimizations.

Release note (bug fix): Prior to this fix, queries with many joins and
projections of multicolumn expressions, e.g. col1 + col2, either
present in the query or within a virtual column definition, could
experience very long optimization times or hangs, where the query is
never sent for execution.

**sql: Add disable_hoist_projection_in_join_limitation session flag**

This commit adds the disable_hoist_projection_in_join_limitation session flag.
    
Release note: none

**opttester: support session settings in opt tests**

This commit adds the set opttest flag which can be used to set
session flags via "set=flagname=value".

Release note: none

Release justification: Low risk fix for lengthy exploration time on complex queries.