### PR TITLE
changefeedccl: enforce 'stop' schemachange policy with changefeed expressions

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -429,6 +429,15 @@ func createChangefeedJobRecord(
 		// TODO: Set the default envelope to row here when using a sink and format
 		// that support it.
 		details.Select = cdceval.AsStringUnredacted(normalized.Clause())
+
+		// TODO(#85143): do not enforce schema_change_policy='stop' for changefeed expressions.
+		schemachangeOptions, err := opts.GetSchemaChangeHandlingOptions()
+		if err != nil {
+			return nil, err
+		}
+		if schemachangeOptions.Policy != changefeedbase.OptSchemaChangePolicyStop {
+			return nil, errors.Errorf(`using "AS SELECT" requires option schema_change_policy='stop'`)
+		}
 	}
 
 	// TODO(dan): In an attempt to present the most helpful error message to the


### PR DESCRIPTION
See commit notes. This PR addresses https://github.com/cockroachdb/cockroach/issues/85143.

I'll leave the original issue open and assigned to me for when we decide it's safe revert these changes.
