### PR TITLE
streamingccl: fix NPE in crdb_internal.stream_ingestion_stats*

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal
@@ -161,3 +161,18 @@ RANGE default  ALTER RANGE default CONFIGURE ZONE USING
 # to, the background generators would conflict with an error.
 statement ok
 SELECT a.* FROM crdb_internal.partitions AS a JOIN crdb_internal.partitions AS b ON a.table_id = b.table_id
+
+subtest replication-builtins
+
+user testuser
+
+query error pq: crdb_internal\.stream_ingestion_stats_json\(\): replication restricted to ADMIN role
+SELECT crdb_internal.stream_ingestion_stats_json(unique_rowid());
+
+user root
+
+query error pq: crdb_internal\.stream_ingestion_stats_json\(\): job.*does not exist
+SELECT crdb_internal.stream_ingestion_stats_json(unique_rowid());
+
+query error pq: crdb_internal\.stream_ingestion_stats_json\(\): job.*is not a stream ingestion job
+SELECT crdb_internal.stream_ingestion_stats_json(id) FROM (SELECT id FROM system.jobs LIMIT 1);

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_job.go
@@ -63,7 +63,11 @@ func getStreamIngestionStats(
 	if err != nil {
 		return nil, err
 	}
-	details := j.Details().(jobspb.StreamIngestionDetails)
+	details, ok := j.Details().(jobspb.StreamIngestionDetails)
+	if !ok {
+		return nil, errors.Errorf("job with id %d is not a stream ingestion job", ingestionJobID)
+	}
+
 	progress := j.Progress()
 	stats := &streampb.StreamIngestionStats{
 		IngestionDetails:  &details,


### PR DESCRIPTION
This fixes a NPE that could occur if the user passed in the Job ID of
a job that isn't a stream ingestion job.

Fixes #86040

Release note: None

Release justification: Bug fix for non-production feature.