### PR TITLE
insights: rename settings and metrics

### DIFF
--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -23,49 +23,47 @@ import (
 )
 
 // LatencyThreshold configures the execution time beyond which a statement is
-// considered an outlier. A LatencyThreshold of 0 (the default) disables the
-// outliers subsystem. This setting lives in an "experimental" namespace
-// because we expect to supplant threshold-based detection with something
-// more statistically interesting, see #79451.
+// considered slow. A LatencyThreshold of 0 (the default) disables this
+// detection.
 var LatencyThreshold = settings.RegisterDurationSetting(
 	settings.TenantWritable,
-	"sql.stats.insights.experimental.latency_threshold",
-	"amount of time after which an executing statement is considered an outlier. Use 0 to disable.",
+	"sql.stats.insights.latency_threshold",
+	"amount of time after which an executing statement is considered slow. Use 0 to disable.",
 	0,
 )
 
-// LatencyQuantileDetectorEnabled turns on a per-fingerprint heuristic-based
-// algorithm for marking statements as outliers, attempting to capture elevated
+// AnomalyDetectionEnabled turns on a per-fingerprint heuristic-based
+// algorithm for marking statements as slow, attempting to capture elevated
 // p99 latency while generally excluding uninteresting executions less than
 // 100ms.
-var LatencyQuantileDetectorEnabled = settings.RegisterBoolSetting(
+var AnomalyDetectionEnabled = settings.RegisterBoolSetting(
 	settings.TenantWritable,
-	"sql.stats.insights.experimental.latency_quantile_detection.enabled",
-	"enable per-fingerprint latency recording and outlier detection",
+	"sql.stats.insights.anomaly_detection.enabled",
+	"enable per-fingerprint latency recording and anomaly detection",
 	false,
 )
 
-// LatencyQuantileDetectorInterestingThreshold sets the bar above which
-// statements are considered "interesting" from an outliers perspective. A
-// statement's latency must first cross this threshold before we begin tracking
-// further execution latencies for its fingerprint (this is a memory
-// optimization), and any potential outlier execution must also cross this
-// threshold to be reported (this is a UX optimization, removing noise).
-var LatencyQuantileDetectorInterestingThreshold = settings.RegisterDurationSetting(
+// AnomalyDetectionLatencyThreshold sets the bar above which we consider
+// statement executions worth inspecting for slow execution. A statement's
+// latency must first cross this threshold before we begin tracking further
+// execution latencies for its fingerprint (this is a memory optimization),
+// and any potential slow execution must also cross this threshold to be
+// reported (this is a UX optimization, removing noise).
+var AnomalyDetectionLatencyThreshold = settings.RegisterDurationSetting(
 	settings.TenantWritable,
-	"sql.stats.insights.experimental.latency_quantile_detection.interesting_threshold",
-	"statements must surpass this threshold to trigger outlier detection and identification",
+	"sql.stats.insights.anomaly_detection.latency_threshold",
+	"statements must surpass this threshold to trigger anomaly detection and identification",
 	100*time.Millisecond,
 	settings.NonNegativeDuration,
 )
 
-// LatencyQuantileDetectorMemoryCap restricts the overall memory available for
+// AnomalyDetectionMemoryLimit restricts the overall memory available for
 // tracking per-statement execution latencies. When changing this setting, keep
 // an eye on the metrics for memory usage and evictions to avoid introducing
 // churn.
-var LatencyQuantileDetectorMemoryCap = settings.RegisterByteSizeSetting(
+var AnomalyDetectionMemoryLimit = settings.RegisterByteSizeSetting(
 	settings.TenantWritable,
-	"sql.stats.insights.experimental.latency_quantile_detection.memory_limit",
+	"sql.stats.insights.anomaly_detection.memory_limit",
 	"the maximum amount of memory allowed for tracking statement latencies",
 	1024*1024,
 )
@@ -93,21 +91,21 @@ var _ metric.Struct = Metrics{}
 func NewMetrics() Metrics {
 	return Metrics{
 		Fingerprints: metric.NewGauge(metric.Metadata{
-			Name:        "sql.stats.insights.latency_quantile_detector.fingerprints",
-			Help:        "Current number of statement fingerprints being monitored for outlier detection",
+			Name:        "sql.stats.insights.anomaly_detection.fingerprints",
+			Help:        "Current number of statement fingerprints being monitored for anomaly detection",
 			Measurement: "Fingerprints",
 			Unit:        metric.Unit_COUNT,
 			MetricType:  prometheus.MetricType_GAUGE,
 		}),
 		Memory: metric.NewGauge(metric.Metadata{
-			Name:        "sql.stats.insights.latency_quantile_detector.memory",
-			Help:        "Current memory used to support outlier detection",
+			Name:        "sql.stats.insights.anomaly_detection.memory",
+			Help:        "Current memory used to support anomaly detection",
 			Measurement: "Memory",
 			Unit:        metric.Unit_BYTES,
 			MetricType:  prometheus.MetricType_GAUGE,
 		}),
 		Evictions: metric.NewCounter(metric.Metadata{
-			Name:        "sql.stats.insights.latency_quantile_detector.evictions",
+			Name:        "sql.stats.insights.anomaly_detection.evictions",
 			Help:        "Evictions of fingerprint latency summaries due to memory pressure",
 			Measurement: "Evictions",
 			Unit:        metric.Unit_COUNT,

--- a/pkg/sql/sqlstats/insights/insights_test.go
+++ b/pkg/sql/sqlstats/insights/insights_test.go
@@ -36,7 +36,7 @@ func BenchmarkInsights(b *testing.B) {
 	// backpressure from the registry.
 	settings := cluster.MakeTestingClusterSettings()
 	insights.LatencyThreshold.Override(ctx, &settings.SV, 100*time.Millisecond)
-	insights.LatencyQuantileDetectorEnabled.Override(ctx, &settings.SV, true)
+	insights.AnomalyDetectionEnabled.Override(ctx, &settings.SV, true)
 
 	// Run these benchmarks with an increasing number of concurrent (simulated)
 	// SQL sessions, to gauge where our runtime performance starts to break

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -53,9 +53,9 @@ func newRegistry(st *cluster.Settings, metrics Metrics) Registry {
 		},
 	}
 	r := &registry{
-		detector: anyDetector{detectors: []detector{
+		detector: compositeDetector{detectors: []detector{
 			latencyThresholdDetector{st: st},
-			newLatencyQuantileDetector(st, metrics),
+			newAnomalyDetector(st, metrics),
 		}}}
 	r.mu.statements = make(map[clusterunique.ID][]*Statement)
 	r.mu.outliers = cache.NewUnorderedCache(config)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -2232,16 +2232,16 @@ var charts = []sectionDescription{
 		Organization: [][]string{{SQLLayer, "SQL Stats", "Insights"}},
 		Charts: []chartDescription{
 			{
-				Title:   "Number of statement fingerprints being monitored for outlier detection",
-				Metrics: []string{"sql.stats.insights.latency_quantile_detector.fingerprints"},
+				Title:   "Current number of statement fingerprints being monitored for anomaly detection",
+				Metrics: []string{"sql.stats.insights.anomaly_detection.fingerprints"},
 			},
 			{
-				Title:   "Current memory used to support outlier detection",
-				Metrics: []string{"sql.stats.insights.latency_quantile_detector.memory"},
+				Title:   "Current memory used to support anomaly detection",
+				Metrics: []string{"sql.stats.insights.anomaly_detection.memory"},
 			},
 			{
 				Title:   "Evictions of fingerprint latency summaries due to memory pressure",
-				Metrics: []string{"sql.stats.insights.latency_quantile_detector.evictions"},
+				Metrics: []string{"sql.stats.insights.anomaly_detection.evictions"},
 			},
 		},
 	},


### PR DESCRIPTION
As we prepare for release, let's fix up these names. We'll make the
cluster settings as public later, once we've enabled them by default.

Release note: None.