### PR TITLE
sql: capture traced statements for telemetry

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -387,7 +387,10 @@ func (p *planner) maybeLogStatementInternal(
 		// We only log to the telemetry channel if enough time has elapsed from
 		// the last event emission.
 		requiredTimeElapsed := 1.0 / float64(maxEventFrequency)
-		if p.stmt.AST.StatementType() != tree.TypeDML {
+		_, tracingEnabled := p.curPlan.instrumentation.Tracing()
+		// Always sample if the current statement is not of type DML or tracing
+		// is enabled for this statement.
+		if p.stmt.AST.StatementType() != tree.TypeDML || tracingEnabled {
 			requiredTimeElapsed = 0
 		}
 		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {


### PR DESCRIPTION
Resolves: #85919

This change ensures that any statement with tracing information is
chosen to be sampled to our telemetry.

Release note: None