### PR TITLE
backupccl: introduce BACKUP-LOCK file

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination_test.go
@@ -123,7 +123,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					defaultDest, localitiesDest, err := backupdest.GetURIsByLocalityKV(to, "")
 					require.NoError(t, err)
 
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := backupdest.ResolveDest(
+					backupDest, err := backupdest.ResolveDest(
 						ctx, username.RootUserName(),
 						jobspb.BackupDetails_Destination{To: to},
 						endTime,
@@ -133,12 +133,12 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					require.NoError(t, err)
 
 					// Not an INTO backup, so no collection of suffix info.
-					require.Equal(t, "", collectionURI)
-					require.Equal(t, "", chosenSuffix)
+					require.Equal(t, "", backupDest.CollectionURI)
+					require.Equal(t, "", backupDest.ChosenSubdir)
 
-					require.Equal(t, defaultDest, defaultURI)
-					require.Equal(t, localitiesDest, urisByLocalityKV)
-					require.Equal(t, incrementalFrom, prevBackupURIs)
+					require.Equal(t, defaultDest, backupDest.DefaultURI)
+					require.Equal(t, localitiesDest, backupDest.URIsByLocalityKV)
+					require.Equal(t, incrementalFrom, backupDest.PrevBackupURIs)
 				}
 
 				// The first initial full backup: BACKUP TO full.
@@ -190,7 +190,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 				) {
 					endTime := hlc.Timestamp{WallTime: backupTime.UnixNano()}
 
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := backupdest.ResolveDest(
+					backupDest, err := backupdest.ResolveDest(
 						ctx, username.RootUserName(),
 						jobspb.BackupDetails_Destination{To: to},
 						endTime,
@@ -200,11 +200,11 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					require.NoError(t, err)
 
 					// Not a backup collection.
-					require.Equal(t, "", collectionURI)
-					require.Equal(t, "", chosenSuffix)
-					require.Equal(t, expectedDefault, defaultURI)
-					require.Equal(t, expectedLocalities, urisByLocalityKV)
-					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+					require.Equal(t, "", backupDest.CollectionURI)
+					require.Equal(t, "", backupDest.ChosenSubdir)
+					require.Equal(t, expectedDefault, backupDest.DefaultURI)
+					require.Equal(t, expectedLocalities, backupDest.URIsByLocalityKV)
+					require.Equal(t, expectedPrevBackups, backupDest.PrevBackupURIs)
 				}
 
 				// Initial full backup: BACKUP TO baseDir.
@@ -336,7 +336,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 					if expectedIncDir != "" {
 						fullBackupExists = true
 					}
-					collectionURI, defaultURI, chosenSuffix, urisByLocalityKV, prevBackupURIs, err := backupdest.ResolveDest(
+					backupDest, err := backupdest.ResolveDest(
 						ctx, username.RootUserName(),
 						jobspb.BackupDetails_Destination{To: collectionTo, Subdir: subdir,
 							IncrementalStorage: incrementalTo, Exists: fullBackupExists},
@@ -354,13 +354,11 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 						localityDests[locality] = u.String()
 					}
 
-					require.Equal(t, collectionLoc, collectionURI)
-					require.Equal(t, expectedSuffix, chosenSuffix)
-
-					require.Equal(t, expectedDefault, defaultURI)
-					require.Equal(t, localityDests, urisByLocalityKV)
-
-					require.Equal(t, expectedPrevBackups, prevBackupURIs)
+					require.Equal(t, collectionLoc, backupDest.CollectionURI)
+					require.Equal(t, expectedSuffix, backupDest.ChosenSubdir)
+					require.Equal(t, expectedDefault, backupDest.DefaultURI)
+					require.Equal(t, localityDests, backupDest.URIsByLocalityKV)
+					require.Equal(t, expectedPrevBackups, backupDest.PrevBackupURIs)
 				}
 
 				// Initial: BACKUP INTO collection

--- a/pkg/ccl/backupccl/backupinfo/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupinfo/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/ioctx",
         "//pkg/util/json",
+        "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -271,6 +271,9 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //
 //   Supported arguments:
 //
+//   + expect-error-regex=<regex>: expects the query to return an error with a string
+//   matching the provided regex
+//
 //   + expect-error-ignore: expects the query to return an error, but we will
 //   ignore it.
 //
@@ -288,8 +291,14 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 //
 //   Supported arguments:
 //
+//   + resume=<tag>: resumes the job referenced by the tag, use in conjunction
+//   with wait-for-state.
+//
 //   + cancel=<tag>: cancels the job referenced by the tag and waits for it to
 //   reach a CANCELED state.
+//
+//   + wait-for-state=<succeeded|paused|failed|cancelled> tag=<tag>: wait for
+//   the job referenced by the tag to reach the specified state.
 //
 // - "let" [args]
 //   Assigns the returned value of the SQL query to the provided args as variables.
@@ -468,6 +477,17 @@ func TestDataDriven(t *testing.T) {
 				if d.HasArg("expect-error-ignore") {
 					require.NotNilf(t, err, "expected error")
 					ret = append(ret, "ignoring expected error")
+					return strings.Join(ret, "\n")
+				}
+
+				// Check if we are expecting an error, and want to match it against a
+				// regex.
+				if d.HasArg("expect-error-regex") {
+					require.NotNilf(t, err, "expected error")
+					var expectErrorRegex string
+					d.ScanArgs(t, "expect-error-regex", &expectErrorRegex)
+					testutils.IsError(err, expectErrorRegex)
+					ret = append(ret, "regex matches error")
 					return strings.Join(ret, "\n")
 				}
 
@@ -674,6 +694,39 @@ func TestDataDriven(t *testing.T) {
 					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
 					runner.Exec(t, `CANCEL JOB $1`, jobID)
 					jobutils.WaitForJobToCancel(t, runner, jobID)
+				} else if d.HasArg("resume") {
+					var resumeJobTag string
+					d.ScanArgs(t, "resume", &resumeJobTag)
+					var jobID jobspb.JobID
+					var ok bool
+					if jobID, ok = ds.jobTags[resumeJobTag]; !ok {
+						t.Fatalf("could not find job with tag %s", resumeJobTag)
+					}
+					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
+					runner.Exec(t, `RESUME JOB $1`, jobID)
+				} else if d.HasArg("wait-for-state") {
+					var tag string
+					d.ScanArgs(t, "tag", &tag)
+					var jobID jobspb.JobID
+					var ok bool
+					if jobID, ok = ds.jobTags[tag]; !ok {
+						t.Fatalf("could not find job with tag %s", tag)
+					}
+					runner := sqlutils.MakeSQLRunner(ds.getSQLDB(t, server, user))
+					var state string
+					d.ScanArgs(t, "wait-for-state", &state)
+					switch state {
+					case "succeeded":
+						jobutils.WaitForJobToSucceed(t, runner, jobID)
+					case "cancelled":
+						jobutils.WaitForJobToCancel(t, runner, jobID)
+					case "paused":
+						jobutils.WaitForJobToPause(t, runner, jobID)
+					case "failed":
+						jobutils.WaitForJobToFail(t, runner, jobID)
+					default:
+						t.Fatalf("unknown state %s", state)
+					}
 				}
 				return ""
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
+++ b/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
@@ -1,0 +1,137 @@
+new-server name=s1
+----
+
+# Test that a backup job does not read its own lock file on resumption,
+# effectively locking itself out. We pause the job after it has written its
+# BACKUP-LOCK file and then resume it to ensure we don't read our own write.
+subtest backup-does-not-read-its-own-lock
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_lock';
+----
+
+backup expect-pausepoint tag=a
+BACKUP INTO 'userfile://defaultdb.public.foo/foo';
+----
+job paused at pausepoint
+
+# The job should have written a `BACKUP-LOCK` file suffixed with a job ID and a
+# timestamp.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.foo_upload_files;
+----
+BACKUP-LOCK
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=a
+----
+
+job tag=a wait-for-state=succeeded
+----
+
+subtest end
+
+
+# Test that a backup job on resume will not rewrite the `BACKUP-LOCK` file if it
+# already sees one, thus maintaining write-once semantics.
+subtest backup-lock-is-write-once
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.write_first_checkpoint';
+----
+
+backup expect-pausepoint tag=b
+BACKUP INTO 'userfile://defaultdb.public.bar/bar';
+----
+job paused at pausepoint
+
+# The job should have written a `BACKUP-LOCK` file suffixed with a job ID and a
+# timestamp.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.bar_upload_files;
+----
+BACKUP-LOCK
+
+# Resume the job and expect it to pause again after writing `BACKUP-LOCK` again.
+job resume=b
+----
+
+job tag=b wait-for-state=paused
+----
+
+# We expect to see only one lock file since the resumed job would see the
+# previously written one.
+query-sql
+SELECT regexp_replace(filename, '.*BACKUP-LOCK-[0-9]+$', 'BACKUP-LOCK') FROM defaultdb.public.bar_upload_files;
+----
+BACKUP-LOCK
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=b
+----
+
+job tag=b wait-for-state=succeeded
+----
+
+subtest end
+
+# Note, `BACKUP TO` is going away, and `BACKUP INTO` picks a timestamped
+# directory making it *impossible* for two backups to write to the same
+# directory in the future.
+#
+# Backup should fail if it sees a BACKUP_LOCK in the bucket.
+subtest backup-lock-file-prevents-concurrent-backups
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.before.flow';
+----
+
+backup expect-pausepoint
+BACKUP TO 'userfile://defaultdb.public.baz/baz';
+----
+job paused at pausepoint
+
+exec-sql expect-error-regex='userfile://defaultdb.public.baz/baz already contains a `BACKUP-LOCK`'
+BACKUP TO 'userfile://defaultdb.public.baz/baz';
+----
+regex matches error
+
+subtest end
+
+# For mixed version compatability the backup job also checks for a
+# `BACKUP-CHECKPOINT` file when ensuring that there are no concurrent backups
+# writing to the same bucket.
+#
+# This test ensures that a backup job does not check for a `BACKUP-CHECKPOINT`
+# lock file after writing its own `BACKUP-CHECKPOINT`.
+subtest backup-does-not-read-its-own-checkpoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'backup.after.write_first_checkpoint';
+----
+
+backup expect-pausepoint tag=d
+BACKUP TO 'userfile://defaultdb.public.bat/bat';
+----
+job paused at pausepoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Resume the job and expect it to succeed.
+job resume=d
+----
+
+job tag=d wait-for-state=succeeded
+----
+
+subtest end


### PR DESCRIPTION
Only one backup job is allowed to write to a backup location.  Prior
to this change, the backup job would rely on the presence of a
BACKUP-CHECKPOINT file to know of the presence of a concurrent backup
job writing to the same location. This was problematic in subtle ways.

In 22.1, we moved backup destination resolution, and the writing of
the checkpoint file to the backup resumer. Before writing the
checkpoint file we would check if anyone else had laid claim to the
location. Now, all operations in a job resumer need to be idempotent
because a job can be resumed an arbitrary number of times, either due
to transient errors or user intervention. One can imagine (and we have
seen more than once in recent roachtests) a situation where a job:

1. Checks for other BACKUP-CHECKPOINT files in the location, but finds none.
2. Writes its own BACKUP-CHECKPOINT file.
3. Gets resumed before it gets to update BackupDetails to indicate it has
completed 1) and 2).

So, when the job repeats 1), it will now see its own BACKUP-CHECKPOINT
file and claim another backup is writing to the location, foolishly locking
itself out.

A similar situation can happen in a mixed version state where the node performs
1) and 2) during planning, and the planner txn retries.

Before we discuss the solution it is important to highlight the mixed
version states to consider:

1) Backups planned/executed by 21.2.x and 22.1.0 nodes will continue
to check BACKUP-CHECKPOINT files before laying claim to a location.

2) Backups planned/executed by 21.2.x and 22.1.0 nodes will continue
to write BACKUP-CHECKPOINT files as their way of claiming a location.

This change introduces a `BACKUP-LOCK` file that going forward will be
used to check and lay claim on a location. The `BACKUP-LOCK` file will
be suffixed with the jobID of the backup job. With this change a backup job will
check for the existence of `BACKUP-LOCK` files suffixed with a job ID other
than their own, before laying claim to a location. We continue to read
the BACKUP-CHECKPOINT file so as to respect the claim laid by backups
started on older binary nodes. Naturally, the job also continues to write
a BACKUP-CHECKPOINT file which prevents older nodes from starting concurrent
backups.

Release note: None

Release justification: This is a forward port of a feature that is
already shipped in 22.1.

Co-authored-by: Aditya Maru <adityamaru@gmail.com>