### PR TITLE
builtins: add trunc(decimal, int) builtin

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -871,6 +871,8 @@ available replica will error.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="trunc"></a><code>trunc(val: <a href="decimal.html">decimal</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="trunc"></a><code>trunc(val: <a href="decimal.html">decimal</a>, scale: <a href="int.html">int</a>) &rarr; <a href="decimal.html">decimal</a></code></td><td><span class="funcdesc"><p>Truncate <code>val</code> to <code>scale</code> decimal places</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="trunc"></a><code>trunc(val: <a href="float.html">float</a>) &rarr; <a href="float.html">float</a></code></td><td><span class="funcdesc"><p>Truncates the decimal values of <code>val</code>.</p>
 </span></td><td>Immutable</td></tr></tbody>
 </table>

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -671,6 +671,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/schemadesc",

--- a/pkg/sql/function_resolver_test.go
+++ b/pkg/sql/function_resolver_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -405,6 +406,8 @@ CREATE FUNCTION sc1.lower(a STRING) RETURNS STRING IMMUTABLE LANGUAGE SQL AS $$ 
 				require.False(t, funcExpr.ResolvedOverload().UDFContainsOnlySignature)
 				if tc.expectedFuncOID > 0 {
 					require.Equal(t, tc.expectedFuncOID, int(funcExpr.ResolvedOverload().Oid))
+				} else {
+					require.False(t, funcdesc.IsOIDUserDefinedFunc(funcExpr.ResolvedOverload().Oid))
 				}
 				require.Equal(t, tc.expectedFuncBody, funcExpr.ResolvedOverload().Body)
 			})

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1249,6 +1249,23 @@ SELECT trunc(-0.0), trunc(0.0), trunc(1.9), trunc(19.5678::decimal)
 ----
 0 0 1 19
 
+query RRRRRRR
+WITH v(x) AS
+  (VALUES('0'::numeric),('1'::numeric),('-1'::numeric),('4.2'::numeric),
+    ('-7.777'::numeric),('9127.777'::numeric),('inf'::numeric),('-inf'::numeric),('nan'::numeric))
+SELECT x, trunc(x), trunc(x,1), trunc(x,2), trunc(x,0), trunc(x,-1), trunc(x,-2)
+FROM v
+----
+0          0          0.0        0.00       0          0          0
+1          1          1.0        1.00       1          0          0
+-1         -1         -1.0       -1.00      -1         0          0
+4.2        4          4.2        4.20       4          0          0
+-7.777     -7         -7.7       -7.77      -7         0          0
+9127.777   9127       9127.7     9127.77    9127       9.12E+3    9.1E+3
+Infinity   Infinity   Infinity   Infinity   Infinity   Infinity   Infinity
+-Infinity  -Infinity  -Infinity  -Infinity  -Infinity  -Infinity  -Infinity
+NaN        NaN        NaN        NaN        NaN        NaN        NaN
+
 query T
 SELECT translate('Techonthenet.com', 'e.to', '456')
 ----

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4645,7 +4645,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-2011  array_in  array_in
+2012  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed
@@ -4683,7 +4683,7 @@ SELECT cur_max_builtin_oid FROM [SELECT max(oid) as cur_max_builtin_oid FROM pg_
 query TT
 SELECT proname, oid FROM pg_catalog.pg_proc WHERE oid = $cur_max_builtin_oid
 ----
-to_regtype  2031
+to_regtype  2032
 
 ## Ensure that unnest works with oid wrapper arrays
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -83,7 +83,7 @@ WHERE relname = 'pg_constraint'
 query OOOO
 SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
-upper  upper  upper  828
+upper  upper  upper  829
 
 query error invalid function name
 SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
@@ -91,7 +91,7 @@ SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 query OOO
 SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
 ----
-upper  upper  828
+upper  upper  829
 
 query error unknown function: blah\(\)
 SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/85620

Release note (sql change): Added the trunc(decimal, int) builtin
function, which truncates the given decimal value to the specified
number of decimal places. A negative value can be used for the scale
parameter, which will truncate to the left of the decimal point.

Example:
```
> select trunc(541.234, 2), trunc(541.234, 0), trunc(541.234, -1);

  trunc  | trunc | trunc
---------+-------+---------
  541.23 |   541 | 5.4E+2
```