### PR TITLE
util: optimize FastIntSet

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -296,6 +296,26 @@ var queries = [...]benchQuery{
 		`,
 		args: []interface{}{1, 2, 3},
 	},
+
+	// Query that initializes column IDs as high as ~320.
+	{
+		name: "many-columns-and-indexes-c",
+		query: `
+			SELECT * FROM
+				k k1, k k2, k k3, k k4, k k5, k k6, k k7, k k8, k k9, k k10, k k11
+			WHERE
+				k1.x = $1 AND k2.y = $2 AND k3.z = $3 AND
+				k1.a = k2.a AND
+				k2.a = k3.a AND
+				k3.a = k4.a AND
+				k5.a = k6.a AND
+				k6.z = k7.z AND
+				k7.z = k8.z AND
+				k8.m = k9.m AND
+				k10.m = k11.m
+		`,
+		args: []interface{}{1, 2, 3},
+	},
 }
 
 func init() {

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -242,7 +242,7 @@ func (s FastIntSet) Ordered() []int {
 func (s FastIntSet) Copy() FastIntSet {
 	var c FastIntSet
 	c.small = s.small
-	if s.large != nil {
+	if s.large != nil && !s.large.IsEmpty() {
 		c.large = new(intsets.Sparse)
 		c.large.Copy(s.large)
 	}
@@ -253,7 +253,7 @@ func (s FastIntSet) Copy() FastIntSet {
 // independently.
 func (s *FastIntSet) CopyFrom(other FastIntSet) {
 	s.small = other.small
-	if other.large != nil {
+	if other.large != nil && !other.large.IsEmpty() {
 		if s.large == nil {
 			s.large = new(intsets.Sparse)
 		}

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -82,14 +82,6 @@ func MakeFastIntSet(vals ...int) FastIntSet {
 	return res
 }
 
-func (s *FastIntSet) toLarge() *intsets.Sparse {
-	if s.large != nil {
-		return s.large
-	}
-	large := new(intsets.Sparse)
-	return large
-}
-
 // fitsInSmall returns whether all elements in this set are between 0 and
 // smallCutoff.
 func (s *FastIntSet) fitsInSmall() bool {
@@ -105,7 +97,7 @@ func (s *FastIntSet) Add(i int) {
 		return
 	}
 	if s.large == nil {
-		s.large = s.toLarge()
+		s.large = new(intsets.Sparse)
 	}
 	if i >= smallCutoff {
 		i -= smallCutoff
@@ -273,7 +265,7 @@ func (s *FastIntSet) UnionWith(rhs FastIntSet) {
 		return
 	}
 	if s.large == nil {
-		s.large = s.toLarge()
+		s.large = new(intsets.Sparse)
 	}
 	s.large.UnionWith(rhs.large)
 }
@@ -295,8 +287,7 @@ func (s *FastIntSet) IntersectionWith(rhs FastIntSet) {
 		// Fast path.
 		return
 	}
-
-	s.large.IntersectionWith(rhs.toLarge())
+	s.large.IntersectionWith(rhs.large)
 }
 
 // Intersection returns the intersection of s and rhs as a new set.
@@ -314,17 +305,17 @@ func (s FastIntSet) Intersects(rhs FastIntSet) bool {
 	if s.large == nil || rhs.large == nil {
 		return false
 	}
-	return s.large.Intersects(rhs.toLarge())
+	return s.large.Intersects(rhs.large)
 }
 
 // DifferenceWith removes any elements in rhs from this set.
 func (s *FastIntSet) DifferenceWith(rhs FastIntSet) {
 	s.small.DifferenceWith(rhs.small)
-	if s.large == nil {
+	if s.large == nil || rhs.large == nil {
 		// Fast path
 		return
 	}
-	s.large.DifferenceWith(rhs.toLarge())
+	s.large.DifferenceWith(rhs.large)
 }
 
 // Difference returns the elements of s that are not in rhs as a new set.

--- a/pkg/util/fast_int_set.go
+++ b/pkg/util/fast_int_set.go
@@ -24,16 +24,45 @@ import (
 )
 
 // FastIntSet keeps track of a set of integers. It does not perform any
-// allocations when the values are small. It is not thread-safe.
+// allocations when the values are in the range [0, smallCutoff). It is not
+// thread-safe.
 type FastIntSet struct {
+	// small is a bitmap that stores values in the range [0, smallCutoff).
 	small bitmap
+	// large is only allocated if values are added to the set that are not in
+	// the range [0, smallCutoff).
+	//
+	// The implementation of intsets.Sparse is a circular, doubly-linked list of
+	// blocks. Each block contains a 256-bit bitmap and an offset. A block with
+	// offset=n contains a value n+i if the i-th bit of the bitmap is set. Block
+	// offsets are always divisible by 256.
+	//
+	// For example, here is a diagram of the set {0, 1, 256, 257, 512}, where
+	// each block is denoted by {offset, bitmap}:
+	//
+	//   ---> {0, ..011} <----> {256, ..011} <----> {512, ..001} <---
+	//   |                                                          |
+	//   ------------------------------------------------------------
+	//
+	// FastIntSet stores only values outside the range [0, smallCutoff) in
+	// large. Values less than 0 are stored in large as-is. For values greater
+	// than or equal to smallCutoff, we subtract by smallCutoff before storing
+	// them in large. When they are retrieved from large, we add smallCutoff to
+	// get the original value. For example, if 300 is added to the FastIntSet,
+	// it would be added to large as the value (300 - smallCutoff).
+	//
+	// This scheme better utilizes the block with offset=0 compared to an
+	// alternative implementation where small and large contain overlapping
+	// values. For example, consider the set {0, 200, 300}. In the overlapping
+	// implementation, two blocks would be allocated: a block with offset=0
+	// would store 0 and 200, and a block with offset=256 would store 300. By
+	// omitting values in the range [0, smallCutoff) in large, only one block is
+	// allocated: a block with offset=0 that stores 200-smallCutoff and
+	// 300-smallCutoff.
 	large *intsets.Sparse
 }
 
-// We maintain a bitmap for small element values (specifically 0 to
-// smallCutoff-1). When this bitmap is sufficient, we avoid allocating the
-// `Sparse` set.  Even when we have to allocate the `Sparse` set, we still
-// maintain the bitmap as it can provide a fast path for certain operations.
+// smallCutoff is the size of the small bitmap.
 // Note: this can be set to a smaller value, e.g. for testing.
 const smallCutoff = 128
 
@@ -58,37 +87,30 @@ func (s *FastIntSet) toLarge() *intsets.Sparse {
 		return s.large
 	}
 	large := new(intsets.Sparse)
-	for i, ok := s.Next(0); ok; i, ok = s.Next(i + 1) {
-		large.Insert(i)
-	}
 	return large
 }
 
 // fitsInSmall returns whether all elements in this set are between 0 and
 // smallCutoff.
 func (s *FastIntSet) fitsInSmall() bool {
-	if s.large == nil {
-		return true
-	}
-	// It is possible that we have a large set allocated but all elements still
-	// fit the cutoff. This can happen if the set used to contain other elements.
-	return s.large.Min() >= 0 && s.large.Max() < smallCutoff
+	return s.large == nil || s.large.IsEmpty()
 }
 
 // Add adds a value to the set. No-op if the value is already in the set. If the
 // large set is not nil and the value is within the range [0, 63], the value is
 // added to both the large and small sets.
 func (s *FastIntSet) Add(i int) {
-	withinSmallBounds := i >= 0 && i < smallCutoff
-	if withinSmallBounds {
+	if i >= 0 && i < smallCutoff {
 		s.small.Set(i)
+		return
 	}
-	if !withinSmallBounds && s.large == nil {
+	if s.large == nil {
 		s.large = s.toLarge()
 	}
-	if s.large != nil {
-		s.large.Insert(i)
+	if i >= smallCutoff {
+		i -= smallCutoff
 	}
+	s.large.Insert(i)
 }
 
 // AddRange adds values 'from' up to 'to' (inclusively) to the set.
@@ -113,8 +135,12 @@ func (s *FastIntSet) AddRange(from, to int) {
 func (s *FastIntSet) Remove(i int) {
 	if i >= 0 && i < smallCutoff {
 		s.small.Unset(i)
+		return
 	}
 	if s.large != nil {
+		if i >= smallCutoff {
+			i -= smallCutoff
+		}
 		s.large.Remove(i)
 	}
 }
@@ -125,6 +151,9 @@ func (s FastIntSet) Contains(i int) bool {
 		return s.small.IsSet(i)
 	}
 	if s.large != nil {
+		if i >= smallCutoff {
+			i -= smallCutoff
+		}
 		return s.large.Has(i)
 	}
 	return false
@@ -137,26 +166,38 @@ func (s FastIntSet) Empty() bool {
 
 // Len returns the number of the elements in the set.
 func (s FastIntSet) Len() int {
-	if s.large == nil {
-		return s.small.OnesCount()
+	l := s.small.OnesCount()
+	if s.large != nil {
+		l += s.large.Len()
 	}
-	return s.large.Len()
+	return l
 }
 
 // Next returns the first value in the set which is >= startVal. If there is no
 // value, the second return value is false.
 func (s FastIntSet) Next(startVal int) (int, bool) {
-	if startVal < 0 && s.large == nil {
+	if startVal < 0 && s.large != nil {
+		if res := s.large.LowerBound(startVal); res < 0 {
+			return res, true
+		}
+	}
+	if startVal < 0 {
+		// Negative values are must be in s.large.
 		startVal = 0
 	}
-	if startVal >= 0 && startVal < smallCutoff {
+	if startVal < smallCutoff {
 		if nextVal, ok := s.small.Next(startVal); ok {
 			return nextVal, true
 		}
 	}
 	if s.large != nil {
+		startVal -= smallCutoff
+		if startVal < 0 {
+			// We already searched for negative values in large above.
+			startVal = 0
+		}
 		res := s.large.LowerBound(startVal)
-		return res, res != intsets.MaxInt
+		return res + smallCutoff, res != intsets.MaxInt
 	}
 	return intsets.MaxInt, false
 }
@@ -164,10 +205,9 @@ func (s FastIntSet) Next(startVal int) (int, bool) {
 // ForEach calls a function for each value in the set (in increasing order).
 func (s FastIntSet) ForEach(f func(i int)) {
 	if !s.fitsInSmall() {
-		for x := s.large.Min(); x != intsets.MaxInt; x = s.large.LowerBound(x + 1) {
+		for x := s.large.Min(); x < 0; x = s.large.LowerBound(x + 1) {
 			f(x)
 		}
-		return
 	}
 	for v := s.small.lo; v != 0; {
 		i := bits.TrailingZeros64(v)
@@ -179,15 +219,17 @@ func (s FastIntSet) ForEach(f func(i int)) {
 		f(64 + i)
 		v &^= 1 << uint(i)
 	}
+	if !s.fitsInSmall() {
+		for x := s.large.LowerBound(0); x != intsets.MaxInt; x = s.large.LowerBound(x + 1) {
+			f(x + smallCutoff)
+		}
+	}
 }
 
 // Ordered returns a slice with all the integers in the set, in increasing order.
 func (s FastIntSet) Ordered() []int {
 	if s.Empty() {
 		return nil
-	}
-	if s.large != nil {
-		return s.large.AppendTo([]int(nil))
 	}
 	result := make([]int, 0, s.Len())
 	s.ForEach(func(i int) {
@@ -226,21 +268,14 @@ func (s *FastIntSet) CopyFrom(other FastIntSet) {
 // UnionWith adds all the elements from rhs to this set.
 func (s *FastIntSet) UnionWith(rhs FastIntSet) {
 	s.small.UnionWith(rhs.small)
-	if s.large == nil && rhs.large == nil {
+	if rhs.large == nil || rhs.large.IsEmpty() {
 		// Fast path.
 		return
 	}
-
 	if s.large == nil {
 		s.large = s.toLarge()
 	}
-	if rhs.large == nil {
-		for i, ok := rhs.Next(0); ok; i, ok = rhs.Next(i + 1) {
-			s.large.Insert(i)
-		}
-	} else {
-		s.large.UnionWith(rhs.large)
-	}
+	s.large.UnionWith(rhs.large)
 }
 
 // Union returns the union of s and rhs as a new set.
@@ -322,7 +357,7 @@ func (s FastIntSet) SubsetOf(rhs FastIntSet) bool {
 		// s doesn't fit in small and rhs does.
 		return false
 	}
-	return s.large.SubsetOf(rhs.large)
+	return s.small.SubsetOf(rhs.small) && s.large.SubsetOf(rhs.large)
 }
 
 // Encode the set and write it to a bytes.Buffer using binary.varint byte

--- a/pkg/util/fast_int_set_test.go
+++ b/pkg/util/fast_int_set_test.go
@@ -313,6 +313,10 @@ func TestFastIntSetString(t *testing.T) {
 			vals: []int{0, 1, 3, 4, 5},
 			exp:  "(0,1,3-5)",
 		},
+		{
+			vals: []int{-1, 0, 1, 127, 128, 255, 256, 257, 512},
+			exp:  "(-1,0,1,127,128,255-257,512)",
+		},
 	}
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {


### PR DESCRIPTION
This PR contains several commits which speed up `util.FastIntSet` and reduce the
allocations it makes in some cases. See the individual commit messages for
details.

The speedup and reduction in allocations can be observed in the optimizer's
`BenchmarkPhases`:

```
name                                                                   old time/op    new time/op    delta
kv-read/Simple/OptBuildNorm-16                                    34.9µs ± 2%    35.0µs ± 4%     ~     (p=1.000 n=5+5)
kv-read/Simple/Explore-16                                         43.9µs ± 2%    43.7µs ± 1%     ~     (p=0.222 n=5+5)
kv-read/Prepared/ExecBuild-16                                     1.18µs ± 1%    1.13µs ± 1%   -3.72%  (p=0.008 n=5+5)
kv-read-const/Simple/OptBuildNorm-16                              35.2µs ± 2%    34.9µs ± 3%     ~     (p=0.151 n=5+5)
kv-read-const/Simple/Explore-16                                   45.2µs ± 5%    44.3µs ± 1%     ~     (p=0.056 n=5+5)
kv-read-const/Prepared/ExecBuild-16                               1.02µs ± 4%    0.97µs ± 1%   -5.18%  (p=0.008 n=5+5)
tpcc-new-order/Simple/OptBuildNorm-16                             71.1µs ± 1%    70.8µs ± 0%     ~     (p=0.548 n=5+5)
tpcc-new-order/Simple/Explore-16                                   117µs ± 1%     116µs ± 2%     ~     (p=0.095 n=5+5)
tpcc-new-order/Prepared/ExecBuild-16                              1.48µs ± 2%    1.44µs ± 1%   -2.67%  (p=0.008 n=5+5)
tpcc-delivery/Simple/OptBuildNorm-16                              65.5µs ± 2%    63.9µs ± 1%   -2.37%  (p=0.032 n=5+4)
tpcc-delivery/Simple/Explore-16                                   96.2µs ± 1%    95.7µs ± 1%     ~     (p=0.690 n=5+5)
tpcc-delivery/Prepared/AssignPlaceholdersNorm-16                  12.5µs ± 1%    12.3µs ± 1%     ~     (p=0.095 n=5+5)
tpcc-delivery/Prepared/Explore-16                                 40.5µs ± 1%    39.4µs ± 0%   -2.75%  (p=0.008 n=5+5)
tpcc-stock-level/Simple/OptBuildNorm-16                            291µs ± 2%     288µs ± 2%     ~     (p=0.310 n=5+5)
tpcc-stock-level/Simple/Explore-16                                 424µs ± 0%     417µs ± 2%   -1.79%  (p=0.016 n=5+5)
tpcc-stock-level/Prepared/AssignPlaceholdersNorm-16               53.8µs ± 0%    53.3µs ± 1%     ~     (p=0.151 n=5+5)
tpcc-stock-level/Prepared/Explore-16                               181µs ± 2%     176µs ± 3%   -2.44%  (p=0.032 n=5+5)
many-columns-and-indexes-a/Simple/OptBuildNorm-16                  309µs ± 0%     254µs ± 2%  -17.78%  (p=0.008 n=5+5)
many-columns-and-indexes-a/Simple/Explore-16                       467µs ± 1%     389µs ± 1%  -16.65%  (p=0.008 n=5+5)
many-columns-and-indexes-a/Prepared/AssignPlaceholdersNorm-16      275µs ± 1%     223µs ± 1%  -18.93%  (p=0.008 n=5+5)
many-columns-and-indexes-a/Prepared/Explore-16                     434µs ± 2%     358µs ± 1%  -17.68%  (p=0.008 n=5+5)
many-columns-and-indexes-b/Simple/OptBuildNorm-16                  331µs ± 1%     281µs ± 2%  -14.91%  (p=0.008 n=5+5)
many-columns-and-indexes-b/Simple/Explore-16                       500µs ± 2%     424µs ± 1%  -15.23%  (p=0.008 n=5+5)
many-columns-and-indexes-b/Prepared/AssignPlaceholdersNorm-16      279µs ± 1%     228µs ± 1%  -17.98%  (p=0.008 n=5+5)
many-columns-and-indexes-b/Prepared/Explore-16                     449µs ± 5%     367µs ± 0%  -18.20%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Simple/OptBuildNorm-16                 13.7ms ± 1%    10.6ms ± 1%  -22.68%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Simple/Explore-16                      45.7ms ± 2%    40.0ms ± 2%  -12.42%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/AssignPlaceholdersNorm-16     11.1ms ± 1%     8.6ms ± 2%  -22.77%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/Explore-16                    43.3ms ± 0%    37.8ms ± 2%  -12.65%  (p=0.008 n=5+5)
ored-preds-100/Simple/OptBuildNorm-16                             2.59ms ± 1%    2.60ms ± 1%     ~     (p=0.690 n=5+5)
ored-preds-100/Simple/Explore-16                                  3.29ms ± 3%    3.31ms ± 2%     ~     (p=0.548 n=5+5)
ored-preds-100/Prepared/ExecBuild-16                              85.5µs ± 1%    84.7µs ± 1%     ~     (p=0.095 n=5+5)
ored-preds-using-params-100/Simple/OptBuildNorm-16                1.88ms ± 1%    1.88ms ± 1%     ~     (p=0.421 n=5+5)
ored-preds-using-params-100/Simple/Explore-16                     2.56ms ± 1%    2.57ms ± 1%     ~     (p=0.413 n=4+5)
ored-preds-using-params-100/Prepared/AssignPlaceholdersNorm-16     468µs ± 3%     472µs ± 2%     ~     (p=0.421 n=5+5)
ored-preds-using-params-100/Prepared/Explore-16                   1.16ms ± 1%    1.17ms ± 1%     ~     (p=0.222 n=5+5)

name                                                                   old alloc/op   new alloc/op   delta
kv-read/Simple/OptBuildNorm-16                                    12.3kB ± 0%    12.3kB ± 0%     ~     (all equal)
kv-read/Simple/Explore-16                                         14.7kB ± 0%    14.7kB ± 0%     ~     (all equal)
kv-read/Prepared/ExecBuild-16                                       704B ± 0%      704B ± 0%     ~     (all equal)
kv-read-const/Simple/OptBuildNorm-16                              12.4kB ± 0%    12.4kB ± 0%     ~     (all equal)
kv-read-const/Simple/Explore-16                                   14.8kB ± 0%    14.8kB ± 0%     ~     (all equal)
kv-read-const/Prepared/ExecBuild-16                                 520B ± 0%      520B ± 0%     ~     (all equal)
tpcc-new-order/Simple/OptBuildNorm-16                             24.0kB ± 0%    24.0kB ± 0%     ~     (p=0.881 n=5+5)
tpcc-new-order/Simple/Explore-16                                  34.0kB ± 0%    33.9kB ± 0%   -0.01%  (p=0.032 n=5+5)
tpcc-new-order/Prepared/ExecBuild-16                                768B ± 0%      768B ± 0%     ~     (all equal)
tpcc-delivery/Simple/OptBuildNorm-16                              19.8kB ± 0%    19.8kB ± 0%     ~     (p=0.722 n=5+5)
tpcc-delivery/Simple/Explore-16                                   26.3kB ± 0%    26.3kB ± 0%     ~     (p=0.802 n=5+5)
tpcc-delivery/Prepared/AssignPlaceholdersNorm-16                  5.44kB ± 0%    5.44kB ± 0%     ~     (all equal)
tpcc-delivery/Prepared/Explore-16                                 13.1kB ± 0%    13.1kB ± 0%     ~     (p=1.000 n=5+5)
tpcc-stock-level/Simple/OptBuildNorm-16                           89.8kB ± 0%    89.8kB ± 0%     ~     (p=0.817 n=5+5)
tpcc-stock-level/Simple/Explore-16                                 120kB ± 0%     120kB ± 0%     ~     (p=0.937 n=5+5)
tpcc-stock-level/Prepared/AssignPlaceholdersNorm-16               18.8kB ± 0%    18.8kB ± 0%     ~     (p=1.000 n=5+5)
tpcc-stock-level/Prepared/Explore-16                              46.9kB ± 0%    46.9kB ± 0%     ~     (p=0.262 n=5+5)
many-columns-and-indexes-a/Simple/OptBuildNorm-16                 16.4kB ± 0%    16.4kB ± 0%     ~     (all equal)
many-columns-and-indexes-a/Simple/Explore-16                      23.1kB ± 0%    23.1kB ± 0%     ~     (p=1.000 n=5+5)
many-columns-and-indexes-a/Prepared/AssignPlaceholdersNorm-16     3.81kB ± 0%    3.81kB ± 0%     ~     (all equal)
many-columns-and-indexes-a/Prepared/Explore-16                    10.5kB ± 0%    10.5kB ± 0%     ~     (p=1.000 n=5+5)
many-columns-and-indexes-b/Simple/OptBuildNorm-16                 23.6kB ± 0%    23.6kB ± 0%     ~     (p=0.730 n=5+5)
many-columns-and-indexes-b/Simple/Explore-16                      30.0kB ± 0%    30.0kB ± 0%     ~     (p=0.159 n=5+5)
many-columns-and-indexes-b/Prepared/AssignPlaceholdersNorm-16     6.05kB ± 0%    6.05kB ± 0%     ~     (p=1.000 n=5+5)
many-columns-and-indexes-b/Prepared/Explore-16                    12.4kB ± 0%    12.4kB ± 0%     ~     (p=0.540 n=5+5)
many-columns-and-indexes-c/Simple/OptBuildNorm-16                 5.43MB ± 0%    4.75MB ± 0%  -12.49%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Simple/Explore-16                      27.0MB ± 0%    26.3MB ± 0%   -2.58%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/AssignPlaceholdersNorm-16     4.27MB ± 0%    3.65MB ± 0%  -14.54%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/Explore-16                    25.8MB ± 0%    25.2MB ± 0%   -2.48%  (p=0.008 n=5+5)
ored-preds-100/Simple/OptBuildNorm-16                              979kB ± 0%     979kB ± 0%     ~     (p=0.889 n=5+5)
ored-preds-100/Simple/Explore-16                                  1.37MB ± 0%    1.37MB ± 0%     ~     (p=0.690 n=5+5)
ored-preds-100/Prepared/ExecBuild-16                              29.6kB ± 0%    29.6kB ± 0%     ~     (all equal)
ored-preds-using-params-100/Simple/OptBuildNorm-16                 568kB ± 0%     568kB ± 0%     ~     (p=0.794 n=5+5)
ored-preds-using-params-100/Simple/Explore-16                      962kB ± 0%     962kB ± 0%     ~     (p=0.841 n=5+5)
ored-preds-using-params-100/Prepared/AssignPlaceholdersNorm-16     348kB ± 0%     348kB ± 0%     ~     (p=0.548 n=5+5)
ored-preds-using-params-100/Prepared/Explore-16                    742kB ± 0%     742kB ± 0%     ~     (p=0.841 n=5+5)

name                                                                   old allocs/op  new allocs/op  delta
kv-read/Simple/OptBuildNorm-16                                      77.0 ± 0%      77.0 ± 0%     ~     (all equal)
kv-read/Simple/Explore-16                                           88.0 ± 0%      88.0 ± 0%     ~     (all equal)
kv-read/Prepared/ExecBuild-16                                       9.00 ± 0%      9.00 ± 0%     ~     (all equal)
kv-read-const/Simple/OptBuildNorm-16                                79.0 ± 0%      79.0 ± 0%     ~     (all equal)
kv-read-const/Simple/Explore-16                                     90.0 ± 0%      90.0 ± 0%     ~     (all equal)
kv-read-const/Prepared/ExecBuild-16                                 6.00 ± 0%      6.00 ± 0%     ~     (all equal)
tpcc-new-order/Simple/OptBuildNorm-16                                128 ± 0%       128 ± 0%     ~     (all equal)
tpcc-new-order/Simple/Explore-16                                     171 ± 0%       171 ± 0%     ~     (all equal)
tpcc-new-order/Prepared/ExecBuild-16                                9.00 ± 0%      9.00 ± 0%     ~     (all equal)
tpcc-delivery/Simple/OptBuildNorm-16                                 120 ± 0%       120 ± 0%     ~     (all equal)
tpcc-delivery/Simple/Explore-16                                      169 ± 0%       169 ± 0%     ~     (all equal)
tpcc-delivery/Prepared/AssignPlaceholdersNorm-16                    27.0 ± 0%      27.0 ± 0%     ~     (all equal)
tpcc-delivery/Prepared/Explore-16                                   77.0 ± 0%      77.0 ± 0%     ~     (all equal)
tpcc-stock-level/Simple/OptBuildNorm-16                              552 ± 0%       552 ± 0%     ~     (all equal)
tpcc-stock-level/Simple/Explore-16                                   711 ± 0%       711 ± 0%     ~     (all equal)
tpcc-stock-level/Prepared/AssignPlaceholdersNorm-16                  105 ± 0%       105 ± 0%     ~     (all equal)
tpcc-stock-level/Prepared/Explore-16                                 264 ± 0%       264 ± 0%     ~     (all equal)
many-columns-and-indexes-a/Simple/OptBuildNorm-16                   69.0 ± 0%      69.0 ± 0%     ~     (all equal)
many-columns-and-indexes-a/Simple/Explore-16                        89.0 ± 0%      89.0 ± 0%     ~     (all equal)
many-columns-and-indexes-a/Prepared/AssignPlaceholdersNorm-16       21.0 ± 0%      21.0 ± 0%     ~     (all equal)
many-columns-and-indexes-a/Prepared/Explore-16                      41.0 ± 0%      41.0 ± 0%     ~     (all equal)
many-columns-and-indexes-b/Simple/OptBuildNorm-16                    128 ± 0%       128 ± 0%     ~     (all equal)
many-columns-and-indexes-b/Simple/Explore-16                         145 ± 0%       146 ± 0%     ~     (p=0.167 n=5+5)
many-columns-and-indexes-b/Prepared/AssignPlaceholdersNorm-16       36.0 ± 0%      36.0 ± 0%     ~     (all equal)
many-columns-and-indexes-b/Prepared/Explore-16                      53.0 ± 0%      53.0 ± 0%     ~     (all equal)
many-columns-and-indexes-c/Simple/OptBuildNorm-16                  72.3k ± 0%     61.7k ± 0%  -14.66%  (p=0.029 n=4+4)
many-columns-and-indexes-c/Simple/Explore-16                        295k ± 0%      284k ± 0%   -3.68%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/AssignPlaceholdersNorm-16      66.1k ± 0%     56.4k ± 0%  -14.69%  (p=0.008 n=5+5)
many-columns-and-indexes-c/Prepared/Explore-16                      289k ± 0%      279k ± 0%   -3.46%  (p=0.008 n=5+5)
ored-preds-100/Simple/OptBuildNorm-16                              16.5k ± 0%     16.5k ± 0%     ~     (p=0.333 n=5+4)
ored-preds-100/Simple/Explore-16                                   17.9k ± 0%     17.9k ± 0%     ~     (all equal)
ored-preds-100/Prepared/ExecBuild-16                                 413 ± 0%       413 ± 0%     ~     (all equal)
ored-preds-using-params-100/Simple/OptBuildNorm-16                 4.08k ± 0%     4.08k ± 0%     ~     (all equal)
ored-preds-using-params-100/Simple/Explore-16                      5.54k ± 0%     5.54k ± 0%     ~     (all equal)
ored-preds-using-params-100/Prepared/AssignPlaceholdersNorm-16     1.44k ± 0%     1.44k ± 0%     ~     (all equal)
ored-preds-using-params-100/Prepared/Explore-16                    2.89k ± 0%     2.89k ± 0%     ~     (all equal)
```
