### PR TITLE
release-22.1: storage: omit `MVCCIterator.Stats()` call during `MVCCScan`/`MVCCGet`

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -1166,7 +1166,3 @@ func (p *pebbleMVCCScanner) intentsRepr() []byte {
 	}
 	return p.intents.Repr()
 }
-
-func (p *pebbleMVCCScanner) stats() IteratorStats {
-	return p.parent.Stats()
-}


### PR DESCRIPTION
Backport:

* #86084
* #74342

/cc https://github.com/orgs/cockroachdb/teams/release

---

Release justification: performance improvements.