### PR TITLE
sql/schemachanger: address found in backup/restore tests

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -137,6 +137,12 @@ func (desc *immutable) ByteSize() int64 {
 	return int64(desc.Size())
 }
 
+// GetDeclarativeSchemaChangerState is part of the catalog.MutableDescriptor
+// interface.
+func (desc *immutable) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
+	return desc.DeclarativeSchemaChangerState.Clone()
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *Mutable) NewBuilder() catalog.DescriptorBuilder {
 	return newBuilder(&desc.FunctionDescriptor, desc.IsUncommittedVersion(), desc.changes)

--- a/pkg/sql/catalog/rewrite/rewrite.go
+++ b/pkg/sql/catalog/rewrite/rewrite.go
@@ -556,6 +556,7 @@ func rewriteSchemaChangerState(
 		// TODO(ajwerner): Remember to rewrite views when the time comes. Currently
 		// views are not handled by the declarative schema changer.
 	}
+	d.SetDeclarativeSchemaChangerState(state)
 	return nil
 }
 

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -158,6 +158,12 @@ func (desc *immutable) ByteSize() int64 {
 	return int64(desc.Size())
 }
 
+// GetDeclarativeSchemaChangerState is part of the catalog.MutableDescriptor
+// interface.
+func (desc *immutable) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
+	return desc.DeclarativeSchemaChangerState.Clone()
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 //
 // It overrides the wrapper's implementation to deal with the fact that

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -116,6 +116,12 @@ func (desc *wrapper) DescriptorProto() *descpb.Descriptor {
 	}
 }
 
+// GetDeclarativeSchemaChangerState is part of the catalog.MutableDescriptor
+// interface.
+func (desc *immutable) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
+	return desc.DeclarativeSchemaChangerState.Clone()
+}
+
 // ByteSize implements the Descriptor interface.
 func (desc *wrapper) ByteSize() int64 {
 	return int64(desc.Size())

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -177,6 +177,12 @@ func (desc *immutable) ByteSize() int64 {
 	return int64(desc.Size())
 }
 
+// GetDeclarativeSchemaChangerState is part of the catalog.MutableDescriptor
+// interface.
+func (desc *immutable) GetDeclarativeSchemaChangerState() *scpb.DescriptorState {
+	return desc.DeclarativeSchemaChangerState.Clone()
+}
+
 // NewBuilder implements the catalog.Descriptor interface.
 //
 // It overrides the wrapper's implementation to deal with the fact that

--- a/pkg/sql/schemachanger/scbackup/job.go
+++ b/pkg/sql/schemachanger/scbackup/job.go
@@ -52,6 +52,7 @@ func CreateDeclarativeSchemaChangeJobs(
 		for _, d := range descs {
 			ds := d.GetDeclarativeSchemaChangerState()
 			ds.JobID = newID
+			d.SetDeclarativeSchemaChangerState(ds)
 			descriptorStates = append(descriptorStates, ds)
 		}
 		currentState, err := scpb.MakeCurrentStateFromDescriptors(


### PR DESCRIPTION
A number of issues were uncovered while investigating a backup and restore issue:

1. The backup and restore tests were not generating backups at every stage of a given plan. Additionally, only the first non-revertible stage had a backup image generated.
2. The declarative schema changer restore code was unable to update the declarative state since the interfaces for getting the declarative schema changer state was inconsistent.  For database descriptors, a clone copy of the state was returned, whereas for other descriptors a mutable pointer was returned. As a result, if a restore needed to fix a job ID inside database descriptor failures could be observed.