### PR TITLE
externalconn: introduce `crdb_internal.external_connections`

### DIFF
--- a/pkg/cloud/externalconn/connectionpb/BUILD.bazel
+++ b/pkg/cloud/externalconn/connectionpb/BUILD.bazel
@@ -26,7 +26,11 @@ go_library(
     embed = [":connectionpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_cockroachdb_errors//:errors"],
+    deps = [
+        "//pkg/sql/protoreflect",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//jsonpb",
+    ],
 )
 
 get_x_data(name = "get_x_data")

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -161,6 +161,7 @@ const (
 	CrdbInternalTenantUsageDetailsViewID
 	CrdbInternalPgCatalogTableIsImplementedTableID
 	CrdbInternalSuperRegions
+	CrdbInternalExternalConnections
 	InformationSchemaID
 	InformationSchemaAdministrableRoleAuthorizationsID
 	InformationSchemaApplicableRolesID


### PR DESCRIPTION
This patch introduces a new crdb_internal table that will be the
driver for the `SHOW` command that will be built for external
connections.

Most notably, every provider must now register a redaction method
that sanitizes the connection details of any information that should
not be displayed.

Informs: #85905

Release note: None