### PR TITLE
rangefeed: bench mvcc range tombstones in BenchmarkCatchUpScan

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_test.go
@@ -31,6 +31,13 @@ import (
 // https://github.com/cockroachdb/cockroach/issues/82715
 //
 // For now, see rangefeed_external_test.go for rudimentary range key tests.
+//
+// To invoke and compare on the numRangeKeys dimension:
+//
+//     go test ./pkg/kv/kvserver/rangefeed/ -run - -count 10 -bench BenchmarkCatchUpScan 2>&1 | tee bench.txt
+//     for flavor in numRangeKeys=0 numRangeKeys=1 numRangeKeys=100; do grep -E "${flavor}[^0-9]+" bench.txt | sed -E "s/${flavor}+/X/" > $flavor.txt; done
+//     benchstat numRangeKeys\={0,1}.txt
+//     benchstat numRangeKeys\={0,100}.txt
 func TestCatchupScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)


### PR DESCRIPTION
```
go test ./pkg/kv/kvserver/rangefeed/ -run - -count 10 -bench BenchmarkCatchUpScan 2>&1 | tee bench.txt
for flavor in numRangeKeys=0 numRangeKeys=1 numRangeKeys=100; do grep -E "${flavor}[^0-9]+" bench.txt | sed -E "s/${flavor}+/X/" > $flavor.txt; done && benchstat numRangeKeys\=*
```

```
benchstat numRangeKeys\={0,1}.txt

name                                                    old time/op  new time/op   delta
CatchUpScan/random-keys/withDiff=true/perc=0.00/X-24     663ms ± 1%    870ms ± 1%  +31.18%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=50.00/X-24    1.20s ± 1%    2.05s ± 0%  +71.31%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=75.00/X-24    1.19s ± 1%    1.62s ± 1%  +36.46%  (p=0.000 n=10+9)
CatchUpScan/random-keys/withDiff=true/perc=95.00/X-24    704ms ± 4%    882ms ± 1%  +25.31%  (p=0.000 n=10+9)
CatchUpScan/random-keys/withDiff=true/perc=99.00/X-24    580ms ± 1%    733ms ± 1%  +26.30%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=0.00/X-24    993ms ± 1%   1215ms ± 2%  +22.33%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=50.00/X-24   821ms ± 1%   1044ms ± 1%  +27.11%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=75.00/X-24   694ms ± 1%    843ms ± 1%  +21.46%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=95.00/X-24   573ms ± 1%    706ms ± 1%  +23.19%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=99.00/X-24   554ms ± 0%    682ms ± 1%  +23.10%  (p=0.000 n=8+10)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/X-24      670ms ± 1%    871ms ± 1%  +29.92%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=true/perc=50.00/X-24     1.33s ± 0%    2.31s ± 0%  +73.67%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=true/perc=75.00/X-24     1.14s ± 1%    1.93s ± 1%  +69.53%  (p=0.000 n=9+10)
CatchUpScan/mixed-case/withDiff=true/perc=95.00/X-24     233ms ± 1%    289ms ± 1%  +24.20%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=true/perc=99.00/X-24     195ms ± 1%    235ms ± 1%  +20.49%  (p=0.000 n=8+10)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/X-24     1.01s ± 1%    1.22s ± 1%  +21.81%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/X-24    839ms ± 1%   1052ms ± 1%  +25.33%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=75.00/X-24    734ms ± 0%    948ms ± 1%  +29.19%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/X-24    214ms ± 3%    245ms ± 1%  +14.12%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=99.00/X-24    190ms ± 1%    222ms ± 1%  +16.81%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=0.00/X-24     643ms ± 2%    845ms ± 1%  +31.30%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=50.00/X-24    313ms ± 2%    422ms ± 2%  +35.11%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=75.00/X-24    152ms ± 2%    205ms ± 1%  +34.65%  (p=0.000 n=10+8)
CatchUpScan/linear-keys/withDiff=true/perc=95.00/X-24   29.3ms ± 5%   40.0ms ± 1%  +36.49%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=99.00/X-24   5.78ms ± 2%   8.05ms ± 3%  +39.24%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=0.00/X-24    940ms ± 1%   1173ms ± 1%  +24.80%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=50.00/X-24   464ms ± 1%    539ms ± 1%  +16.20%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=75.00/X-24   225ms ± 2%    261ms ± 2%  +16.32%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=95.00/X-24  42.9ms ± 1%   50.4ms ± 2%  +17.58%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=99.00/X-24  8.44ms ± 1%  10.12ms ± 2%  +19.91%  (p=0.000 n=8+10)
```

```
benchstat numRangeKeys\={0,100}.txt

name                                                    old time/op  new time/op  delta
CatchUpScan/random-keys/withDiff=true/perc=0.00/X-24     663ms ± 1%   945ms ± 1%   +42.51%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=50.00/X-24    1.20s ± 1%   2.58s ± 0%  +115.84%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=75.00/X-24    1.19s ± 1%   1.62s ± 1%   +35.94%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=95.00/X-24    704ms ± 4%  1022ms ± 1%   +45.12%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=true/perc=99.00/X-24    580ms ± 1%   859ms ± 0%   +48.05%  (p=0.000 n=10+9)
CatchUpScan/random-keys/withDiff=false/perc=0.00/X-24    993ms ± 1%  1228ms ± 1%   +23.61%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=50.00/X-24   821ms ± 1%  1057ms ± 1%   +28.73%  (p=0.000 n=10+9)
CatchUpScan/random-keys/withDiff=false/perc=75.00/X-24   694ms ± 1%   923ms ± 1%   +33.04%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=95.00/X-24   573ms ± 1%   823ms ± 1%   +43.56%  (p=0.000 n=10+10)
CatchUpScan/random-keys/withDiff=false/perc=99.00/X-24   554ms ± 0%   801ms ± 1%   +44.51%  (p=0.000 n=8+10)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/X-24      670ms ± 1%   956ms ± 1%   +42.65%  (p=0.000 n=10+9)
CatchUpScan/mixed-case/withDiff=true/perc=50.00/X-24     1.33s ± 0%   3.15s ± 0%  +136.94%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=true/perc=75.00/X-24     1.14s ± 1%   2.56s ± 0%  +124.96%  (p=0.000 n=9+10)
CatchUpScan/mixed-case/withDiff=true/perc=95.00/X-24     233ms ± 1%   395ms ± 0%   +69.80%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=true/perc=99.00/X-24     195ms ± 1%   347ms ± 1%   +78.15%  (p=0.000 n=8+9)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/X-24     1.01s ± 1%   1.24s ± 1%   +23.17%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/X-24    839ms ± 1%  1066ms ± 1%   +27.10%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=75.00/X-24    734ms ± 0%   964ms ± 1%   +31.29%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/X-24    214ms ± 3%   353ms ± 1%   +64.88%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=99.00/X-24    190ms ± 1%   329ms ± 1%   +72.95%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=0.00/X-24     643ms ± 2%   916ms ± 2%   +42.40%  (p=0.000 n=10+9)
CatchUpScan/linear-keys/withDiff=true/perc=50.00/X-24    313ms ± 2%   466ms ± 1%   +49.05%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=75.00/X-24    152ms ± 2%   209ms ± 1%   +37.74%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=true/perc=95.00/X-24   29.3ms ± 5%  40.3ms ± 1%   +37.42%  (p=0.000 n=10+9)
CatchUpScan/linear-keys/withDiff=true/perc=99.00/X-24   5.78ms ± 2%  7.70ms ± 1%   +33.23%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=0.00/X-24    940ms ± 1%  1189ms ± 2%   +26.60%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=50.00/X-24   464ms ± 1%   541ms ± 1%   +16.67%  (p=0.000 n=10+9)
CatchUpScan/linear-keys/withDiff=false/perc=75.00/X-24   225ms ± 2%   262ms ± 1%   +16.78%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=95.00/X-24  42.9ms ± 1%  50.3ms ± 1%   +17.21%  (p=0.000 n=10+10)
CatchUpScan/linear-keys/withDiff=false/perc=99.00/X-24  8.44ms ± 1%  9.89ms ± 1%   +17.26%  (p=0.000 n=8+10)
```


Fixes https://github.com/cockroachdb/cockroach/issues/86128.

Release note: None
Release justification: critical bug fix & benchmarking for new functionality (mvcc range deletions)
