### PR TITLE
sql: step the transaction before auto-commit

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2145,6 +2145,10 @@ func (ex *connExecutor) handleAutoCommit(
 	if err != nil {
 		return ex.makeErrEvent(err, stmt)
 	}
+	if err = ex.state.mu.txn.Step(ctx); err != nil {
+		log.VEventf(ctx, 2, "AutoCommit. err: %v", err)
+		return ex.makeErrEvent(err, stmt)
+	}
 	ev, payload := ex.commitSQLTransaction(ctx, stmt, ex.commitSQLTransactionInternal)
 	if perr, ok := payload.(payloadWithError); ok {
 		err = perr.errorCause()

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -858,3 +858,23 @@ SELECT comment FROM system.comments LIMIT 1
 
 statement ok
 DROP DATABASE comment_db
+
+statement ok
+USE test
+
+# Test that a schema can be created when writing to the eventlog table is
+# disabled. This is a regression test for #86132.
+subtest create_schema_no_eventlog
+
+statement ok
+SET CLUSTER SETTING server.eventlog.enabled = false
+
+statement ok
+CREATE SCHEMA sc
+
+statement ok
+DROP SCHEMA sc
+
+statement ok
+SET CLUSTER SETTING server.eventlog.enabled = false
+


### PR DESCRIPTION
We want the pre-commit validation to see the side-effects of all previous
statements. If we don't step the transaction, we won't see writes which
occurred in the last statement. The shocking thing is that this all worked
before this change. The reason it worked was that the internal executor usage
that happened as a part of logging every schema change resulted in the txn
being stepped. That is a separate, and more complex bug to fix. It will be
described and addressed separately.

Fixes #86132

Release justification: Important bug fix 

Release note: None