### PR TITLE
kvserver: default admission.kv.pause_replication_io_threshold to 0.8

### DIFF
--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -28,9 +28,7 @@ var pauseReplicationIOThreshold = settings.RegisterFloatSetting(
 	settings.SystemOnly,
 	"admission.kv.pause_replication_io_threshold",
 	"pause replication to non-essential followers when their I/O admission control score exceeds the given threshold (zero to disable)",
-	// TODO(tbg): set a sub-one default.
-	// See: https://github.com/cockroachdb/cockroach/issues/83920
-	10000,
+	0.8,
 	func(v float64) error {
 		if v == 0 {
 			return nil

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -12,6 +12,7 @@ package kvserver
 
 import (
 	"context"
+	"math"
 	"time"
 	"unsafe"
 
@@ -770,6 +771,9 @@ func (s *Store) updateIOThresholdMap() {
 		ioThresholdMap[sd.StoreID] = &ioThreshold
 	}
 	threshold := pauseReplicationIOThreshold.Get(&s.cfg.Settings.SV)
+	if threshold <= 0 {
+		threshold = math.MaxFloat64
+	}
 	old, cur := s.ioThresholds.Replace(ioThresholdMap, threshold)
 	// Log whenever the set of overloaded stores changes.
 	shouldLog := log.V(1) || old.seq != cur.seq


### PR DESCRIPTION
Closes https://github.com/cockroachdb/cockroach/issues/83920.

Release note (ops change): The
`admission.kv.pause_replication_threshold` cluster setting is now set to
a default value of 0.8. On a fully migrated v22.2+ deployment, this will
allow the KV layer to pause replication streams to followers located on
stores that are close to activating their I/O admission control
subsystem (thereby protecting these followers from additional overload).
The cluster setting can be disabled by setting to zero.

Release justification: enables new functionality
