### PR TITLE
kvserver: replace ad-hoc stats in RaftTransport by metrics

### DIFF
--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -11,12 +11,8 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"net"
-	"sort"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -139,23 +135,6 @@ type RaftMessageHandler interface {
 	) error
 }
 
-// TODO(tbg): remove all of these metrics. The "NodeID" in this struct refers to the remote NodeID, i.e. when we send
-// a message it refers to the recipient and when we receive a message it refers to the sender. This doesn't map to
-// metrics well, where everyone should report on their local decisions. Instead have a *RaftTransportMetrics struct
-// that is per-Store and tracks metrics on behalf of that Store.
-//
-// See: https://github.com/cockroachdb/cockroach/issues/83917
-type raftTransportStats struct {
-	nodeID        roachpb.NodeID
-	clientDropped int64
-}
-
-type raftTransportStatsSlice []*raftTransportStats
-
-func (s raftTransportStatsSlice) Len() int           { return len(s) }
-func (s raftTransportStatsSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
-func (s raftTransportStatsSlice) Less(i, j int) bool { return s[i].nodeID < s[j].nodeID }
-
 // RaftTransport handles the rpc messages for raft.
 //
 // The raft transport is asynchronous with respect to the caller, and
@@ -176,7 +155,6 @@ type RaftTransport struct {
 	metrics *RaftTransportMetrics
 
 	queues   [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*chan *RaftMessageRequest
-	stats    [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*raftTransportStats
 	dialer   *nodedialer.Dialer
 	handlers syncutil.IntMap // map[roachpb.StoreID]*RaftMessageHandler
 }
@@ -208,66 +186,9 @@ func NewRaftTransport(
 		dialer:         dialer,
 	}
 	t.initMetrics()
-
 	if grpcServer != nil {
 		RegisterMultiRaftServer(grpcServer, t)
 	}
-	// statsMap is used to associate a queue with its raftTransportStats.
-	statsMap := make(map[roachpb.NodeID]*raftTransportStats)
-	clearStatsMap := func() {
-		for k := range statsMap {
-			delete(statsMap, k)
-		}
-	}
-	if t.stopper != nil && log.V(1) {
-		ctx := t.AnnotateCtx(context.Background())
-		_ = t.stopper.RunAsyncTask(ctx, "raft-transport", func(ctx context.Context) {
-			ticker := time.NewTicker(10 * time.Second)
-			defer ticker.Stop()
-			lastStats := make(map[roachpb.NodeID]raftTransportStats)
-			var stats raftTransportStatsSlice
-			for {
-				select {
-				case <-ticker.C:
-					stats = stats[:0]
-					getStats := func(k int64, v unsafe.Pointer) bool {
-						s := (*raftTransportStats)(v)
-						// Clear the queue length stat. Note that this field is only
-						// mutated by this goroutine.
-						stats = append(stats, s)
-						statsMap[roachpb.NodeID(k)] = s
-						return true
-					}
-					for c := range t.stats {
-						clearStatsMap()
-						t.stats[c].Range(getStats)
-					}
-					clearStatsMap() // no need to hold on to references to stats
-
-					sort.Sort(stats)
-
-					var buf bytes.Buffer
-					// NB: The header is 80 characters which should display in a single
-					// line on most terminals.
-					fmt.Fprintf(&buf,
-						"         qdropped\n")
-					for _, s := range stats {
-						cur := raftTransportStats{
-							nodeID:        s.nodeID,
-							clientDropped: atomic.LoadInt64(&s.clientDropped),
-						}
-						fmt.Fprintf(&buf, "  %3d: %6d\n",
-							cur.nodeID, cur.clientDropped)
-						lastStats[s.nodeID] = cur
-					}
-					log.Infof(ctx, "stats:\n%s", buf.String())
-				case <-t.stopper.ShouldQuiesce():
-					return
-				}
-			}
-		})
-	}
-
 	return t
 }
 
@@ -327,18 +248,6 @@ func newRaftMessageResponse(
 	return resp
 }
 
-func (t *RaftTransport) getStats(
-	nodeID roachpb.NodeID, class rpc.ConnectionClass,
-) *raftTransportStats {
-	statsMap := &t.stats[class]
-	value, ok := statsMap.Load(int64(nodeID))
-	if !ok {
-		stats := &raftTransportStats{nodeID: nodeID}
-		value, _ = statsMap.LoadOrStore(int64(nodeID), unsafe.Pointer(stats))
-	}
-	return (*raftTransportStats)(value)
-}
-
 // RaftMessageBatch proxies the incoming requests to the listening server interface.
 func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer) error {
 	errCh := make(chan error, 1)
@@ -353,7 +262,6 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 			SpanOpt:  stop.ChildSpan,
 		}, func(ctx context.Context) {
 			errCh <- func() error {
-				var stats *raftTransportStats
 				stream := &lockedRaftMessageResponseStream{wrapped: stream}
 				for {
 					batch, err := stream.Recv()
@@ -362,23 +270,6 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 					}
 					if len(batch.Requests) == 0 {
 						continue
-					}
-
-					// This code always uses the DefaultClass. Class is primarily a
-					// client construct and the server has no way to determine which
-					// class an inbound connection holds on the client side. Because of
-					// this we associate all server receives and sends with the
-					// DefaultClass. This data is exclusively used to print a debug
-					// log message periodically. Using this policy may lead to a
-					// DefaultClass log line showing a high rate of server recv but
-					// a low rate of client sends if most of the traffic is due to
-					// system ranges.
-					//
-					// TODO(ajwerner): consider providing transport metadata to inform
-					// the server of the connection class or keep shared stats for all
-					// connection with a host.
-					if stats == nil {
-						stats = t.getStats(batch.Requests[0].FromReplica.NodeID, rpc.DefaultClass)
 					}
 
 					for i := range batch.Requests {
@@ -484,7 +375,6 @@ func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
 func (t *RaftTransport) processQueue(
 	nodeID roachpb.NodeID,
 	ch chan *kvserverpb.RaftMessageRequest,
-	stats *raftTransportStats,
 	stream MultiRaft_RaftMessageBatchClient,
 	class rpc.ConnectionClass,
 ) error {
@@ -585,10 +475,9 @@ func (t *RaftTransport) SendAsync(
 	req *kvserverpb.RaftMessageRequest, class rpc.ConnectionClass,
 ) (sent bool) {
 	toNodeID := req.ToReplica.NodeID
-	stats := t.getStats(toNodeID, class)
 	defer func() {
 		if !sent {
-			atomic.AddInt64(&stats.clientDropped, 1)
+			t.metrics.MessagesDropped.Inc(1)
 		}
 	}()
 
@@ -609,7 +498,7 @@ func (t *RaftTransport) SendAsync(
 	if !existingQueue {
 		// Note that startProcessNewQueue is in charge of deleting the queue.
 		ctx := t.AnnotateCtx(context.Background())
-		if !t.startProcessNewQueue(ctx, toNodeID, class, stats) {
+		if !t.startProcessNewQueue(ctx, toNodeID, class) {
 			return false
 		}
 	}
@@ -633,10 +522,7 @@ func (t *RaftTransport) SendAsync(
 //
 // Returns whether the worker was started (the queue is deleted either way).
 func (t *RaftTransport) startProcessNewQueue(
-	ctx context.Context,
-	toNodeID roachpb.NodeID,
-	class rpc.ConnectionClass,
-	stats *raftTransportStats,
+	ctx context.Context, toNodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (started bool) {
 	cleanup := func(ch chan *kvserverpb.RaftMessageRequest) {
 		// Account for the remainder of `ch` which was never sent.
@@ -648,7 +534,7 @@ func (t *RaftTransport) startProcessNewQueue(
 		for {
 			select {
 			case <-ch:
-				atomic.AddInt64(&stats.clientDropped, 1)
+				t.metrics.MessagesDropped.Inc(1)
 			default:
 				return
 			}
@@ -680,7 +566,7 @@ func (t *RaftTransport) startProcessNewQueue(
 			return
 		}
 
-		if err := t.processQueue(toNodeID, ch, stats, stream, class); err != nil {
+		if err := t.processQueue(toNodeID, ch, stream, class); err != nil {
 			log.Warningf(ctx, "while processing outgoing Raft queue to node %d: %s:", toNodeID, err)
 		}
 	}

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -17,6 +17,8 @@ type RaftTransportMetrics struct {
 	SendQueueSize *metric.Gauge
 	MessagesSent  *metric.Counter
 	MessagesRcvd  *metric.Counter
+	ReverseSent   *metric.Counter
+	ReverseRcvd   *metric.Counter
 }
 
 func (t *RaftTransport) initMetrics() {
@@ -42,6 +44,26 @@ messages to at least one peer.`,
 		MessagesRcvd: metric.NewCounter(metric.Metadata{
 			Name:        "raft.transport.rcvd",
 			Help:        "Number of Raft messages received by the Raft Transport",
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		ReverseSent: metric.NewCounter(metric.Metadata{
+			Name: "raft.transport.reverse-sent",
+			Help: `Messages sent in the reverse direction of a stream.
+
+These messages should be rare. They are mostly informational, and are not actual
+responses to Raft messages. Responses are sent over another stream.`,
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		ReverseRcvd: metric.NewCounter(metric.Metadata{
+			Name: "raft.transport.reverse-rcvd",
+			Help: `Messages received from the reverse direction of a stream.
+
+These messages should be rare. They are mostly informational, and are not actual
+responses to Raft messages. Responses are received over another stream.`,
 			Measurement: "Messages",
 			Unit:        metric.Unit_COUNT,
 		}),

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -15,10 +15,13 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 // RaftTransportMetrics is the set of metrics for a given RaftTransport.
 type RaftTransportMetrics struct {
 	SendQueueSize *metric.Gauge
-	MessagesSent  *metric.Counter
-	MessagesRcvd  *metric.Counter
-	ReverseSent   *metric.Counter
-	ReverseRcvd   *metric.Counter
+
+	MessagesDropped *metric.Counter
+	MessagesSent    *metric.Counter
+	MessagesRcvd    *metric.Counter
+
+	ReverseSent *metric.Counter
+	ReverseRcvd *metric.Counter
 }
 
 func (t *RaftTransport) initMetrics() {
@@ -33,6 +36,13 @@ messages to at least one peer.`,
 			Measurement: "Messages",
 			Unit:        metric.Unit_COUNT,
 		}, t.queuedMessageCount),
+
+		MessagesDropped: metric.NewCounter(metric.Metadata{
+			Name:        "raft.transport.sends-dropped",
+			Help:        "Number of Raft message sends dropped by the Raft Transport",
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}),
 
 		MessagesSent: metric.NewCounter(metric.Metadata{
 			Name:        "raft.transport.sent",

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -15,6 +15,8 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 // RaftTransportMetrics is the set of metrics for a given RaftTransport.
 type RaftTransportMetrics struct {
 	SendQueueSize *metric.Gauge
+	MessagesSent  *metric.Counter
+	MessagesRcvd  *metric.Counter
 }
 
 func (t *RaftTransport) initMetrics() {
@@ -29,5 +31,19 @@ messages to at least one peer.`,
 			Measurement: "Messages",
 			Unit:        metric.Unit_COUNT,
 		}, t.queuedMessageCount),
+
+		MessagesSent: metric.NewCounter(metric.Metadata{
+			Name:        "raft.transport.sent",
+			Help:        "Number of Raft messages sent by the Raft Transport",
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}),
+
+		MessagesRcvd: metric.NewCounter(metric.Metadata{
+			Name:        "raft.transport.rcvd",
+			Help:        "Number of Raft messages received by the Raft Transport",
+			Measurement: "Messages",
+			Unit:        metric.Unit_COUNT,
+		}),
 	}
 }

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -107,8 +107,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		ln = nil
 		wg.Done()
 	}()
-	var stats raftTransportStats
-	tp.startProcessNewQueue(ctxBoom, 1, rpc.SystemClass, &stats)
+	tp.startProcessNewQueue(ctxBoom, 1, rpc.SystemClass)
 
 	wg.Wait()
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1885,6 +1885,14 @@ var charts = []sectionDescription{
 				Title:   "Send Queue Messages Count",
 				Metrics: []string{"raft.transport.send-queue-size"},
 			},
+			{
+				Title:   "Raft Messages Sent",
+				Metrics: []string{"raft.transport.sent"},
+			},
+			{
+				Title:   "Raft Messages Received",
+				Metrics: []string{"raft.transport.rcvd"},
+			},
 		},
 	},
 	{

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1886,6 +1886,10 @@ var charts = []sectionDescription{
 				Metrics: []string{"raft.transport.send-queue-size"},
 			},
 			{
+				Title:   "Raft Message Sends Dropped",
+				Metrics: []string{"raft.transport.sends-dropped"},
+			},
+			{
 				Title:   "Raft Messages Sent",
 				Metrics: []string{"raft.transport.sent"},
 			},

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1893,6 +1893,14 @@ var charts = []sectionDescription{
 				Title:   "Raft Messages Received",
 				Metrics: []string{"raft.transport.rcvd"},
 			},
+			{
+				Title:   "Reverse Messages Sent",
+				Metrics: []string{"raft.transport.reverse-sent"},
+			},
+			{
+				Title:   "Reverse Messages Received",
+				Metrics: []string{"raft.transport.reverse-rcvd"},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
These stats were only printed in text to the logs, and hard to use and match
with other existing metrics in monitoring.

There is a queue size metric introduced in 5d51ab34 which properly exports the
`queue` counter to monitoring. The exported graphs allow observing both the
current, and historical queue sizes (including the approx. max size), so this
PR safely removes both stats as obsolete.

This PR also similarly replaces all the remaining ad-hoc counters with proper
metrics, and removes the plumbing and data structures that were previously
maintaining those stats.

The granularity of the new metrics is per-node/transport. This is due to the
metrics infrastructure not being particularly good at handling high cardinality
combinations of labels such as O(N^2) node ID pairs.

Part of #83917

Release note: None