### PR TITLE
sql: fix interface conversion panic when hydrating returns an error

### DIFF
--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -38,7 +38,10 @@ func (tc *Collection) hydrateTypesInTableDesc(
 		desc,
 		false, /* includeOffline */
 		false /*avoidLeased*/)
-	return ret.(catalog.TableDescriptor), err
+	if err != nil {
+		return nil, err
+	}
+	return ret.(catalog.TableDescriptor), nil
 }
 
 // hydrateTypesInDescWithOptions installs user defined type metadata in all


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/83882#issuecomment-1213352308

There are multiple ways to get a nil return value here, so it's unclear
what the actual error was here--with any luck further nemesis runs will turn it
up. Checked the immediate call sites and they all look like they can handle a nil.

Release note: None