### PR TITLE
release-22.1: jobs: make expiration use intended txn priority

### DIFF
--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -723,7 +723,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				return errors.WithAssertionFailure(err)
 			}
 			_, err := r.ex.ExecEx(
-				ctx, "expire-sessions", nil,
+				ctx, "expire-sessions", txn,
 				sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 				removeClaimsForDeadSessionsQuery,
 				s.ID().UnsafeBytes(),
@@ -770,7 +770,7 @@ func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) error {
 				return errors.WithAssertionFailure(err)
 			}
 			_, err := r.ex.ExecEx(
-				ctx, "remove-claims-for-session", nil,
+				ctx, "remove-claims-for-session", txn,
 				sessiondata.InternalExecutorOverride{User: security.RootUserName()},
 				removeClaimsForSessionQuery, s.ID().UnsafeBytes(),
 			)


### PR DESCRIPTION
Backport 1/1 commits from #85930.

/cc @cockroachdb/release

Release justification: bug fix

---

In aed014f these operations were supposed to be changed to use
MinUserPriority. However, they weren't using the appropriate txn, so it
didn't have the intended effect.

Release note: None
