### PR TITLE
kvserver: add queue size metric to RaftTransport

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "raft_log_truncator.go",
         "raft_snapshot_queue.go",
         "raft_transport.go",
+        "raft_transport_metrics.go",
         "raft_truncator_replica.go",
         "replica.go",
         "replica_application_cmd.go",

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -968,15 +968,6 @@ handling consumes writes.
 		Unit:        metric.Unit_BYTES,
 	}
 
-	metaRaftEnqueuedPending = metric.Metadata{
-		Name: "raft.enqueued.pending",
-		Help: `Number of pending outgoing messages in the Raft Transport queue.
-
-The queue is bounded in size, so instead of unbounded growth one would observe a
-ceiling value in the tens of thousands.`,
-		Measurement: "Messages",
-		Unit:        metric.Unit_COUNT,
-	}
 	metaRaftCoalescedHeartbeatsPending = metric.Metadata{
 		Name:        "raft.heartbeats.pending",
 		Help:        "Number of pending heartbeats and responses waiting to be coalesced",
@@ -1753,7 +1744,6 @@ type StoreMetrics struct {
 
 	RaftPausedFollowerCount *metric.Gauge
 
-	RaftEnqueuedPending            *metric.Gauge
 	RaftCoalescedHeartbeatsPending *metric.Gauge
 
 	// Replica queue metrics.
@@ -2263,8 +2253,6 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RaftLogTruncated:           metric.NewCounter(metaRaftLogTruncated),
 
 		RaftPausedFollowerCount: metric.NewGauge(metaRaftFollowerPaused),
-
-		RaftEnqueuedPending: metric.NewGauge(metaRaftEnqueuedPending),
 
 		// This Gauge measures the number of heartbeats queued up just before
 		// the queue is cleared, to avoid flapping wildly.

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -1,0 +1,33 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver
+
+import "github.com/cockroachdb/cockroach/pkg/util/metric"
+
+// RaftTransportMetrics is the set of metrics for a given RaftTransport.
+type RaftTransportMetrics struct {
+	SendQueueSize *metric.Gauge
+}
+
+func (t *RaftTransport) initMetrics() {
+	t.metrics = &RaftTransportMetrics{
+		SendQueueSize: metric.NewFunctionalGauge(metric.Metadata{
+			Name: "raft.transport.send-queue-size",
+			Help: `Number of pending outgoing messages in the Raft Transport queue.
+
+The queue is composed of multiple bounded channels associated with different
+peers. The overall size of tens of thousands could indicate issues streaming
+messages to at least one peer.`,
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}, t.queuedMessageCount),
+	}
+}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3287,8 +3287,6 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		s.metrics.ClosedTimestampMaxBehindNanos.Update(nanos)
 	}
 
-	s.metrics.RaftEnqueuedPending.Update(s.cfg.Transport.queuedMessageCount())
-
 	return nil
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -467,6 +467,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	raftTransport := kvserver.NewRaftTransport(
 		cfg.AmbientCtx, st, cfg.AmbientCtx.Tracer, nodeDialer, grpcServer.Server, stopper,
 	)
+	registry.AddMetricStruct(raftTransport.Metrics())
 
 	ctSender := sidetransport.NewSender(stopper, st, clock, nodeDialer)
 	ctReceiver := sidetransport.NewReceiver(nodeIDContainer, stopper, stores, nil /* testingKnobs */)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1729,10 +1729,6 @@ var charts = []sectionDescription{
 				Metrics: []string{"raft.commandsapplied"},
 			},
 			{
-				Title:   "Enqueued",
-				Metrics: []string{"raft.enqueued.pending"},
-			},
-			{
 				Title:   "Keys/Sec Avg.",
 				Metrics: []string{"rebalancing.writespersecond"},
 			},

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1883,6 +1883,15 @@ var charts = []sectionDescription{
 		},
 	},
 	{
+		Organization: [][]string{{ReplicationLayer, "Raft", "Transport"}},
+		Charts: []chartDescription{
+			{
+				Title:   "Send Queue Messages Count",
+				Metrics: []string{"raft.transport.send-queue-size"},
+			},
+		},
+	},
+	{
 		Organization: [][]string{{ReplicationLayer, "Ranges"}},
 		Charts: []chartDescription{
 			{

--- a/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.fixtures.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/nodes/nodes.fixtures.ts
@@ -806,7 +806,6 @@ export const getNodeStatus = () => {
           "queue.tsmaintenance.process.success": 3,
           "queue.tsmaintenance.processingnanos": 174301000,
           "raft.commandsapplied": 0,
-          "raft.enqueued.pending": 0,
           "raft.entrycache.accesses": 485,
           "raft.entrycache.bytes": 217172,
           "raft.entrycache.hits": 331,


### PR DESCRIPTION
Currently, there is a `RaftEnqueuePending` metric in `StoreMetrics` which exposes
the `RaftTransport` outgoing queue size. However, this is a per-`Store` metric, so
it duplicates the same variable across all the stores. The metric should be
tracked on a per-node/transport basis.

This PR introduces a per-transport `SendQueueSize` metric to replace the old
`RaftEnqueuePending`. It also does the necessary plumbing to include it to
the exported metrics, since it's the first metric in `RaftTransport`.

<img width="1350" alt="Screenshot 2022-08-10 at 15 37 47" src="https://user-images.githubusercontent.com/3757441/183929666-0f6523d7-5877-4f2f-8460-4f013f87966d.png">

Touches #83917

Release note: None