### PR TITLE
release-22.1: ui: use TimeScaleState reducer to align time window across pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
@@ -146,7 +146,7 @@ const abbreviateNumber = (num: number, fixedDecimals: number) => {
 };
 
 const formatPercentage = (n: number, fractionDigits: number) => {
-  return `${(n * 100).toFixed(fractionDigits)}%`;
+  return n?.toFixed ? `${(n * 100).toFixed(fractionDigits)}%` : "0%";
 };
 
 // computeNormalizedIncrement computes a human-friendly increment between tick
@@ -191,7 +191,7 @@ function computeAxisDomain(extent: Extent, factor = 1): AxisDomain {
   // but with a metric prefix for large numbers (i.e. 1000 will display as "1k")
   let unitFormat: (v: number) => string;
   if (Math.floor(increment) !== increment) {
-    unitFormat = (n: number) => n.toFixed(1);
+    unitFormat = (n: number) => n?.toFixed(1) || "0";
   } else {
     unitFormat = (n: number) => abbreviateNumber(n, 4);
   }
@@ -209,7 +209,7 @@ function ComputeCountAxisDomain(extent: Extent): AxisDomain {
   // fractional metric prefix; this is because the use of fractional metric
   // prefixes (i.e. milli, micro, nano) have proved confusing to users.
   const metricFormat = (n: number) => abbreviateNumber(n, 4);
-  const decimalFormat = (n: number) => n.toFixed(4);
+  const decimalFormat = (n: number) => n?.toFixed(4) || "0";
   axisDomain.guideFormat = (n: number) => {
     if (n < 1) {
       return decimalFormat(n);

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsSagas.ts
@@ -41,9 +41,9 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 import { TimeScale, toDateRange } from "@cockroachlabs/cluster-ui";
 import Long from "long";
+import { setTimeScale } from "src/redux/timeScale";
 
 export function* createDiagnosticsReportSaga(
   action: PayloadAction<CreateStatementDiagnosticsReportPayload>,
@@ -157,7 +157,7 @@ export function* setCombinedStatementsTimeScaleSaga(
 ) {
   const ts = action.payload;
 
-  yield put(globalTimeScaleLocalSetting.set(ts));
+  yield put(setTimeScale(ts));
   const [start, end] = toDateRange(ts);
   const req = new CombinedStatementsRequest({
     combined: true,

--- a/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
@@ -18,6 +18,8 @@ import { PayloadAction } from "src/interfaces/action";
 import _ from "lodash";
 import { defaultTimeScaleOptions } from "@cockroachlabs/cluster-ui";
 import moment from "moment";
+import { createSelector } from "reselect";
+import { AdminUIState } from "src/redux/state";
 
 export const SET_SCALE = "cockroachui/timewindow/SET_SCALE";
 export const SET_METRICS_MOVING_WINDOW =
@@ -157,6 +159,11 @@ export function setMetricsFixedWindow(
     payload: tw,
   };
 }
+
+export const selectTimeScale = createSelector(
+  (state: AdminUIState) => state.timeScale,
+  timeScaleState => timeScaleState.scale,
+);
 
 export type AdjustTimeScaleReturnType = {
   timeScale: TimeScale;

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -68,6 +68,8 @@ import {
   TimeWindow,
   TimeScale,
   adjustTimeScale,
+  setTimeScale,
+  selectTimeScale,
 } from "src/redux/timeScale";
 import { InlineAlert } from "src/components";
 import { Anchor, TimeScaleDropdown } from "@cockroachlabs/cluster-ui";
@@ -77,8 +79,6 @@ import {
   selectResolution10sStorageTTL,
   selectResolution30mStorageTTL,
 } from "src/redux/clusterSettings";
-import { setGlobalTimeScaleAction } from "src/redux/statements";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 interface GraphDashboard {
   label: string;
   component: (props: GraphDashboardProps) => React.ReactElement<any>[];
@@ -423,7 +423,7 @@ const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
   hoverState: hoverStateSelector(state),
   resolution10sStorageTTL: selectResolution10sStorageTTL(state),
   resolution30mStorageTTL: selectResolution30mStorageTTL(state),
-  timeScale: globalTimeScaleLocalSetting.selector(state),
+  timeScale: selectTimeScale(state),
 });
 
 const mapDispatchToProps: MapDispatchToProps = {
@@ -433,7 +433,7 @@ const mapDispatchToProps: MapDispatchToProps = {
   hoverOn,
   hoverOff,
   setMetricsFixedWindow: setMetricsFixedWindow,
-  setTimeScale: setGlobalTimeScaleAction,
+  setTimeScale: setTimeScale,
 };
 
 export default compose(

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/customChart/index.tsx
@@ -41,9 +41,9 @@ import {
   TimeWindow,
   TimeScale,
   setMetricsFixedWindow,
+  selectTimeScale,
+  setTimeScale,
 } from "src/redux/timeScale";
-import { setGlobalTimeScaleAction } from "src/redux/statements";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 
 export interface CustomChartProps {
   refreshNodes: typeof refreshNodes;
@@ -324,14 +324,14 @@ const mapStateToProps = (state: AdminUIState) => ({
   nodesSummary: nodesSummarySelector(state),
   nodesQueryValid: state.cachedData.nodes.valid,
   metricsMetadata: metricsMetadataSelector(state),
-  timeScale: globalTimeScaleLocalSetting.selector(state),
+  timeScale: selectTimeScale(state),
 });
 
 const mapDispatchToProps = {
   refreshNodes,
   refreshMetricMetadata,
   setMetricsFixedWindow: setMetricsFixedWindow,
-  setTimeScale: setGlobalTimeScaleAction,
+  setTimeScale: setTimeScale,
 };
 
 export default withRouter(

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -173,7 +173,7 @@ class MetricsDataProvider extends React.Component<
     (props: MetricsDataProviderProps) => props.timeInfo,
     this.queriesSelector,
     (timeInfo, queries) => {
-      if (!timeInfo) {
+      if (!timeInfo || queries.length === 0) {
         return undefined;
       }
       return new protos.cockroach.ts.tspb.TimeSeriesQueryRequest({

--- a/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/shared/containers/metricDataProvider/index.tsx
@@ -37,7 +37,7 @@ import {
 } from "@cockroachlabs/cluster-ui";
 import { History } from "history";
 import { refreshSettings } from "src/redux/apiReducers";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
+import { selectTimeScale } from "src/redux/timeScale";
 
 /**
  * queryFromProps is a helper method which generates a TimeSeries Query data
@@ -249,27 +249,26 @@ class MetricsDataProvider extends React.Component<
 
 // timeInfoSelector converts the current global time window into a set of Long
 // timestamps, which can be sent with requests to the server.
-const timeInfoSelector = createSelector(
-  (state: AdminUIState) => state,
-  state => {
-    const scale = globalTimeScaleLocalSetting.selector(state);
-    const [startMoment, endMoment] = toDateRange(scale);
-    const start = startMoment.valueOf();
-    const end = endMoment.valueOf();
-    const syncedScale = findClosestTimeScale(
-      defaultTimeScaleOptions,
-      util.MilliToSeconds(end - start),
-    );
+const timeInfoSelector = createSelector(selectTimeScale, scale => {
+  if (!_.isObject(scale)) {
+    return null;
+  }
+  const [startMoment, endMoment] = toDateRange(scale);
+  const start = startMoment.valueOf();
+  const end = endMoment.valueOf();
+  const syncedScale = findClosestTimeScale(
+    defaultTimeScaleOptions,
+    util.MilliToSeconds(end - start),
+  );
 
-    return {
-      start: Long.fromNumber(util.MilliToNano(start)),
-      end: Long.fromNumber(util.MilliToNano(end)),
-      sampleDuration: Long.fromNumber(
-        util.MilliToNano(syncedScale.sampleSize.asMilliseconds()),
-      ),
-    };
-  },
-);
+  return {
+    start: Long.fromNumber(util.MilliToNano(start)),
+    end: Long.fromNumber(util.MilliToNano(end)),
+    sampleDuration: Long.fromNumber(
+      util.MilliToNano(syncedScale.sampleSize.asMilliseconds()),
+    ),
+  };
+});
 
 const current = () => {
   let now = moment();

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementDetails.tsx
@@ -30,7 +30,6 @@ import {
   StatementDetails,
   StatementDetailsDispatchProps,
   StatementDetailsStateProps,
-  TimeScale,
   toRoundedDateRange,
   util,
 } from "@cockroachlabs/cluster-ui";
@@ -40,7 +39,6 @@ import {
   setGlobalTimeScaleAction,
 } from "src/redux/statements";
 import { createStatementDiagnosticsAlertLocalSetting } from "src/redux/alerts";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 import {
   trackCancelDiagnosticsBundleAction,
@@ -56,6 +54,8 @@ import {
   statementDetailsLatestQueryAction,
   statementDetailsLatestFormattedQueryAction,
 } from "src/redux/sqlActivity";
+import { selectTimeScale } from "src/redux/timeScale";
+
 type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
 
 const { generateStmtDetailsToID } = util;
@@ -65,8 +65,7 @@ export const selectStatementDetails = createSelector(
     getMatchParamByName(props.match, statementAttr),
   (_state: AdminUIState, props: RouteComponentProps): string =>
     queryByName(props.location, appNamesAttr),
-  (state: AdminUIState): TimeScale =>
-    globalTimeScaleLocalSetting.selector(state),
+  selectTimeScale,
   (state: AdminUIState) => state.cachedData.statementDetails,
   (
     fingerprintID,
@@ -112,7 +111,7 @@ const mapStateToProps = (
     latestFormattedQuery:
       state.sqlActivity.statementDetailsLatestFormattedQuery,
     statementsError: state.cachedData.statements.lastError,
-    timeScale: globalTimeScaleLocalSetting.selector(state),
+    timeScale: selectTimeScale(state),
     nodeNames: nodeDisplayNameByIDSelector(state),
     nodeRegions: nodeRegionsByIDSelector(state),
     diagnosticsReports: selectDiagnosticsReportsByStatementFingerprint(

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -603,6 +603,9 @@ function makeStateWithStatementsAndLastReset(
     localSettings: {
       "timeScale/SQLActivity": timeScale,
     },
+    timeScale: {
+      scale: timeScale,
+    },
   });
 
   const [start, end] = toRoundedDateRange(timeScale);

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -27,7 +27,6 @@ import {
   createStatementDiagnosticsAlertLocalSetting,
   cancelStatementDiagnosticsAlertLocalSetting,
 } from "src/redux/alerts";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 import { queryByName } from "src/util/query";
 
@@ -52,6 +51,7 @@ import {
 import { resetSQLStatsAction } from "src/redux/sqlStats";
 import { LocalSetting } from "src/redux/localsettings";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
+import { selectTimeScale } from "src/redux/timeScale";
 
 type ICollectedStatementStatistics = protos.cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 type IStatementDiagnosticsReport = protos.cockroach.server.serverpb.IStatementDiagnosticsReport;
@@ -270,7 +270,7 @@ export default withRouter(
       apps: selectApps(state),
       columns: statementColumnsLocalSetting.selectorToArray(state),
       databases: selectDatabases(state),
-      timeScale: globalTimeScaleLocalSetting.selector(state),
+      timeScale: selectTimeScale(state),
       filters: filtersLocalSetting.selector(state),
       lastReset: selectLastReset(state),
       nodeRegions: nodeRegionsByIDSelector(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionDetails.tsx
@@ -20,7 +20,6 @@ import {
   selectData,
   selectLastError,
 } from "src/views/transactions/transactionsPage";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 import {
   TransactionDetailsStateProps,
   TransactionDetailsDispatchProps,
@@ -28,6 +27,7 @@ import {
   TransactionDetails,
 } from "@cockroachlabs/cluster-ui";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
+import { selectTimeScale } from "src/redux/timeScale";
 
 export const selectTransaction = createSelector(
   (state: AdminUIState) => state.cachedData.statements,
@@ -65,7 +65,7 @@ export default withRouter(
     ): TransactionDetailsStateProps => {
       const { isLoading, transaction } = selectTransaction(state, props);
       return {
-        timeScale: globalTimeScaleLocalSetting.selector(state),
+        timeScale: selectTimeScale(state),
         error: selectLastError(state),
         isTenant: false,
         nodeRegions: nodeRegionsByIDSelector(state),

--- a/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/transactionsPage.tsx
@@ -26,9 +26,9 @@ import {
   util,
 } from "@cockroachlabs/cluster-ui";
 import { nodeRegionsByIDSelector } from "src/redux/nodes";
-import { globalTimeScaleLocalSetting } from "src/redux/globalTimeScale";
 import { setGlobalTimeScaleAction } from "src/redux/statements";
 import { LocalSetting } from "src/redux/localsettings";
+import { selectTimeScale } from "src/redux/timeScale";
 
 // selectStatements returns the array of AggregateStatistics to show on the
 // TransactionsPage, based on if the appAttr route parameter is set.
@@ -87,7 +87,7 @@ const TransactionsPageConnected = withRouter(
     (state: AdminUIState) => ({
       columns: transactionColumnsLocalSetting.selectorToArray(state),
       data: selectData(state),
-      timeScale: globalTimeScaleLocalSetting.selector(state),
+      timeScale: selectTimeScale(state),
       error: selectLastError(state),
       filters: filtersLocalSetting.selector(state),
       lastReset: selectLastReset(state),


### PR DESCRIPTION
Backport:
  * 1/1 commits from "ui: use TimeScaleState reducer to align time window across pages" (#85826)
  * 2/2 commits from "ui: fix errors on numbers formatting on metrics graphs " (#86041)

Please see individual PRs for details.

/cc @cockroachdb/release

----

Release justification: fixes for high-priority or high-severity bugs in existing functionality
