### PR TITLE
ui: fix errors on numbers formatting on metrics graphs 

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
@@ -135,7 +135,7 @@ const abbreviateNumber = (num: number, fixedDecimals: number) => {
 };
 
 const formatPercentage = (n: number, fractionDigits: number) => {
-  return `${(n * 100).toFixed(fractionDigits)}%`;
+  return n?.toFixed ? `${(n * 100).toFixed(fractionDigits)}%` : "0%";
 };
 
 // computeNormalizedIncrement computes a human-friendly increment between tick
@@ -180,7 +180,7 @@ function computeAxisDomain(extent: Extent, factor = 1): AxisDomain {
   // but with a metric prefix for large numbers (i.e. 1000 will display as "1k")
   let unitFormat: (v: number) => string;
   if (Math.floor(increment) !== increment) {
-    unitFormat = (n: number) => n.toFixed(1);
+    unitFormat = (n: number) => n?.toFixed(1) || "0";
   } else {
     unitFormat = (n: number) => abbreviateNumber(n, 4);
   }
@@ -198,7 +198,7 @@ function ComputeCountAxisDomain(extent: Extent): AxisDomain {
   // fractional metric prefix; this is because the use of fractional metric
   // prefixes (i.e. milli, micro, nano) have proved confusing to users.
   const metricFormat = (n: number) => abbreviateNumber(n, 4);
-  const decimalFormat = (n: number) => n.toFixed(4);
+  const decimalFormat = (n: number) => n?.toFixed(4) || "0";
   axisDomain.guideFormat = (n: number) => {
     if (n < 1) {
       return decimalFormat(n);

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -172,7 +172,7 @@ class MetricsDataProvider extends React.Component<
     (props: MetricsDataProviderProps) => props.timeInfo,
     this.queriesSelector,
     (timeInfo, queries) => {
-      if (!timeInfo) {
+      if (!timeInfo || queries.length === 0) {
         return undefined;
       }
       return new protos.cockroach.ts.tspb.TimeSeriesQueryRequest({


### PR DESCRIPTION
ui: prevent sending metrics query requests in none queries available

Before, there waa an issue when on initial Metrics page loading
query request was dispatched without any queries in payload.
It led to failed request with error that queries list is empty.
This fix introduces validation that frontend creates query
request if queries list is not empty.

ui: use d3-format lib to format data points on graphs

This patch uses d3.format function to format numbers
instead of Number.toFixed func. It is necessary to
properly handle cases when provided number is primitive
or undefined and fails to call `toFixed` method.
Initially, we used d3 formatting functions before
moving this code to `cluster-ui`, so this change
brings this functionality back.
