### PR TITLE
insights: remove the ingester for now

### DIFF
--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -140,5 +140,5 @@ type Registry interface {
 
 // New builds a new Registry.
 func New(st *cluster.Settings, metrics Metrics) Registry {
-	return newConcurrentBufferIngester(newRegistry(st, metrics))
+	return newRegistry(st, metrics)
 }


### PR DESCRIPTION
In #85350 we introduced a data race that's affecting many branches in
CI. Until we can get to the bottom of it, probably in #83080, let's just
remove the offending codepath.

Release note: None