### PR TITLE
bazel: bump size of `streamingest_test`

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamingest/BUILD.bazel
@@ -65,7 +65,7 @@ go_library(
 
 go_test(
     name = "streamingest_test",
-    size = "large",
+    size = "enormous",
     srcs = [
         "main_test.go",
         "stream_ingestion_frontier_processor_test.go",


### PR DESCRIPTION
Release note: None