### PR TITLE
sql: don't panic on auth check with unopen txn

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -127,7 +127,7 @@ func (p *planner) CheckPrivilegeForUser(
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.
-	if p.txn == nil || !p.txn.IsOpen() {
+	if p.txn == nil {
 		return errors.AssertionFailedf("cannot use CheckPrivilege without a txn")
 	}
 
@@ -326,7 +326,7 @@ func (p *planner) CheckAnyPrivilege(
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.
-	if p.txn == nil || !p.txn.IsOpen() {
+	if p.txn == nil {
 		return errors.AssertionFailedf("cannot use CheckAnyPrivilege without a txn")
 	}
 
@@ -377,7 +377,7 @@ func (p *planner) UserHasAdminRole(ctx context.Context, user username.SQLUsernam
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.
-	if p.txn == nil || !p.txn.IsOpen() {
+	if p.txn == nil {
 		return false, errors.AssertionFailedf("cannot use HasAdminRole without a txn")
 	}
 
@@ -654,7 +654,7 @@ func (p *planner) HasRoleOption(ctx context.Context, roleOption roleoption.Optio
 	// Verify that the txn is valid in any case, so that
 	// we don't get the risk to say "OK" to root requests
 	// with an invalid API usage.
-	if p.txn == nil || !p.txn.IsOpen() {
+	if p.txn == nil {
 		return false, errors.AssertionFailedf("cannot use HasRoleOption without a txn")
 	}
 


### PR DESCRIPTION
Relates to https://github.com/cockroachdb/cockroach/issues/80764 and https://github.com/cockroachdb/cockroach/issues/82034

Ever since c00ea8479d5ac1683aedcab3ff3fed0612464b72 was merged, the KV
layer has disallowed use of an aborted txn. Therefore, the checks here
are no longer necessary.

This should actually help with debugging, since now if the aborted txn
is used, we should get back an error that has the reason for the abort
(or restart), instead of a panic that does not have that info.

Release note: None