### PR TITLE
release-21.2: kvserver: add cluster setting for TxnCleanupThreshold

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -676,6 +676,7 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 	gcTTL := 24 * time.Hour
 	intentAgeThreshold := gc.IntentAgeThreshold.Default()
 	intentBatchSize := gc.MaxIntentsPerCleanupBatch.Default()
+	txnCleanupThreshold := gc.TxnCleanupThreshold.Default()
 
 	if len(args) > 3 {
 		var err error
@@ -744,7 +745,11 @@ func runDebugGCCmd(cmd *cobra.Command, args []string) error {
 			context.Background(),
 			&desc, snap,
 			now, thresh,
-			gc.RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: intentBatchSize},
+			gc.RunOptions{
+				IntentAgeThreshold:              intentAgeThreshold,
+				MaxIntentsPerIntentCleanupBatch: intentBatchSize,
+				TxnCleanupThreshold:             txnCleanupThreshold,
+			},
 			gcTTL, gc.NoopGCer{},
 			func(_ context.Context, _ []roachpb.Intent) error { return nil },
 			func(_ context.Context, _ *roachpb.Transaction) error { return nil },

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
@@ -927,6 +928,7 @@ func splitTriggerHelper(
 	// Initialize the RHS range's AbortSpan by copying the LHS's.
 	if err := rec.AbortSpan().CopyTo(
 		ctx, batch, batch, h.AbsPostSplitRight(), ts, split.RightDesc.RangeID,
+		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
 	); err != nil {
 		return enginepb.MVCCStats{}, result.Result{}, err
 	}
@@ -1085,6 +1087,7 @@ func mergeTrigger(
 
 	if err := abortspan.New(merge.RightDesc.RangeID).CopyTo(
 		ctx, batch, batch, ms, ts, merge.LeftDesc.RangeID,
+		gc.TxnCleanupThreshold.Get(&rec.ClusterSettings().SV),
 	); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -171,7 +172,7 @@ func TestStoreSplitAbortSpan(t *testing.T) {
 		return r
 	}
 
-	thresh := kvserverbase.TxnCleanupThreshold.Nanoseconds()
+	thresh := gc.TxnCleanupThreshold.Default().Nanoseconds()
 	// Make sure this test doesn't run out of padding time if we significantly
 	// reduce TxnCleanupThreshold in the future for whatever reason.
 	require.Greater(t, thresh, int64(time.Minute))

--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/base",
         "//pkg/keys",
         "//pkg/kv/kvserver/abortspan",
-        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/rditer",
         "//pkg/roachpb:with-mocks",
         "//pkg/settings",
@@ -41,7 +40,6 @@ go_test(
     embed = [":gc"],
     deps = [
         "//pkg/keys",
-        "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/rditer",
         "//pkg/roachpb:with-mocks",
         "//pkg/storage",

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -58,6 +57,20 @@ var IntentAgeThreshold = settings.RegisterDurationSetting(
 		}
 		return nil
 	},
+)
+
+// TxnCleanupThreshold is the threshold after which a transaction is
+// considered abandoned and fit for removal, as measured by the
+// maximum of its last heartbeat and read timestamp. Abort spans for the
+// transaction are cleaned up at the same time.
+//
+// TODO(tschottdorf): need to enforce at all times that this is much
+// larger than the heartbeat interval used by the coordinator.
+var TxnCleanupThreshold = settings.RegisterDurationSetting(
+	"kv.gc.txn_cleanup_threshold",
+	"the threshold after which a transaction is considered abandoned and "+
+		"fit for removal, as measured by the maximum of its last heartbeat and timestamp",
+	time.Hour,
 )
 
 // MaxIntentsPerCleanupBatch is the maximum number of intents that GC will send
@@ -205,6 +218,10 @@ type RunOptions struct {
 	MaxTxnsPerIntentCleanupBatch int64
 	// IntentCleanupBatchTimeout is the timeout for processing a batch of intents. 0 to disable.
 	IntentCleanupBatchTimeout time.Duration
+	// TxnCleanupThreshold is the threshold after which a transaction is
+	// considered abandoned and fit for removal, as measured by the maximum of
+	// its last heartbeat and read timestamp.
+	TxnCleanupThreshold time.Duration
 }
 
 // CleanupIntentsFunc synchronously resolves the supplied intents
@@ -236,7 +253,7 @@ func Run(
 	cleanupTxnIntentsAsyncFn CleanupTxnIntentsAsyncFunc,
 ) (Info, error) {
 
-	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
+	txnExp := now.Add(-options.TxnCleanupThreshold.Nanoseconds(), 0)
 	if err := gcer.SetGCThreshold(ctx, Threshold{
 		Key: newThreshold,
 		Txn: txnExp,

--- a/pkg/kv/kvserver/gc/gc_old_test.go
+++ b/pkg/kv/kvserver/gc/gc_old_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -56,7 +55,7 @@ func runGCOld(
 
 	// Compute intent expiration (intent age at which we attempt to resolve).
 	intentExp := now.Add(-options.IntentAgeThreshold.Nanoseconds(), 0)
-	txnExp := now.Add(-kvserverbase.TxnCleanupThreshold.Nanoseconds(), 0)
+	txnExp := now.Add(-TxnCleanupThreshold.Default().Nanoseconds(), 0)
 
 	gc := MakeGarbageCollector(now, gcTTL)
 

--- a/pkg/kv/kvserver/gc/gc_random_test.go
+++ b/pkg/kv/kvserver/gc/gc_random_test.go
@@ -60,6 +60,7 @@ var (
 )
 
 const intentAgeThreshold = 2 * time.Hour
+const txnCleanupThreshold = time.Hour
 
 // TestRunNewVsOld exercises the behavior of Run relative to the old
 // implementation. It runs both the new and old implementation and ensures
@@ -100,7 +101,10 @@ func TestRunNewVsOld(t *testing.T) {
 			ttl := time.Duration(tc.ttl) * time.Second
 			newThreshold := CalculateThreshold(tc.now, ttl)
 			gcInfoOld, err := runGCOld(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, ttl,
+				newThreshold, RunOptions{
+					IntentAgeThreshold:  intentAgeThreshold,
+					TxnCleanupThreshold: txnCleanupThreshold,
+				}, ttl,
 				&oldGCer,
 				oldGCer.resolveIntents,
 				oldGCer.resolveIntentsAsync)
@@ -108,7 +112,10 @@ func TestRunNewVsOld(t *testing.T) {
 
 			newGCer := makeFakeGCer()
 			gcInfoNew, err := Run(ctx, tc.ds.desc(), snap, tc.now,
-				newThreshold, RunOptions{IntentAgeThreshold: intentAgeThreshold}, ttl,
+				newThreshold, RunOptions{
+					IntentAgeThreshold:  intentAgeThreshold,
+					TxnCleanupThreshold: txnCleanupThreshold,
+				}, ttl,
 				&newGCer,
 				newGCer.resolveIntents,
 				newGCer.resolveIntentsAsync)
@@ -135,7 +142,10 @@ func BenchmarkRun(b *testing.B) {
 		snap := eng.NewSnapshot()
 		ttl := time.Duration(spec.ttl) * time.Second
 		return runGCFunc(ctx, spec.ds.desc(), snap, spec.now,
-			CalculateThreshold(spec.now, ttl), RunOptions{IntentAgeThreshold: intentAgeThreshold},
+			CalculateThreshold(spec.now, ttl), RunOptions{
+				IntentAgeThreshold:  intentAgeThreshold,
+				TxnCleanupThreshold: txnCleanupThreshold,
+			},
 			ttl,
 			NoopGCer{},
 			func(ctx context.Context, intents []roachpb.Intent) error {

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -136,13 +136,19 @@ func TestIntentAgeThresholdSetting(t *testing.T) {
 	fakeGCer := makeFakeGCer()
 
 	// Test GC desired behavior.
-	info, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentLongThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
+	info, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentLongThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Zero(t, info.IntentsConsidered,
 		"Expected no intents considered by GC with default threshold")
 
-	info, err = Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentShortThreshold}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
+	info, err = Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentShortThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &fakeGCer, fakeGCer.resolveIntents,
 		fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	assert.Equal(t, 1, info.IntentsConsidered,
@@ -189,7 +195,10 @@ func TestIntentCleanupBatching(t *testing.T) {
 	// Base GCer will cleanup all intents in one go and its result is used as a baseline
 	// to compare batched runs for checking completeness.
 	baseGCer := makeFakeGCer()
-	_, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{IntentAgeThreshold: intentAgeThreshold}, gcTTL, &baseGCer, baseGCer.resolveIntents,
+	_, err := Run(ctx, &desc, snap, nowTs, nowTs, RunOptions{
+		IntentAgeThreshold:  intentAgeThreshold,
+		TxnCleanupThreshold: txnCleanupThreshold,
+	}, gcTTL, &baseGCer, baseGCer.resolveIntents,
 		baseGCer.resolveIntentsAsync)
 	if err != nil {
 		t.Fatal("Can't prepare test fixture. Non batched GC run fails.")
@@ -199,7 +208,11 @@ func TestIntentCleanupBatching(t *testing.T) {
 	var batchSize int64 = 7
 	fakeGCer := makeFakeGCer()
 	info, err := Run(ctx, &desc, snap, nowTs, nowTs,
-		RunOptions{IntentAgeThreshold: intentAgeThreshold, MaxIntentsPerIntentCleanupBatch: batchSize}, gcTTL,
+		RunOptions{
+			IntentAgeThreshold:              intentAgeThreshold,
+			MaxIntentsPerIntentCleanupBatch: batchSize,
+			TxnCleanupThreshold:             txnCleanupThreshold,
+		}, gcTTL,
 		&fakeGCer, fakeGCer.resolveIntents, fakeGCer.resolveIntentsAsync)
 	require.NoError(t, err, "GC Run shouldn't fail")
 	maxIntents := 0

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -33,15 +33,6 @@ var MergeQueueEnabled = settings.RegisterBoolSetting(
 	true,
 )
 
-// TxnCleanupThreshold is the threshold after which a transaction is
-// considered abandoned and fit for removal, as measured by the
-// maximum of its last heartbeat and timestamp. Abort spans for the
-// transaction are cleaned up at the same time.
-//
-// TODO(tschottdorf): need to enforce at all times that this is much
-// larger than the heartbeat interval used by the coordinator.
-const TxnCleanupThreshold = time.Hour
-
 // CmdIDKey is a Raft command id. This will be logged unredacted - keep it random.
 type CmdIDKey string
 


### PR DESCRIPTION
Backport 1/1 commits from #85472.

/cc @cockroachdb/release

---

The value was previously hardcoded to 1h, it would be useful to be able
to lower it. Fixes #82541.

Release note: None
Release justification: Adds a cluster setting that would've come in handy in earlier escalations.
