### PR TITLE
server: skip TestConsumeJoinToken under race.

### DIFF
--- a/pkg/server/addjoin_test.go
+++ b/pkg/server/addjoin_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,7 @@ import (
 func TestConsumeJoinToken(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderRaceWithIssue(t, 85988)
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()
 	sql.FeatureTLSAutoJoinEnabled.Override(ctx, &settings.SV, true)


### PR DESCRIPTION
Related issue: https://github.com/cockroachdb/cockroach/issues/85988.

Release note: None.