### PR TITLE
roachtest: remove DISABLE_COCKROACHDB_TELEMETRY from django test script

### DIFF
--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -254,7 +254,6 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': 26257,
-				'DISABLE_COCKROACHDB_TELEMETRY': True,
     },
     'other': {
         'ENGINE': 'django_cockroachdb',
@@ -263,7 +262,6 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': 26257,
-				'DISABLE_COCKROACHDB_TELEMETRY': True,
     },
 }
 SECRET_KEY = 'django_tests_secret_key'


### PR DESCRIPTION
It's configured incorrectly here (it's a top-level setting rather than
a part of DATABASES), and it isn't required because [telemetry is disabled
by django-cockroachdb](https://github.com/cockroachdb/django-cockroachdb/blob/0d44aaed3b414e263ee9f9ffb7ed71f585fdb9a1/django_cockroachdb/base.py#L68-L69) when running Django's test suite.

Release note: None