### PR TITLE
kvserver: allow certain read-only requests to drop latches before evaluation

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -90,6 +90,11 @@ func declareKeysExport(
 ) {
 	DefaultDeclareIsolatedKeys(rs, header, req, latchSpans, lockSpans, maxOffset)
 	latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{Key: keys.RangeGCThresholdKey(header.RangeID)})
+	// Export requests will usually not hold latches during their evaluation.
+	//
+	// See call to `AssertAllowed()` in GetGCThreshold() to understand why we need
+	// to disable these assertions for export requests.
+	latchSpans.DisableUndeclaredAccessAssertions()
 }
 
 // evalExport dumps the requested keys into files of non-overlapping key ranges
@@ -123,6 +128,10 @@ func evalExport(
 	// *revisions* since the gc threshold, so noting that in the reply allows the
 	// BACKUP to correctly note the supported time bounds for RESTORE AS OF SYSTEM
 	// TIME.
+	//
+	// NOTE: Since export requests may not be holding latches during evaluation,
+	// this `GetGCThreshold()` call is going to potentially return a higher GC
+	// threshold than the pebble state we're evaluating over. This is copacetic.
 	if args.MVCCFilter == roachpb.MVCCFilter_All {
 		reply.StartTime = args.StartTime
 		if args.StartTime.IsEmpty() {

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -53,13 +53,14 @@ func Get(
 	var intent *roachpb.Intent
 	var err error
 	val, intent, err = storage.MVCCGet(ctx, reader, args.Key, h.Timestamp, storage.MVCCGetOptions{
-		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
-		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
-		Txn:              h.Txn,
-		FailOnMoreRecent: args.KeyLocking != lock.None,
-		Uncertainty:      cArgs.Uncertainty,
-		MemoryAccount:    cArgs.EvalCtx.GetResponseMemoryAccount(),
-		LockTable:        cArgs.Concurrency,
+		Inconsistent:          h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
+		Txn:                   h.Txn,
+		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		Uncertainty:           cArgs.Uncertainty,
+		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:             cArgs.Concurrency,
+		DontInterleaveIntents: cArgs.DontInterleaveIntents,
 	})
 	if err != nil {
 		return result.Result{}, err

--- a/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_reverse_scan.go
@@ -40,18 +40,19 @@ func ReverseScan(
 	var err error
 
 	opts := storage.MVCCScanOptions{
-		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
-		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
-		Txn:              h.Txn,
-		MaxKeys:          h.MaxSpanRequestKeys,
-		MaxIntents:       storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
-		TargetBytes:      h.TargetBytes,
-		AllowEmpty:       h.AllowEmpty,
-		WholeRowsOfSize:  h.WholeRowsOfSize,
-		FailOnMoreRecent: args.KeyLocking != lock.None,
-		Reverse:          true,
-		MemoryAccount:    cArgs.EvalCtx.GetResponseMemoryAccount(),
-		LockTable:        cArgs.Concurrency,
+		Inconsistent:          h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
+		Txn:                   h.Txn,
+		MaxKeys:               h.MaxSpanRequestKeys,
+		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		TargetBytes:           h.TargetBytes,
+		AllowEmpty:            h.AllowEmpty,
+		WholeRowsOfSize:       h.WholeRowsOfSize,
+		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		Reverse:               true,
+		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:             cArgs.Concurrency,
+		DontInterleaveIntents: cArgs.DontInterleaveIntents,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/cmd_scan.go
+++ b/pkg/kv/kvserver/batcheval/cmd_scan.go
@@ -40,19 +40,20 @@ func Scan(
 	var err error
 
 	opts := storage.MVCCScanOptions{
-		Inconsistent:     h.ReadConsistency != roachpb.CONSISTENT,
-		SkipLocked:       h.WaitPolicy == lock.WaitPolicy_SkipLocked,
-		Txn:              h.Txn,
-		Uncertainty:      cArgs.Uncertainty,
-		MaxKeys:          h.MaxSpanRequestKeys,
-		MaxIntents:       storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
-		TargetBytes:      h.TargetBytes,
-		AllowEmpty:       h.AllowEmpty,
-		WholeRowsOfSize:  h.WholeRowsOfSize,
-		FailOnMoreRecent: args.KeyLocking != lock.None,
-		Reverse:          false,
-		MemoryAccount:    cArgs.EvalCtx.GetResponseMemoryAccount(),
-		LockTable:        cArgs.Concurrency,
+		Inconsistent:          h.ReadConsistency != roachpb.CONSISTENT,
+		SkipLocked:            h.WaitPolicy == lock.WaitPolicy_SkipLocked,
+		Txn:                   h.Txn,
+		Uncertainty:           cArgs.Uncertainty,
+		MaxKeys:               h.MaxSpanRequestKeys,
+		MaxIntents:            storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV),
+		TargetBytes:           h.TargetBytes,
+		AllowEmpty:            h.AllowEmpty,
+		WholeRowsOfSize:       h.WholeRowsOfSize,
+		FailOnMoreRecent:      args.KeyLocking != lock.None,
+		Reverse:               false,
+		MemoryAccount:         cArgs.EvalCtx.GetResponseMemoryAccount(),
+		LockTable:             cArgs.Concurrency,
+		DontInterleaveIntents: cArgs.DontInterleaveIntents,
 	}
 
 	switch args.ScanFormat {

--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -121,7 +121,8 @@ type CommandArgs struct {
 	Args    roachpb.Request
 	Now     hlc.ClockTimestamp
 	// *Stats should be mutated to reflect any writes made by the command.
-	Stats       *enginepb.MVCCStats
-	Concurrency *concurrency.Guard
-	Uncertainty uncertainty.Interval
+	Stats                 *enginepb.MVCCStats
+	Concurrency           *concurrency.Guard
+	Uncertainty           uncertainty.Interval
+	DontInterleaveIntents bool
 }

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1651,7 +1651,6 @@ Note that the measurement does not include the duration for replicating the eval
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-
 	metaPopularKeyCount = metric.Metadata{
 		Name:        "kv.loadsplitter.popularkey",
 		Help:        "Load-based splitter could not find a split key and the most popular sampled split key occurs in >= 25% of the samples.",
@@ -1678,6 +1677,18 @@ Note that the measurement does not include the duration for replicating the eval
 		Help:        "The write ahead log fsync latency",
 		Measurement: "Fsync Latency",
 		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaReplicaReadBatchDroppedLatchesBeforeEval = metric.Metadata{
+		Name:        "kv.replica_read_batch_evaluate.dropped_latches_before_eval",
+		Help:        `Number of times read-only batches dropped latches before evaluation.`,
+		Measurement: "Batches",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaReplicaReadBatchWithoutInterleavingIter = metric.Metadata{
+		Name:        "kv.replica_read_batch_evaluate.without_interleaving_iter",
+		Help:        `Number of read-only batches evaluated without an intent interleaving iter.`,
+		Measurement: "Batches",
+		Unit:        metric.Unit_COUNT,
 	}
 )
 
@@ -1974,6 +1985,9 @@ type StoreMetrics struct {
 	// Replica batch evaluation metrics.
 	ReplicaReadBatchEvaluationLatency  *metric.Histogram
 	ReplicaWriteBatchEvaluationLatency *metric.Histogram
+
+	ReplicaReadBatchDroppedLatchesBeforeEval *metric.Counter
+	ReplicaReadBatchWithoutInterleavingIter  *metric.Counter
 
 	FlushUtilization *metric.GaugeFloat64
 	FsyncLatency     *metric.ManualWindowHistogram
@@ -2517,6 +2531,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		),
 		FlushUtilization: metric.NewGaugeFloat64(metaStorageFlushUtilization),
 		FsyncLatency:     metric.NewManualWindowHistogram(metaStorageFsyncLatency, pebble.FsyncLatencyBuckets),
+
+		ReplicaReadBatchDroppedLatchesBeforeEval: metric.NewCounter(metaReplicaReadBatchDroppedLatchesBeforeEval),
+		ReplicaReadBatchWithoutInterleavingIter:  metric.NewCounter(metaReplicaReadBatchWithoutInterleavingIter),
 	}
 
 	{

--- a/pkg/kv/kvserver/replica_evaluate_test.go
+++ b/pkg/kv/kvserver/replica_evaluate_test.go
@@ -674,6 +674,10 @@ func TestEvaluateBatch(t *testing.T) {
 
 			var r resp
 			r.d = d
+			evalPath := readWrite
+			if d.readOnly {
+				evalPath = readOnlyDefault
+			}
 			r.br, r.res, r.pErr = evaluateBatch(
 				ctx,
 				d.idKey,
@@ -681,10 +685,10 @@ func TestEvaluateBatch(t *testing.T) {
 				d.MockEvalCtx.EvalContext(),
 				&d.ms,
 				&d.ba,
-				nil, /* g */
-				nil, /* st */
+				nil,
+				nil,
 				uncertainty.Interval{},
-				d.readOnly,
+				evalPath,
 			)
 
 			tc.check(t, r)

--- a/pkg/kv/kvserver/replica_gossip.go
+++ b/pkg/kv/kvserver/replica_gossip.go
@@ -97,7 +97,10 @@ func (r *Replica) MaybeGossipNodeLivenessRaftMuLocked(
 	defer rw.Close()
 
 	br, result, pErr :=
-		evaluateBatch(ctx, kvserverbase.CmdIDKey(""), rw, rec, nil, &ba, nil /* g */, nil /* st */, uncertainty.Interval{}, true /* readOnly */)
+		evaluateBatch(
+			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, &ba,
+			nil /* g */, nil /* st */, uncertainty.Interval{}, readOnlyDefault,
+		)
 	if pErr != nil {
 		return errors.Wrapf(pErr.GoError(), "couldn't scan node liveness records in span %s", span)
 	}

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -24,12 +24,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 )
 
@@ -89,27 +91,38 @@ func (r *Replica) executeReadOnlyBatch(
 	if err := r.checkExecutionCanProceedAfterStorageSnapshot(ctx, ba, st); err != nil {
 		return nil, g, nil, roachpb.NewError(err)
 	}
-	// TODO(nvanbenschoten): once all replicated intents are pulled into the
-	// concurrency manager's lock-table, we can be sure that if we reached this
-	// point, we will not conflict with any of them during evaluation. This in
-	// turn means that we can bump the timestamp cache *before* evaluation
-	// without risk of starving writes. Once we start doing that, we're free to
-	// release latches immediately after we acquire an engine iterator as long
-	// as we're performing a non-locking read. Note that this also requires that
-	// the request is not being optimistically evaluated (optimistic evaluation
-	// does not wait for latches or check locks). It would also be nice, but not
-	// required for correctness, that the read-only engine eagerly create an
-	// iterator (that is later cloned) while the latches are held, so that this
-	// request does not "see" the effect of any later requests that happen after
-	// the latches are released.
+	ok, stillNeedsInterleavedIntents, pErr := r.canDropLatchesBeforeEval(ctx, rw, ba, g, st)
+	if pErr != nil {
+		return nil, g, nil, pErr
+	}
+	evalPath := readOnlyDefault
+	if ok {
+		// Since the concurrency manager has sequenced this request all the intents
+		// that are in the concurrency manager's lock table, and we've scanned the
+		// replicated lock-table keyspace above in `canDropLatchesBeforeEval`, we
+		// can be sure that if we reached this point, we will not conflict with any
+		// of them during evaluation. This in turn means that we can bump the
+		// timestamp cache *before* evaluation without risk of starving writes.
+		// Consequently, we're free to release latches here since we've acquired a
+		// pebble iterator as long as we're performing a non-locking read (also
+		// checked in `canDropLatchesBeforeEval`). Note that this also requires that
+		// the request is not being optimistically evaluated (optimistic evaluation
+		// does not wait for latches or check locks).
+		log.VEventf(ctx, 3, "lock table scan complete without conflicts; dropping latches early")
+		if !stillNeedsInterleavedIntents {
+			evalPath = readOnlyWithoutInterleavedIntents
+		}
+		r.updateTimestampCacheAndDropLatches(ctx, g, ba, nil /* br */, nil /* pErr */, st)
+		g = nil
+	}
 
 	var result result.Result
-	br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, g, &st, ui)
+	br, result, pErr = r.executeReadOnlyBatchWithServersideRefreshes(ctx, rw, rec, ba, g, &st, ui, evalPath)
 
 	// If the request hit a server-side concurrency retry error, immediately
 	// propagate the error. Don't assume ownership of the concurrency guard.
 	if isConcurrencyRetryError(pErr) {
-		if g.EvalKind == concurrency.OptimisticEval {
+		if g != nil && g.EvalKind == concurrency.OptimisticEval {
 			// Since this request was not holding latches, it could have raced with
 			// intent resolution. So we can't trust it to add discovered locks, if
 			// there is a latch conflict. This means that a discovered lock plus a
@@ -130,7 +143,7 @@ func (r *Replica) executeReadOnlyBatch(
 		return nil, g, nil, pErr
 	}
 
-	if g.EvalKind == concurrency.OptimisticEval {
+	if g != nil && g.EvalKind == concurrency.OptimisticEval {
 		if pErr == nil {
 			// Gather the spans that were read -- we distinguish the spans in the
 			// request from the spans that were actually read, using resume spans in
@@ -162,17 +175,11 @@ func (r *Replica) executeReadOnlyBatch(
 	if pErr == nil {
 		pErr = r.handleReadOnlyLocalEvalResult(ctx, ba, result.Local)
 	}
-
-	// Otherwise, update the timestamp cache and release the concurrency guard.
-	// Note:
-	// - The update to the timestamp cache is not gated on pErr == nil,
-	//   since certain semantic errors (e.g. ConditionFailedError on CPut)
-	//   require updating the timestamp cache (see updatesTSCacheOnErr).
-	// - For optimistic evaluation, used for limited scans, the update to the
-	//   timestamp cache limits itself to the spans that were read, by using
-	//   the ResumeSpans.
-	ec, g := endCmds{repl: r, g: g, st: st}, nil
-	ec.done(ctx, ba, br, pErr)
+	if g != nil {
+		// If we didn't already drop latches earlier, do so now.
+		r.updateTimestampCacheAndDropLatches(ctx, g, ba, br, pErr, st)
+		g = nil
+	}
 
 	// Semi-synchronously process any intents that need resolving here in
 	// order to apply back pressure on the client which generated them. The
@@ -192,7 +199,11 @@ func (r *Replica) executeReadOnlyBatch(
 		// prohibits any concurrent requests for the same range. See #17760.
 		allowSyncProcessing := ba.ReadConsistency == roachpb.CONSISTENT &&
 			ba.WaitPolicy != lock.WaitPolicy_SkipLocked
-		if err := r.store.intentResolver.CleanupIntentsAsync(ctx, intents, allowSyncProcessing); err != nil {
+		if err := r.store.intentResolver.CleanupIntentsAsync(
+			ctx,
+			intents,
+			allowSyncProcessing,
+		); err != nil {
 			log.Warningf(ctx, "%v", err)
 		}
 	}
@@ -206,6 +217,109 @@ func (r *Replica) executeReadOnlyBatch(
 		log.Event(ctx, "read completed")
 	}
 	return br, nil, nil, pErr
+}
+
+// updateTimestampCacheAndDropLatches updates the timestamp cache and releases
+// the concurrency guard.
+// Note:
+// - If `br` is nil, then this method assumes that latches are being released
+// before evaluation of the request, and the timestamp cache is updated based
+// only on the spans declared in the request.
+// - The update to the timestamp cache is not gated on pErr == nil, since
+// certain semantic errors (e.g. ConditionFailedError on CPut) require updating
+// the timestamp cache (see updatesTSCacheOnErr).
+// - For optimistic evaluation, used for limited scans, the update to the
+// timestamp cache limits itself to the spans that were read, by using the
+// ResumeSpans.
+func (r *Replica) updateTimestampCacheAndDropLatches(
+	ctx context.Context,
+	g *concurrency.Guard,
+	ba *roachpb.BatchRequest,
+	br *roachpb.BatchResponse,
+	pErr *roachpb.Error,
+	st kvserverpb.LeaseStatus,
+) {
+	ec := endCmds{repl: r, g: g, st: st}
+	ec.done(ctx, ba, br, pErr)
+}
+
+var allowDroppingLatchesBeforeEval = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.transaction.dropping_latches_before_eval.enabled",
+	"if enabled, allows certain read-only KV requests to drop latches before they evaluate",
+	true,
+)
+
+// canDropLatchesBeforeEval determines whether a given batch request can proceed
+// with evaluation without continuing to hold onto its latches[1] and if so,
+// whether the evaluation of the requests in the batch needs an intent
+// interleaving iterator[2].
+//
+// [1] whether the request can safely release latches at this point in the
+// execution.
+// For certain qualifying types of requests (certain types of read-only
+// requests: see `canReadOnlyRequestDropLatchesBeforeEval`), this method
+// performs a scan of the lock table keyspace corresponding to the latch spans
+// declared by the BatchRequest.
+// If no conflicting intents are found, then it is deemed safe for this request
+// to release its latches at this point. This is because read-only requests
+// evaluate over a stable pebble snapshot (see the call to
+// `PinEngineStateForIterators` in `executeReadOnlyBatch`), so if there are no
+// lock conflicts, the rest of the execution is guaranteed to be isolated from
+// the effects of other requests.
+// If any conflicting intents are found, then it returns a WriteIntentError
+// which needs to be handled by the caller before proceeding.
+//
+// [2] if the request can drop its latches early, whether it needs an intent
+// interleaving iterator to perform its evaluation.
+// If the aforementioned lock table scan determines that any of the requests in
+// the batch may need access to the intent history of a key, then an intent
+// interleaving iterator is needed to perform the evaluation.
+func (r *Replica) canDropLatchesBeforeEval(
+	ctx context.Context,
+	rw storage.ReadWriter,
+	ba *roachpb.BatchRequest,
+	g *concurrency.Guard,
+	st kvserverpb.LeaseStatus,
+) (ok, stillNeedsIntentInterleaving bool, pErr *roachpb.Error) {
+	if !allowDroppingLatchesBeforeEval.Get(&r.store.cfg.Settings.SV) ||
+		!canReadOnlyRequestDropLatchesBeforeEval(ba, g) {
+		// If the request does not qualify, we neither drop latches nor use a
+		// non-interleaving iterator.
+		return false /* ok */, true /* stillNeedsIntentInterleaving */, nil
+	}
+
+	log.VEventf(
+		ctx, 3, "can drop latches early for batch (%v); scanning lock table first to detect conflicts", ba,
+	)
+
+	maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&r.store.cfg.Settings.SV)
+	var intents []roachpb.Intent
+	// Check if any of the requests within the batch need to resolve any intents
+	// or if any of them need to use an intent interleaving iterator.
+	for _, req := range ba.Requests {
+		start, end := req.GetInner().Header().Key, req.GetInner().Header().EndKey
+		needsIntentInterleavingForThisRequest, err := storage.ScanConflictingIntents(
+			ctx, rw, ba.Txn, ba.Header.Timestamp, start, end, &intents, maxIntents,
+		)
+		if err != nil {
+			return false /* ok */, true /* stillNeedsIntentInterleaving */, roachpb.NewError(
+				errors.Wrap(err, "scanning intents"),
+			)
+		}
+		stillNeedsIntentInterleaving = stillNeedsIntentInterleaving || needsIntentInterleavingForThisRequest
+		if maxIntents != 0 && int64(len(intents)) >= maxIntents {
+			break
+		}
+	}
+	if len(intents) > 0 {
+		return false /* ok */, false /* stillNeedsIntentInterleaving */, maybeAttachLease(
+			roachpb.NewError(&roachpb.WriteIntentError{Intents: intents}), &st.Lease,
+		)
+	}
+	// If there were no conflicts, then the request can drop its latches and
+	// proceed with evaluation.
+	return true /* ok */, stillNeedsIntentInterleaving, nil
 }
 
 // evalContextWithAccount wraps an EvalContext to provide a non-nil
@@ -256,6 +370,19 @@ func (e evalContextWithAccount) GetResponseMemoryAccount() *mon.BoundAccount {
 	return e.memAccount
 }
 
+// batchEvalPath enumerates the different evaluation paths that can be taken by
+// a batch.
+type batchEvalPath int
+
+const (
+	// readOnlyDefault is the default evaluation path taken by read only requests.
+	readOnlyDefault batchEvalPath = iota
+	// readOnlyWithoutInterleavedIntents indicates that the request does not need
+	// an intent interleaving iterator during its evaluation.
+	readOnlyWithoutInterleavedIntents
+	readWrite
+)
+
 // executeReadOnlyBatchWithServersideRefreshes invokes evaluateBatch and retries
 // at a higher timestamp in the event of some retriable errors if allowed by the
 // batch/txn.
@@ -267,6 +394,7 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 	g *concurrency.Guard,
 	st *kvserverpb.LeaseStatus,
 	ui uncertainty.Interval,
+	evalPath batchEvalPath,
 ) (br *roachpb.BatchResponse, res result.Result, pErr *roachpb.Error) {
 	log.Event(ctx, "executing read-only batch")
 
@@ -317,14 +445,25 @@ func (r *Replica) executeReadOnlyBatchWithServersideRefreshes(
 			log.VEventf(ctx, 2, "server-side retry of batch")
 		}
 		now := timeutil.Now()
-		br, res, pErr = evaluateBatch(ctx, kvserverbase.CmdIDKey(""), rw, rec, nil, ba, g, st, ui, true /* readOnly */)
+		br, res, pErr = evaluateBatch(
+			ctx, kvserverbase.CmdIDKey(""), rw, rec, nil /* ms */, ba, g, st, ui, evalPath,
+		)
 		r.store.metrics.ReplicaReadBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 		// Allow only one retry.
 		if pErr == nil || retries > 0 {
 			break
 		}
 		// If we can retry, set a higher batch timestamp and continue.
-		if !canDoServersideRetry(ctx, pErr, ba, br, g, hlc.Timestamp{} /* deadline */) {
+		//
+		// Note that if the batch request has already released its latches (as
+		// indicated by the latch guard being nil) before this point, then it cannot
+		// retry at a higher timestamp because it is not isolated at higher
+		// timestamps.
+		latchesHeld := g != nil
+		if !latchesHeld || !canDoServersideRetry(ctx, pErr, ba, br, g, hlc.Timestamp{}) {
+			// TODO(aayush,arul): These metrics are incorrect at the moment since
+			// hitting this branch does not mean that we won't serverside retry, it
+			// just means that we will have to reacquire latches.
 			r.store.Metrics().ReadEvaluationServerSideRetryFailure.Inc(1)
 			break
 		} else {

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -109,7 +109,9 @@ func (r *Replica) executeReadOnlyBatch(
 		// the request is not being optimistically evaluated (optimistic evaluation
 		// does not wait for latches or check locks).
 		log.VEventf(ctx, 3, "lock table scan complete without conflicts; dropping latches early")
+		r.store.metrics.ReplicaReadBatchDroppedLatchesBeforeEval.Inc(1)
 		if !stillNeedsInterleavedIntents {
+			r.store.metrics.ReplicaReadBatchWithoutInterleavingIter.Inc(1)
 			evalPath = readOnlyWithoutInterleavedIntents
 		}
 		r.updateTimestampCacheAndDropLatches(ctx, g, ba, nil /* br */, nil /* pErr */, st)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2133,8 +2133,8 @@ func TestReplicaLatching(t *testing.T) {
 	}{
 		// Read/read doesn't wait.
 		{true, true, false, false},
-		// A write doesn't wait for an earlier read (except for local keys).
-		{true, false, false, true},
+		// A write doesn't wait for an earlier read.
+		{true, false, false, false},
 		// A read must wait for an earlier write.
 		{false, true, true, true},
 		// Writes always wait for other writes.
@@ -2458,7 +2458,7 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 	blockReader.Store(false)
 	blockWriter.Store(false)
 	blockCh := make(chan struct{}, 1)
-	blockedCh := make(chan struct{}, 1)
+	waitForRequestBlocked := make(chan struct{}, 1)
 
 	tc := testContext{}
 	tsc := TestStoreConfig(nil)
@@ -2469,10 +2469,10 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 				return nil
 			}
 			if filterArgs.Req.Method() == roachpb.Get && blockReader.Load().(bool) {
-				blockedCh <- struct{}{}
+				waitForRequestBlocked <- struct{}{}
 				<-blockCh
 			} else if filterArgs.Req.Method() == roachpb.Put && blockWriter.Load().(bool) {
-				blockedCh <- struct{}{}
+				waitForRequestBlocked <- struct{}{}
 				<-blockCh
 			}
 			return nil
@@ -2490,17 +2490,79 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 		interferes  bool
 	}{
 		// Reader & writer have same timestamps.
-		{makeTS(1, 0), makeTS(1, 0), roachpb.Key("a"), true, true},
-		{makeTS(1, 0), makeTS(1, 0), roachpb.Key("b"), false, true},
-		// Reader has earlier timestamp.
-		{makeTS(1, 0), makeTS(1, 1), roachpb.Key("c"), true, false},
-		{makeTS(1, 0), makeTS(1, 1), roachpb.Key("d"), false, false},
-		// Writer has earlier timestamp.
-		{makeTS(1, 1), makeTS(1, 0), roachpb.Key("e"), true, true},
-		{makeTS(1, 1), makeTS(1, 0), roachpb.Key("f"), false, true},
-		// Local keys always interfere.
-		{makeTS(1, 0), makeTS(1, 1), keys.RangeDescriptorKey(roachpb.RKey("a")), true, true},
-		{makeTS(1, 0), makeTS(1, 1), keys.RangeDescriptorKey(roachpb.RKey("b")), false, true},
+		//
+		// Reader goes first, but the reader does not need to hold latches during
+		// evaluation, so we expect no interference.
+		{
+			readerTS:    makeTS(1, 0),
+			writerTS:    makeTS(1, 0),
+			key:         roachpb.Key("a"),
+			readerFirst: true,
+			interferes:  false,
+		},
+		// Writer goes first, but the writer does need to hold latches during
+		// evaluation, so it should block the reader.
+		{
+			readerTS:    makeTS(1, 0),
+			writerTS:    makeTS(1, 0),
+			key:         roachpb.Key("b"),
+			readerFirst: false,
+			interferes:  true,
+		},
+		// Reader has earlier timestamp, so it doesn't interfere with the write
+		// that's in its future.
+		{
+			readerTS:    makeTS(1, 0),
+			writerTS:    makeTS(1, 1),
+			key:         roachpb.Key("c"),
+			readerFirst: true,
+			interferes:  false,
+		},
+		{
+			readerTS:    makeTS(1, 0),
+			writerTS:    makeTS(1, 1),
+			key:         roachpb.Key("d"),
+			readerFirst: false,
+			interferes:  false,
+		},
+		// Writer has an earlier timestamp. We expect no interference for the writer
+		// as the reader will be evaluating over a pebble snapshot. We'd expect the
+		// writer to be able to continue without interference but to get bumped by
+		// the timestamp cache.
+		{
+			readerTS:    makeTS(1, 1),
+			writerTS:    makeTS(1, 0),
+			key:         roachpb.Key("e"),
+			readerFirst: true,
+			interferes:  false,
+		},
+		// We expect the reader to block for the writer that's writing in the
+		// reader's past.
+		{
+			readerTS:    makeTS(1, 1),
+			writerTS:    makeTS(1, 0),
+			key:         roachpb.Key("f"),
+			readerFirst: false,
+			interferes:  true,
+		},
+		// Even though local key accesses are NonMVCC, the reader should not block
+		// the writer because it should not need to hold its latches during
+		// evaluation.
+		{
+			readerTS:    makeTS(1, 0),
+			writerTS:    makeTS(1, 1),
+			key:         keys.RangeDescriptorKey(roachpb.RKey("a")),
+			readerFirst: true,
+			interferes:  false,
+		},
+		// The writer will block the reader since it holds NonMVCC latches during
+		// evaluation.
+		{
+			readerTS:   makeTS(1, 0),
+			writerTS:   makeTS(1, 1),
+			key:        keys.RangeDescriptorKey(roachpb.RKey("b")),
+			interferes: true,
+		},
 	}
 	for _, test := range testCases {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
@@ -2524,7 +2586,8 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 					_, pErr := tc.Sender().Send(context.Background(), baR)
 					errCh <- pErr
 				}()
-				<-blockedCh
+				// Wait for the above read to get blocked on blockCh.
+				<-waitForRequestBlocked
 				go func() {
 					_, pErr := tc.Sender().Send(context.Background(), baW)
 					errCh <- pErr
@@ -2535,7 +2598,9 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 					_, pErr := tc.Sender().Send(context.Background(), baW)
 					errCh <- pErr
 				}()
-				<-blockedCh
+				// Wait for the above write to get blocked on blockCh while it's holding
+				// latches.
+				<-waitForRequestBlocked
 				go func() {
 					_, pErr := tc.Sender().Send(context.Background(), baR)
 					errCh <- pErr

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -677,7 +677,7 @@ func (r *Replica) evaluateWriteBatchWrapper(
 ) (storage.Batch, *roachpb.BatchResponse, result.Result, *roachpb.Error) {
 	batch, opLogger := r.newBatchedEngine(ba, g)
 	now := timeutil.Now()
-	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, false /* readOnly */)
+	br, res, pErr := evaluateBatch(ctx, idKey, batch, rec, ms, ba, g, st, ui, readWrite)
 	r.store.metrics.ReplicaWriteBatchEvaluationLatency.RecordValue(timeutil.Since(now).Nanoseconds())
 	if pErr == nil {
 		if opLogger != nil {

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -337,11 +337,12 @@ func TestExplainMVCCSteps(t *testing.T) {
 	srv, godb, _ := serverutils.StartServer(t, base.TestServerArgs{Insecure: true})
 	defer srv.Stopper().Stop(ctx)
 	r := sqlutils.MakeSQLRunner(godb)
+
 	r.Exec(t, "CREATE TABLE ab (a PRIMARY KEY, b) AS SELECT g, g FROM generate_series(1,1000) g(g)")
 	r.Exec(t, "CREATE TABLE bc (b PRIMARY KEY, c) AS SELECT g, g FROM generate_series(1,1000) g(g)")
 
 	scanQuery := "SELECT count(*) FROM ab"
-	expectedSteps, expectedSeeks := 1000, 2
+	expectedSteps, expectedSeeks := 1000, 1
 	foundSteps, foundSeeks := getMVCCStats(t, r, scanQuery)
 
 	assert.Equal(t, expectedSteps, foundSteps)
@@ -352,7 +353,7 @@ func TestExplainMVCCSteps(t *testing.T) {
 	// Update all rows.
 	r.Exec(t, "UPDATE ab SET b=b+1 WHERE true")
 
-	expectedSteps, expectedSeeks = 2000, 2
+	expectedSteps, expectedSeeks = 2000, 1
 	foundSteps, foundSeeks = getMVCCStats(t, r, scanQuery)
 
 	assert.Equal(t, expectedSteps, foundSteps)

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -3750,4 +3750,16 @@ var charts = []sectionDescription{
 			},
 		},
 	},
+	{
+		Organization: [][]string{{ReplicationLayer, "Batches"}},
+		Charts: []chartDescription{
+			{
+				Title: "Total number of attempts to evaluate read-only batches",
+				Metrics: []string{
+					"kv.replica_read_batch_evaluate.dropped_latches_before_eval",
+					"kv.replica_read_batch_evaluate.without_interleaving_iter",
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
This commit introduces a change to the way certain types of read-only requests
are evaluated. Traditionally, read-only requests have held their latches
throughout their execution. This commit allows certain qualifying reads to be
able to release their latches earlier.

At a high level, reads may attempt to resolve all conflicts upfront by
performing a sort of "validation" phase before they perform their MVCC scan.
This validation phase performs a scan of the lock table keyspace in order to
find any conflicting intents that may need to be resolved before the actual
evaluation of the request over the MVCC keyspace. If no conflicting intents are
found, then (since https://github.com/cockroachdb/cockroach/pull/76312), the
request is guaranteed to be fully isolated against all other concurrent
requests and can be allowed to release its latches at this point. This allows
the actual evaluation of the read (over the MVCC part of the keyspace) to
proceed without latches being held, which is the main motivation of this work.
This validation phase could be thought of as an extension to the validation
that the concurrency manager already performs when requests are sequenced
through it, by trying to detect any conflicting intents that have already been
pulled into the in-memory lock table.

Additionally, for certain types of requests that can drop their latches early,
and do not need to access the `IntentHistory` for any of their parent txn's
intents, this commit attempts to make their MVCC scan cheaper by eliminating
the need for an `intentInterleavingIterator`. This is enabled by the
observation that once the validation phase is complete, the only remaining
intents in the read's declared span must be intents belonging to the reader's
transaction. So if the reader doesn't need to read an intent that isn't the
latest intent on a key, then it doesn't need access to the key's
`IntentHistory` (which lives in the lock-table keyspace), and doesn't need to
use an `intentInterleavingIterator`.

Release note (performance improvement): certain types of reads will now have a
far smaller contention footprint with conflicting concurrent writers

Resolves https://github.com/cockroachdb/cockroach/issues/66485

Release justification: high benefit change to existing functionality, part of
22.2 roadmap
