### PR TITLE
sql/types: do not panic formatting unhydrated UDTs

### DIFF
--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1861,6 +1861,13 @@ func (t *T) SQLString() string {
 		if t.Oid() == oid.T_anyenum {
 			return "anyenum"
 		}
+		// We do not expect to be in a situation where we want to format a
+		// user-defined type to a string and do not have the TypeMeta hydrated,
+		// but there have been bugs in the past, and returning a less informative
+		// string is better than a nil-pointer panic.
+		if t.TypeMeta.Name == nil {
+			return fmt.Sprintf("@%d", t.Oid())
+		}
 		return t.TypeMeta.Name.FQName()
 	}
 	return strings.ToUpper(t.Name())

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -1077,3 +1077,12 @@ func TestDelimiter(t *testing.T) {
 		}
 	}
 }
+
+// Prior to the patch which introduced this test, the below calls would
+// have panicked.
+func TestEnumWithoutTypeMetaNameDoesNotPanicInSQLString(t *testing.T) {
+	typ := MakeEnum(100100, 100101)
+	require.Equal(t, "@100100", typ.SQLString())
+	arrayType := MakeArray(typ)
+	require.Equal(t, "@100100[]", arrayType.SQLString())
+}


### PR DESCRIPTION
Before this patch, if a bug resulted in a UDT's types.T getting to a point
where it was being formatted to a string without being hydrated, a panic would
occur. Now the type is formatted into an OIDTypeReference which is slightly
less pretty, but is valid.

Relates to #85447

Release note: None