### PR TITLE
sql: make round builtin avoid negative zeros

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1187,10 +1187,10 @@ SELECT round(123.456::float, -1), round(123.456::float, -2), round(123.456::floa
 ----
 120 100 0
 
-query RRRR
-SELECT round(123.456::decimal, -1), round(123.456::decimal, -2), round(123.456::decimal, -3), round(123.456::decimal, -200)
+query RRRRR
+SELECT round(123.456::decimal, -1), round(123.456::decimal, -2), round(123.456::decimal, -3), round(123.456::decimal, -200), round(-0.1::decimal)
 ----
-1.2E+2  1E+2  0E+3  0E+200
+1.2E+2  1E+2  0E+3  0E+200  0
 
 query RRRR
 SELECT round('nan'::decimal), round('nan'::decimal, 1), round('nan'::float), round('nan'::float, 1)

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -769,6 +769,9 @@ func roundDDecimal(d *tree.DDecimal, scale int32) (tree.Datum, error) {
 func roundDecimal(x *apd.Decimal, scale int32) (tree.Datum, error) {
 	dd := &tree.DDecimal{}
 	_, err := tree.HighPrecisionCtx.Quantize(&dd.Decimal, x, -scale)
+	if dd.IsZero() {
+		dd.Negative = false
+	}
 	return dd, err
 }
 


### PR DESCRIPTION
fixes  https://github.com/cockroachdb/cockroach/issues/28404

Previously, the round function could return -0.
In PostgreSQL, the function returns 0 without a negative sign,
so this commit changes the behavior of round to match that.

Release note (sql change): The round(decimal) builtin function
no longer returns negative 0 for any input.