### PR TITLE
kv: permit different max clock offsets on different nodes in same cluster

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -90,7 +90,6 @@ go_test(
     embed = [":rpc"],
     deps = [
         "//pkg/base",
-        "//pkg/cli/exit",
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/roachpb",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1821,7 +1821,6 @@ func (rpcCtx *Context) runHeartbeat(
 func (rpcCtx *Context) NewHeartbeatService() *HeartbeatService {
 	return &HeartbeatService{
 		clock:                                 rpcCtx.Clock,
-		maxOffset:                             rpcCtx.MaxOffset,
 		remoteClockMonitor:                    rpcCtx.RemoteClocks,
 		clusterName:                           rpcCtx.ClusterName(),
 		disableClusterNameVerification:        rpcCtx.Config.DisableClusterNameVerification,

--- a/pkg/rpc/context_test.go
+++ b/pkg/rpc/context_test.go
@@ -133,7 +133,6 @@ func TestHeartbeatCB(t *testing.T) {
 		s := newTestServer(t, serverCtx)
 		RegisterHeartbeatServer(s, &HeartbeatService{
 			clock:              clock,
-			maxOffset:          maxOffset,
 			remoteClockMonitor: serverCtx.RemoteClocks,
 			clusterID:          serverCtx.StorageClusterID,
 			nodeID:             serverCtx.NodeID,
@@ -1025,7 +1024,6 @@ func TestHeartbeatHealthTransport(t *testing.T) {
 	s := grpc.NewServer(grpc.Creds(credentials.NewTLS(tlsConfig)))
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,
@@ -1207,7 +1205,6 @@ func TestOffsetMeasurement(t *testing.T) {
 	s := newTestServer(t, serverCtx)
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              serverClock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,
@@ -1391,7 +1388,6 @@ func TestRemoteOffsetUnhealthy(t *testing.T) {
 		s := newTestServer(t, nodeCtxs[i].ctx)
 		RegisterHeartbeatServer(s, &HeartbeatService{
 			clock:              clock,
-			maxOffset:          maxOffset,
 			remoteClockMonitor: nodeCtxs[i].ctx.RemoteClocks,
 			clusterID:          nodeCtxs[i].ctx.StorageClusterID,
 			nodeID:             nodeCtxs[i].ctx.NodeID,
@@ -1586,7 +1582,6 @@ func grpcRunKeepaliveTestCase(testCtx context.Context, c grpcKeepaliveTestCase) 
 	hss := &HeartbeatStreamService{
 		HeartbeatService: HeartbeatService{
 			clock:              clock,
-			maxOffset:          maxOffset,
 			remoteClockMonitor: serverCtx.RemoteClocks,
 			clusterID:          serverCtx.StorageClusterID,
 			nodeID:             serverCtx.NodeID,
@@ -1868,7 +1863,6 @@ func TestClusterIDMismatch(t *testing.T) {
 	s := newTestServer(t, serverCtx)
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,
@@ -1943,7 +1937,6 @@ func TestClusterNameMismatch(t *testing.T) {
 			s := newTestServer(t, serverCtx)
 			RegisterHeartbeatServer(s, &HeartbeatService{
 				clock:                          clock,
-				maxOffset:                      maxOffset,
 				remoteClockMonitor:             serverCtx.RemoteClocks,
 				clusterID:                      serverCtx.StorageClusterID,
 				nodeID:                         serverCtx.NodeID,
@@ -1995,7 +1988,6 @@ func TestNodeIDMismatch(t *testing.T) {
 	s := newTestServer(t, serverCtx)
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,
@@ -2070,7 +2062,6 @@ func TestVersionCheckBidirectional(t *testing.T) {
 			s := newTestServer(t, serverCtx)
 			RegisterHeartbeatServer(s, &HeartbeatService{
 				clock:              clock,
-				maxOffset:          maxOffset,
 				remoteClockMonitor: serverCtx.RemoteClocks,
 				clusterID:          serverCtx.StorageClusterID,
 				nodeID:             serverCtx.NodeID,
@@ -2118,7 +2109,6 @@ func TestGRPCDialClass(t *testing.T) {
 	s := newTestServer(t, serverCtx)
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,
@@ -2178,7 +2168,6 @@ func TestTestingKnobs(t *testing.T) {
 	))
 	RegisterHeartbeatServer(s, &HeartbeatService{
 		clock:              clock,
-		maxOffset:          maxOffset,
 		remoteClockMonitor: serverCtx.RemoteClocks,
 		clusterID:          serverCtx.StorageClusterID,
 		nodeID:             serverCtx.NodeID,

--- a/pkg/rpc/heartbeat.proto
+++ b/pkg/rpc/heartbeat.proto
@@ -44,6 +44,7 @@ message PingRequest {
   // The address of the client.
   optional string origin_addr = 3 [(gogoproto.nullable) = false];
   // The configured maximum clock offset (in nanoseconds) on the server.
+  // TODO(nvanbenschoten): remove this field in v23.1. It is no longer read.
   optional int64 origin_max_offset_nanos = 4 [(gogoproto.nullable) = false];
   // Cluster ID to prevent connections between nodes in different clusters.
   optional bytes origin_cluster_id = 5 [


### PR DESCRIPTION
Fixes #66868.

Before this commit, it was not possible to change the maximum clock offset of a cluster without shutting down all nodes in the cluster and bringing them all back up with a new `--max-offset` flag. This was enforced by protection added in #9612, which would crash a node if it detected different settings on different nodes. A stop-the-world cluster restart is quite disruptive and prevents us from changing the default value of the `--max-offset` flag between releases of CockroachDB or on existing CC clusters.

This commit removes this protection. The change itself is trivial. The real work is convincing ourselves that it is safe to run in a mixed max-offset cluster. We do that below.

In the following table, we detail each use of `--max-offset`. We then explore the hazards of running in a cluster with mixed `--max-offset` settings.

### Uses of `--max-offset`

| Use         | Description |
| ----------- | ----------- |
| `kv.NewTxn` | Used to configure the transaction's global uncertainty limit |
| `computeIntervalForNonTxn` | Used to configure the non-transacitonal request's global uncertainty limit |
| `TxnCoordSender.maybeCommitWait` | **When in "linearizable" mode**, used to sleep until all clocks beyond local HLC |
| `Txn.DeadlineLikelySufficient` | Used to estimate whether the current txn deadline is sufficiently far in the future |
| `closedts.TargetForPolicy` | Used to estimate lead time for global tables |
| `Replica.leaseStatus` | Used to determine the start of the stasis period for leases |
| `startupmigrations.LeaseManager.timeRemaining` | Used to determine the time remaining on a migration lease |
| `RemoteClockMonitor.VerifyClockOffset` | Used to detect clock synchronization errors |

### Hazards of mixed `--max-offset`

| Use         | skew < min(max-offset) | min(max-offset) < skew < max(max-offset) | max(max-offset) < skew |
| ----------- | ----------- | ----------- | ----------- |
| `kv.NewTxn` | N/A       | Stale reads       | Stale reads       |
| `computeIntervalForNonTxn` | N/A       | Stale reads       | Stale reads       |
| `TxnCoordSender.maybeCommitWait` | N/A       | Causal reverse       | Causal reverse       |
| `Txn.DeadlineLikelySufficient` | N/A       | Deadline exceeded retry errors       | Deadline exceeded retry errors       |
| `closedts.TargetForPolicy` | N/A       | Global table reads redirect to leaseholder       | Global table reads redirect to leaseholder       |
| `Replica.leaseStatus` | N/A       | Stale reads for non-txn requests       | Stale reads for non-txn requests       |
| `startupmigrations.LeaseManager.timeRemaining` | N/A       | Lease replaced unexpectedly, [error](https://github.com/cockroachdb/cockroach/blob/8e3ee57f3c8ea734c7221ff4c758c91cd928b6d3/pkg/startupmigrations/leasemanager/lease.go#L167)       | Lease replaced unexpectedly, [error](https://github.com/cockroachdb/cockroach/blob/8e3ee57f3c8ea734c7221ff4c758c91cd928b6d3/pkg/startupmigrations/leasemanager/lease.go#L167)       |
| `RemoteClockMonitor.VerifyClockOffset` | N/A       | Nodes in minority self-terminate **if their own max-offset < skew**  | Nodes in minority self-terminate       |

Notice that in all cases except the last, the outcome of `min(max-offset) < skew < max(max-offset)` and `max(max-offset) < skew` are identical. This means that, ignoring the last use, the hazards of `max-offset < skew` in a cluster with a homogeneous setting for `--max-offset` is the same as the hazard of `min(max-offset) < skew` in a cluster with a heterogeneous setting for `--max-offset`. As a result, we can consider `min(max-offset)` to be the "effective" max-offset of a cluster.

#### Use in `Replica.leaseStatus`

The use in `Replica.leaseStatus` of the max clock offset to determine whether a request falls into a lease's stasis period is a subtle case here, so it deserves a bit more explanation. As a reminder, the lease stasis period is described [here](https://github.com/cockroachdb/cockroach/blob/8e3ee57f3c8ea734c7221ff4c758c91cd928b6d3/pkg/kv/kvserver/kvserverpb/lease_status.proto#L27).

Consider the case where `min(max-offset) < skew < max(max-offset)` and a request is sent to an outgoing leaseholder near the end of its lease. The interesting case is where the outgoing leaseholder has a smaller max-offset than the skew. In such cases, it may not consider a non-transaction request to be in its stasis period even though a different replica saw the lease as expired, requested a new lease, and served a write. This could allow the non-transactional request to serve a stale read.

Transactional requests are [not subject](https://github.com/cockroachdb/cockroach/blob/8e3ee57f3c8ea734c7221ff4c758c91cd928b6d3/pkg/kv/kvserver/replica_range_lease.go#L611) to the stasis period, so they are not discussed in this example. However, the effect of `min(max-offset) < skew < max(max-offset)` is the same — stale reads.

#### Use in `RemoteClockMonitor.VerifyClockOffset`

The use of `RemoteClockMonitor.VerifyClockOffset` also deserves discussion because it's the one case where mixed `--max-offset` values make a difference. If the nodes with skew (i.e. those in the minority) have lower `--max-offset` values, they will self-terminate. However, if the nodes with skew have higher `--max-offset` values, they will not self-terminate. This could leave the cluster open to the other hazards indefinitely, without the skewed nodes ever deciding to self-terminate. For instance, these skewed nodes could continue to perform writes at high timestamps, causing other nodes with lower `--max-offset` values to serve stale reads.

One option I explored to address this was to have `RemoteClockMonitor.VerifyClockOffset` use the minimum max offset across the cluster instead of its local max offset when verifying clocks. This would be possible by using the `OriginMaxOffsetNanos` value communicated in each `PingRequest`. I decided against this for now in favor of keeping things simple, as it had some rough edges around ignoring stale max-offset values. It's also not clear how this protection will work in a world with dynamic clock uncertainty error bounds.

----

After this lands, we'll need to remove the following text in the docs, which was added in https://github.com/cockroachdb/docs/pull/10988 and in other PRs:
```
Note that this value must be the same on all nodes in the cluster and cannot be
changed with a rolling upgrade. In order to change it, first stop every node in
the cluster. Then once the entire cluster is offline, restart each node with the
new value.
```
and
```
For existing clusters, changing the setting will require restarting all of the
nodes in your cluster at the same time; it cannot be done with a rolling
restart.
```

----

Release note (ops change): clusters can now run nodes with different --max-offset settings at the same time. This enables operators to perform a rolling restart to change the value of each node's --max-offset flag.