### PR TITLE
sql: declarative schema changer falls back to legacy on udf descriptor

### DIFF
--- a/pkg/sql/schemachanger/scdecomp/BUILD.bazel
+++ b/pkg/sql/schemachanger/scdecomp/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/iterutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -16,10 +16,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
@@ -103,9 +103,10 @@ func (w *walkCtx) walkRoot() {
 	case catalog.TableDescriptor:
 		w.walkRelation(d)
 	case catalog.FunctionDescriptor:
-		// TODO (Chengxiong) #83235 implement DROP FUNCTION
-		panic(unimplemented.NewWithIssue(
-			83235, "function descriptor not supported in declarative schema changer"))
+		// TODO (Chengxiong) #83235 implement DROP FUNCTION.
+		// Fall back to legacy schema changer if there is any function descriptor in
+		// the drop cascade dependency graph.
+		panic(scerrors.NotImplementedErrorf(nil, "function descriptor not supported in declarative schema changer"))
 	default:
 		panic(errors.AssertionFailedf("unexpected descriptor type %T: %+v",
 			w.desc, w.desc))


### PR DESCRIPTION
This commit changes the error to use `scerrors.NotImplemented`, when
a function descriptor is encountered, to enable declarative schema
changer to fall back to legacy schema changer.

Release note (sql change): declarative schema changer now falls back
to legacy schema changer when a user-defined function is found in the
dependency graph when a `DROP` statement instead of throwing an
unimplemented error.