### PR TITLE
sql: fix log spam during idx recommendation if txn was closed

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -684,6 +684,8 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 	opc.reset(ctx)
 	stmtType := opc.p.stmt.AST.StatementType()
 
+	reset := false
+	var recommendations []string
 	if idxRec.ShouldGenerateIndexRecommendation(
 		ih.fingerprint,
 		ih.planGist.Hash(),
@@ -713,25 +715,17 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 			err = opc.makeQueryIndexRecommendation(ctx)
 			if err != nil {
 				log.Warningf(ctx, "unable to generate index recommendations: %s", err)
-			} else {
-				idxRec.UpdateIndexRecommendations(
-					ih.fingerprint,
-					ih.planGist.Hash(),
-					planner.SessionData().Database,
-					stmtType,
-					ih.indexRecommendations,
-					true,
-				)
 			}
 		}
-	} else {
-		ih.indexRecommendations = idxRec.UpdateIndexRecommendations(
-			ih.fingerprint,
-			ih.planGist.Hash(),
-			planner.SessionData().Database,
-			stmtType,
-			[]string{},
-			false,
-		)
+		reset = true
+		recommendations = ih.indexRecommendations
 	}
+	ih.indexRecommendations = idxRec.UpdateIndexRecommendations(
+		ih.fingerprint,
+		ih.planGist.Hash(),
+		planner.SessionData().Database,
+		stmtType,
+		recommendations,
+		reset,
+	)
 }


### PR DESCRIPTION
Previously, if a transaction (from planner.txn) was already closed,
due to one-phase commit optimization or an error, we were still
trying to generate a recommendation, causing log spam.
This commit now checks if we have a transaction open that can be
used, otherwise it won't try to generate recommendation.

This commit also updates the cache, even if the recommendation
generations fails, this way we won't keep trying constantly,
and instead will wait for the next hour to try again.

Fixes #85875

Release note: None