### PR TITLE
jobs: make expiration use intended txn priority

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -729,7 +729,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				return errors.WithAssertionFailure(err)
 			}
 			_, err := r.ex.ExecEx(
-				ctx, "expire-sessions", nil,
+				ctx, "expire-sessions", txn,
 				sessiondata.InternalExecutorOverride{User: username.RootUserName()},
 				removeClaimsForDeadSessionsQuery,
 				s.ID().UnsafeBytes(),
@@ -776,7 +776,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				return errors.WithAssertionFailure(err)
 			}
 			_, err := r.ex.ExecEx(
-				ctx, "remove-claims-for-session", nil,
+				ctx, "remove-claims-for-session", txn,
 				sessiondata.InternalExecutorOverride{User: username.RootUserName()},
 				removeClaimsForSessionQuery, s.ID().UnsafeBytes(),
 			)


### PR DESCRIPTION
In aed014f these operations were supposed to be changed to use
MinUserPriority. However, they weren't using the appropriate txn, so it
didn't have the intended effect.

Release note: None