### PR TITLE
release-22.1: ccl/sqlproxyccl: ensure that connections cannot be transferred before init

### DIFF
--- a/pkg/ccl/sqlproxyccl/conn_migration_test.go
+++ b/pkg/ccl/sqlproxyccl/conn_migration_test.go
@@ -91,6 +91,7 @@ func TestForwarder_tryBeginTransfer(t *testing.T) {
 		f := &forwarder{}
 		f.mu.request = &processor{}
 		f.mu.response = &processor{}
+		f.mu.isInitialized = true
 
 		started, cleanupFn := f.tryBeginTransfer()
 		require.False(t, started)
@@ -107,6 +108,7 @@ func TestForwarder_tryBeginTransfer(t *testing.T) {
 		f := &forwarder{}
 		f.mu.request = &processor{}
 		f.mu.response = &processor{}
+		f.mu.isInitialized = true
 
 		started, cleanupFn := f.tryBeginTransfer()
 		require.True(t, started)

--- a/pkg/ccl/sqlproxyccl/forwarder_test.go
+++ b/pkg/ccl/sqlproxyccl/forwarder_test.go
@@ -44,6 +44,12 @@ func TestForward(t *testing.T) {
 		err := f.run(p1, p2)
 		require.NoError(t, err)
 
+		func() {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			require.True(t, f.mu.isInitialized)
+		}()
+
 		// Close the connection right away to simulate processor error.
 		p1.Close()
 
@@ -77,6 +83,11 @@ func TestForward(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, f.ctx.Err())
 		require.False(t, f.IsIdle())
+		func() {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			require.True(t, f.mu.isInitialized)
+		}()
 
 		f.mu.Lock()
 		requestProc := f.mu.request
@@ -217,6 +228,11 @@ func TestForward(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, f.ctx.Err())
 		require.False(t, f.IsIdle())
+		func() {
+			f.mu.Lock()
+			defer f.mu.Unlock()
+			require.True(t, f.mu.isInitialized)
+		}()
 
 		f.mu.Lock()
 		responseProc := f.mu.response

--- a/pkg/ccl/sqlproxyccl/proxy_handler_test.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler_test.go
@@ -781,11 +781,6 @@ func TestConnectionRebalancingDisabled(t *testing.T) {
 	const podCount = 2
 	tenantID := serverutils.TestTenantID()
 	tenants := startTestTenantPods(ctx, t, s, tenantID, podCount)
-	defer func() {
-		for _, tenant := range tenants {
-			tenant.Stopper().Stop(ctx)
-		}
-	}()
 
 	// Register one SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
@@ -869,11 +864,6 @@ func TestPodWatcher(t *testing.T) {
 	const podCount = 4
 	tenantID := serverutils.TestTenantID()
 	tenants := startTestTenantPods(ctx, t, s, tenantID, podCount)
-	defer func() {
-		for _, tenant := range tenants {
-			tenant.Stopper().Stop(ctx)
-		}
-	}()
 
 	// Register only 3 SQL pods in the directory server. We will add the 4th
 	// once the watcher has been established.
@@ -1334,11 +1324,6 @@ func TestCurConnCountMetric(t *testing.T) {
 	// Start a single SQL pod.
 	tenantID := serverutils.TestTenantID()
 	tenants := startTestTenantPods(ctx, t, s, tenantID, 1)
-	defer func() {
-		for _, tenant := range tenants {
-			tenant.Stopper().Stop(ctx)
-		}
-	}()
 
 	// Register the SQL pod in the directory server.
 	tds := tenantdirsvr.NewTestStaticDirectoryServer(s.Stopper(), nil /* timeSource */)
@@ -1878,7 +1863,8 @@ func queryAddr(ctx context.Context, t *testing.T, db queryer) string {
 
 // startTestTenantPods starts count SQL pods for the given tenant, and returns
 // a list of tenant servers. Note that a default admin testuser with the
-// password hunter2 will be created.
+// password hunter2 will be created. The test tenants will automatically be
+// stopped once the server's stopper (from ts) is stopped.
 func startTestTenantPods(
 	ctx context.Context,
 	t *testing.T,

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/test_static_directory_svr.go
@@ -344,7 +344,7 @@ func (d *TestStaticDirectoryServer) RemovePod(tenantID roachpb.TenantID, podAddr
 }
 
 // Start starts the test directory server using an in-memory listener. This
-// returns an error if the server cannot be started. If the sevrer has already
+// returns an error if the server cannot be started. If the server has already
 // been started, this is a no-op.
 func (d *TestStaticDirectoryServer) Start(ctx context.Context) error {
 	d.process.Lock()


### PR DESCRIPTION
Backport 1/1 commits from #85931.

/cc @cockroachdb/release

----

Related to #80446.

In #80446, we updated the connection tracker to track server assignments
instead of forwarders. This also meant that there is a possibility where we
can start transferring the connection before we even resumed the forwarder
for the first time, breaking the TransferConnection invariant where the
processors must be resumed before being called.

This commit fixes that issue by introducing a new isInitialized flag to the
forwarder, which will only get set to true once run returns. Attempting to
transfer a connection with isInitialized=false will return an error. This
should fix flakes that we've been seeing on CI.

Release note: None

Release justification: sqlproxy bug fix. This ensures that we don't resume
the processors mid connection transfer, causing unexpected issues on the
client's end. Note that this situation is rare since it involves ensuring
timely behavior of forwarder.Run and forwarder.TransferConnection at the same
time.