### PR TITLE
sql: add contention time to execution_insights table

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1245,7 +1245,8 @@ func populateQueryLevelStats(ctx context.Context, p *planner) {
 	var err error
 	queryLevelStats, err := execstats.GetQueryLevelStats(
 		trace, p.execCfg.TestingKnobs.DeterministicExplain, flowsMetadata)
-	ih.queryLevelStatsWithErr = execstats.MakeQueryLevelStatsWithErr(queryLevelStats, err)
+	queryLevelStatsWithErr := execstats.MakeQueryLevelStatsWithErr(queryLevelStats, err)
+	ih.queryLevelStatsWithErr = &queryLevelStatsWithErr
 	if err != nil {
 		const msg = "error getting query level stats for statement: %s: %+v"
 		if buildutil.CrdbTestBuild {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6330,7 +6330,8 @@ CREATE TABLE crdb_internal.%s (
 	priority                   FLOAT NOT NULL,
 	retries                    INT8 NOT NULL,
 	last_retry_reason          STRING,
-	exec_node_ids              INT[] NOT NULL
+	exec_node_ids              INT[] NOT NULL,
+	contention                 INTERVAL
 )`
 
 var crdbInternalClusterExecutionInsightsTable = virtualSchemaTable{
@@ -6397,6 +6398,14 @@ func populateExecutionInsights(
 			autoRetryReason = tree.NewDString(insight.Statement.AutoRetryReason)
 		}
 
+		contentionTime := tree.DNull
+		if insight.Statement.Contention != nil {
+			contentionTime = tree.NewDInterval(
+				duration.MakeDuration(insight.Statement.Contention.Nanoseconds(), 0, 0),
+				types.DefaultIntervalTypeMetadata,
+			)
+		}
+
 		err = errors.CombineErrors(err, addRow(
 			tree.NewDString(hex.EncodeToString(insight.Session.ID.GetBytes())),
 			tree.NewDUuid(tree.DUuid{UUID: insight.Transaction.ID}),
@@ -6418,6 +6427,7 @@ func populateExecutionInsights(
 			tree.NewDInt(tree.DInt(insight.Statement.Retries)),
 			autoRetryReason,
 			execNodeIDs,
+			contentionTime,
 		))
 	}
 	return

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -394,7 +394,13 @@ func (p *planner) maybeLogStatementInternal(
 			requiredTimeElapsed = 0
 		}
 		if telemetryMetrics.maybeUpdateLastEmittedTime(telemetryMetrics.timeNow(), requiredTimeElapsed) {
-			contentionNanos := telemetryMetrics.getContentionTime(p.instrumentation.queryLevelStatsWithErr.Stats.ContentionTime.Nanoseconds())
+			var contentionNanos int64
+			if queryLevelStats, ok := p.instrumentation.GetQueryLevelStats(); ok {
+				contentionNanos = queryLevelStats.ContentionTime.Nanoseconds()
+			}
+
+			contentionNanos = telemetryMetrics.getContentionTime(contentionNanos)
+
 			skippedQueries := telemetryMetrics.resetSkippedQueryCount()
 			sampledQuery := eventpb.SampledQuery{
 				CommonSQLExecDetails:     execDetails,

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -263,7 +263,8 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    priority FLOAT8 NOT NULL,
    retries INT8 NOT NULL,
    last_retry_reason STRING NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   contention INTERVAL NULL
 )  CREATE TABLE crdb_internal.cluster_execution_insights (
    session_id STRING NOT NULL,
    txn_id UUID NOT NULL,
@@ -284,7 +285,8 @@ CREATE TABLE crdb_internal.cluster_execution_insights (
    priority FLOAT8 NOT NULL,
    retries INT8 NOT NULL,
    last_retry_reason STRING NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   contention INTERVAL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_inflight_traces (
    trace_id INT8 NOT NULL,
@@ -973,7 +975,8 @@ CREATE TABLE crdb_internal.node_execution_insights (
    priority FLOAT8 NOT NULL,
    retries INT8 NOT NULL,
    last_retry_reason STRING NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   contention INTERVAL NULL
 )  CREATE TABLE crdb_internal.node_execution_insights (
    session_id STRING NOT NULL,
    txn_id UUID NOT NULL,
@@ -994,7 +997,8 @@ CREATE TABLE crdb_internal.node_execution_insights (
    priority FLOAT8 NOT NULL,
    retries INT8 NOT NULL,
    last_retry_reason STRING NULL,
-   exec_node_ids INT8[] NOT NULL
+   exec_node_ids INT8[] NOT NULL,
+   contention INTERVAL NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_inflight_trace_spans (
    trace_id INT8 NOT NULL,

--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -57,6 +57,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+        "@com_google_protobuf//:duration_proto",
         "@com_google_protobuf//:timestamp_proto",
     ],
 )

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -14,6 +14,7 @@ option go_package = "insights";
 
 import "gogoproto/gogo.proto";
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/duration.proto";
 
 enum Concern {
   // SlowExecution is for statement executions that either take longer than a predetermined
@@ -63,6 +64,7 @@ message Statement {
   string auto_retry_reason = 16;
   // Nodes is the ordered list of nodes ids on which the statement was executed.
   repeated int64 nodes = 17;
+  google.protobuf.Duration contention = 18 [(gogoproto.stdduration) = true];
 }
 
 message Insight {

--- a/pkg/sql/sqlstats/insights/integration/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/integration/BUILD.bazel
@@ -16,6 +16,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/timeutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -12,8 +12,10 @@ package integration
 
 import (
 	"context"
+	gosql "database/sql"
 	"fmt"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -28,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -96,6 +99,102 @@ func TestInsightsIntegration(t *testing.T) {
 		require.Equal(t, "SELECT pg_sleep($1)", query)
 		require.Equal(t, "completed", status)
 		require.GreaterOrEqual(t, endInsights.Sub(startInsights).Seconds(), queryDelayInSeconds)
+
+		return nil
+	}, 1*time.Second)
+}
+
+func TestInsightsIntegrationForContention(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Start the cluster. (One node is sufficient; the outliers system is currently in-memory only.)
+	ctx := context.Background()
+	settings := cluster.MakeTestingClusterSettings()
+	args := base.TestClusterArgs{ServerArgs: base.TestServerArgs{Settings: settings}}
+	tc := testcluster.StartTestCluster(t, 1, args)
+	defer tc.Stopper().Stop(ctx)
+	conn := tc.ServerConn(0)
+
+	_, err := conn.Exec("SET tracing = true;")
+	require.NoError(t, err)
+	_, err = conn.Exec("SET cluster setting sql.txn_stats.sample_rate  = 1;")
+	require.NoError(t, err)
+	_, err = conn.Exec("CREATE TABLE t (id string, s string);")
+	require.NoError(t, err)
+
+	// Enable detection by setting a latencyThreshold > 0.
+	latencyThreshold := 100 * time.Millisecond
+	insights.LatencyThreshold.Override(ctx, &settings.SV, latencyThreshold)
+
+	// Create a new connection, and then in a go routine have it start a transaction, update a row,
+	// sleep for a time, and then complete the transaction.
+	// With original connection attempt to update the same row being updated concurrently
+	// in the separate go routine, this will be blocked until the original transaction completes.
+	var wgTxnStarted sync.WaitGroup
+	wgTxnStarted.Add(1)
+
+	// Lock to wait for the txn to complete to avoid the test finishing before the txn is committed
+	var wgTxnDone sync.WaitGroup
+	wgTxnDone.Add(1)
+
+	go func() {
+		tx, errTxn := conn.BeginTx(ctx, &gosql.TxOptions{})
+		require.NoError(t, errTxn)
+		_, errTxn = tx.ExecContext(ctx, "INSERT INTO t (id, s) VALUES ('test', 'originalValue');")
+		require.NoError(t, errTxn)
+		wgTxnStarted.Done()
+		_, errTxn = tx.ExecContext(ctx, "select pg_sleep(.5);")
+		require.NoError(t, errTxn)
+		errTxn = tx.Commit()
+		require.NoError(t, errTxn)
+		wgTxnDone.Done()
+	}()
+
+	start := timeutil.Now()
+
+	// Need to wait for the txn to start to ensure lock contention
+	wgTxnStarted.Wait()
+	// This will be blocked until the updateRowWithDelay finishes.
+	_, err = conn.ExecContext(ctx, "UPDATE t SET s = 'mainThread' where id = 'test';")
+	require.NoError(t, err)
+	end := timeutil.Now()
+	require.GreaterOrEqual(t, end.Sub(start), 500*time.Millisecond)
+
+	wgTxnDone.Wait()
+
+	// Verify the table content is valid.
+	testutils.SucceedsWithin(t, func() error {
+		rows, err := conn.QueryContext(ctx, "SELECT "+
+			"query, "+
+			"contention::FLOAT "+
+			"FROM crdb_internal.node_execution_insights where query like 'UPDATE t SET s =%'")
+		if err != nil {
+			return err
+		}
+
+		rowCount := 0
+		for rows.Next() {
+			rowCount++
+			if err != nil {
+				return err
+			}
+
+			var contentionFromQuery float64
+			var queryText string
+			err = rows.Scan(&queryText, &contentionFromQuery)
+			if err != nil {
+				return err
+			}
+
+			if contentionFromQuery < .2 {
+				return fmt.Errorf("contention time is %f should be greater than .2 since block is delayed by .5 seconds", contentionFromQuery)
+			}
+		}
+
+		if rowCount < 1 {
+			return fmt.Errorf("node_execution_insights did not return any rows")
+		}
 
 		return nil
 	}, 1*time.Second)

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -217,6 +217,7 @@ type RecordedStmtStats struct {
 	EndTime              time.Time
 	FullScan             bool
 	SessionData          *sessiondata.SessionData
+	ExecStats            *execstats.QueryLevelStats
 }
 
 // RecordedTxnStats stores the statistics of a transaction to be recorded.


### PR DESCRIPTION
This contention time is based on tracing, so
it will only be available for the small percent
of queries that gets traced.

part of [81024](https://github.com/cockroachdb/cockroach/issues/81024)

Release justification: category 2

Release note (sql change): Adds contention 
 time to execution_insights