### PR TITLE
release-22.1: kvserver: lower priority level for mvcc gc work

### DIFF
--- a/pkg/kv/kvserver/gc/BUILD.bazel
+++ b/pkg/kv/kvserver/gc/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/settings",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/util/admission",
         "//pkg/util/bufalloc",
         "//pkg/util/contextutil",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -97,6 +98,20 @@ var MaxIntentKeyBytesPerCleanupBatch = settings.RegisterIntSetting(
 	"if non zero, gc will split found intents into batches of this size when trying to resolve them",
 	1e6,
 	settings.NonNegativeInt,
+)
+
+// AdmissionPriority determines the admission priority level to use for MVCC GC
+// work.
+var AdmissionPriority = settings.RegisterEnumSetting(
+	settings.SystemOnly,
+	"kv.gc.admission_priority",
+	"the admission priority to use for mvcc gc work",
+	"bulk_normal_pri",
+	map[int64]string{
+		int64(admission.BulkNormalPri): "bulk_normal_pri",
+		int64(admission.NormalPri):     "normal_pri",
+		int64(admission.UserHighPri):   "user_high_pri",
+	},
 )
 
 // CalculateThreshold calculates the GC threshold given the policy and the

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/intentresolver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -35,9 +36,9 @@ import (
 )
 
 const (
-	// mvccGCQueueTimerDuration is the duration between MVCC GCs of queued
-	// replicas.
-	mvccGCQueueTimerDuration = 1 * time.Second
+	// mvccGCQueueDefaultTimerDuration is the default duration between MVCC GCs
+	// of queued replicas.
+	mvccGCQueueDefaultTimerDuration = 1 * time.Second
 	// mvccGCQueueTimeout is the timeout for a single MVCC GC run.
 	mvccGCQueueTimeout = 10 * time.Minute
 	// mvccGCQueueIntentBatchTimeout is the timeout for resolving a single batch
@@ -62,6 +63,16 @@ const (
 
 	probablyLargeAbortSpanSysCountThreshold = 10000
 	largeAbortSpanBytesThreshold            = 16 * (1 << 20) // 16mb
+)
+
+// mvccGCQueueInterval is a setting that controls how long the mvcc GC queue
+// waits between processing replicas.
+var mvccGCQueueInterval = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.mvcc_gc.queue_interval",
+	"how long the mvcc gc queue waits between processing replicas",
+	mvccGCQueueDefaultTimerDuration,
+	settings.NonNegativeDuration,
 )
 
 func largeAbortSpan(ms enginepb.MVCCStats) bool {
@@ -651,8 +662,8 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 
 // timer returns a constant duration to space out GC processing
 // for successive queued replicas.
-func (*mvccGCQueue) timer(_ time.Duration) time.Duration {
-	return mvccGCQueueTimerDuration
+func (mgcq *mvccGCQueue) timer(_ time.Duration) time.Duration {
+	return mvccGCQueueInterval.Get(&mgcq.store.ClusterSettings().SV)
 }
 
 // purgatoryChan returns nil.


### PR DESCRIPTION
Backport 2/2 commits from #85823.

/cc @cockroachdb/release

---

GC could be expected to be LowPri, so that it does not impact
user-facing traffic when resources (e.g. CPU, write capacity of the
store) are scarce. However long delays in GC can slow down user-facing
traffic due to more versions in the store, and can increase write
amplification of the store since there is more live data. Ideally, we
should adjust this priority based on how far behind we are with respect
to GC-ing a particular range. Keeping the priority level static at
NormalPri proved disruptive when a large volume of MVCC GC work is
suddenly accrued (if an old protected timestamp record was just released
for ex. following a long paused backup job being completed/canceled, or
just an old, long running backup job finishing).

After dynamic priority adjustment, it's not yet clear whether we need
additional pacing mechanisms to provide better latency isolation,
similar to ongoing work for backups. MVCC GC work is CPU intensive:
\#82955. This patch is also speculative in nature and in response to
observed incidents where NormalPri proved too disruptive. Fuller
treatment would entail working off of reliable reproductions of this
behaviour.

We also added a cluster setting (kv.mvcc_gc.queue_interval)
that controls how long the MVCC GC queue waits between
processing replicas. It was previously hardcoded to 1s (which is the
default value), but changing it would've come in handy in support
incidents as a form of manual pacing of MVCC GC work (we have a similar
useful knob for the merge queue).

Release note (performance improvement): Previously if there was sudden
increase in the volume of pending MVCC GC work, there was an impact on
foreground latencies. These sudden increases commonly occurred when:
- gc.ttlseconds was reduced dramatically over tables/indexes that accrue
  a lot of MVCC garbage (think "rows being frequently deleted")
- a paused backup job from a while ago (think > 1 day) was
  canceled/failed
- a backup job that started a while ago (think > 1 day) just finished
Indicators of a large increase in the volume of pending MVCC GC work is
a steep climb in the "GC Queue" graph found in the DB console page, when
navigating to 'Metrics', and selecting the 'Queues' dashboard. With this
patch, the effect on foreground latencies as a result of this sudden
build up should be reduced.

Release justification: stability improvement.