### PR TITLE
backupccl: elide data from offline tables during RESTORE

### DIFF
--- a/pkg/ccl/backupccl/key_rewriter.go
+++ b/pkg/ccl/backupccl/key_rewriter.go
@@ -216,7 +216,12 @@ func MakeKeyRewriterPrefixIgnoringInterleaved(tableID descpb.ID, indexID descpb.
 
 // RewriteKey modifies key (possibly in place), changing all table IDs to their
 // new value.
-func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
+//
+// The caller should only pass a nonzero walltime if the function should return
+// an error when it encounters a key from an in-progress import. Currently, this
+// is only relevant for RESTORE. See the checkAndRewriteTableKey function for
+// more details.
+func (kr *KeyRewriter) RewriteKey(key []byte, wallTime int64) ([]byte, bool, error) {
 	// If we are reading a system tenant backup and this is a tenant key then it
 	// is part of a backup *of* that tenant, so we only restore it if we have a
 	// tenant rekey for it, i.e. we're restoring that tenant.
@@ -236,7 +241,7 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 		return nil, false, err
 	}
 
-	rekeyed, ok, err := kr.rewriteTableKey(noTenantPrefix)
+	rekeyed, ok, err := kr.checkAndRewriteTableKey(noTenantPrefix, wallTime)
 	if err != nil {
 		return nil, false, err
 	}
@@ -258,23 +263,43 @@ func (kr *KeyRewriter) RewriteKey(key []byte) ([]byte, bool, error) {
 	return rekeyed, ok, err
 }
 
-// rewriteTableKey rewrites the table IDs in the key.
-// It assumes that any tenant ID has been stripped from the key so it operates
-// with the system codec. It is the responsibility of the caller to either
-// remap, or re-prepend any required tenant prefix.
-func (kr *KeyRewriter) rewriteTableKey(key []byte) ([]byte, bool, error) {
+// ErrImportingKeyError indicates the current key is apart of an in-progress import
+var ErrImportingKeyError = errors.New("skipping rewrite of an importing key")
+
+// checkAndRewriteTableKey rewrites the table IDs in the key. It assumes that
+// any tenant ID has been stripped from the key so it operates with the system
+// codec. It is the responsibility of the caller to either remap, or re-prepend
+// any required tenant prefix.
+//
+// The caller may also pass the key's walltime (part of the MVCC key's
+// timestamp), which the function uses to detect and filter out keys from
+// in-progress imports. If the caller passes a zero valued walltime, no
+// filtering occurs. Filtering is necessary during restore because the restoring
+// cluster should not contain keys from an in-progress import.
+func (kr *KeyRewriter) checkAndRewriteTableKey(key []byte, wallTime int64) ([]byte, bool, error) {
 	// Fetch the original table ID for descriptor lookup. Ignore errors because
 	// they will be caught later on if tableID isn't in descs or kr doesn't
 	// perform a rewrite.
 	_, tableID, _ := keys.SystemSQLCodec.DecodeTablePrefix(key)
+
+	desc := kr.descs[descpb.ID(tableID)]
+	if desc == nil {
+		return nil, false, errors.Errorf("missing descriptor for table %d", tableID)
+	}
+
+	// If the user passes a non-zero walltime for the key, and the key's table is
+	// undergoing an IMPORT (indicated by a non zero
+	// GetInProgressImportStartTime), then this function returns an error if this
+	// key is a part of the import -- i.e. the key's walltime is greater than the
+	// import start time. It is up to the caller to handle this error properly.
+	if importTime := desc.GetInProgressImportStartTime(); wallTime > 0 && importTime > 0 && wallTime >= importTime {
+		return nil, false, ErrImportingKeyError
+	}
+
 	// Rewrite the first table ID.
 	key, ok := kr.prefixes.rewriteKey(key)
 	if !ok {
 		return nil, false, nil
-	}
-	desc := kr.descs[descpb.ID(tableID)]
-	if desc == nil {
-		return nil, false, errors.Errorf("missing descriptor for table %d", tableID)
 	}
 	return key, true, nil
 }

--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -83,7 +83,7 @@ func TestKeyRewriter(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
 		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
 			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func TestKeyRewriter(t *testing.T) {
 	t.Run("prefix end", func(t *testing.T) {
 		key := roachpb.Key(rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
 			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())).PrefixEnd()
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -131,7 +131,7 @@ func TestKeyRewriter(t *testing.T) {
 		}
 
 		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -147,6 +147,40 @@ func TestKeyRewriter(t *testing.T) {
 		}
 	})
 
+	t.Run("importing", func(t *testing.T) {
+
+		// Create a new key rewriter with a table descriptor undergoing an in-progress import.
+		desc.ID = oldID + 20
+		desc.ImportStartWallTime = 2
+		newKr, err := MakeKeyRewriterFromRekeys(keys.SystemSQLCodec, []execinfrapb.TableRekey{
+			{OldID: uint32(oldID), NewDesc: mustMarshalDesc(t, desc.TableDesc())},
+		}, nil /* tenantRekeys */, false /* restoreTenantFromStream */)
+		require.NoError(t, err)
+
+		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
+			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
+
+		// If the passed in walltime is at or above the ImportStartWalltime, an error should return
+		_, _, err = newKr.RewriteKey(key, 2)
+		require.Error(t, err, ErrImportingKeyError.Error())
+
+		// Else, the key should get encoded normally.
+		newKey, ok, err := newKr.RewriteKey(key, 1)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !ok {
+			t.Fatal("expected rewrite")
+		}
+		_, id, err := encoding.DecodeUvarintAscending(newKey)
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if descpb.ID(id) != oldID+20 {
+			t.Fatalf("got %d expected %d", id, newID)
+		}
+	})
 	systemTenant := roachpb.SystemTenantID
 	tenant3 := roachpb.MakeTenantID(3)
 	tenant4 := roachpb.MakeTenantID(4)
@@ -162,7 +196,7 @@ func TestKeyRewriter(t *testing.T) {
 		require.NoError(t, err)
 
 		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		require.NoError(t, err)
 		if !ok {
 			t.Fatalf("expected rewrite")
@@ -207,7 +241,7 @@ func TestKeyRewriter(t *testing.T) {
 		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
 		oldNoTenantKey, oldTenantID, err := keys.DecodeTenantPrefix(key)
 		require.NoError(t, err)
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		require.NoError(t, err)
 		if !ok {
 			t.Fatalf("expected rewrite")

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -464,7 +464,15 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
 		value := roachpb.Value{RawBytes: valueScratch}
 
-		key.Key, ok, err = kr.RewriteKey(key.Key)
+		key.Key, ok, err = kr.RewriteKey(key.Key, key.Timestamp.WallTime)
+
+		if errors.Is(err, ErrImportingKeyError) {
+			// The keyRewriter returns ErrImportingKeyError iff the key is part of an
+			// in-progress import. Keys from in-progress imports never get restored,
+			// since the key's table gets restored to its pre-import state. Therefore,
+			// elide ingesting this key.
+			continue
+		}
 		if err != nil {
 			return summary, err
 		}

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1768,7 +1768,7 @@ func doRestorePlan(
 	if err := rewrite.TableDescs(tables, descriptorRewrites, intoDB); err != nil {
 		return err
 	}
-	if err := rewrite.DatabaseDescs(databases, descriptorRewrites); err != nil {
+	if err := rewrite.DatabaseDescs(databases, descriptorRewrites, map[descpb.ID]struct{}{}); err != nil {
 		return err
 	}
 	if err := rewrite.SchemaDescs(schemas, descriptorRewrites); err != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -1,0 +1,584 @@
+# This test ensures that table, database and cluster backups properly
+# backup and restore an IMPORT INTO of an empty table (foo) and a non empty table (foofoo).
+#
+# On a fully upgraded cluster: the table should get rolled back to its pre-import state after RESTORE
+# On an unfinalized cluster: a backed up import should not get restored
+
+
+new-server name=s1
+----
+
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' WITH revision_history;
+----
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/' WITH revision_history;
+----
+
+# Ensure incremental backups do NOT re-capture the importing rows while the tables are offline
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+----
+
+
+save-cluster-ts tag=t0
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job resume=a
+----
+
+job resume=aa
+----
+
+job tag=a wait-for-state=succeeded
+----
+
+
+job tag=aa wait-for-state=succeeded
+----
+
+
+# NOTE: currently the backups below re-capture the _2_ versions of each imported key:
+#  1: the original data that was already captured in the previous backup because BACKUP currently
+#     re-backs up the whole span once the table goes back online. This will change.
+#  2. when the import job resumes, the data is re-ingested, hence a second version of the imported
+#     data gets ingested into the backing up cluster, and consequently, the incremental backup.
+#     This occurs because when a restore job resumes after all data was initially ingested, the last
+#     check pointed restore span entry (i.e. in the mu.requestsCompleted object) gets re-ingested.
+#     -- in this case, there's only one span in the restore job, so all data gets re-ingested.
+
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+----
+
+
+# In all backup chains, the following rows get captured:
+# - Full backup: the original data + data from in-progress import (1 row in foo, 2 in foofoo)
+# - First incremental backup: nothing, no new data was ingested and the table is still offline
+# - Second incremental backup (2 row in foo, 3 in foofoo):
+#   - a full backup of the importing data because the tables returned online (1 row in foo, 2 in foofoo)
+#   - and duplicates of the importing data (1 row in foo, 1 in foofoo) because of import job
+#     checkpointing behavior. See note above.
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+# Ensure all the RESTOREs contain foo (no data) and foofoo (1 row) as of system time t0
+new-server name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+
+restore aost=t0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+----
+
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+restore aost=t0
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME t0;
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+
+exec-sql
+DROP TABLE d.foo;
+DROP TABLE d.foofoo;
+DROP TABLE d.baz;
+----
+
+
+restore aost=t0
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' AS OF SYSTEM TIME t0 WITH into_db='d';
+----
+
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+
+# Ensure the imported data exists as of latest time
+new-server name=s3 share-io-dir=s1 allow-implicit-access
+----
+
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+
+query-sql
+SELECT * FROM d.foo;
+----
+1 x
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+1 x
+10 x0
+
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
+----
+
+
+query-sql
+SELECT * FROM d.foo;
+----
+1 x
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+1 x
+10 x0
+
+
+exec-sql
+DROP TABLE d.foo;
+DROP TABLE d.foofoo;
+DROP TABLE d.baz;
+----
+
+
+exec-sql
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' WITH into_db= d;
+----
+
+
+query-sql
+SELECT * FROM d.foo;
+----
+1 x
+
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+1 x
+10 x0
+
+
+#######################
+# Version Gate Testing
+#######################
+
+# In an unfinalized cluster, back up some in-progress imports, and ensure that once the tables come
+# back online, we fully back them again, even if the cluster is not fully upgraded. Test on cluster
+# and database backups.
+#
+# Note that during IMPORT planning on an unfinalized cluster, the
+# ImportStartTime is not bound to the table's descriptor, therefore during
+# RESTORE AOST in-progress IMPORT, these tables should get thrown out.
+#
+# TODO(msbutler): cover mixed version RESTORE TABLE
+
+
+new-server name=s4 share-io-dir=s1 allow-implicit-access beforeVersion=Start22_2
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=b
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=bb
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# The first backup in the chain will capture data from offline tables, even
+# though the cluster has not finalized to 22.2. Ensure this works in cluster and database backups.
+# The 'database' and 'database_upgrade' backup chains will test different backup chain / upgrade
+# sequences.
+
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database_upgrade/' with revision_history;
+----
+
+
+save-cluster-ts tag=m0
+----
+
+
+# This next set of incremental backups should not capture any new data, as no new data was ingested
+# into the table since the last backup.
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+CREATE VIEW show_cluster_backup AS
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+
+
+exec-sql
+CREATE VIEW show_database_backup AS
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+
+
+query-sql
+SELECT * FROM show_cluster_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+
+
+query-sql
+SELECT * FROM show_database_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job resume=b
+----
+
+
+job tag=b wait-for-state=succeeded
+----
+
+
+job resume=bb
+----
+
+
+job tag=bb wait-for-state=succeeded
+----
+
+
+# Ensure that once the tables come back online, everything gets backed
+# up again, as these imports may have non-mvcc ops in them. Ensure this in the
+# unfinalized cluster and in the finalized cluster.
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+query-sql
+SELECT * FROM show_cluster_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+query-sql
+SELECT * FROM show_database_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+upgrade-server version=Start22_2
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database_upgrade/' with revision_history;
+----
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database_upgrade/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+# Restore the backups taken from a mixed version chain
+new-server name=s5 share-io-dir=s1 allow-implicit-access
+----
+
+
+# Ensure the RESTOREs omit the tables with in progress imports (foo and foofoo)
+# as their descriptors will not have the import start time.
+restore aost=m0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME m0;
+----
+
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d];
+----
+baz
+
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+restore aost=m0
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME m0;
+----
+
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d];
+----
+baz
+
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+# Restore AOST after the table comes back online
+restore
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
+----
+
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d];
+----
+foo
+foofoo
+baz
+show_cluster_backup
+show_database_backup
+

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -1,0 +1,442 @@
+# This test ensures that table, database and cluster backups properly backup and
+# restore (i.e. capture) an in progress database or table RESTORE. The
+# in-progress restore may take other kinds of descriptors offline (e.g. type,
+# schema), so this test ensures that the capturing restore handles these other offline
+# descriptors properly.
+#
+# TODO(msbutler): currently, a user cannot explicitly target a restoring table
+# or database in their backup because of a schema change bug (#86626, #86691).
+# I.e., the user cannot run:
+#  - BACKUP DATABASE my_offline_restoring_database
+#  - BACKUP TABLE my_offline_restoring_table.
+#
+# The user can only backup offline tables if they are implicitly covered in the
+# target, i.e. RESTORE DATABASE my_database_that_contains_an_offline_table. Once
+# the schema change bugs are fixed, a user should be able to explicitly target
+# offline tables.
+
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE b;
+USE b;
+CREATE SCHEMA me;
+CREATE TYPE me.greeting AS ENUM ('hello', 'howdy', 'heyyy');
+CREATE TABLE me.baz (x INT, y me.greeting);
+CREATE INDEX greeting_idx ON me.baz (y);
+INSERT INTO me.baz VALUES (1,'howdy'), (2,'hello'), (3,'heyyy');
+CREATE DATABASE d;
+USE d;
+----
+
+
+# Run a backup to then restore from and test that future backups capture the
+# in-progress restore data.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
+----
+
+#######
+# Case 1: Capture an in-progress database restore with cluster restore
+#######
+
+# Pause a RESTORE DATABASE job, so a cluster backup can back up the restoring data.
+restore expect-pausepoint tag=a
+RESTORE DATABASE b FROM LATEST IN 'nodelocal://0/cluster/' with new_db_name=b2;
+----
+job paused at pausepoint
+
+
+# This incremental cluster backup should capture the offline restoring database
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+save-cluster-ts tag=t0
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next incremental backup observes that everything is back online
+#
+# Note: when a restore job resumes after all data was initially ingested, the last
+# check pointed restore span entry (i.e. in the mu.requestsCompleted object) gets reingested.
+# -- in this case, the greeting_idx index gets re-ingested.
+job resume=a
+----
+
+
+job tag=a wait-for-state=succeeded
+----
+
+# This backup should capture the online restored database
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+# Display the backed up objects from the restoring b2 database
+# - The first incremental backup captures all its schema objects
+#   and all data ingested AOST the backup (i.e. 3 rows in b2.baz).
+# - The second incremental backs up all data from b2 starting from t0,
+#   since the table returned online after the first incremental backup.
+#   (i.e. 3 rows in b2.baz).
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  database_name = 'b2'
+ORDER BY
+  start_time, database_name;
+----
+b2 public schema <nil> incremental
+b2 me schema <nil> incremental
+b2 greeting type <nil> incremental
+b2 _greeting type <nil> incremental
+b2 baz table 3 incremental
+b2 public schema <nil> incremental
+b2 me schema <nil> incremental
+b2 greeting type <nil> incremental
+b2 _greeting type <nil> incremental
+b2 baz table 3 incremental
+
+
+# Ensure the restored cluster contains nothing from the in-progress restoring database as of system
+# time t0
+new-server name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+
+restore aost=t0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+----
+
+
+query-sql
+SELECT database_name FROM [SHOW DATABASES] WHERE database_name = 'b2';
+----
+
+
+# Ensure restored cluster contains the restored database as of latest time
+new-server name=s3 share-io-dir=s1 allow-implicit-access
+----
+
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+
+query-sql
+SELECT database_name FROM [SHOW DATABASES] WHERE database_name = 'b2';
+----
+b2
+
+
+query-sql
+SELECT * FROM b2.me.baz;
+----
+1 howdy
+2 hello
+3 heyyy
+
+
+query-sql
+SELECT * FROM [SHOW INDEX FROM b2.me.baz] WHERE index_name = 'greeting_idx';
+----
+baz greeting_idx true 1 y ASC false false true
+baz greeting_idx true 2 rowid ASC false true true
+
+
+#################
+# Case 2: capture an in-progress table restore with a database restore. The table restore also
+# introduces a user defined schema.
+##################
+
+exec-sql
+USE d;
+DROP SCHEMA IF EXISTS me CASCADE;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
+----
+
+
+restore expect-pausepoint tag=b
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d';
+----
+job paused at pausepoint
+
+
+# ensure user cannot override offline schema created by table restore into data database d
+exec-sql
+CREATE SCHEMA me;
+----
+pq: schema "me" already exists
+
+
+# This backup should capture 3 rows from restoring table table baz
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' WITH revision_history;
+----
+
+save-cluster-ts tag=m0
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+job resume=b
+----
+
+
+job tag=b wait-for-state=succeeded
+----
+
+
+# This backup should capture 3 rows from restoring table table baz, since it just came online
+# (this will change once we more selectively reintroduce offline spans)
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+# Display the backed up objects from the restoring d database
+# - The full backup captures all its schema objects
+#   and all data ingested AOST the backup
+# - The second incremental backs up all data from d starting from t0,
+#   since the table returned online after the first incremental backup.
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  database_name = 'd'
+ORDER BY
+  start_time, database_name;
+----
+d public schema <nil> full
+d me schema <nil> full
+d greeting type <nil> full
+d _greeting type <nil> full
+d baz table 3 full
+d public schema <nil> incremental
+d me schema <nil> incremental
+d greeting type <nil> incremental
+d _greeting type <nil> incremental
+d baz table 3 incremental
+
+
+# Ensure that restoring the database, AOST the in-progress restore, elides the restoring descriptors
+restore aost=m0
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME m0 with new_db_name = d_aost;
+----
+
+
+query-sql
+SHOW TABLES FROM d_aost;
+----
+
+
+query-sql
+SELECT schema_name FROM [SHOW SCHEMAS FROM d_aost] WHERE schema_name='me';
+----
+
+# Restore AOST completed in-progress restore, implying baz is online.
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name = d_latest
+----
+
+
+query-sql
+SELECT schema_name, table_name, type FROM [SHOW TABLES FROM d_latest];
+----
+me baz table
+
+###################
+# Case 3: same as case 2, except the table restore restores into an existing
+# user defined schema, instead of creating its own.
+###################
+
+exec-sql
+DROP DATABASE d_aost;
+DROP DATABASE d_latest;
+CREATE DATABASE d_with_schema;
+CREATE SCHEMA d_with_schema.me;
+CREATE TABLE d_with_schema.me.bar (x INT);
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
+----
+
+
+restore expect-pausepoint tag=bb
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d_with_schema';
+----
+job paused at pausepoint
+
+
+# Ensure one can write into the schema that is currently getting restored
+exec-sql
+INSERT INTO d_with_schema.me.bar VALUES (1);
+----
+
+
+# This backup should capture 3 rows from restoring table table baz
+exec-sql
+BACKUP DATABASE d_with_schema INTO 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+save-cluster-ts tag=n0
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+job resume=bb
+----
+
+
+job tag=bb wait-for-state=succeeded
+----
+
+exec-sql
+BACKUP DATABASE d_with_schema INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+# Ensure that restoring the tables, AOST the in-progress restore, elides the restoring descriptors.
+restore aost=n0
+RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME n0 with new_db_name = d_aost;
+----
+
+
+# only the pre-existing table, bar, should be around (not the restoring one, baz)
+query-sql
+SELECT schema_name, table_name, type FROM [SHOW TABLES FROM d_aost];
+----
+me bar table
+
+
+# ensure the existing schema is in the cluster
+query-sql
+SELECT schema_name FROM [SHOW SCHEMAS FROM d_aost] WHERE schema_name='me';
+----
+me
+
+
+exec-sql
+RESTORE DATABASE d_with_schema FROM LATEST IN 'nodelocal://0/database/' with new_db_name = d_latest
+----
+
+
+query-sql
+SELECT schema_name, table_name, type FROM [SHOW TABLES FROM d_latest];
+----
+me bar table
+me baz table
+
+
+###################
+# Case 4: capture a table restore creating its own user defined schema with another table restore
+###################
+
+
+exec-sql
+DROP DATABASE d_aost;
+DROP DATABASE d_latest;
+DROP SCHEMA d.me CASCADE;
+CREATE DATABASE d_aost;
+CREATE DATABASE d_latest;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
+----
+
+
+restore expect-pausepoint tag=bbb
+RESTORE TABLE b.me.baz FROM LATEST IN 'nodelocal://0/cluster/' WITH into_db='d';
+----
+job paused at pausepoint
+
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/' WITH revision_history;
+----
+
+
+save-cluster-ts tag=o0
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+job resume=bbb
+----
+
+
+job tag=bbb wait-for-state=succeeded
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' WITH revision_history;
+----
+
+
+# Ensure that restoring the table, AOST the in-progress restore, elides the restoring descriptors.
+restore aost=o0
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' AS OF SYSTEM TIME o0 with into_db = d_aost;
+----
+
+
+# No tables or schema should exist in d_aost, as all descriptors in the back up are offline.
+query-sql
+SHOW TABLES FROM d_aost;
+----
+
+
+query-sql
+SELECT schema_name FROM [SHOW SCHEMAS FROM d_aost] WHERE schema_name='me';
+----
+
+
+exec-sql
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' with into_db = d_latest
+----
+
+
+query-sql
+SELECT schema_name FROM [SHOW SCHEMAS FROM d_latest] WHERE schema_name='me';
+----
+me
+
+
+query-sql
+SELECT schema_name, table_name, type FROM [SHOW TABLES FROM d_latest];
+----
+me baz table

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -101,11 +101,15 @@ func backupRestoreTestSetupWithParams(
 
 	sqlDB = sqlutils.MakeSQLRunner(tc.Conns[0])
 
+	// Lower the initial buffering adder ingest size to allow concurrent import jobs to run without
+	// borking the memory monitor.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.pk_buffer_size = '16MiB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.index_buffer_size = '16MiB'`)
+
 	// Set the max buffer size to something low to prevent backup/restore tests
 	// from hitting OOM errors. If any test cares about this setting in
 	// particular, they will override it inline after setting up the test cluster.
 	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '16MiB'`)
-
 	sqlDB.Exec(t, `CREATE DATABASE data`)
 	l := workloadsql.InsertsDataLoader{BatchSize: 1000, Concurrency: 4}
 	if _, err := workloadsql.Setup(ctx, sqlDB.DB.(*gosql.DB), bankData, l); err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -619,7 +619,7 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
-	rekey, ok, err := sip.rekeyer.RewriteKey(key)
+	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
 	if !ok {
 		return nil, errors.New("every key is expected to match tenant prefix")
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -652,7 +652,7 @@ func noteKeyVal(
 	validator *streamClientValidator, keyVal roachpb.KeyValue, spec streamclient.SubscriptionToken,
 ) {
 	if validator.rekeyer != nil {
-		rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key)
+		rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key, 0 /* wallTime*/)
 		if err != nil {
 			panic(err.Error())
 		}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -288,6 +288,8 @@ message DescriptorRewrite {
 
   // NewDBName represents the new name given to a restored database during a database restore
   string new_db_name = 4 [(gogoproto.customname) = "NewDBName"];
+
+  // Next ID is 6
 }
 
 message RestoreDetails {

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -262,7 +262,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 					return errors.Wrap(err, "checking if existing table is empty")
 				}
 				details.Tables[i].WasEmpty = len(res) == 0
-				if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V22_1) {
+				if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.Start22_2) {
 					// Update the descriptor in the job record and in the database with the ImportStartTime
 					details.Tables[i].Desc.ImportStartWallTime = details.Walltime
 					err := bindImportStartTime(ctx, p, tblDesc.GetID(), details.Walltime)
@@ -454,7 +454,6 @@ func (r *importResumer) prepareTablesForIngestion(
 	// wait for all nodes to see the same descriptor version before doing so.
 	if !hasExistingTables {
 		importDetails.Walltime = p.ExecCfg().Clock.Now().WallTime
-		// TODO(msbutler): add import start time to IMPORT PGDUMP/MYSQL descriptor
 	} else {
 		importDetails.Walltime = 0
 	}


### PR DESCRIPTION
A previous PR (https://github.com/cockroachdb/cockroach/pull/83915) enabled BACKUP to target offline descriptors
(including IMPORTing and RESTOREing tables), but didn't fully handle their
rollback on RESTORE. This PR ensures RESTORE properly handles these offline
tables:
- An offline table created by RESTORE or IMPORT PGDUMP is fully discarded. The
  table does not exist in the restoring cluster.
- An offline table created by an IMPORT INTO has all importing data elided in
  the restore processor and is restored online to its pre import state.

If the RESTORE occurs AOST after the table returns online, the table is
RESTOREd to its post offline state.

Currently, all tables that return online are fully re-backed up. For many
situations above, this is unecessary. Future work should ensure that these
tables are not re-backed up when we know all operations within the
incremental backup interval on the table were MVCC.

This patch only applies to BACKUP and RESTORE flavors that implicitly target an
offline importing/restoring table. A future PR should allow a user to
explicitly target an existing offline table undergoing an IMPORT.

Fixes #86054

Release justification: fixes bug where offline tables were not properly handled
in restore.