### PR TITLE
externalconn: add gs support to External Connections

### DIFF
--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -269,3 +269,36 @@ DROP EXTERNAL CONNECTION "foo-userfile";
 ----
 
 subtest end
+
+subtest basic-gs
+
+disable-check-external-storage
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-gs" AS 'gs://bucket/path?AUTH=implicit&ASSUME_ROLE=soccer,cricket,football'
+----
+
+# Reject invalid gs external connections.
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-param-gs" AS 'gs://bucket/path?INVALIDPARAM=baz'
+----
+pq: failed to construct External Connection details: failed to create gs external connection: unknown GS query parameters: INVALIDPARAM
+
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-creds-gs" AS 'gs://bucket/path?AUTH=specified&CREDENTIALS=123'
+----
+pq: failed to construct External Connection details: failed to create gs external connection: error getting credentials from CREDENTIALS: illegal base64 data at input byte 0
+
+inspect-system-table
+----
+foo-gs STORAGE {"provider": "gs", "simpleUri": {"uri": "gs://bucket/path?AUTH=implicit&ASSUME_ROLE=soccer,cricket,football"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-gs";
+----
+
+enable-check-external-storage
+----
+
+subtest end

--- a/pkg/ccl/cloudccl/gcp/BUILD.bazel
+++ b/pkg/ccl/cloudccl/gcp/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "gcp_test",
     srcs = [
-        "gcp_kms_connection_test.go",
+        "gcp_connection_test.go",
         "main_test.go",
     ],
     deps = [
@@ -30,6 +30,7 @@ go_test(
         "//pkg/util/randutil",
         "@com_github_stretchr_testify//require",
         "@com_google_cloud_go_kms//apiv1",
+        "@com_google_cloud_go_storage//:storage",
         "@org_golang_x_oauth2//google",
     ],
 )

--- a/pkg/cloud/externalconn/connectionpb/connection.go
+++ b/pkg/cloud/externalconn/connectionpb/connection.go
@@ -15,7 +15,7 @@ import "github.com/cockroachdb/errors"
 // Type returns the ConnectionType of the receiver.
 func (d *ConnectionDetails) Type() ConnectionType {
 	switch d.Provider {
-	case ConnectionProvider_nodelocal, ConnectionProvider_s3, ConnectionProvider_userfile:
+	case ConnectionProvider_nodelocal, ConnectionProvider_s3, ConnectionProvider_userfile, ConnectionProvider_gs:
 		return TypeStorage
 	case ConnectionProvider_gcp_kms:
 		return TypeKMS

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -21,6 +21,7 @@ enum ConnectionProvider {
   nodelocal = 1;
   s3 = 4;
   userfile = 5;
+  gs = 6;
 
   // KMS providers.
   gcp_kms = 2;

--- a/pkg/cloud/gcp/BUILD.bazel
+++ b/pkg/cloud/gcp/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "gcp_kms.go",
         "gcp_kms_connection.go",
+        "gcs_connection.go",
         "gcs_retry.go",
         "gcs_storage.go",
     ],

--- a/pkg/cloud/gcp/gcs_connection.go
+++ b/pkg/cloud/gcp/gcs_connection.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package gcp
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/errors"
+)
+
+func parseAndValidateGCSConnectionURI(
+	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri *url.URL,
+) (externalconn.ExternalConnection, error) {
+	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri.String()); err != nil {
+		return nil, errors.Wrap(err, "failed to create gs external connection")
+	}
+
+	connDetails := connectionpb.ConnectionDetails{
+		Provider: connectionpb.ConnectionProvider_gs,
+		Details: &connectionpb.ConnectionDetails_SimpleURI{
+			SimpleURI: &connectionpb.SimpleURI{
+				URI: uri.String(),
+			},
+		},
+	}
+	return externalconn.NewExternalConnection(connDetails), nil
+}
+
+func init() {
+	externalconn.RegisterConnectionDetailsFromURIFactory(
+		gcsScheme,
+		parseAndValidateGCSConnectionURI,
+	)
+}


### PR DESCRIPTION
This change registers Google Storage `gs` as a supported
External Connection.

Release note (sql change): Users can now
`CREATE EXTERNAL CONNECTION` to represent an underlying
google storage resource.

Release justification: low risk change to new functionality around External Connections