### PR TITLE
ui: remove back to sessions link

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -241,13 +241,8 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
       return (
         <section className={cx("section")}>
           <h3>Unable to find session</h3>
-          There is no currently active session with the id{" "}
+          There is no session with the id{" "}
           {getMatchParamByName(this.props.match, sessionAttr)}.
-          <div>
-            <Link className={cx("back-link")} to={"/sessions"}>
-              Back to Sessions
-            </Link>
-          </div>
         </section>
       );
     }


### PR DESCRIPTION
Previously we had two back to sessions button and
one of them was pointing to the wrong link.
This commit removes the link and update the message
for sessions for found, to say any type of session
was not found, since now we show closed session info.

Fixes #85267

<img width="496" alt="Screen Shot 2022-08-12 at 1 22 54 PM" src="https://user-images.githubusercontent.com/1017486/184411717-e292cc12-5b5b-4c6a-ad13-1f341ba352ed.png">

Release note (ui change): Remove back to sessions link on
Session Details not found page.