### PR TITLE
externalconn: support userfile in External Connections

### DIFF
--- a/pkg/ccl/backupccl/backupdest/backup_destination.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination.go
@@ -41,9 +41,6 @@ import (
 )
 
 const (
-	// LocalityURLParam is the parameter name used when specifying a locality tag
-	// in a locality aware backup/restore.
-	LocalityURLParam = "COCKROACH_LOCALITY"
 	// DefaultLocalityValue is the default locality tag used in a locality aware
 	// backup/restore when an explicit COCKROACH_LOCALITY is not specified.
 	DefaultLocalityValue = "default"
@@ -411,9 +408,9 @@ func getLocalityAndBaseURI(uri, appendPath string) (string, string, error) {
 		return "", "", err
 	}
 	q := parsedURI.Query()
-	localityKV := q.Get(LocalityURLParam)
+	localityKV := q.Get(cloud.LocalityURLParam)
 	// Remove the backup locality parameter.
-	q.Del(LocalityURLParam)
+	q.Del(cloud.LocalityURLParam)
 	parsedURI.RawQuery = q.Encode()
 
 	parsedURI.Path = backuputils.JoinURLPath(parsedURI.Path, appendPath)
@@ -438,7 +435,7 @@ func GetURIsByLocalityKV(
 		}
 		if localityKV != "" && localityKV != DefaultLocalityValue {
 			return "", nil, errors.Errorf("%s %s is invalid for a single BACKUP location",
-				LocalityURLParam, localityKV)
+				cloud.LocalityURLParam, localityKV)
 		}
 		return baseURI, urisByLocalityKV, nil
 	}
@@ -451,7 +448,7 @@ func GetURIsByLocalityKV(
 		if localityKV == "" {
 			return "", nil, errors.Errorf(
 				"multiple URLs are provided for partitioned BACKUP, but %s is not specified",
-				LocalityURLParam,
+				cloud.LocalityURLParam,
 			)
 		}
 		if localityKV == DefaultLocalityValue {

--- a/pkg/ccl/backupccl/backupdest/backup_destination_test.go
+++ b/pkg/ccl/backupccl/backupdest/backup_destination_test.go
@@ -83,7 +83,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 				parsedURI.Path = backuputils.JoinURLPath(parsedURI.Path, locality)
 			}
 			q := parsedURI.Query()
-			q.Add(backupdest.LocalityURLParam, locality)
+			q.Add(cloud.LocalityURLParam, locality)
 			parsedURI.RawQuery = q.Encode()
 			localizedURIs[i] = parsedURI.String()
 		}

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-nodelocal
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-nodelocal
@@ -146,11 +146,6 @@ SELECT * FROM defaultdb.schema.foo
 5
 6
 
-exec-sql
-DROP DATABASE d CASCADE
-----
-pq: database "d" does not exist
-
 subtest end
 
 subtest incremental-location-backup-restore-nodelocal
@@ -213,80 +208,5 @@ public schema full
 public schema incremental
 schema schema full
 schema schema incremental
-
-subtest end
-
-subtest backup-restore-privileges
-
-exec-sql
-CREATE USER testuser;
-----
-
-exec-sql
-CREATE EXTERNAL CONNECTION root AS 'nodelocal://1/root'
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/noprivs'
-----
-pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
-
-exec-sql
-GRANT SYSTEM EXTERNALCONNECTION TO testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/privs'
-----
-
-exec-sql
-CREATE TABLE foo (id INT);
-----
-
-exec-sql
-GRANT SELECT ON TABLE foo TO testuser
-----
-
-exec-sql user=testuser
-BACKUP TABLE foo INTO 'external://fails'
-----
-pq: user testuser does not have USAGE privilege on external_connection fails
-
-exec-sql
-GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
-----
-
-exec-sql user=testuser
-BACKUP TABLE foo INTO 'external://fails'
-----
-
-# Sanity check that the user can't write to any other external connection.
-exec-sql user=testuser
-BACKUP TABLE foo INTO 'external://root'
-----
-pq: user testuser does not have USAGE privilege on external_connection root
-
-# Revoke the USAGE privilege to test that restore also requires it.
-exec-sql
-REVOKE USAGE ON EXTERNAL CONNECTION fails FROM testuser;
-----
-
-exec-sql user=testuser
-RESTORE TABLE foo FROM LATEST IN 'external://fails'
-----
-pq: user testuser does not have USAGE privilege on external_connection fails
-
-exec-sql
-GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
-----
-
-exec-sql
-CREATE DATABASE failsdb;
-GRANT CREATE ON DATABASE failsdb TO testuser;
-----
-
-exec-sql user=testuser
-RESTORE TABLE foo FROM LATEST IN 'external://fails' WITH into_db=failsdb;
-----
 
 subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
@@ -1,0 +1,77 @@
+new-server name=s1
+----
+
+subtest backup-restore-privileges
+
+exec-sql
+CREATE USER testuser;
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION root AS 'nodelocal://1/root'
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION fails AS 'userfile:///noprivs'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/privs'
+----
+
+exec-sql
+CREATE TABLE foo (id INT);
+----
+
+exec-sql
+GRANT SELECT ON TABLE foo TO testuser
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://fails'
+----
+pq: user testuser does not have USAGE privilege on external_connection fails
+
+exec-sql
+GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://fails'
+----
+
+# Sanity check that the user can't write to any other external connection.
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://root'
+----
+pq: user testuser does not have USAGE privilege on external_connection root
+
+# Revoke the USAGE privilege to test that restore also requires it.
+exec-sql
+REVOKE USAGE ON EXTERNAL CONNECTION fails FROM testuser;
+----
+
+exec-sql user=testuser
+RESTORE TABLE foo FROM LATEST IN 'external://fails'
+----
+pq: user testuser does not have USAGE privilege on external_connection fails
+
+exec-sql
+GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+----
+
+exec-sql
+CREATE DATABASE failsdb;
+GRANT CREATE ON DATABASE failsdb TO testuser;
+----
+
+exec-sql user=testuser
+RESTORE TABLE foo FROM LATEST IN 'external://fails' WITH into_db=failsdb;
+----
+
+subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-userfile
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-userfile
@@ -1,0 +1,191 @@
+new-server name=s1
+----
+
+subtest basic-backup-userfile
+
+exec-sql
+CREATE EXTERNAL CONNECTION 'conn-foo' AS 'userfile:///foo';
+----
+
+exec-sql
+CREATE DATABASE d;
+CREATE SCHEMA d.schema;
+CREATE TABLE d.schema.foo (id INT PRIMARY KEY);
+INSERT INTO d.schema.foo VALUES (1), (2), (3);
+----
+
+# Cluster backup.
+exec-sql
+BACKUP INTO 'external://conn-foo/cluster';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/cluster'] ORDER BY object_name;
+----
+bank table full
+comments table full
+d database full
+data database full
+database_role_settings table full
+defaultdb database full
+external_connections table full
+foo table full
+locations table full
+postgres database full
+public schema full
+public schema full
+public schema full
+public schema full
+role_id_seq table full
+role_members table full
+role_options table full
+scheduled_jobs table full
+schema schema full
+settings table full
+system database full
+tenant_settings table full
+ui table full
+userfiles_root_upload_files table full
+userfiles_root_upload_payload table full
+users table full
+zones table full
+
+# Database backup.
+exec-sql
+BACKUP DATABASE d INTO 'external://conn-foo/database';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/database'] ORDER BY object_name;
+----
+d database full
+foo table full
+public schema full
+schema schema full
+
+# Table backup.
+exec-sql
+BACKUP TABLE d.schema.foo INTO 'external://conn-foo/table';
+----
+
+exec-sql
+INSERT INTO d.schema.foo VALUES (4), (5), (6);
+----
+
+# Incremental table backup.
+exec-sql
+BACKUP TABLE d.schema.foo INTO LATEST IN 'external://conn-foo/table';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
+'external://conn-foo/table'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+schema schema full
+schema schema incremental
+
+subtest end
+
+subtest basic-restore-userfile
+
+# Database restore.
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'external://conn-foo/database' WITH new_db_name='d2'
+----
+
+query-sql
+SELECT * FROM d2.schema.foo
+----
+1
+2
+3
+
+exec-sql
+DROP DATABASE d2 CASCADE
+----
+
+# Table restore.
+exec-sql
+RESTORE TABLE d.schema.foo FROM LATEST IN 'external://conn-foo/table' WITH into_db = 'defaultdb'
+----
+
+query-sql
+SELECT * FROM defaultdb.schema.foo
+----
+1
+2
+3
+4
+5
+6
+
+subtest end
+
+subtest incremental-location-backup-restore-userfile
+
+switch-server name=s1
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION full AS 'userfile:///full'
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION inc AS 'userfile:///inc'
+----
+
+# Take a full backup.
+exec-sql
+BACKUP DATABASE d INTO 'external://full';
+----
+
+# Take an incremental with an explicit location.
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'external://full' WITH incremental_location = 'external://inc';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full' WITH
+incremental_location = 'external://inc'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+public schema full
+public schema incremental
+schema schema full
+schema schema incremental
+
+# Ensure you can also specify an incremental location as a path to the same
+# external connection URI.
+exec-sql
+BACKUP DATABASE d INTO 'external://full/nested';
+----
+
+# Take an incremental with an explicit location that is a subdir of the external
+# connection endpoint.
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'external://full/nested' WITH incremental_location = 'external://inc/nested';
+----
+
+query-sql
+SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN 'external://full/nested'
+WITH incremental_location = 'external://inc/nested'] ORDER BY (object_name, backup_type);
+----
+d database full
+d database incremental
+foo table full
+foo table incremental
+public schema full
+public schema incremental
+schema schema full
+schema schema incremental
+
+subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -233,4 +233,39 @@ inspect-system-table
 ----
 foo-kafka STORAGE {"provider": "kafka", "simpleUri": {"uri": "kafka://broker.address.com:9092?topic_prefix=bar_&tls_enabled=true&ca_cert=Zm9vCg==&sasl_enabled=true&sasl_user={sasl user}&sasl_password={url-encoded password}&sasl_mechanism=SCRAM-SHA-256"}}
 
+exec-sql
+DROP EXTERNAL CONNECTION "foo-kafka"
+----
+
+subtest end
+
+subtest basic-userfile
+
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-userfile" AS 'userfile:///foo/bar';
+----
+
+inspect-system-table
+----
+foo-userfile STORAGE {"provider": "userfile", "simpleUri": {"uri": "userfile:///foo/bar"}}
+
+# Reject invalid userfile URIs.
+exec-sql
+CREATE EXTERNAL CONNECTION "path-clean-userfile" AS 'userfile:///foo/..';
+----
+pq: failed to construct External Connection details: failed to create userfile external connection: path /foo/.. changes after normalization to /. userfile upload does not permit such path constructs
+
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-param-userfile" AS 'userfile:///foo?INVALIDPARAM=param';
+----
+pq: failed to construct External Connection details: failed to create userfile external connection: unknown userfile query parameters: INVALIDPARAM
+
+inspect-system-table
+----
+foo-userfile STORAGE {"provider": "userfile", "simpleUri": {"uri": "userfile:///foo/bar"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-userfile";
+----
+
 subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -216,4 +216,39 @@ inspect-system-table
 ----
 foo-kafka STORAGE {"provider": "kafka", "simpleUri": {"uri": "kafka://broker.address.com:9092?topic_prefix=bar_&tls_enabled=true&ca_cert=Zm9vCg==&sasl_enabled=true&sasl_user={sasl user}&sasl_password={url-encoded password}&sasl_mechanism=SCRAM-SHA-256"}}
 
+exec-sql
+DROP EXTERNAL CONNECTION "foo-kafka"
+----
+
+subtest end
+
+subtest basic-userfile
+
+exec-sql
+CREATE EXTERNAL CONNECTION "foo-userfile" AS 'userfile:///foo/bar';
+----
+
+inspect-system-table
+----
+foo-userfile STORAGE {"provider": "userfile", "simpleUri": {"uri": "userfile:///foo/bar"}}
+
+# Reject invalid userfile URIs.
+exec-sql
+CREATE EXTERNAL CONNECTION "path-clean-userfile" AS 'userfile:///foo/..';
+----
+pq: failed to construct External Connection details: failed to create userfile external connection: path /foo/.. changes after normalization to /. userfile upload does not permit such path constructs
+
+exec-sql
+CREATE EXTERNAL CONNECTION "invalid-param-userfile" AS 'userfile:///foo?INVALIDPARAM=param';
+----
+pq: failed to construct External Connection details: failed to create userfile external connection: unknown userfile query parameters: INVALIDPARAM
+
+inspect-system-table
+----
+foo-userfile STORAGE {"provider": "userfile", "simpleUri": {"uri": "userfile:///foo/bar"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION "foo-userfile";
+----
+
 subtest end

--- a/pkg/cloud/externalconn/connectionpb/connection.go
+++ b/pkg/cloud/externalconn/connectionpb/connection.go
@@ -15,7 +15,7 @@ import "github.com/cockroachdb/errors"
 // Type returns the ConnectionType of the receiver.
 func (d *ConnectionDetails) Type() ConnectionType {
 	switch d.Provider {
-	case ConnectionProvider_nodelocal, ConnectionProvider_s3:
+	case ConnectionProvider_nodelocal, ConnectionProvider_s3, ConnectionProvider_userfile:
 		return TypeStorage
 	case ConnectionProvider_gs_kms:
 		return TypeKMS

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -20,6 +20,7 @@ enum ConnectionProvider {
   // External Storage providers.
   nodelocal = 1;
   s3 = 4;
+  userfile = 5;
 
   // KMS providers.
   gs_kms = 2;

--- a/pkg/cloud/externalconn/providers/BUILD.bazel
+++ b/pkg/cloud/externalconn/providers/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/cloud/amazon",
         "//pkg/cloud/gcp",
         "//pkg/cloud/nodelocal",
+        "//pkg/cloud/userfile",
     ],
 )
 

--- a/pkg/cloud/externalconn/providers/registry.go
+++ b/pkg/cloud/externalconn/providers/registry.go
@@ -20,4 +20,5 @@ import (
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/amazon"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/gcp"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/nodelocal"
+	_ "github.com/cockroachdb/cockroach/pkg/cloud/userfile"
 )

--- a/pkg/cloud/uris.go
+++ b/pkg/cloud/uris.go
@@ -29,6 +29,9 @@ const (
 	// AuthParamSpecified is the query parameter for the specified authentication
 	// mode in a URI.
 	AuthParamSpecified = cloudpb.ExternalStorageAuthSpecified
+	// LocalityURLParam is the parameter name used when specifying a locality tag
+	// in a locality aware backup/restore.
+	LocalityURLParam = "COCKROACH_LOCALITY"
 )
 
 // GetPrefixBeforeWildcard gets the prefix of a path that does not contain glob-
@@ -121,6 +124,16 @@ func (u *ConsumeURL) RemainingQueryParams() (res []string) {
 		u.q = u.Query()
 	}
 	for p := range u.q {
+		// The `COCKROACH_LOCALITY` parameter is supported for all External Storage
+		// implementations and is not used when creating the External Storage, but
+		// instead during backup/restore resolution. So, this parameter is not
+		// "consumed" by the individual External Storage implementations in their
+		// parse functions and so it will always show up in this method. We should
+		// consider this param invisible when validating that all the passed in
+		// query parameters are supported for an External Storage URI.
+		if p == LocalityURLParam {
+			continue
+		}
 		res = append(res, p)
 	}
 	return

--- a/pkg/cloud/userfile/BUILD.bazel
+++ b/pkg/cloud/userfile/BUILD.bazel
@@ -3,13 +3,19 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "userfile",
-    srcs = ["file_table_storage.go"],
+    srcs = [
+        "file_table_connection.go",
+        "file_table_storage.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cloud/userfile",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",
+        "//pkg/cloud/externalconn",
+        "//pkg/cloud/externalconn/connectionpb",
+        "//pkg/cloud/externalconn/utils",
         "//pkg/cloud/userfile/filetable",
         "//pkg/kv",
         "//pkg/security/username",

--- a/pkg/cloud/userfile/file_table_connection.go
+++ b/pkg/cloud/userfile/file_table_connection.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package userfile
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/errors"
+)
+
+func parseAndValidateUserfileConnectionURI(
+	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri *url.URL,
+) (externalconn.ExternalConnection, error) {
+	if err := utils.CheckExternalStorageConnection(ctx, execCfg, user, uri.String()); err != nil {
+		return nil, errors.Wrap(err, "failed to create userfile external connection")
+	}
+
+	connDetails := connectionpb.ConnectionDetails{
+		Provider: connectionpb.ConnectionProvider_userfile,
+		Details: &connectionpb.ConnectionDetails_SimpleURI{
+			SimpleURI: &connectionpb.SimpleURI{
+				URI: uri.String(),
+			},
+		},
+	}
+	return externalconn.NewExternalConnection(connDetails), nil
+}
+
+func init() {
+	externalconn.RegisterConnectionDetailsFromURIFactory(
+		scheme,
+		parseAndValidateUserfileConnectionURI,
+	)
+}


### PR DESCRIPTION
This change registers `userfile` as a supported scheme that
can be represented by an External Connection.

Release note (sql change): Users can now
`CREATE EXTERNAL CONNECTION` to represent an underlying
userfile resource.