### PR TITLE
release-22.1: kvserver: add cluster setting for TxnCleanupThreshold

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -687,6 +687,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	gcTTL := 24 * time.Hour
 	intentAgeThreshold := gc.IntentAgeThreshold.Default()
 	intentBatchSize := gc.MaxIntentsPerCleanupBatch.Default()
+	txnCleanupThreshold := gc.TxnCleanupThreshold.Default()
 
 	if len(args) > 3 {
 		var err error
@@ -755,7 +756,11 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			context.Background(),
 			&desc, snap,
 			now, thresh,
-			gc.RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: intentBatchSize},
+			gc.RunOptions{
+				IntentAgeThreshold:              intentAgeThreshold,
+				MaxIntentsPerIntentCleanupBatch: intentBatchSize,
+				TxnCleanupThreshold:             txnCleanupThreshold,
+			},
 			gcTTL, gc.NoopGCer{},
 			func(_ context.Context, _ []roachpb.Intent) error { return nil },
 			func(_ context.Context, _ *roachpb.Transaction) error { return nil },

--- a/pkg/kv/kvserver/abortspan/BUILD.bazel
+++ b/pkg/kv/kvserver/abortspan/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/keys",
-        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",
         "//pkg/storage",
         "//pkg/storage/enginepb",

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -1028,6 +1029,7 @@ func splitTriggerHelper(
 	// Initialize the RHS range's AbortSpan by copying the LHS's.
 	if err := rec.AbortSpan().CopyTo(
 		ctx, batch, batch, h.AbsPostSplitRight(), ts, split.RightDesc.RangeID,
+		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
 	); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}
@@ -1175,6 +1177,7 @@ func mergeTrigger(
 
 	if err := abortspan.New(merge.RightDesc.RangeID).CopyTo(
 		ctx, batch, batch, ms, ts, merge.LeftDesc.RangeID,
+		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
 	); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -172,7 +173,7 @@ func TestStoreSplitAbortSpan(t *testing.T) {
 		return r
 	}
 
-	thresh := kvserverbase.TxnCleanupThreshold.Nanoseconds()
+	thresh := gc.TxnCleanupThreshold.Default().Nanoseconds()
 	// Make sure this test doesn't run out of padding time if we significantly
 	// reduce TxnCleanupThreshold in the future for whatever reason.
 	require.Greater(t, thresh, int64(time.Minute))

--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/base",
         "//pkg/keys",
         "//pkg/kv/kvserver/abortspan",
-        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/rditer",
         "//pkg/roachpb",
         "//pkg/settings",
@@ -41,7 +40,6 @@ go_test(
     embed = [":gc"],
     deps = [
         "//pkg/keys",
-        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/rditer",
         "//pkg/roachpb",
         "//pkg/storage",

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -59,6 +58,21 @@ var IntentAgeThreshold = settings.RegisterDurationSetting(
 		}
 		return nil
 	},
+)
+
+// TxnCleanupThreshold is the threshold after which a transaction is
+// considered abandoned and fit for removal, as measured by the
+// maximum of its last heartbeat and read timestamp. Abort spans for the
+// transaction are cleaned up at the same time.
+//
+// TODO(tschottdorf): need to enforce at all times that this is much
+// larger than the heartbeat interval used by the coordinator.
+var TxnCleanupThreshold = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.gc.txn_cleanup_threshold",
+	"the threshold after which a transaction is considered abandoned and "+
+		"fit for removal, as measured by the maximum of its last heartbeat and timestamp",
+	time.Hour,
 )
 
 // MaxIntentsPerCleanupBatch is the maximum number of intents that GC will send
@@ -208,6 +222,10 @@ type RunOptions struct {
 	MaxTxnsPerIntentCleanupBatch int64
 	// IntentCleanupBatchTimeout is the timeout for processing a batch of intents. 0 to disable.
 	IntentCleanupBatchTimeout time.Duration
+	// TxnCleanupThreshold is the threshold after which a transaction is
+	// considered abandoned and fit for removal, as measured by the maximum of
+	// its last heartbeat and read timestamp.
+	TxnCleanupThreshold time.Duration
 }
 
 // CleanupIntentsFunc synchronously resolves the supplied intents
@@ -239,7 +257,7 @@ func Run(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
+	txnExp := now.Add(-options.TxnCleanupThreshold.Nanoseconds(), 0)
 	if err := gcer.SetGCThreshold(ctx, Threshold{
 		Key: newThreshold,
 		Txn: txnExp,

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -56,7 +55,7 @@ func runGCOld(
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-options.IntentAgeThreshold.Nanoseconds(), 0)
-	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
+	txnExp := now.Add(-TxnCleanupThreshold.Default().Nanoseconds(), 0)
 
 	gc := MakeGarbageCollector(now, gcTTL)
 

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -60,6 +60,7 @@ var (
 )
 
 const intentAgeThreshold = 2 * time.Hour
+const txnCleanupThreshold = time.Hour
 
 // TestRunNewVsOld exercises the behavior of Run relative to the old
 // implementation. It runs both the new and old implementation and ensures
@@ -100,7 +101,10 @@ func TestRunNewVsOld(t *testing.T) {
 			ttl := time.Duration(tc.ttl) * time.Second
 			newThreshold := CalculateThreshold(tc.now, ttl)
 			gcInfoOld, err := runGCOld(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, ttl,
+				newThreshold, RunOptions{
+					IntentAgeThreshold:  intentAgeThreshold,
+					TxnCleanupThreshold: txnCleanupThreshold,
+				}, ttl,
 				&oldGCer,
 				oldGCer.resolveIntents,
 				oldGCer.resolveIntentsAsync)
@@ -108,7 +112,10 @@ func TestRunNewVsOld(t *testing.T) {
 
 			newGCer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, ttl,
+				newThreshold, RunOptions{
+					IntentAgeThreshold:  intentAgeThreshold,
+					TxnCleanupThreshold: txnCleanupThreshold,
+				}, ttl,
 				&newGCer,
 				newGCer.resolveIntents,
 				newGCer.resolveIntentsAsync)
@@ -135,7 +142,10 @@ func BenchmarkRun(b *testing.B) {
 		snap := eng.NewSnapshot()
 		ttl := time.Duration(spec.ttl) * time.Second
 		return runGCFunc(ctx, spec.ds.desc(), snap, spec.now,
-			CalculateThreshold(spec.now, ttl), RunOptions{IntentAgeThreshold: intentAgeThreshold},
+			CalculateThreshold(spec.now, ttl), RunOptions{
+				IntentAgeThreshold:  intentAgeThreshold,
+				TxnCleanupThreshold: txnCleanupThreshold,
+			},
 			ttl,
 			NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -136,13 +136,19 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	fakeGCer := makeFakeGCer()
 
 	// Test GC desired behavior.
-	info, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentLongThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
+	info, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentLongThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Zero(t, info.IntentsConsidered,
 		"Expected no intents considered by GC with default threshold")
 
-	info, err = Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentShortThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
+	info, err = Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentShortThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Equal(t, 1, info.IntentsConsidered,
@@ -189,7 +195,10 @@ func TestIntentCleanupBatching(t *testing.T) {
 	// Base GCer will cleanup all intents in one go and its result is used as a baseline
 	// to compare batched runs for checking completeness.
 	baseGCer := makeFakeGCer()
-	_, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentAgeThreshold}, gcTTL, &baseGCer, baseGCer.resolveIntents,
+	_, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentAgeThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &baseGCer, baseGCer.resolveIntents,
 		baseGCer.resolveIntentsAsync)
 	if err != nil {
 		t.Fatal("Can't prepare test fixture. Non batched GC run fails.")
@@ -199,7 +208,11 @@ func TestIntentCleanupBatching(t *testing.T) {
 	var batchSize int64 = 7
 	fakeGCer := makeFakeGCer()
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
-		RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: batchSize}, gcTTL,
+		RunOptions{
+			IntentAgeThreshold:              intentAgeThreshold,
+			MaxIntentsPerIntentCleanupBatch: batchSize,
+			TxnCleanupThreshold:             txnCleanupThreshold,
+		}, gcTTL,
 		&fakeGCer, fakeGCer.resolveIntents, fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	maxIntents := 0

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -34,15 +34,6 @@ var MergeQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
-// TxnCleanupThreshold is the threshold after which a transaction is
-// considered abandoned and fit for removal, as measured by the
-// maximum of its last heartbeat and timestamp. Abort spans for the
-// transaction are cleaned up at the same time.
-//
-// TODO(tschottdorf): need to enforce at all times that this is much
-// larger than the heartbeat interval used by the coordinator.
-const TxnCleanupThreshold = time.Hour
-
 // CmdIDKey is a Raft command id. This will be logged unredacted - keep it random.
 type CmdIDKey string
 

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -219,6 +218,7 @@ func makeMVCCGCQueueScore(
 	// trigger GC at the same time.
 	r := makeMVCCGCQueueScoreImpl(
 		ctx, int64(repl.RangeID), now, ms, gcTTL, lastGC, canAdvanceGCThreshold,
+		gc.TxnCleanupThreshold.Get(&repl.ClusterSettings().SV),
 	)
 	return r
 }
@@ -321,6 +321,7 @@ func makeMVCCGCQueueScoreImpl(
 	gcTTL time.Duration,
 	lastGC hlc.Timestamp,
 	canAdvanceGCThreshold bool,
+	txnCleanupThreshold time.Duration,
 ) mvccGCQueueScore {
 	ms.Forward(now.WallTime)
 	var r mvccGCQueueScore
@@ -403,7 +404,7 @@ func makeMVCCGCQueueScoreImpl(
 
 	// Finally, queue if we find large abort spans for abandoned transactions.
 	if largeAbortSpan(ms) && !r.ShouldQueue &&
-		(r.LastGC == 0 || r.LastGC > kvserverbase.TxnCleanupThreshold) {
+		(r.LastGC == 0 || r.LastGC > txnCleanupThreshold) {
 		r.ShouldQueue = true
 		r.FinalScore++
 	}
@@ -563,12 +564,14 @@ func (mgcq *mvccGCQueue) process(
 	intentAgeThreshold := gc.IntentAgeThreshold.Get(&repl.store.ClusterSettings().SV)
 	maxIntentsPerCleanupBatch := gc.MaxIntentsPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
 	maxIntentKeyBytesPerCleanupBatch := gc.MaxIntentKeyBytesPerCleanupBatch.Get(&repl.store.ClusterSettings().SV)
+	txnCleanupThreshold := gc.TxnCleanupThreshold.Get(&repl.store.ClusterSettings().SV)
 
 	info, err := gc.Run(ctx, desc, snap, gcTimestamp, newThreshold,
 		gc.RunOptions{
 			IntentAgeThreshold:                     intentAgeThreshold,
 			MaxIntentsPerIntentCleanupBatch:        maxIntentsPerCleanupBatch,
 			MaxIntentKeyBytesPerIntentCleanupBatch: maxIntentKeyBytesPerCleanupBatch,
+			TxnCleanupThreshold:                    txnCleanupThreshold,
 			MaxTxnsPerIntentCleanupBatch:           intentresolver.MaxTxnsPerIntentCleanupBatch,
 			IntentCleanupBatchTimeout:              mvccGCQueueIntentBatchTimeout,
 		},

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -110,7 +110,9 @@ func TestMVCCGCQueueMakeGCScoreInvariantQuick(t *testing.T) {
 		now := initialNow.Add(timePassed.Nanoseconds(), 0)
 		r := makeMVCCGCQueueScoreImpl(
 			ctx, int64(seed), now, ms, time.Duration(ttlSec)*time.Second, hlc.Timestamp{},
-			true /* canAdvanceGCThreshold */)
+			true,      /* canAdvanceGCThreshold */
+			time.Hour, /* txnCleanupThreshold */
+		)
 		wouldHaveToDeleteSomething := gcBytes*int64(ttlSec) < ms.GCByteAge(now.WallTime)
 		result := !r.ShouldQueue || wouldHaveToDeleteSomething
 		if !result {
@@ -132,7 +134,9 @@ func TestMVCCGCQueueMakeGCScoreAnomalousStats(t *testing.T) {
 			LiveBytes:         int64(liveBytes),
 			ValBytes:          int64(valBytes),
 			KeyBytes:          int64(keyBytes),
-		}, 60*time.Second, hlc.Timestamp{}, true /* canAdvanceGCThreshold */)
+		}, 60*time.Second, hlc.Timestamp{}, true, /* canAdvanceGCThreshold */
+			time.Hour, /* txnCleanupThreshold */
+		)
 		return r.DeadFraction >= 0 && r.DeadFraction <= 1
 	}, &quick.Config{MaxCount: 1000}); err != nil {
 		t.Fatal(err)
@@ -148,7 +152,7 @@ func TestMVCCGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 	ms.SysBytes += largeAbortSpanBytesThreshold
 	ms.SysCount++
 
-	expiration := kvserverbase.TxnCleanupThreshold.Nanoseconds() + 1
+	expiration := gc.TxnCleanupThreshold.Default().Nanoseconds() + 1
 
 	// GC triggered if abort span should all be gc'able and it's large.
 	{
@@ -157,6 +161,7 @@ func TestMVCCGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 			hlc.Timestamp{WallTime: expiration + 1},
 			ms, 10000*time.Second,
 			hlc.Timestamp{}, true, /* canAdvanceGCThreshold */
+			time.Hour, /* txnCleanupThreshold */
 		)
 		require.True(t, r.ShouldQueue)
 		require.NotZero(t, r.FinalScore)
@@ -172,6 +177,7 @@ func TestMVCCGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 			hlc.Timestamp{WallTime: expiration + 1},
 			ms, 10000*time.Second,
 			hlc.Timestamp{}, true, /* canAdvanceGCThreshold */
+			time.Hour, /* txnCleanupThreshold */
 		)
 		require.True(t, r.ShouldQueue)
 		require.NotZero(t, r.FinalScore)
@@ -183,6 +189,7 @@ func TestMVCCGCQueueMakeGCScoreLargeAbortSpan(t *testing.T) {
 			hlc.Timestamp{WallTime: expiration},
 			ms, 10000*time.Second,
 			hlc.Timestamp{WallTime: expiration - 100}, true, /* canAdvanceGCThreshold */
+			time.Hour, /* txnCleanupThreshold */
 		)
 		require.False(t, r.ShouldQueue)
 		require.Zero(t, r.FinalScore)
@@ -222,7 +229,9 @@ func TestMVCCGCQueueMakeGCScoreIntentCooldown(t *testing.T) {
 			}
 
 			r := makeMVCCGCQueueScoreImpl(
-				ctx, seed, now, ms, gcTTL, tc.lastGC, true /* canAdvanceGCThreshold */)
+				ctx, seed, now, ms, gcTTL, tc.lastGC, true, /* canAdvanceGCThreshold */
+				time.Hour, /* txnCleanupThreshold */
+			)
 			require.Equal(t, tc.expectGC, r.ShouldQueue)
 		})
 	}
@@ -342,7 +351,9 @@ func (cws *cachedWriteSimulator) shouldQueue(
 	cws.t.Helper()
 	ts := hlc.Timestamp{}.Add(ms.LastUpdateNanos+after.Nanoseconds(), 0)
 	r := makeMVCCGCQueueScoreImpl(context.Background(), 0 /* seed */, ts, ms, ttl,
-		hlc.Timestamp{}, true /* canAdvanceGCThreshold */)
+		hlc.Timestamp{}, true, /* canAdvanceGCThreshold */
+		time.Hour, /* txnCleanupThreshold */
+	)
 	if fmt.Sprintf("%.2f", r.FinalScore) != fmt.Sprintf("%.2f", prio) || b != r.ShouldQueue {
 		cws.t.Errorf("expected queued=%t (is %t), prio=%.2f, got %.2f: after=%s, ttl=%s:\nms: %+v\nscore: %s",
 			b, r.ShouldQueue, prio, r.FinalScore, after, ttl, ms, r)
@@ -469,6 +480,7 @@ func TestMVCCGCQueueProcess(t *testing.T) {
 	tc.Start(ctx, t, stopper)
 
 	const intentAgeThreshold = 2 * time.Hour
+	const txnCleanupThreshold = time.Hour
 
 	tc.manualClock.Increment(48 * 60 * 60 * 1e9) // 2d past the epoch
 	now := tc.Clock().Now().WallTime
@@ -613,7 +625,10 @@ func TestMVCCGCQueueProcess(t *testing.T) {
 
 		now := tc.Clock().Now()
 		newThreshold := gc.CalculateThreshold(now, conf.TTL())
-		return gc.Run(ctx, desc, snap, now, newThreshold, gc.RunOptions{IntentAgeThreshold: intentAgeThreshold},
+		return gc.Run(ctx, desc, snap, now, newThreshold, gc.RunOptions{
+			IntentAgeThreshold:  intentAgeThreshold,
+			TxnCleanupThreshold: txnCleanupThreshold,
+		},
 			conf.TTL(), gc.NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {
 				return nil
@@ -704,7 +719,7 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 	manual.Set(3 * 24 * time.Hour.Nanoseconds())
 
 	testTime := manual.UnixNano() + 2*time.Hour.Nanoseconds()
-	gcExpiration := testTime - kvserverbase.TxnCleanupThreshold.Nanoseconds()
+	gcExpiration := testTime - gc.TxnCleanupThreshold.Default().Nanoseconds()
 
 	type spec struct {
 		status      roachpb.TransactionStatus


### PR DESCRIPTION
Backport 1/1 commits from #85472.

/cc @cockroachdb/release

---

The value was previously hardcoded to 1h, it would be useful to be able
to lower it. Fixes #82541.

Release note: None
Release justification: Adds a cluster setting that would've come in handy in earlier escalations.