### PR TITLE
ui/cluster-ui: prevent returning new obj from session storage every time

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/localsettings.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/localsettings.ts
@@ -157,6 +157,9 @@ export class LocalSetting<S, T> {
       innerSelector,
       () => getValueFromSessionStorage(this.key),
       (uiSettings, cachedValue) => {
+        if (cachedValue != null && uiSettings[this.key] == null) {
+          uiSettings[this.key] = cachedValue;
+        }
         return uiSettings[this.key] ?? cachedValue ?? defaultValue;
       },
     );

--- a/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/activeStatementsSelectors.tsx
@@ -27,13 +27,15 @@ const selectedColumnsLocalSetting = new LocalSetting<
   null,
 );
 
+const defaultActiveFilters = { app: defaultFilters.app };
+
 const filtersLocalSetting = new LocalSetting<
   AdminUIState,
   ActiveStatementFilters
 >(
   "filters/ActiveStatementsPage",
   (state: AdminUIState) => state.localSettings,
-  { app: defaultFilters.app },
+  defaultActiveFilters,
 );
 
 const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(

--- a/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/transactions/activeTransactionsSelectors.tsx
@@ -28,13 +28,15 @@ const transactionsColumnsLocalSetting = new LocalSetting<
   null,
 );
 
+const defaultActiveTxnFilters = { app: defaultFilters.app };
+
 const filtersLocalSetting = new LocalSetting<
   AdminUIState,
   ActiveTransactionFilters
 >(
   "filters/ActiveTransactionsPage",
   (state: AdminUIState) => state.localSettings,
-  { app: defaultFilters.app },
+  defaultActiveTxnFilters,
 );
 
 const sortSettingLocalSetting = new LocalSetting<AdminUIState, SortSetting>(


### PR DESCRIPTION
When we retrieve from localSettings in db-console, we retrieve
in the following order: `localSettings ?? sessionStorage ?? defaultValue`
The value from the session storage is retrieved via parsing a JSON
string and returning a new object. In the active execution pages, we
update the URL search string every time the filters object changes to
reflect any filters selected. Due to the local settings behaviour,
we could end up in an infinite update loop if we continously read from
session storage since a new object was being returned each time
(e.g. on a hard refresh). To prevent this, when retrieving a stored
value, if it exists in session storage but not local storage, we can
set the local setting to be parsed object from session storage.

Release note (bug fix): active execution pages will no longer crash
if there are no filters set in local settings.

Release justification: bug fix