### PR TITLE
storage: use `RangeKeyChanged()` in `ComputeStats()`

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -648,7 +648,7 @@ func (b *SSTBatcher) addSSTable(
 	sendStart := timeutil.Now()
 
 	// Currently, the SSTBatcher cannot ingest range keys, so it is safe to
-	// ComputeStatsForRange with an iterator that only surfaces point keys.
+	// ComputeStats with an iterator that only surfaces point keys.
 	iterOpts := storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsOnly,
 		LowerBound: start,

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -213,7 +213,7 @@ func (rsl StateLoader) SetRangeAppliedState(
 		RaftAppliedIndexTerm: appliedIndexTerm,
 	}
 	// The RangeAppliedStateKey is not included in stats. This is also reflected
-	// in ComputeStatsForRange.
+	// in ComputeStats.
 	ms := (*enginepb.MVCCStats)(nil)
 	return storage.MVCCPutProto(ctx, readWriter, ms, rsl.RangeAppliedStateKey(),
 		hlc.Timestamp{}, hlc.ClockTimestamp{}, nil, as)


### PR DESCRIPTION
This patch makes use of `RangeKeyChanged()` in `ComputeStats()`, for
more efficient processing of MVCC range tombstones.

```
name                                                       old time/op    new time/op    delta
MVCCComputeStats_Pebble/valueSize=8/numRangeKeys=0-24         230ms ± 0%     220ms ± 1%   -4.57%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=8/numRangeKeys=1-24         344ms ± 1%     271ms ± 1%  -21.18%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=8/numRangeKeys=100-24       365ms ± 1%     293ms ± 0%  -19.80%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=32/numRangeKeys=0-24        162ms ± 1%     154ms ± 0%   -4.92%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=32/numRangeKeys=1-24        239ms ± 0%     190ms ± 0%  -20.75%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=32/numRangeKeys=100-24      260ms ± 1%     209ms ± 0%  -19.54%  (p=0.008 n=5+5)
MVCCComputeStats_Pebble/valueSize=256/numRangeKeys=0-24      55.7ms ± 8%    51.0ms ± 7%     ~     (p=0.095 n=5+5)
MVCCComputeStats_Pebble/valueSize=256/numRangeKeys=1-24      72.8ms ± 2%    58.6ms ± 1%  -19.49%  (p=0.016 n=5+4)
MVCCComputeStats_Pebble/valueSize=256/numRangeKeys=100-24    82.1ms ± 5%    67.9ms ± 3%  -17.26%  (p=0.008 n=5+5)
```

Touches #84544.

Release note: None