### PR TITLE
cc/backupccl: skip empty names in metadata SST

### DIFF
--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -56,6 +56,9 @@ func TestMetadataSST(t *testing.T) {
 	// history.
 	sqlDB.Exec(t, `CREATE TABLE data.foo(k INT, v INT)`)
 	sqlDB.Exec(t, `CREATE INDEX idx ON data.bank (balance)`)
+	sqlDB.Exec(t, `CREATE DATABASE emptydb`)
+	sqlDB.Exec(t, `CREATE TABLE emptydb.bar(k INT, v INT)`)
+	sqlDB.Exec(t, `DROP DATABASE emptydb`)
 
 	sqlDB.Exec(t, `BACKUP TO $1 WITH revision_history`, userfile)
 	checkMetadata(ctx, t, tc, userfile)

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata.go
@@ -359,6 +359,10 @@ func writeNamesToMetadata(
 	sort.Sort(names)
 
 	for i, rev := range names {
+		if rev.name == "" {
+			continue
+		}
+
 		if i > 0 {
 			prev := names[i-1]
 			prev.ts = rev.ts

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -82,7 +82,7 @@ var WriteMetadataSST = settings.RegisterBoolSetting(
 	settings.TenantWritable,
 	"kv.bulkio.write_metadata_sst.enabled",
 	"write experimental new format BACKUP metadata file",
-	false,
+	true,
 )
 
 // IsGZipped detects whether the given bytes represent GZipped data. This check


### PR DESCRIPTION
Previously, descriptor changes that resulted in an empty name (for dropped
descriptors) were included in the names section of the backup metadata SST,
skip these when populating the names section.

Fixes #85564

Release note: None