### PR TITLE
storage: omit `MVCCIterator.Stats()` call during `MVCCScan`/`MVCCGet`

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -1403,7 +1403,3 @@ func (p *pebbleMVCCScanner) intentsRepr() []byte {
 	}
 	return p.intents.Repr()
 }
-
-func (p *pebbleMVCCScanner) stats() IteratorStats {
-	return p.parent.Stats()
-}


### PR DESCRIPTION
`MVCCScan` and `MVCCGet` attach iterator statistics to an active trace.
However, they would fetch the iterator statistics even if no trace was
active, which has a significant cost. This patch avoids fetching the
stats when there is no active trace.

```
name                                                                 old time/op    new time/op    delta
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=0-24     3.59µs ± 0%    3.34µs ± 0%  -7.02%  (p=0.000 n=10+8)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=1-24     7.43µs ± 1%    7.01µs ± 0%  -5.70%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=0-24    4.62µs ± 1%    4.36µs ± 1%  -5.53%  (p=0.000 n=10+10)
MVCCGet_Pebble/batch=true/versions=10/valueSize=8/numRangeKeys=1-24    10.4µs ± 1%    10.0µs ± 1%  -3.79%  (p=0.000 n=10+10)
```

Resolves #86083.
Touches #64503.

Release note: None