### PR TITLE
CODEOWNERS: stop dev-inf PR review requests for gen file list changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,6 +188,8 @@
 /pkg/ccl/sqlproxyccl/        @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
 
 /pkg/gen/                    @cockroachdb/dev-inf
+/pkg/gen/*.bzl               @cockroachdb/dev-inf-noreview
+/pkg/gen/gen.bzl             @cockroachdb/dev-inf
 
 /pkg/acceptance/             @cockroachdb/sql-experience
 /pkg/base/                   @cockroachdb/unowned @cockroachdb/kv-prs @cockroachdb/server-prs


### PR DESCRIPTION
Changes to most of the generated pkg/gen/*.bzl files happen for many PRs
and they don't need to be reviewed by dev inf. Let's stop getting PR
review requests for them.

Release note: None
Release justification: non-production code change