### PR TITLE
storage: optimize `pointSynthesizingIter` for `MVCCScan`

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -1199,7 +1199,7 @@ func (p *pebbleMVCCScanner) enablePointSynthesis() {
 		if ok, _ := p.parent.Valid(); !ok {
 			panic(errors.AssertionFailedf("enablePointSynthesis called with invalid iter"))
 		}
-		if _, ok := p.parent.(*pointSynthesizingIter); ok {
+		if p.pointIter != nil {
 			panic(errors.AssertionFailedf("enablePointSynthesis called when already enabled"))
 		}
 		if _, hasRange := p.parent.HasPointAndRange(); !hasRange {
@@ -1255,6 +1255,12 @@ func (p *pebbleMVCCScanner) iterValid() bool {
 	// is convenient to check for any range keys and enable point synthesis here.
 	if p.parent.RangeKeyChanged() {
 		p.enablePointSynthesis()
+	}
+	if util.RaceEnabled && p.pointIter == nil {
+		if _, hasRange := p.parent.HasPointAndRange(); hasRange {
+			panic(errors.AssertionFailedf("range key did not trigger point synthesis at %s",
+				p.parent.UnsafeKey()))
+		}
 	}
 	return true
 }


### PR DESCRIPTION
**storage: improve `pebbleMVCCScanner` range key assertions**

Release note: None

**storage: use `RangeKeyChanged()` in `pointSynthesizingIter`**

This patch uses `RangeKeyChanged()` to detect changes to range keys in
`pointSynthesizingIter`, avoiding repeated key decoding and comparisons
in the hot path.

```
name                                                                  old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24        5.89µs ± 1%    5.94µs ± 0%  +0.74%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24        12.9µs ± 0%    13.0µs ± 1%    ~     (p=0.151 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24      41.9µs ± 1%    43.0µs ± 1%  +2.62%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24      75.7µs ± 1%    71.9µs ± 1%  -4.90%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24    2.97ms ± 1%    2.97ms ± 1%    ~     (p=0.841 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24    5.62ms ± 1%    5.13ms ± 0%  -8.88%  (p=0.008 n=5+5)
```

Touches #83049.

Release note: None
  
**storage: memoize parent state in `pointSynthesizingIter`**

This patch memoizes the parent iterator state in `pointSynthesizingIter`
every time its position changes, which omits a number of redundant
function calls and key comparisons.

```
name                                                                  old time/op    new time/op     delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24        5.66µs ± 1%     5.57µs ± 1%   -1.61%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24        12.3µs ± 1%     11.9µs ± 1%   -3.33%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24      38.7µs ± 2%     38.8µs ± 1%     ~     (p=0.448 n=9+9)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24      67.0µs ± 1%     60.0µs ± 1%  -10.45%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24    2.81ms ± 1%     2.83ms ± 1%   +0.73%  (p=0.002 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24    4.99ms ± 1%     4.29ms ± 1%  -14.03%  (p=0.000 n=10+9)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=0-24      3.33µs ± 2%     3.33µs ± 3%     ~     (p=0.382 n=10+10)
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=1-24      6.71µs ± 2%     6.59µs ± 1%   -1.90%  (p=0.000 n=10+10)
```

Touches #83049.

Release note: None
  
**storage: omit `pointSynthesizingIter` start key comparison**

This patch adds a field `rangeKeyStartPassed` which is set to `true`
when the iterator moves past the start key of a range key in the forward
direction. This allows omitting a key comparison for subsequent point
keys until encountering a new range key.

```
name                                                                    old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24          5.57µs ± 1%    5.58µs ± 2%    ~     (p=0.841 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=1-24          11.8µs ± 1%    11.9µs ± 0%  +0.71%  (p=0.016 n=5+5)
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=100-24         164µs ± 1%     163µs ± 1%    ~     (p=0.548 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24        38.9µs ± 1%    38.8µs ± 1%    ~     (p=0.841 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=1-24        61.7µs ± 1%    59.5µs ± 0%  -3.65%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=100-24       170µs ± 1%     165µs ± 1%  -3.07%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24      2.89ms ± 1%    2.82ms ± 0%  -2.29%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=1-24      4.37ms ± 0%    4.28ms ± 0%  -1.90%  (p=0.008 n=5+5)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=100-24    5.38ms ± 1%    5.40ms ± 1%    ~     (p=0.690 n=5+5)
```

Touches #83049.

Release note: None
  
**storage: clean up `pointSynthesizingIter`**

This patch makes some minor cleanups of `pointSynthesizingIter`. There
are no visible behavioral changes.

Release note: None