### PR TITLE
sql: make copy atomic by default and add optin to old behavior

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2839,31 +2839,8 @@ func (ex *connExecutor) initPlanner(ctx context.Context, p *planner) {
 func (ex *connExecutor) resetPlanner(
 	ctx context.Context, p *planner, txn *kv.Txn, stmtTS time.Time,
 ) {
-	p.txn = txn
-	p.stmt = Statement{}
-	p.instrumentation = instrumentationHelper{}
-
-	p.cancelChecker.Reset(ctx)
-
-	p.semaCtx = tree.MakeSemaContext()
-	p.semaCtx.SearchPath = &ex.sessionData().SearchPath
-	p.semaCtx.Annotations = nil
-	p.semaCtx.TypeResolver = p
-	p.semaCtx.FunctionResolver = p
-	p.semaCtx.TableNameResolver = p
-	p.semaCtx.DateStyle = ex.sessionData().GetDateStyle()
-	p.semaCtx.IntervalStyle = ex.sessionData().GetIntervalStyle()
-
+	p.resetPlanner(ctx, txn, stmtTS, ex.sessionData())
 	ex.resetEvalCtx(&p.extendedEvalCtx, txn, stmtTS)
-
-	p.autoCommit = false
-	p.isPreparing = false
-
-	p.schemaResolver.txn = txn
-	p.schemaResolver.sessionDataStack = p.EvalContext().SessionDataStack
-	p.evalCatalogBuiltins.Init(p.execCfg.Codec, txn, p.Descriptors())
-	p.skipDescriptorCache = false
-	p.typeResolutionDbID = descpb.InvalidID
 }
 
 // txnStateTransitionsApplyWrapper is a wrapper on top of Machine built with the

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -98,7 +98,7 @@ func newFileUploadMachine(
 
 	// We need a planner to do the initial planning, even if a planner
 	// is not required after that.
-	cleanup := c.p.preparePlannerForCopy(ctx, txnOpt)
+	cleanup := c.p.preparePlannerForCopy(ctx, &txnOpt, false /* finalBatch */, c.implicitTxn)
 	defer func() {
 		retErr = cleanup(ctx, retErr)
 	}()
@@ -191,7 +191,7 @@ func (f *fileUploadMachine) run(ctx context.Context) error {
 	return err
 }
 
-func (f *fileUploadMachine) writeFile(ctx context.Context) error {
+func (f *fileUploadMachine) writeFile(ctx context.Context, finalBatch bool) error {
 	for i := 0; i < f.c.rows.Len(); i++ {
 		r := f.c.rows.At(i)
 		b := []byte(*r[0].(*tree.DBytes))

--- a/pkg/sql/copyshim.go
+++ b/pkg/sql/copyshim.go
@@ -81,15 +81,14 @@ func RunCopyFrom(
 	txn *kv.Txn,
 	copySQL string,
 	data []string,
+	copyBatchRowSizeOverride int,
+	atomic bool,
 ) (int, error) {
 	execCfg := s.ExecutorConfig().(ExecutorConfig)
 	dsp := execCfg.DistSQLPlanner
 	stmt, err := parser.ParseOne(copySQL)
 	if err != nil {
 		return -1, err
-	}
-	if txn == nil {
-		txn = s.DB().NewTxn(ctx, "test")
 	}
 
 	// TODO(cucaroach): test open transaction and implicit txn, this will require
@@ -98,6 +97,7 @@ func RunCopyFrom(
 	txnOpt.resetPlanner = func(ctx context.Context, p *planner, txn *kv.Txn, txnTS time.Time, stmtTS time.Time) {
 		p.cancelChecker.Reset(ctx)
 		p.optPlanningCtx.init(p)
+		p.resetPlanner(ctx, txn, stmtTS, p.sessionDataMutatorIterator.sds.Top())
 	}
 	p, cleanup := newInternalPlanner("copytest",
 		txn,
@@ -114,6 +114,8 @@ func RunCopyFrom(
 		return -1, err
 	}
 	defer cleanup()
+
+	p.SessionData().CopyFromAtomicEnabled = atomic
 
 	// Write what the client side would write into a buffer and then make it the conn's data.
 	var buf []byte
@@ -145,15 +147,12 @@ func RunCopyFrom(
 	if err != nil {
 		return -1, err
 	}
+	if copyBatchRowSizeOverride != 0 {
+		c.copyBatchRowSize = copyBatchRowSizeOverride
+	}
 
 	if err := c.run(ctx); err != nil {
 		return -1, err
-	}
-
-	if txn != nil {
-		if err := txn.Commit(ctx); err != nil {
-			return -1, err
-		}
 	}
 
 	return rows, nil

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3333,6 +3333,10 @@ func (m *sessionDataMutator) SetCopyFastPathEnabled(val bool) {
 	m.data.CopyFastPathEnabled = val
 }
 
+func (m *sessionDataMutator) SetCopyFromAtomicEnabled(val bool) {
+	m.data.CopyFromAtomicEnabled = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2395,7 +2395,7 @@ func (t *logicTest) processSubtest(
 			// sql.DB interface doesn't support COPY so fixing it the right way
 			// that would require major surgery (ie making logictest use libpq
 			// or something low level like that).
-			rows, err := sql.RunCopyFrom(context.Background(), t.cluster.Server(0), "test", nil, query.sql, []string{data.String()})
+			rows, err := sql.RunCopyFrom(context.Background(), t.cluster.Server(0), "test", nil, query.sql, []string{data.String()}, 0 /* rowsPerBatch */, true /* atomic */)
 			result := fmt.Sprintf("%d", rows)
 			if err != nil {
 				if !expectError {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4677,6 +4677,7 @@ bytea_output                                          hex
 check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
+copy_from_atomic_enabled                              on
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4161,6 +4161,7 @@ bytea_output                                          hex                 NULL  
 check_function_bodies                                 on                  NULL      NULL        NULL        string
 client_encoding                                       UTF8                NULL      NULL        NULL        string
 client_min_messages                                   notice              NULL      NULL        NULL        string
+copy_from_atomic_enabled                              on                  NULL      NULL        NULL        string
 cost_scans_with_default_col_size                      off                 NULL      NULL        NULL        string
 database                                              test                NULL      NULL        NULL        string
 datestyle                                             ISO, MDY            NULL      NULL        NULL        string
@@ -4288,6 +4289,7 @@ bytea_output                                          hex                 NULL  
 check_function_bodies                                 on                  NULL  user     NULL      on                  on
 client_encoding                                       UTF8                NULL  user     NULL      UTF8                UTF8
 client_min_messages                                   notice              NULL  user     NULL      notice              notice
+copy_from_atomic_enabled                              on                  NULL  user     NULL      on                  on
 cost_scans_with_default_col_size                      off                 NULL  user     NULL      off                 off
 database                                              test                NULL  user     NULL      ·                   test
 datestyle                                             ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
@@ -4410,6 +4412,7 @@ check_function_bodies                                 NULL    NULL     NULL     
 client_encoding                                       NULL    NULL     NULL     NULL        NULL
 client_min_messages                                   NULL    NULL     NULL     NULL        NULL
 copy_fast_path_enabled                                NULL    NULL     NULL     NULL        NULL
+copy_from_atomic_enabled                              NULL    NULL     NULL     NULL        NULL
 cost_scans_with_default_col_size                      NULL    NULL     NULL     NULL        NULL
 crdb_version                                          NULL    NULL     NULL     NULL        NULL
 database                                              NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -34,6 +34,7 @@ bytea_output                                          hex
 check_function_bodies                                 on
 client_encoding                                       UTF8
 client_min_messages                                   notice
+copy_from_atomic_enabled                              on
 cost_scans_with_default_col_size                      off
 database                                              test
 datestyle                                             ISO, MDY

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -281,6 +281,9 @@ message LocalOnlySessionData {
   // disable_hoist_projection_in_join_limitation disables the restrictions
   // placed on projection hoisting during query planning in the optimizer.
   bool disable_hoist_projection_in_join_limitation = 76;
+  // CopyFromAtomicEnabled controls whether implicit txn copy from operations
+  // are atomic or segmented.
+  bool copy_from_atomic_enabled = 77;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2173,6 +2173,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`copy_from_atomic_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`copy_from_atomic_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("copy_from_atomic_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetCopyFromAtomicEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().CopyFromAtomicEnabled), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
Previously COPY under an implicit transaction would use auto committed
batches of 100 rows. This decision was made years ago when large txn
support wasn't what it is now. Today we handle large transactions better
so make the default behavior atomic and provide a session setting to get
back the old behavior. It's possible in busy clusters with large COPY's
there may be contention and retries that make non-atomic copy desirable.
    
Fixes: #85887

Release note (backward-incompatible change): COPY FROM operations are
now atomic by default instead of being segmented into 100 row
transactions. Set the copy_from_atomic_enabled session setting to
false to get the old behavior.

Release justification: low risk high benefit correctness fix to existing
functionality