### PR TITLE
sql/stats: generate statistics forecasts

### DIFF
--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -201,6 +201,9 @@ type TableStatistic interface {
 	// HistogramType returns the type that the histogram was created on. For
 	// inverted index histograms, this will always return types.Bytes.
 	HistogramType() *types.T
+
+	// IsForecast returns true if this statistic is a forecast.
+	IsForecast() bool
 }
 
 // HistogramBucket contains the data for a single histogram bucket. Note

--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast
@@ -1,0 +1,599 @@
+# LogicTest: local
+
+# Tests that verify we create and use table statistics forecasts correctly.
+
+# Verify that we create and use statistics forecasts for a simple table that
+# grows at a constant rate.
+
+statement ok
+CREATE TABLE g (a INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+
+statement ok
+ALTER TABLE g INJECT STATISTICS '[
+      {
+          "avg_size": 1,
+          "columns": [
+              "a"
+          ],
+          "created_at": "1988-08-05 00:00:00.000000",
+          "distinct_count": 3,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 3
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "a"
+          ],
+          "created_at": "1988-08-06 00:00:00.000000",
+          "distinct_count": 6,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "a"
+          ],
+          "created_at": "1988-08-07 00:00:00.000000",
+          "distinct_count": 9,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 9
+      }
+]'
+
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE g WITH FORECAST]
+ORDER BY created
+----
+__auto__      {a}  1988-08-05 00:00:00 +0000 +0000  3   3   0  1
+__auto__      {a}  1988-08-06 00:00:00 +0000 +0000  6   6   0  1
+__auto__      {a}  1988-08-07 00:00:00 +0000 +0000  9   9   0  1
+__forecast__  {a}  1988-08-08 00:00:00 +0000 +0000  12  12  0  1
+
+query T
+EXPLAIN SELECT * FROM g WHERE a >= 9 AND a < 12
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 3 (25% of the table; stats collected <hidden> ago; using stats forecast)
+  table: g@g_pkey
+  spans: [/9 - /11]
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM g WHERE a >= 0 AND a < 100
+----
+scan g
+ ├── columns: a:1
+ ├── constraint: /1: [/0 - /99]
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=12, distinct(1)=10, null(1)=0, avgsize(1)=1]
+ │   histogram(1)=  0 1.3333 0 0.66667 0 0.66667 0 1.3333 0 1.3333 0 0.66667 0 0.66667 0 1.3333 0 1.3333 0 0.66667 0 0.66667 0 1.3333
+ │                <---- 0 ------- 1 ------- 2 ------ 3 ------ 4 ------- 5 ------- 6 ------ 7 ------ 8 ------- 9 ------ 10 ------ 11 -
+ ├── cost: 21.13
+ ├── key: (1)
+ └── distribution: test
+
+# Verify that we create and use statistics forecasts for a simple table that
+# shrinks at a constant rate.
+
+statement ok
+CREATE TABLE s (b INT PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+
+statement ok
+ALTER TABLE s INJECT STATISTICS '[
+      {
+          "avg_size": 1,
+          "columns": [
+              "b"
+          ],
+          "created_at": "1988-08-05 00:00:00.000000",
+          "distinct_count": 9,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "6"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "7"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "8"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 9
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "b"
+          ],
+          "created_at": "1988-08-06 00:00:00.000000",
+          "distinct_count": 6,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "3"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "4"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "5"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6
+      },
+      {
+          "avg_size": 1,
+          "columns": [
+              "b"
+          ],
+          "created_at": "1988-08-07 00:00:00.000000",
+          "distinct_count": 3,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "0"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1"
+              },
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "2"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 3
+      }
+]'
+
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE s WITH FORECAST]
+ORDER BY created
+----
+__auto__      {b}  1988-08-05 00:00:00 +0000 +0000  9  9  0  1
+__auto__      {b}  1988-08-06 00:00:00 +0000 +0000  6  6  0  1
+__auto__      {b}  1988-08-07 00:00:00 +0000 +0000  3  3  0  1
+__forecast__  {b}  1988-08-08 00:00:00 +0000 +0000  0  0  0  1
+
+query T
+SELECT jsonb_pretty(stat)
+FROM (
+SELECT jsonb_array_elements(statistics) AS stat
+FROM [SHOW STATISTICS USING JSON FOR TABLE s WITH FORECAST]
+)
+WHERE stat->>'name' = '__forecast__'
+----
+{
+    "avg_size": 1,
+    "columns": [
+        "b"
+    ],
+    "created_at": "1988-08-08 00:00:00",
+    "distinct_count": 0,
+    "histo_col_type": "INT8",
+    "histo_version": 2,
+    "name": "__forecast__",
+    "null_count": 0,
+    "row_count": 0
+}
+
+query T
+EXPLAIN SELECT * FROM s WHERE b >= 0 AND b < 12
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 1 (100% of the table; stats collected <hidden> ago; using stats forecast)
+  table: s@s_pkey
+  spans: [/0 - /11]
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM s WHERE b >= 0 AND b < 100
+----
+scan s
+ ├── columns: b:1
+ ├── constraint: /1: [/0 - /99]
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, avgsize(1)=1]
+ │   histogram(1)=
+ ├── cost: 10.02
+ ├── key: (1)
+ └── distribution: test
+
+# Verify that we create and use statistics forecasts for a simple table that
+# changes at a constant rate.
+
+statement ok
+CREATE TABLE c (h TIMESTAMPTZ PRIMARY KEY) WITH (sql_stats_automatic_collection_enabled = false)
+
+statement ok
+ALTER TABLE c INJECT STATISTICS '[
+      {
+          "avg_size": 7,
+          "columns": [
+              "h"
+          ],
+          "created_at": "1988-08-05 00:00:00.000000",
+          "distinct_count": 24,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1988-08-04 00:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-04 06:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-04 12:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-04 18:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 0,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-05 00:00:00+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 24
+      },
+      {
+          "avg_size": 7,
+          "columns": [
+              "h"
+          ],
+          "created_at": "1988-08-06 00:00:00.000000",
+          "distinct_count": 24,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1988-08-05 00:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-05 06:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-05 12:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-05 18:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 0,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-06 00:00:00+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 24
+      },
+      {
+          "avg_size": 7,
+          "columns": [
+              "h"
+          ],
+          "created_at": "1988-08-07 00:00:00.000000",
+          "distinct_count": 24,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 1,
+                  "num_range": 0,
+                  "upper_bound": "1988-08-06 00:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-06 06:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-06 12:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 1,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-06 18:00:00+00:00"
+              },
+              {
+                  "distinct_range": 5,
+                  "num_eq": 0,
+                  "num_range": 5,
+                  "upper_bound": "1988-08-07 00:00:00+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "histo_version": 2,
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 24
+      }
+]'
+
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE c WITH FORECAST]
+ORDER BY created
+----
+__auto__      {h}  1988-08-05 00:00:00 +0000 +0000  24  24  0  7
+__auto__      {h}  1988-08-06 00:00:00 +0000 +0000  24  24  0  7
+__auto__      {h}  1988-08-07 00:00:00 +0000 +0000  24  24  0  7
+__forecast__  {h}  1988-08-08 00:00:00 +0000 +0000  24  24  0  7
+
+query T
+EXPLAIN SELECT * FROM c WHERE h >= '1988-08-07'
+----
+distribution: local
+vectorized: true
+·
+• scan
+  estimated row count: 24 (100% of the table; stats collected <hidden> ago; using stats forecast)
+  table: c@c_pkey
+  spans: [/'1988-08-07 00:00:00+00:00' - ]
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT * FROM c WHERE h >= '1988-08-07'
+----
+scan c
+ ├── columns: h:1
+ ├── constraint: /1: [/'1988-08-07 00:00:00+00:00' - ]
+ ├── stats: [rows=24, distinct(1)=24, null(1)=0, avgsize(1)=7]
+ │   histogram(1)=  0               1               5               1               5               1               5               1               4               1
+ │                <--- '1988-08-07 00:00:00+00:00' --- '1988-08-07 06:00:00+00:00' --- '1988-08-07 12:00:00+00:00' --- '1988-08-07 18:00:00+00:00' --- '1988-08-08 00:00:00+00:00'
+ ├── cost: 39.7
+ ├── key: (1)
+ └── distribution: test

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -207,6 +207,13 @@ func TestExecBuild_fk(
 	runExecBuildLogicTest(t, "fk")
 }
 
+func TestExecBuild_forecast(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "forecast")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -475,10 +475,31 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 						}
 						duration = string(humanizeutil.LongDuration(timeSinceStats))
 					}
+
+					var forecastStr string
+					if s.Forecast {
+						if e.ob.flags.Redact.Has(RedactVolatile) {
+							forecastStr = "; using stats forecast"
+						} else {
+							timeSinceStats := timeutil.Since(s.ForecastAt)
+							if timeSinceStats >= 0 {
+								forecastStr = fmt.Sprintf(
+									"; using stats forecast for %s ago", humanizeutil.LongDuration(timeSinceStats),
+								)
+							} else {
+								timeSinceStats *= -1
+								forecastStr = fmt.Sprintf(
+									"; using stats forecast for %s in the future",
+									humanizeutil.LongDuration(timeSinceStats),
+								)
+							}
+						}
+					}
+
 					e.ob.AddField("estimated row count", fmt.Sprintf(
-						"%s (%s%% of the table; stats collected %s ago)",
+						"%s (%s%% of the table; stats collected %s ago%s)",
 						estimatedRowCountString, percentageStr,
-						duration,
+						duration, forecastStr,
 					))
 				} else {
 					e.ob.AddField("estimated row count", estimatedRowCountString)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -310,6 +310,12 @@ type EstimatedStats struct {
 	// LimitHint is the "soft limit" of the number of result rows that may be
 	// required. See physical.Required for details.
 	LimitHint float64
+	// Forecast is set only for scans; it is true if the stats for the scan were
+	// forecasted rather than collected.
+	Forecast bool
+	// ForecastAt is set only for scans with forecasted stats; it is the time the
+	// forecast was for (which could be in the past, present, or future).
+	ForecastAt time.Time
 }
 
 // ExecutionStats contain statistics about a given operator gathered from the

--- a/pkg/sql/opt/testutils/testcat/BUILD.bazel
+++ b/pkg/sql/opt/testutils/testcat/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     deps = [
         "//pkg/config/zonepb",
         "//pkg/geo/geoindex",
+        "//pkg/jobs/jobspb",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -1228,6 +1229,11 @@ func (ts *TableStat) HistogramType() *types.T {
 		panic(err)
 	}
 	return tree.MustBeStaticallyKnownType(colTypeRef)
+}
+
+// IsForecast is part of the cat.TableStatistic interface.
+func (ts *TableStat) IsForecast() bool {
+	return ts.js.Name == jobspb.ForecastStatsName
 }
 
 // TableStats is a slice of TableStat pointers.

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/geo/geoindex"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1683,6 +1684,11 @@ func (os *optTableStat) Histogram() []cat.HistogramBucket {
 // HistogramType is part of the cat.TableStatistic interface.
 func (os *optTableStat) HistogramType() *types.T {
 	return os.stat.HistogramData.ColumnType
+}
+
+// IsForecast is part of the cat.TableStatistic interface.
+func (os *optTableStat) IsForecast() bool {
+	return os.stat.Name == jobspb.ForecastStatsName
 }
 
 // optFamily is a wrapper around descpb.ColumnFamilyDescriptor that keeps a

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -616,6 +616,8 @@ func (s *sampleAggregator) generateHistogram(
 			prevCapacity, sr.Cap(),
 		)
 	}
+	// TODO(michae2): Instead of using the flowCtx's evalCtx, investigate
+	// whether this can use a nil *eval.Context.
 	h, _, err := stats.EquiDepthHistogram(evalCtx, colType, values, numRows, distinctCount, maxBuckets)
 	return h, err
 }

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -566,6 +566,9 @@ func (ec *Context) SetStmtTimestamp(ts time.Time) {
 
 // GetLocation returns the session timezone.
 func (ec *Context) GetLocation() *time.Location {
+	if ec == nil {
+		return time.UTC
+	}
 	return ec.SessionData().GetLocation()
 }
 

--- a/pkg/sql/show_stats.go
+++ b/pkg/sql/show_stats.go
@@ -179,7 +179,7 @@ func (p *planner) ShowTableStats(ctx context.Context, n *tree.ShowTableStats) (p
 					observed[i], observed[j] = observed[j], observed[i]
 				}
 
-				forecasts := stats.ForecastTableStatistics(ctx, p.EvalContext(), observed)
+				forecasts := stats.ForecastTableStatistics(ctx, observed)
 
 				// Iterate in reverse order to match the ORDER BY "columnIDs".
 				for i := len(forecasts) - 1; i >= 0; i-- {

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -773,8 +773,14 @@ func checkStatsCount(
 		if err != nil {
 			return err
 		}
-		if len(stats) != expected {
-			return fmt.Errorf("expected %d stat(s) but found %d", expected, len(stats))
+		var count int
+		for i := range stats {
+			if stats[i].Name != jobspb.ForecastStatsName {
+				count++
+			}
+		}
+		if count != expected {
+			return fmt.Errorf("expected %d stat(s) but found %d", expected, count)
 		}
 		return nil
 	})

--- a/pkg/sql/stats/forecast_test.go
+++ b/pkg/sql/stats/forecast_test.go
@@ -18,10 +18,8 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -581,7 +579,6 @@ func TestForecastColumnStatistics(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
-	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 
@@ -593,7 +590,7 @@ func TestForecastColumnStatistics(t *testing.T) {
 			expected := tc.forecast.toTableStatistic(jobspb.ForecastStatsName, i)
 			at := testStatTime(tc.at)
 
-			forecast, err := forecastColumnStatistics(ctx, evalCtx, observed, at, 1)
+			forecast, err := forecastColumnStatistics(ctx, observed, at, 1)
 			if err != nil {
 				if !tc.err {
 					t.Errorf("test case %d unexpected forecastColumnStatistics err: %v", i, err)

--- a/pkg/sql/stats/quantile_test.go
+++ b/pkg/sql/stats/quantile_test.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -41,19 +40,18 @@ func TestRandomQuantileRoundTrip(t *testing.T) {
 		types.Float4,
 	}
 	colTypes = append(colTypes, types.Scalar...)
-	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	rng, seed := randutil.NewTestRand()
 	for _, colType := range colTypes {
 		if canMakeQuantile(histVersion, colType) {
 			for i := 0; i < 5; i++ {
 				t.Run(fmt.Sprintf("%v/%v", colType.Name(), i), func(t *testing.T) {
-					hist, rowCount := randHist(evalCtx, colType, rng)
+					hist, rowCount := randHist(colType, rng)
 					qfun, err := makeQuantile(hist, rowCount)
 					if err != nil {
 						t.Errorf("seed: %v unexpected makeQuantile error: %v", seed, err)
 						return
 					}
-					hist2, err := qfun.toHistogram(evalCtx, colType, rowCount)
+					hist2, err := qfun.toHistogram(colType, rowCount)
 					if err != nil {
 						t.Errorf("seed: %v unexpected quantile.toHistogram error: %v", seed, err)
 						return
@@ -70,12 +68,10 @@ func TestRandomQuantileRoundTrip(t *testing.T) {
 // randHist makes a random histogram of the specified type, with [1, 200]
 // buckets. Not all types are supported. Every bucket will have NumEq > 0 but
 // could have NumRange == 0.
-func randHist(
-	compareCtx tree.CompareContext, colType *types.T, rng *rand.Rand,
-) (histogram, float64) {
+func randHist(colType *types.T, rng *rand.Rand) (histogram, float64) {
 	numBuckets := rng.Intn(200) + 1
 	buckets := make([]cat.HistogramBucket, numBuckets)
-	bounds := randBounds(compareCtx, colType, rng, numBuckets)
+	bounds := randBounds(colType, rng, numBuckets)
 	buckets[0].NumEq = float64(rng.Intn(100) + 1)
 	buckets[0].UpperBound = bounds[0]
 	rowCount := buckets[0].NumEq
@@ -98,6 +94,7 @@ func randHist(
 		rowCount += rows
 	}
 	// Set DistinctRange in all buckets.
+	var compareCtx *eval.Context
 	for i := 1; i < len(buckets); i++ {
 		lowerBound := getNextLowerBound(compareCtx, buckets[i-1].UpperBound)
 		buckets[i].DistinctRange = estimatedDistinctValuesInRange(
@@ -111,9 +108,7 @@ func randHist(
 // type. Not all types are supported. This differs from randgen.RandDatum in
 // that it generates no "interesting" Datums, and differs from
 // randgen.RandDatumSimple in that it generates distinct Datums without repeats.
-func randBounds(
-	compareCtx tree.CompareContext, colType *types.T, rng *rand.Rand, num int,
-) tree.Datums {
+func randBounds(colType *types.T, rng *rand.Rand, num int) tree.Datums {
 	datums := make(tree.Datums, num)
 
 	// randInts creates an ordered slice of num distinct random ints in the closed
@@ -566,10 +561,9 @@ func TestQuantileToHistogram(t *testing.T) {
 			err:  true,
 		},
 	}
-	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			hist, err := tc.qfun.toHistogram(evalCtx, types.Float, tc.rows)
+			hist, err := tc.qfun.toHistogram(types.Float, tc.rows)
 			if err != nil {
 				if !tc.err {
 					t.Errorf("test case %d unexpected quantile.toHistogram err: %v", i, err)
@@ -843,7 +837,7 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 			err: true,
 		},
 	}
-	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	var compareCtx *eval.Context
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			val, err := toQuantileValue(tc.dat)
@@ -867,7 +861,7 @@ func TestQuantileValueRoundTrip(t *testing.T) {
 				t.Errorf("test case %d (%v) unexpected fromQuantileValue err: %v", i, tc.typ.Name(), err)
 				return
 			}
-			cmp, err := res.CompareError(evalCtx, tc.dat)
+			cmp, err := res.CompareError(compareCtx, tc.dat)
 			if err != nil {
 				t.Errorf("test case %d (%v) unexpected CompareError err: %v", i, tc.typ.Name(), err)
 				return
@@ -1120,7 +1114,7 @@ func TestQuantileValueRoundTripOverflow(t *testing.T) {
 			res: quantileMaxTimestampSec,
 		},
 	}
-	evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
+	var compareCtx *eval.Context
 	for i, tc := range testCases {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			d, err := fromQuantileValue(tc.typ, tc.val)
@@ -1134,7 +1128,7 @@ func TestQuantileValueRoundTripOverflow(t *testing.T) {
 				t.Errorf("test case %d (%v) expected fromQuantileValue err", i, tc.typ.Name())
 				return
 			}
-			cmp, err := d.CompareError(evalCtx, tc.dat)
+			cmp, err := d.CompareError(compareCtx, tc.dat)
 			if err != nil {
 				t.Errorf("test case %d (%v) unexpected CompareError err: %v", i, tc.typ.Name(), err)
 				return

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -720,5 +720,8 @@ ORDER BY "createdAt" DESC, "columnIDs" DESC, "statisticID" DESC
 		return nil, err
 	}
 
+	forecasts := ForecastTableStatistics(ctx, statsList)
+	statsList = append(forecasts, statsList...)
+
 	return statsList, nil
 }


### PR DESCRIPTION
**sql/stats: use nil eval.Context as CompareContext when forecasting**

When forecasting table statistics, we don't need a full *eval.Context.
We can simply use a nil *eval.Context as a tree.CompareContext. This
means we don't have to plumb an eval.Context into the stats cache.

Assists: #79872

Release note: None

**sql/stats: generate statistics forecasts in the stats cache**

As of this commit, we now try to generate statistics forecasts for every
column of every table. This happens whenever statistics are loaded into
or refreshed in the stats cache. We use only the forecasts that fit the
historical collected statistics very well, meaning we have high
confidence in their accuracy.

Fixes: #79872

Release note (performance improvement): Enable table statistics
forecasts, which predict future statistics based on historical collected
statistics. Forecasts help the optimizer produce better plans for
queries that read data modified after the latest statistics collection.
We use only the forecasts that fit the historical collected statistics
very well, meaning we have high confidence in their accuracy. Forecasts
can be viewed using `SHOW STATISTICS FOR TABLE ... WITH FORECAST`.

**sql: show forecasted stats time in EXPLAIN**

When using statistics forecasts, add the forecast time (which could be
in the future) to EXPLAIN output. This both indicates that forecasts are
in use, and gives us an idea of how up-to-date / ahead they are.

Assists: #79872

Release note: None

**sql/opt: add tests for statistics forecasts**

Add a few simple testcases for usage of statistics forecasts by the
optimizer.

Assists: #79872

Release note: None

---

Release justification: Enable feature before we get too far into
stability period.