### PR TITLE
ui: search is case insensitive on insights page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -87,11 +87,12 @@ export const filterTransactionInsights = (
     filteredTransactions = filteredTransactions.filter(txn => !isInternal(txn));
   }
   if (search) {
+    search = search.toLowerCase();
     filteredTransactions = filteredTransactions.filter(
       txn =>
         !search ||
-        txn.executionID?.includes(search) ||
-        txn.queries?.find(query => query.includes(search)),
+        txn.executionID.toLowerCase()?.includes(search) ||
+        txn.queries?.find(query => query.toLowerCase().includes(search)),
     );
   }
   return filteredTransactions;


### PR DESCRIPTION
Previously, search was case sensitive on Insights page,
this commit makes it so the search is case insensitive
for both id and fingerprint.

Release note: None