### PR TITLE
sql: allow anonymous args and numeric arg references in UDFs

### DIFF
--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -212,13 +212,15 @@ func (n *createFunctionNode) getMutableFuncDesc(
 	pbArgs := make([]descpb.FunctionDescriptor_Argument, len(n.cf.Args))
 	argNameSeen := make(map[tree.Name]struct{})
 	for i, arg := range n.cf.Args {
-		if _, ok := argNameSeen[arg.Name]; ok {
-			// Argument names cannot be used more than once.
-			return nil, false, pgerror.Newf(
-				pgcode.InvalidFunctionDefinition, "parameter name %q used more than once", arg.Name,
-			)
+		if arg.Name != "" {
+			if _, ok := argNameSeen[arg.Name]; ok {
+				// Argument names cannot be used more than once.
+				return nil, false, pgerror.Newf(
+					pgcode.InvalidFunctionDefinition, "parameter name %q used more than once", arg.Name,
+				)
+			}
+			argNameSeen[arg.Name] = struct{}{}
 		}
-		argNameSeen[arg.Name] = struct{}{}
 		pbArg, err := makeFunctionArg(params.ctx, arg, params.p)
 		if err != nil {
 			return nil, false, err

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1419,6 +1419,129 @@ SELECT fetch_b(99999999)
 ----
 NULL
 
+
+subtest args
+
+# TODO(mgartner): Technically $3 is a parameter, and the error message should be
+# more similar to Postgres's "there is no parameter $3".
+statement error no value provided for placeholder: \$3
+CREATE FUNCTION err(x INT, y INT) RETURNS INT LANGUAGE SQL AS 'SELECT x + y + $1 + $2 + $3'
+
+statement error no value provided for placeholder: \$3
+CREATE FUNCTION err(INT, INT) RETURNS INT LANGUAGE SQL AS 'SELECT $1 + $2 + $3'
+
+statement error placeholder index must be between 1 and 65536
+CREATE FUNCTION err(INT) RETURNS INT LANGUAGE SQL AS 'SELECT 1 + $0'
+
+statement ok
+CREATE FUNCTION add(x INT, y INT, z INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT (x - $1 + x) + ($2 - y + $2) + (z - $3 + z);
+$$
+
+statement ok
+CREATE FUNCTION mult(x INT, y INT, z INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT $1 * y * (z - $3 + z);
+$$
+
+query II rowsort
+SELECT a + b + a, add(a, b, a) FROM ab
+----
+3   3
+6   6
+9   9
+9   9
+11  11
+
+query I
+SELECT a FROM ab WHERE (a + b + b) != add(a, b, b)
+----
+
+query II rowsort
+SELECT
+  (a + b + a) * (a + 3 + 7) * (b + 11 + 17),
+  mult(add(a, b, a), add(a, 3, 7), add(b, 11, 17))
+FROM ab
+----
+957   957
+2160  2160
+3627  3627
+3654  3654
+4785  4785
+
+statement ok
+PREPARE do_math(INT, INT, INT, INT) AS
+SELECT
+  (a + b + a) * (a + $1 + $2) * (b + $3 + $4),
+  mult(add(a, b, a), add(a, $1, $2), add(b, $3, $4))
+FROM ab
+
+query II rowsort
+EXECUTE do_math(3, 7, 11, 17)
+----
+957   957
+2160  2160
+3627  3627
+3654  3654
+4785  4785
+
+statement error pgcode 54023 functions cannot have more than 100 arguments
+CREATE FUNCTION err(
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT
+) RETURNS INT LANGUAGE SQL AS 'SELECT $1';
+
+# Up to 100 arguments are allowed.
+statement ok
+CREATE FUNCTION add(
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT,
+  INT, INT, INT, INT, INT, INT, INT, INT, INT, INT
+) RETURNS INT LANGUAGE SQL AS $$
+  SELECT $1 + $2 + $3 + $4 + $5 + $6 + $7 + $8 + $9 + $10 +
+    $11 + $12 + $13 + $14 + $15 + $16 + $17 + $18 + $19 + $20 +
+    $21 + $22 + $23 + $24 + $25 + $26 + $27 + $28 + $29 + $30 +
+    $31 + $32 + $33 + $34 + $35 + $36 + $37 + $38 + $39 + $40 +
+    $41 + $42 + $43 + $44 + $45 + $46 + $47 + $48 + $49 + $50 +
+    $51 + $52 + $53 + $54 + $55 + $56 + $57 + $58 + $59 + $60 +
+    $61 + $62 + $63 + $64 + $65 + $66 + $67 + $68 + $69 + $70 +
+    $71 + $72 + $73 + $74 + $75 + $76 + $77 + $78 + $79 + $80 +
+    $81 + $82 + $83 + $84 + $85 + $86 + $87 + $88 + $89 + $90 +
+    $91 + $92 + $93 + $94 + $95 + $96 + $97 + $98 + $99 + $100;
+$$;
+
+query TI
+SELECT sum(i),
+  add(1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+  11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+  21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+  31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+  41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+  51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+  61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+  71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+  81, 82, 83, 84, 85, 86, 87, 88, 89, 90,
+  91, 92, 93, 94, 95, 96, 97, 98, 99, 100)
+FROM generate_series(1, 100) AS g(i)
+----
+5050  5050
+
+
 subtest volatility
 
 statement ok

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -95,8 +95,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 	// bodyScope is the base scope for each statement in the body. We add the
 	// named arguments to the scope so that references to them in the body can
 	// be resolved.
-	// TODO(mgartner): Support numeric argument references, like $1. We should
-	// error if there is a reference $n and less than n arguments.
 	bodyScope := b.allocScope()
 	for i := range cf.Args {
 		arg := &cf.Args[i]
@@ -106,12 +104,9 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 		}
 
 		// Add the argument to the base scope of the body.
-		id := b.factory.Metadata().AddColumn(string(arg.Name), typ)
-		bodyScope.appendColumn(&scopeColumn{
-			name: scopeColName(arg.Name),
-			typ:  typ,
-			id:   id,
-		})
+		argColName := funcArgColName(arg.Name, i)
+		col := b.synthesizeColumn(bodyScope, argColName, typ, nil /* expr */, nil /* scalar */)
+		col.setArgOrd(i)
 
 		// Collect the user defined type dependencies.
 		typeIDs, err := typedesc.GetTypeDescriptorClosure(typ)

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -420,3 +420,301 @@ project
                                └── eq
                                     ├── variable: b:3
                                     └── variable: abc.a:2
+
+exec-ddl
+CREATE FUNCTION add_num_args(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT $1+$2;
+$$;
+----
+
+build format=show-scalars
+SELECT add_num_args(1, 2)
+----
+project
+ ├── columns: add_num_args:4
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add_num_args [as=add_num_args:4]
+           ├── args: x:1 y:2
+           ├── input
+           │    ├── const: 1
+           │    └── const: 2
+           └── body
+                └── project
+                     ├── columns: "?column?":3
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":3]
+                               ├── variable: x:1
+                               └── variable: y:2
+
+build format=show-scalars
+SELECT add_num_args(add_num_args(1, 2), 3)
+----
+project
+ ├── columns: add_num_args:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add_num_args [as=add_num_args:7]
+           ├── args: x:4 y:5
+           ├── input
+           │    ├── udf: add_num_args
+           │    │    ├── args: x:1 y:2
+           │    │    ├── input
+           │    │    │    ├── const: 1
+           │    │    │    └── const: 2
+           │    │    └── body
+           │    │         └── project
+           │    │              ├── columns: "?column?":3
+           │    │              ├── values
+           │    │              │    └── tuple
+           │    │              └── projections
+           │    │                   └── plus [as="?column?":3]
+           │    │                        ├── variable: x:1
+           │    │                        └── variable: y:2
+           │    └── const: 3
+           └── body
+                └── project
+                     ├── columns: "?column?":6
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":6]
+                               ├── variable: x:4
+                               └── variable: y:5
+
+build format=show-scalars
+SELECT * FROM abc WHERE a = add_num_args(add_num_args(b, c), 3)
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── variable: a:1
+                └── udf: add_num_args
+                     ├── args: x:9 y:10
+                     ├── input
+                     │    ├── udf: add_num_args
+                     │    │    ├── args: x:6 y:7
+                     │    │    ├── input
+                     │    │    │    ├── variable: b:2
+                     │    │    │    └── variable: c:3
+                     │    │    └── body
+                     │    │         └── project
+                     │    │              ├── columns: "?column?":8
+                     │    │              ├── values
+                     │    │              │    └── tuple
+                     │    │              └── projections
+                     │    │                   └── plus [as="?column?":8]
+                     │    │                        ├── variable: x:6
+                     │    │                        └── variable: y:7
+                     │    └── const: 3
+                     └── body
+                          └── project
+                               ├── columns: "?column?":11
+                               ├── values
+                               │    └── tuple
+                               └── projections
+                                    └── plus [as="?column?":11]
+                                         ├── variable: x:9
+                                         └── variable: y:10
+
+assign-placeholders-build query-args=(33) format=show-scalars
+SELECT add_num_args(1, $1) FROM abc WHERE a = add_num_args($1, 2)
+----
+project
+ ├── columns: add_num_args:12
+ ├── select
+ │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── scan abc
+ │    │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    └── filters
+ │         └── eq
+ │              ├── variable: a:1
+ │              └── udf: add_num_args
+ │                   ├── args: x:6 y:7
+ │                   ├── input
+ │                   │    ├── const: 33
+ │                   │    └── const: 2
+ │                   └── body
+ │                        └── project
+ │                             ├── columns: "?column?":8
+ │                             ├── values
+ │                             │    └── tuple
+ │                             └── projections
+ │                                  └── plus [as="?column?":8]
+ │                                       ├── variable: x:6
+ │                                       └── variable: y:7
+ └── projections
+      └── udf: add_num_args [as=add_num_args:12]
+           ├── args: x:9 y:10
+           ├── input
+           │    ├── const: 1
+           │    └── const: 33
+           └── body
+                └── project
+                     ├── columns: "?column?":11
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":11]
+                               ├── variable: x:9
+                               └── variable: y:10
+
+# --------------------------------------------------
+# UDFs with anonymous arguments.
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION add_anon(INT, INT) RETURNS INT LANGUAGE SQL AS $$
+  SELECT $1+$2;
+$$;
+----
+
+build format=show-scalars
+SELECT add_anon(1, 2)
+----
+project
+ ├── columns: add_anon:4
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add_anon [as=add_anon:4]
+           ├── args: arg1:1 arg2:2
+           ├── input
+           │    ├── const: 1
+           │    └── const: 2
+           └── body
+                └── project
+                     ├── columns: "?column?":3
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":3]
+                               ├── variable: arg1:1
+                               └── variable: arg2:2
+
+build format=show-scalars
+SELECT add_anon(add_anon(1, 2), 3)
+----
+project
+ ├── columns: add_anon:7
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: add_anon [as=add_anon:7]
+           ├── args: arg1:4 arg2:5
+           ├── input
+           │    ├── udf: add_anon
+           │    │    ├── args: arg1:1 arg2:2
+           │    │    ├── input
+           │    │    │    ├── const: 1
+           │    │    │    └── const: 2
+           │    │    └── body
+           │    │         └── project
+           │    │              ├── columns: "?column?":3
+           │    │              ├── values
+           │    │              │    └── tuple
+           │    │              └── projections
+           │    │                   └── plus [as="?column?":3]
+           │    │                        ├── variable: arg1:1
+           │    │                        └── variable: arg2:2
+           │    └── const: 3
+           └── body
+                └── project
+                     ├── columns: "?column?":6
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":6]
+                               ├── variable: arg1:4
+                               └── variable: arg2:5
+
+build format=show-scalars
+SELECT * FROM abc WHERE a = add_anon(add_anon(b, c), 3)
+----
+project
+ ├── columns: a:1!null b:2 c:3
+ └── select
+      ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── scan abc
+      │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── filters
+           └── eq
+                ├── variable: a:1
+                └── udf: add_anon
+                     ├── args: arg1:9 arg2:10
+                     ├── input
+                     │    ├── udf: add_anon
+                     │    │    ├── args: arg1:6 arg2:7
+                     │    │    ├── input
+                     │    │    │    ├── variable: b:2
+                     │    │    │    └── variable: c:3
+                     │    │    └── body
+                     │    │         └── project
+                     │    │              ├── columns: "?column?":8
+                     │    │              ├── values
+                     │    │              │    └── tuple
+                     │    │              └── projections
+                     │    │                   └── plus [as="?column?":8]
+                     │    │                        ├── variable: arg1:6
+                     │    │                        └── variable: arg2:7
+                     │    └── const: 3
+                     └── body
+                          └── project
+                               ├── columns: "?column?":11
+                               ├── values
+                               │    └── tuple
+                               └── projections
+                                    └── plus [as="?column?":11]
+                                         ├── variable: arg1:9
+                                         └── variable: arg2:10
+
+assign-placeholders-build query-args=(33) format=show-scalars
+SELECT add_anon(1, $1) FROM abc WHERE a = add_anon($1, 2)
+----
+project
+ ├── columns: add_anon:12
+ ├── select
+ │    ├── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── scan abc
+ │    │    └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    └── filters
+ │         └── eq
+ │              ├── variable: a:1
+ │              └── udf: add_anon
+ │                   ├── args: arg1:6 arg2:7
+ │                   ├── input
+ │                   │    ├── const: 33
+ │                   │    └── const: 2
+ │                   └── body
+ │                        └── project
+ │                             ├── columns: "?column?":8
+ │                             ├── values
+ │                             │    └── tuple
+ │                             └── projections
+ │                                  └── plus [as="?column?":8]
+ │                                       ├── variable: arg1:6
+ │                                       └── variable: arg2:7
+ └── projections
+      └── udf: add_anon [as=add_anon:12]
+           ├── args: arg1:9 arg2:10
+           ├── input
+           │    ├── const: 1
+           │    └── const: 33
+           └── body
+                └── project
+                     ├── columns: "?column?":11
+                     ├── values
+                     │    └── tuple
+                     └── projections
+                          └── plus [as="?column?":11]
+                               ├── variable: arg1:9
+                               └── variable: arg2:10

--- a/pkg/sql/opt/testutils/testcat/function.go
+++ b/pkg/sql/opt/testutils/testcat/function.go
@@ -76,7 +76,7 @@ func (tc *Catalog) CreateFunction(c *tree.CreateFunction) {
 		if err != nil {
 			panic(err)
 		}
-		argTypes.SetAt(i, arg.Name.String(), typ)
+		argTypes.SetAt(i, string(arg.Name), typ)
 	}
 
 	// Resolve the return type.


### PR DESCRIPTION
It is now possible to create UDFs with anonymous arguments that can be
referenced like a placeholder in a prepared statement. For example:

    CREATE FUNCTION add(INT, INT) RETURNS INT LANGUAGE SQL AS $$
      SELECT $1 + $2;
    $$

Named arguments can also be referenced by numeric placeholders. For
example:

    CREATE FUNCTION add(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$
      SELECT x + $2;
    $$

Release note: None

Release justification: Adds critical functionality to a new feature.
