### PR TITLE
sql: fix aggregation of statistics

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5571,7 +5571,7 @@ SELECT
   plan_hash,
   app_name,
   max(metadata) as metadata,
-  crdb_internal.merge_statement_stats(array_agg(statistics)),
+  crdb_internal.merge_statement_stats(array_agg(DISTINCT statistics)),
   max(sampled_plan),
   aggregation_interval,
   array_remove(array_agg(index_rec), NULL) AS index_recommendations

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1512,7 +1512,7 @@ CREATE VIEW crdb_internal.statement_statistics (
     plan_hash,
     app_name,
     max(metadata) AS metadata,
-    crdb_internal.merge_statement_stats(array_agg(statistics)),
+    crdb_internal.merge_statement_stats(array_agg(DISTINCT statistics)),
     max(sampled_plan),
     aggregation_interval,
     array_remove(array_agg(index_rec), NULL) AS index_recommendations
@@ -1571,7 +1571,7 @@ CREATE VIEW crdb_internal.statement_statistics (
     plan_hash,
     app_name,
     max(metadata) AS metadata,
-    crdb_internal.merge_statement_stats(array_agg(statistics)),
+    crdb_internal.merge_statement_stats(array_agg(DISTINCT statistics)),
     max(sampled_plan),
     aggregation_interval,
     array_remove(array_agg(index_rec), NULL) AS index_recommendations


### PR DESCRIPTION
Previously, because we were using a join, we were double
counting statistics when we had the same fingerprint in
memory and persisted.
This commit adds a `DISTINCT` so we only count them once.

Fixes #85958

Release note: None