### PR TITLE
opt: remove TableMeta.IsSkipLocked

### DIFF
--- a/pkg/sql/opt/memo/multiplicity_builder.go
+++ b/pkg/sql/opt/memo/multiplicity_builder.go
@@ -233,11 +233,16 @@ func filtersMatchLeftRowsAtMostOnce(left, right RelExpr, filters FiltersExpr) bo
 //      the left and the column it references from the right. All left columns
 //      must come from the same foreign key.
 //
-// In both the self-join and the foreign key cases, the left columns must be
-// not-null, and the right columns must be either unfiltered, or the left and
-// right must be Select expressions where the left side filters imply the right
-// side filters and right columns are unfiltered in the right Select's input
-// (see condition #3b in the comment for verifyFiltersAreValidEqualities).
+// In both the self-join and the foreign key cases that are not cross-joins
+// (cases 2a and 2b):
+//
+//   - The left columns must be not-null, and
+//   - One of the following must be true:
+//     - The right columns are unfiltered, or
+//     - The left and right side of the join must be Select expressions where
+//       the left side filters imply the right side filters, and the right
+//       columns - are unfiltered in the right Select's input (see condition
+//       #3b in the comment for verifyFilterAreValidEqualities).
 //
 // Why do the left columns have to be non-null, and the right columns unfiltered
 // or filtered identically as their corresponding left column? In both the
@@ -447,8 +452,7 @@ func rightHasSingleFilterThatMatchesLeft(left, right RelExpr, leftCol, rightCol 
 }
 
 // checkSelfJoinCase returns true if all equalities in the given FiltersExpr
-// are between columns from the same position in the same base table. Panics
-// if verifyFilters is not checked first.
+// are between columns from the same position in the same base table.
 func checkSelfJoinCase(md *opt.Metadata, filters FiltersExpr) bool {
 	for i := range filters {
 		eq, _ := filters[i].Condition.(*EqExpr)
@@ -470,8 +474,7 @@ func checkSelfJoinCase(md *opt.Metadata, filters FiltersExpr) bool {
 
 // checkForeignKeyCase returns true if all equalities in the given FiltersExpr
 // are between not-null foreign key columns on the left and unfiltered
-// referenced columns on the right. Panics if verifyFiltersAreValidEqualities is
-// not checked first.
+// referenced columns on the right.
 func checkForeignKeyCase(
 	md *opt.Metadata, leftNotNullCols, rightUnfilteredCols opt.ColSet, filters FiltersExpr,
 ) bool {
@@ -479,7 +482,8 @@ func checkForeignKeyCase(
 		// There are no unfiltered columns from the right; a valid foreign key
 		// relation is not possible. This check, which is a duplicate of a check
 		// in verifyFiltersAreValidEqualities, is necessary in the case of a
-		// cross-join because verifyFiltersAreValidEqualities is not called.
+		// cross-join because verifyFiltersAreValidEqualities is not called (see
+		// case 1a in filtersMatchAllLeftRows).
 		return false
 	}
 
@@ -553,7 +557,8 @@ func checkForeignKeyCase(
 					// can't be used in a filter. This check, which is a
 					// duplicate of a check in verifyFiltersAreValidEqualities,
 					// is necessary in the case of a cross-join because
-					// verifyFiltersAreValidEqualities is not called.
+					// verifyFiltersAreValidEqualities is not called (see case
+					// 1a in filtersMatchAllLeftRows).
 					continue
 				}
 				if filtersHaveEquality(filters, leftColID, rightColID) {

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -161,12 +161,12 @@ func TestGetJoinMultiplicity(t *testing.T) {
 			expected: "left-rows(exactly-one), right-rows(exactly-one)",
 		},
 		{ // 9
-			// SELECT * FROM xy LEFT JOIN uv ON x = u;
-			joinOp:   opt.LeftJoinOp,
+			// SELECT * FROM xy INNER JOIN uv ON x = u;
+			joinOp:   opt.InnerJoinOp,
 			left:     xyScan,
 			right:    uvScan,
 			on:       ob.makeFilters(ob.makeEquality(xyCols[0], uvCols[0])),
-			expected: "left-rows(exactly-one), right-rows(zero-or-one)",
+			expected: "left-rows(zero-or-one), right-rows(zero-or-one)",
 		},
 		{ // 10
 			// SELECT *

--- a/pkg/sql/opt/memo/multiplicity_builder_test.go
+++ b/pkg/sql/opt/memo/multiplicity_builder_test.go
@@ -408,6 +408,22 @@ func TestGetJoinMultiplicity(t *testing.T) {
 			expected: "left-rows(zero-or-one), right-rows(exactly-one)",
 		},
 		{ // 31
+			// SELECT * FROM xy INNER JOIN xy AS xy2 ON xy.x = xy2.x FOR UPDATE OF xy SKIP LOCKED;
+			joinOp:   opt.InnerJoinOp,
+			left:     xyScanSkipLocked,
+			right:    xyScan2,
+			on:       ob.makeFilters(ob.makeEquality(xyColsSkipLocked[0], xyCols2[0])),
+			expected: "left-rows(exactly-one), right-rows(zero-or-one)",
+		},
+		{ // 32
+			// SELECT * FROM xy AS xy2 INNER JOIN xy ON xy.x = xy2.x FOR UPDATE OF xy2 SKIP LOCKED;
+			joinOp:   opt.InnerJoinOp,
+			left:     xyScan2,
+			right:    xyScanSkipLocked,
+			on:       ob.makeFilters(ob.makeEquality(xyColsSkipLocked[0], xyCols2[0])),
+			expected: "left-rows(zero-or-one), right-rows(exactly-one)",
+		},
+		{ // 33
 			// SELECT * FROM xy INNER JOIN fk_tab ON r1 = x FOR UPDATE SKIP LOCKED;
 			joinOp:   opt.InnerJoinOp,
 			left:     xyScanSkipLocked,
@@ -415,7 +431,7 @@ func TestGetJoinMultiplicity(t *testing.T) {
 			on:       ob.makeFilters(ob.makeEquality(fkColsSkipLocked[0], xyColsSkipLocked[0])),
 			expected: "left-rows(zero-or-more), right-rows(zero-or-one)",
 		},
-		{ // 32
+		{ // 34
 			// SELECT * FROM fk_tab INNER JOIN xy ON r1 = x FOR UPDATE OF fk_tab SKIP LOCKED;
 			joinOp:   opt.InnerJoinOp,
 			left:     fkScanSkipLocked,
@@ -423,7 +439,7 @@ func TestGetJoinMultiplicity(t *testing.T) {
 			on:       ob.makeFilters(ob.makeEquality(fkColsSkipLocked[0], xyCols[0])),
 			expected: "left-rows(exactly-one), right-rows(zero-or-more)",
 		},
-		{ // 33
+		{ // 35
 			// SELECT * FROM fk_tab INNER JOIN xy ON r1 = x FOR UPDATE OF xy SKIP LOCKED;
 			joinOp:   opt.InnerJoinOp,
 			left:     fkScan,

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -490,7 +490,6 @@ func (md *Metadata) DuplicateTable(
 		Table:                    tabMeta.Table,
 		Alias:                    tabMeta.Alias,
 		IgnoreForeignKeys:        tabMeta.IgnoreForeignKeys,
-		IsSkipLocked:             tabMeta.IsSkipLocked,
 		Constraints:              constraints,
 		ComputedCols:             computedCols,
 		partialIndexPredicates:   partialIndexPredicates,

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -592,15 +592,12 @@ func (b *Builder) buildScan(
 	}
 	if locking.isSet() {
 		private.Locking = locking.get()
-		if private.Locking.WaitPolicy == tree.LockWaitSkipLocked {
-			if tab.FamilyCount() > 1 {
-				// TODO(rytaft): We may be able to support this if enough columns are
-				// pruned that only a single family is scanned.
-				panic(pgerror.Newf(pgcode.FeatureNotSupported,
-					"SKIP LOCKED cannot be used for tables with multiple column families",
-				))
-			}
-			tabMeta.IsSkipLocked = true
+		if private.Locking.WaitPolicy == tree.LockWaitSkipLocked && tab.FamilyCount() > 1 {
+			// TODO(rytaft): We may be able to support this if enough columns are
+			// pruned that only a single family is scanned.
+			panic(pgerror.Newf(pgcode.FeatureNotSupported,
+				"SKIP LOCKED cannot be used for tables with multiple column families",
+			))
 		}
 	}
 	if b.evalCtx.AsOfSystemTime != nil && b.evalCtx.AsOfSystemTime.BoundedStaleness {

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -141,12 +141,6 @@ type TableMeta struct {
 	// depend on the consistency of unique without index constraints.
 	IgnoreUniqueWithoutIndexKeys bool
 
-	// IsSkipLocked is true if this table is scanned with SKIP LOCKED. If true, we
-	// should disable any rules that depend on preserved-multiplicity consistency
-	// of this table (i.e. rules that assume there is always a PK row for every
-	// secondary index row or a FK row for every FK reference).
-	IsSkipLocked bool
-
 	// Constraints stores a *FiltersExpr containing filters that are known to
 	// evaluate to true on the table data. This list is extracted from validated
 	// check constraints; specifically, those check constraints that we can prove
@@ -208,7 +202,6 @@ func (tm *TableMeta) copyFrom(from *TableMeta, copyScalarFn func(Expr) Expr) {
 		Alias:                        from.Alias,
 		IgnoreForeignKeys:            from.IgnoreForeignKeys,
 		IgnoreUniqueWithoutIndexKeys: from.IgnoreUniqueWithoutIndexKeys,
-		IsSkipLocked:                 from.IsSkipLocked,
 		// Annotations are not copied.
 	}
 


### PR DESCRIPTION
#### opt: fix duplicate join multiplicity test

Test case 9 in `TestGetJoinMultiplicity` was a duplicate of test case 2.
It has been updated to be similar, but use an `INNER JOIN` instead of a
`LEFT JOIN`, which I believe it was originally supposed to be - there is
no similar existing test case.

Release note: None

#### opt: remove TableMeta.IsSkipLocked

`TableMeta.IsSkipLocked` was used by the multiplicity builder to
determine whether a column was filtered or not by a `SKIP LOCKED` scan.
However, this field was unnecessary. The `deriveUnfilteredCols` function
in the multiplicity builder already traverses expressions all the way
down to `ScanExpr`s, only collecting unfiltered columns if they
originate from a scan where `ScanExpr.IsUnfiltered` returns true.
`ScanExpr.IsUnfiltered` returns false if the scan is a `SKIP LOCKED`
scan. Therefore, no additional mechanism is required to detect columns
filtered by `SKIP LOCKED` scans.

I noticed that `TableMeta.IsSkipLocked` was not needed because the
multiplicity builder unit tests added in #85720 never set it, yet the
tests passed.

This commit also adds more multiplicity builder unit tests for
self-joins with `SKIP LOCKED`.

Release note: None

#### opt: ensure min cardinality of zero for expressions with SKIP LOCKED

This commit ensures that the minimum cardinality of a scan or
lookup-join with `SKIP LOCKED` is zero. This shouldn't be needed because
the logical to derive the cardinality for these expressions should never
produce a non-zero minimum cardinality, but this provides extra safety.

Release note: None

#### opt: improve comments in multiplicity builder

Release note: None
