### PR TITLE
sql: don't create idx recommendations for internal queries

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1202,7 +1202,10 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// on the optimizer, check if is still open before generating index recommendations.
 	if planner.txn.IsOpen() {
 		// Set index recommendations, so it can be saved on statement statistics.
-		planner.instrumentation.SetIndexRecommendations(ctx, ex.server.idxRecommendationsCache, planner)
+		// TODO(yuzefovich): figure out whether we want to set isInternalPlanner
+		// to true for the internal executors.
+		isInternal := ex.executorType == executorTypeInternal || planner.isInternalPlanner
+		planner.instrumentation.SetIndexRecommendations(ctx, ex.server.idxRecommendationsCache, planner, isInternal)
 	}
 
 	// Record the statement summary. This also closes the plan if the

--- a/pkg/sql/idxrecommendations/idx_recommendations.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations.go
@@ -21,13 +21,14 @@ import (
 // for specific statements, and update accordingly.
 type IdxRecommendations interface {
 	ShouldGenerateIndexRecommendation(
-		fingerprint string, planHash uint64, database string, stmtType tree.StatementType,
+		fingerprint string, planHash uint64, database string, stmtType tree.StatementType, isInternal bool,
 	) bool
 	UpdateIndexRecommendations(
 		fingerprint string,
 		planHash uint64,
 		database string,
 		stmtType tree.StatementType,
+		isInternal bool,
 		recommendations []string,
 		reset bool,
 	) []string

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -678,7 +678,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 // If true it will generate and update the idx recommendations cache,
 // if false, uses the value on index recommendations cache and updates its counter.
 func (ih *instrumentationHelper) SetIndexRecommendations(
-	ctx context.Context, idxRec *idxrecommendations.IndexRecCache, planner *planner,
+	ctx context.Context, idxRec *idxrecommendations.IndexRecCache, planner *planner, isInternal bool,
 ) {
 	opc := planner.optPlanningCtx
 	opc.reset(ctx)
@@ -691,6 +691,7 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 		ih.planGist.Hash(),
 		planner.SessionData().Database,
 		stmtType,
+		isInternal,
 	) {
 		f := opc.optimizer.Factory()
 		// EvalContext() has the context with the already closed span, so we
@@ -725,6 +726,7 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 		ih.planGist.Hash(),
 		planner.SessionData().Database,
 		stmtType,
+		isInternal,
 		recommendations,
 		reset,
 	)


### PR DESCRIPTION
Previously we were generating recommendations for internal
queries. This commit adds a check and if is internal, it
won't generate a recommendation.

Partially addresses #85934

Release note: None