### PR TITLE
sql: deflake TestSchemaChangeRetry

### DIFF
--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -309,11 +309,6 @@ func TestUnsplitRanges(t *testing.T) {
 		if _, err := sqlDB.Exec(tc.query); err != nil {
 			t.Fatal(err)
 		}
-		// Push a new zone config for a few tables with TTL=0 so the data
-		// is deleted immediately.
-		if _, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, tableDesc.GetID()); err != nil {
-			t.Fatal(err)
-		}
 
 		// Check GC worked!
 		testutils.SucceedsSoon(t, func() error {


### PR DESCRIPTION
Now that GC happens eagerly in the GC job, we need to hold off the GC job to
make sure that key counts match the test's expectations.

Fixes flakes like [this one](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_BazelEssentialCi/6093943)

Release justification: Testing only change. 

Release note: None