### PR TITLE
rangefeed: correctly handle intent outside of time-bound

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -194,13 +194,17 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 				return errors.AssertionFailedf("unexpected inline key %s", unsafeKey)
 			}
 
-			// This is an MVCCMetadata key for an intent. The catchUp scan only cares
-			// about committed values, so ignore this and skip past the corresponding
-			// provisional key-value. To do this, iterate to the provisional
-			// key-value, validate its timestamp, then iterate again. When using
-			// MVCCIncrementalIterator we know that the provisional value will also be
-			// within the time bounds so we use Next.
-			i.Next()
+			// This is an MVCCMetadata key for an intent. The catchUp scan
+			// only cares about committed values, so ignore this and skip past
+			// the corresponding provisional key-value. To do this, iterate to
+			// the provisional key-value, validate its timestamp, then iterate
+			// again. If we arrived here with a preceding call to NextIgnoringTime
+			// (in the with-diff case), it's possible that the intent is not within
+			// the time bounds. Using `NextIgnoringTime` on the next line makes sure
+			// that we are guaranteed to validate the version that belongs to the
+			// intent.
+			i.NextIgnoringTime()
+
 			if ok, err := i.Valid(); err != nil {
 				return errors.Wrap(err, "iterating to provisional value for intent")
 			} else if !ok {
@@ -210,6 +214,11 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 				return errors.Errorf("expected provisional value for intent with ts %s, found %s",
 					meta.Timestamp, i.UnsafeKey().Timestamp)
 			}
+			// Now move to the next key of interest. Note that if in the last
+			// iteration of the loop we called `NextIgnoringTime`, the fact that we
+			// hit an intent proves that there wasn't a previous value, so we can
+			// (in fact, have to, to avoid surfacing unwanted keys) unconditionally
+			// enforce time bounds.
 			i.Next()
 			continue
 		}

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -149,3 +149,49 @@ func TestCatchupScanInlineError(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "unexpected inline value")
 }
+
+func TestCatchupScanSeesOldIntent(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	// Regression test for [#85886]. When with-diff is specified, the iterator may
+	// be positioned on an intent that is outside the time bounds. When we read
+	// the intent and want to load the version, we must make sure to ignore time
+	// bounds, or we'll see a wholly unrelated version.
+	//
+	// [#85886]: https://github.com/cockroachdb/cockroach/issues/85886
+
+	ctx := context.Background()
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	// b -> version @ 1100 (visible)
+	// d -> intent @ 990   (iterator will be positioned here because of with-diff option)
+	// e -> version @ 1100
+	tsCutoff := hlc.Timestamp{WallTime: 1000} // the lower bound of the catch-up scan
+	tsIntent := tsCutoff.Add(-10, 0)          // the intent is below the lower bound
+	tsVersionInWindow := tsCutoff.Add(10, 0)  // an unrelated version is above the lower bound
+
+	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("b"),
+		tsVersionInWindow, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("foo"), nil))
+
+	txn := roachpb.MakeTransaction("foo", roachpb.Key("d"), roachpb.NormalUserPriority, tsIntent, 100, 0)
+	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("d"),
+		tsIntent, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("intent"), &txn))
+
+	require.NoError(t, storage.MVCCPut(ctx, eng, nil, roachpb.Key("e"),
+		tsVersionInWindow, hlc.ClockTimestamp{}, roachpb.MakeValueFromString("bar"), nil))
+
+	// Run a catchup scan across the span and watch it succeed.
+	span := roachpb.Span{Key: keys.LocalMax, EndKey: keys.MaxKey}
+	iter := NewCatchUpIterator(eng, span, tsCutoff, nil)
+	defer iter.Close()
+
+	keys := map[string]struct{}{}
+	require.NoError(t, iter.CatchUpScan(func(e *roachpb.RangeFeedEvent) error {
+		keys[string(e.Val.Key)] = struct{}{}
+		return nil
+	}, true /* withDiff */))
+	require.Equal(t, map[string]struct{}{
+		"b": {},
+		"e": {},
+	}, keys)
+}


### PR DESCRIPTION
Release note (bug fix): Changefeed jobs undergoing a catch-up scans
could fail with an error "expected provisional value for intent with ts
X, found Y". The problem would eitehr spontaneously resolve or be
rectified after a high-priority scan of the affected index. This bug is
now fixed.