### PR TITLE
sql: use the correct txn when creating external connection

### DIFF
--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -111,9 +110,7 @@ func (p *planner) createExternalConnection(
 
 	// Create the External Connection and persist it in the
 	// `system.external_connections` table.
-	return params.ExecCfg().DB.Txn(params.ctx, func(ctx context.Context, txn *kv.Txn) error {
-		return ex.Create(params.ctx, params.ExecCfg().InternalExecutor, params.p.User(), txn)
-	})
+	return ex.Create(params.ctx, params.ExecCfg().InternalExecutor, params.p.User(), p.Txn())
 }
 
 func (c *createExternalConectionNode) Next(_ runParams) (bool, error) { return false, nil }


### PR DESCRIPTION
We need to use the planners' txn when creating an external
connection. Using a DB().Txn here was an oversight.

Release note: None