### PR TITLE
kvserver/batcheval: add `IdempotentTombstone` for `DeleteRange`

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -921,7 +921,7 @@ func TestEvalAddSSTable(t *testing.T) {
 								require.NoError(t, err)
 								require.True(t, v.IsTombstone(), "MVCC range keys must be tombstones")
 								require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, 0, nil))
+									ctx, b, nil, kv.RangeKey.StartKey, kv.RangeKey.EndKey, kv.RangeKey.Timestamp, v.MVCCValueHeader.LocalTimestamp, nil, nil, false, 0, nil))
 							default:
 								t.Fatalf("unknown KV type %T", kv)
 							}

--- a/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_clear_range_test.go
@@ -145,7 +145,7 @@ func TestCmdClearRange(t *testing.T) {
 				for _, rk := range rangeTombstones {
 					localTS := hlc.ClockTimestamp{WallTime: rk.Timestamp.WallTime - 1e9} // give range key a value if > 0
 					require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, 0, nil))
+						ctx, eng, nil, rk.StartKey, rk.EndKey, rk.Timestamp, localTS, nil, nil, false, 0, nil))
 				}
 
 				// Write some random point keys within the cleared span, above the range tombstones.

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -106,8 +106,8 @@ func DeleteRange(
 				statsCovered = &s
 			}
 			err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
-				args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound, maxIntents,
-				statsCovered)
+				args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound,
+				args.IdempotentTombstone, maxIntents, statsCovered)
 			return result.Result{}, err
 		}
 
@@ -122,6 +122,10 @@ func DeleteRange(
 			// other types of requests, preventing further resume span muddling.
 			return result.Result{}, errors.AssertionFailedf(
 				"MaxSpanRequestKeys must be greater than zero when using predicated based DeleteRange")
+		}
+		if args.IdempotentTombstone {
+			return result.Result{}, errors.AssertionFailedf(
+				"IdempotentTombstone not compatible with Predicates")
 		}
 		// TODO (msbutler): Tune the threshold once DeleteRange and DeleteRangeUsingTombstone have
 		// been further optimized.

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -42,7 +42,7 @@ func TestRefreshRange(t *testing.T) {
 	require.NoError(t, storage.MVCCPut(
 		ctx, eng, nil, roachpb.Key("c"), hlc.Timestamp{WallTime: 5}, hlc.ClockTimestamp{}, roachpb.Value{}, nil))
 	require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-		ctx, eng, nil, roachpb.Key("d"), roachpb.Key("f"), hlc.Timestamp{WallTime: 7}, hlc.ClockTimestamp{}, nil, nil, 0, nil))
+		ctx, eng, nil, roachpb.Key("d"), roachpb.Key("f"), hlc.Timestamp{WallTime: 7}, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
 
 	testcases := map[string]struct {
 		start, end string

--- a/pkg/kv/kvserver/gc/data_distribution_test.go
+++ b/pkg/kv/kvserver/gc/data_distribution_test.go
@@ -62,7 +62,7 @@ func (ds dataDistribution) setupTest(
 				"invalid test data, range can't be used together with value: key=%s, rangeKey=%s",
 				kv.Key.String(), rangeKey.String())
 			err := storage.MVCCDeleteRangeUsingTombstone(ctx, eng, &ms, rangeKey.StartKey,
-				rangeKey.EndKey, rangeKey.Timestamp, hlc.ClockTimestamp{}, nil, nil, 1, nil)
+				rangeKey.EndKey, rangeKey.Timestamp, hlc.ClockTimestamp{}, nil, nil, false, 1, nil)
 			require.NoError(t, err, "failed to put delete range")
 		} else if txn == nil {
 			if kv.Key.Timestamp.IsEmpty() {

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -503,13 +503,10 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 		return ms, hlc.Timestamp{WallTime: time.Millisecond.Nanoseconds() * int64(valCount)}
 	}
 
-	deleteWithTobmstone := func(rw storage.ReadWriter, delTime hlc.Timestamp, ms *enginepb.MVCCStats) {
-		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(ctx, rw, ms,
-			[]byte{0}, []byte{0xff},
-			delTime, hlc.ClockTimestamp{},
-			nil, nil, 1, nil))
+	deleteWithTombstone := func(rw storage.ReadWriter, delTime hlc.Timestamp, ms *enginepb.MVCCStats) {
+		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
+			ctx, rw, ms, []byte{0}, []byte{0xff}, delTime, hlc.ClockTimestamp{}, nil, nil, false, 1, nil))
 	}
-	_ = deleteWithTobmstone
 	deleteWithPoints := func(rw storage.ReadWriter, delTime hlc.Timestamp, ms *enginepb.MVCCStats) {
 		for _, key := range keys {
 			require.NoError(t, storage.MVCCPut(ctx, rw, ms, key, delTime, hlc.ClockTimestamp{}, roachpb.Value{}, nil))
@@ -527,7 +524,7 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 
 	rangeMs := ms
 	pointMs := ms
-	deleteWithTobmstone(eng.NewBatch(), deletionTime, &rangeMs)
+	deleteWithTombstone(eng.NewBatch(), deletionTime, &rangeMs)
 	deleteWithPoints(eng.NewBatch(), deletionTime, &pointMs)
 
 	gcTTL := time.Minute * 30

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -181,7 +181,7 @@ func TestReplicaChecksumSHA512(t *testing.T) {
 
 		if len(endKey) > 0 {
 			require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-				ctx, eng, nil, key, endKey, ts, localTS, nil, nil, 0, nil))
+				ctx, eng, nil, key, endKey, ts, localTS, nil, nil, false, 0, nil))
 		} else {
 			require.NoError(t, storage.MVCCPut(ctx, eng, nil, key, ts, localTS, value, nil))
 		}

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -378,6 +378,12 @@ message DeleteRangeRequest {
   // The caller must check the MVCCRangeTombstones version gate before using
   // this parameter, as it is new in 22.2.
   bool use_range_tombstone = 5;
+  // If enabled together with UseRangeTombstone, the MVCC range tombstone will
+  // only be written if there exists point key/tombstones in the span that
+  // aren't already covered by an MVCC range tombstone. As a convenience, it
+  // considers empty spans equivalent to being covered by an MVCC range
+  // tombstone, so it will omit the write across an entirely empty span too.
+  bool idempotent_tombstone = 7;
 
   DeleteRangePredicates predicates = 6 [(gogoproto.nullable) = false];
 }

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -729,7 +729,7 @@ func setupMVCCData(
 			startKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(start)))
 			endKey := roachpb.Key(encoding.EncodeUvarintAscending([]byte("key-"), uint64(end)))
 			require.NoError(b, MVCCDeleteRangeUsingTombstone(
-				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, 0, nil))
+				ctx, batch, nil, startKey, endKey, ts, hlc.ClockTimestamp{}, nil, nil, false, 0, nil))
 		}
 		require.NoError(b, batch.Commit(false /* sync */))
 	}
@@ -1383,6 +1383,7 @@ func runMVCCDeleteRangeUsingTombstone(
 				hlc.ClockTimestamp{},
 				leftPeekBound,
 				rightPeekBound,
+				false, // idempotent
 				0,
 				msCovered,
 			); err != nil {

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -333,7 +333,8 @@ func (m mvccDeleteRangeUsingRangeTombstoneOp) run(ctx context.Context) string {
 	}
 
 	err := storage.MVCCDeleteRangeUsingTombstone(ctx, writer, nil, m.key, m.endKey, m.ts,
-		hlc.ClockTimestamp{}, m.key, m.endKey, math.MaxInt64 /* maxIntents */, nil /* msCovered */)
+		hlc.ClockTimestamp{}, m.key, m.endKey, false /* idempotent */, math.MaxInt64, /* maxIntents */
+		nil /* msCovered */)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err)
 	}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4793,15 +4793,15 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				}
 			}
 			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("r"),
-				roachpb.Key("r-del").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, 0, nil); err != nil {
+				roachpb.Key("r-del").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
 				t.Fatal(err)
 			}
 			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
-				roachpb.Key("u").Next(), ts2, hlc.ClockTimestamp{}, nil, nil, 0, nil); err != nil {
+				roachpb.Key("u").Next(), ts2, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
 				t.Fatal(err)
 			}
 			if err := MVCCDeleteRangeUsingTombstone(ctx, engine, ms, roachpb.Key("t"),
-				roachpb.Key("u").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, 0, nil); err != nil {
+				roachpb.Key("u").Next(), ts3, hlc.ClockTimestamp{}, nil, nil, false, 0, nil); err != nil {
 				t.Fatal(err)
 			}
 			if log.V(1) {
@@ -5230,7 +5230,7 @@ func (d rangeTestData) populateEngine(
 			ts = v.point.Key.Timestamp
 		} else {
 			require.NoError(t, MVCCDeleteRangeUsingTombstone(ctx, engine, ms, v.rangeTombstone.StartKey,
-				v.rangeTombstone.EndKey, v.rangeTombstone.Timestamp, hlc.ClockTimestamp{}, nil, nil, 0, nil),
+				v.rangeTombstone.EndKey, v.rangeTombstone.Timestamp, hlc.ClockTimestamp{}, nil, nil, false, 0, nil),
 				"failed to insert range tombstone into engine (%s)", v.rangeTombstone.String())
 			ts = v.rangeTombstone.Timestamp
 		}

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -1,0 +1,286 @@
+# Tests idempotent MVCC range tombstone writes.
+#
+# Set up some point keys, point tombstones x, range tombstones o--o,
+# and intents [].
+#
+# 6                                 [i6]
+# 5
+# 4  x       c4      e4  x                   o---------------o
+# 3  o-----------o                           k3          x
+# 2  a2                      g2                      o-------o
+# 1                                                  m1
+# 0                                                              p0
+#    a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
+run ok
+put k=a ts=2 v=a2
+del_range_ts k=a end=d ts=3
+del k=a ts=4
+put k=c ts=4 v=c4
+put k=e ts=4 v=e4
+del k=f ts=4
+put k=g ts=2 v=g2
+put k=m ts=1 v=m1
+del_range_ts k=m end=o ts=2
+put k=k ts=3 v=k3
+del k=n ts=3
+put k=p ts=0 v=p0
+del_range_ts k=k end=o ts=4
+with t=A
+  txn_begin ts=6
+  put k=i v=i6
+----
+del: "a": found key false
+del: "f": found key false
+del: "n": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+
+# Writing below point keys and tombstones errors, as does below range keys.
+run error
+del_range_ts k=e end=f ts=3 idempotent
+----
+>> at end:
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "e" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+
+run error
+del_range_ts k=f end=g ts=3 idempotent
+----
+>> at end:
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "f" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+
+run error
+del_range_ts k=l end=m ts=3 idempotent
+----
+>> at end:
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*roachpb.WriteTooOldError:) WriteTooOldError: write for key "l" at timestamp 3.000000000,0 too old; wrote at 4.000000000,1
+
+# Writing below intents error.
+run error
+del_range_ts k=i end=j ts=3 idempotent
+----
+>> at end:
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+error: (*roachpb.WriteIntentError:) conflicting intents on "i"
+
+# Idempotent writes: exact, left, right, subset.
+run stats ok
+del_range_ts k=k end=o ts=5 idempotent
+del_range_ts k=k end=l ts=5 idempotent
+del_range_ts k=n end=o ts=5 idempotent
+del_range_ts k=k end=m ts=5 idempotent
+----
+>> del_range_ts k=k end=o ts=5 idempotent
+stats: no change
+>> del_range_ts k=k end=l ts=5 idempotent
+stats: no change
+>> del_range_ts k=n end=o ts=5 idempotent
+stats: no change
+>> del_range_ts k=k end=m ts=5 idempotent
+stats: no change
+>> at end:
+rangekey: {a-d}/[3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=3 range_key_bytes=48 range_val_count=4 live_count=5 live_bytes=155 gc_bytes_age=14602 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+
+# Non-idempotent writes above tombstone and point.
+run stats ok
+del_range_ts k=a end=b ts=5 idempotent
+del_range_ts k=c end=d ts=5 idempotent
+----
+>> del_range_ts k=a end=b ts=5 idempotent
+stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2108
+>> del_range_ts k=c end=d ts=5 idempotent
+stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 live_count=-1 live_bytes=-21 gc_bytes_age=+4103
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+
+# Writing on top of stacked range keys is also idempotent.
+run stats ok
+del_range_ts k=a end=d ts=6 idempotent
+----
+>> del_range_ts k=a end=d ts=6 idempotent
+stats: no change
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=5 range_key_bytes=92 range_val_count=8 live_count=4 live_bytes=134 gc_bytes_age=20813 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+
+# Non-idempotent writes on top of bare point keys.
+run stats ok
+del_range_ts k=e end=f ts=5 idempotent
+del_range_ts k=f end=g ts=5 idempotent
+----
+>> del_range_ts k=e end=f ts=5 idempotent
+stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3230
+>> del_range_ts k=f end=g ts=5 idempotent
+stats: no change
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94
+
+
+# Writes across empty key space is considered idempotent.
+run stats ok
+del_range_ts k=h end=i ts=5 idempotent
+del_range_ts k=j end=p ts=5 idempotent
+----
+>> del_range_ts k=h end=i ts=5 idempotent
+stats: no change
+>> del_range_ts k=j end=p ts=5 idempotent
+stats: no change
+>> at end:
+rangekey: {a-b}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {e-g}/[5.000000000,0=/<empty>]
+rangekey: {k-m}/[4.000000000,0=/<empty>]
+rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "e"/4.000000000,0 -> /BYTES/e4
+data: "f"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/6.000000000,0 -> /BYTES/i6
+data: "k"/3.000000000,0 -> /BYTES/k3
+data: "m"/1.000000000,0 -> /BYTES/m1
+data: "n"/3.000000000,0 -> /<empty>
+meta: "p"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/p0 mergeTs=<nil> txnDidNotUpdateMeta=false
+stats: key_count=10 key_bytes=140 val_count=11 val_bytes=118 range_key_count=6 range_key_bytes=105 range_val_count=9 live_count=3 live_bytes=113 gc_bytes_age=24043 intent_count=1 intent_bytes=19 separated_intent_count=1 intent_age=94


### PR DESCRIPTION
This patch adds the parameter `IdempotentTombstone` for `DeleteRange`.
When enabled, a `DeleteRange` request with `UseRangeTombstone` will
first look for any point keys/tombstones in the span that aren't already
covered by an MVCC range tombstone, and omit writing the tombstone if
none are found. As a convenience, it considers empty spans equivalent to
being covered by an MVCC range tombstone, so it will omit the write
across an entirely empty span too.

Resolves #85725.

Release note: None