### PR TITLE
flowinfra, typedesc: fix some issues with type hydration

### DIFF
--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -796,6 +796,9 @@ func EnsureTypeIsHydrated(
 				return err
 			}
 		}
+	} else if t.Family() == types.ArrayFamily {
+		// Hydrate the element type.
+		return EnsureTypeIsHydrated(ctx, t.ArrayContents(), res)
 	}
 	if !t.UserDefined() || t.IsHydrated() {
 		return nil
@@ -897,11 +900,7 @@ func (desc *immutable) HydrateTypeInfoWithName(
 	case descpb.TypeDescriptor_ALIAS:
 		if typ.UserDefined() {
 			switch typ.Family() {
-			case types.ArrayFamily:
-				// Hydrate the element type.
-				elemType := typ.ArrayContents()
-				return EnsureTypeIsHydrated(ctx, elemType, res)
-			case types.TupleFamily:
+			case types.ArrayFamily, types.TupleFamily:
 				return EnsureTypeIsHydrated(ctx, typ, res)
 			default:
 				return errors.AssertionFailedf("unhandled alias type family %s", typ.Family())

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfra/execopnode",
         "//pkg/sql/execinfra/execreleasable",

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -192,7 +192,7 @@ func processProducerMessage(
 	draining *bool,
 	msg *execinfrapb.ProducerMessage,
 ) processMessageResult {
-	err := sd.AddMessage(ctx, msg)
+	err := sd.AddMessage(ctx, msg, &flowBase.FlowCtx)
 	if err != nil {
 		return processMessageResult{
 			err: errors.Wrapf(err, "%s",
@@ -225,7 +225,7 @@ func processProducerMessage(
 
 		if log.V(3) && row != nil {
 			if types == nil {
-				types = sd.Types()
+				types = sd.types()
 			}
 			log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
 		}

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -152,7 +152,7 @@ func TestOutbox(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
-		err = decoder.AddMessage(context.Background(), msg)
+		err = decoder.AddMessage(context.Background(), msg, &flowCtx)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -81,7 +81,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []*types.T, records []ro
 			msg := se.FormMessage(context.Background())
 			// Make a copy of the data buffer.
 			msg.Data.RawBytes = append([]byte(nil), msg.Data.RawBytes...)
-			err := sd.AddMessage(context.Background(), msg)
+			err := sd.AddMessage(context.Background(), msg, nil /* flowCtx */)
 			if err != nil {
 				tb.Fatal(err)
 			}
@@ -138,7 +138,7 @@ func TestEmptyStreamEncodeDecode(t *testing.T) {
 	var se flowinfra.StreamEncoder
 	var sd flowinfra.StreamDecoder
 	msg := se.FormMessage(context.Background())
-	if err := sd.AddMessage(context.Background(), msg); err != nil {
+	if err := sd.AddMessage(context.Background(), msg, nil /* flowCtx */); err != nil {
 		t.Fatal(err)
 	}
 	if msg.Header == nil {
@@ -220,7 +220,7 @@ func BenchmarkStreamDecoder(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var sd flowinfra.StreamDecoder
-				if err := sd.AddMessage(ctx, msg); err != nil {
+				if err := sd.AddMessage(ctx, msg, nil /* flowCtx */); err != nil {
 					b.Fatal(err)
 				}
 				for j := 0; j < flowinfra.OutboxBufRows; j++ {

--- a/pkg/sql/flowinfra/stream_decoder.go
+++ b/pkg/sql/flowinfra/stream_decoder.go
@@ -13,6 +13,8 @@ package flowinfra
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -59,7 +61,11 @@ type StreamDecoder struct {
 // msg.Data.Metadata until all the rows in the message are retrieved with GetRow.
 //
 // If an error is returned, no records have been buffered in the StreamDecoder.
-func (sd *StreamDecoder) AddMessage(ctx context.Context, msg *execinfrapb.ProducerMessage) error {
+//
+// flowCtx can be nil in tests.
+func (sd *StreamDecoder) AddMessage(
+	ctx context.Context, msg *execinfrapb.ProducerMessage, flowCtx *execinfra.FlowCtx,
+) error {
 	if msg.Header != nil {
 		if sd.headerReceived {
 			return errors.Errorf("received multiple headers")
@@ -72,6 +78,16 @@ func (sd *StreamDecoder) AddMessage(ctx context.Context, msg *execinfrapb.Produc
 		}
 		sd.typingReceived = true
 		sd.typing = msg.Typing
+		if flowCtx != nil {
+			// Before we can safely use types, we need to make sure they are
+			// hydrated.
+			resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
+			for i := range sd.typing {
+				if err := typedesc.EnsureTypeIsHydrated(ctx, sd.typing[i].Type, &resolver); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	if len(msg.Data.RawBytes) > 0 {
@@ -156,9 +172,9 @@ func (sd *StreamDecoder) GetRow(
 	return rowBuf, nil, nil
 }
 
-// Types returns the types of the columns; can only be used after we received at
+// types returns the types of the columns; can only be used after we received at
 // least one row.
-func (sd *StreamDecoder) Types() []*types.T {
+func (sd *StreamDecoder) types() []*types.T {
 	types := make([]*types.T, len(sd.typing))
 	for i := range types {
 		types[i] = sd.typing[i].Type


### PR DESCRIPTION
**flowinfra: hydrate types for the inbound streams**

The inbound stream handler receives the type information as metadata
(unlike other components of the row-based flows), and we forgot to do
the hydration of those types. The impact is limited though - the types
are only used in a single place when verbose logging is enabled on
`inbound` file (but it could lead to a crash when a user-defined type
was encountered).

Fixes: #85447.

Release note: None

**typedesc: fix hydration of arrays of enums**

It seems that previously it was possible for an array of enums to not be
hydrated properly if `EnsureTypeIsHydrated` was called with that type
since the type would not be treated as "user defined" (because it has
a "non-user defined" oid), and this is now fixed.

Fixes: #85376.

Release note: None