### PR TITLE
opt: add EliminateProject and EliminateSelect as essential rules

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1003,6 +1003,9 @@ func (o *Optimizer) disableRules(probability float64) {
 		// appearing consecutively in ordering columns, which can cause
 		// incorrect results until #84191 is addressed.
 		int(opt.SimplifyRootOrdering),
+		// Needed to prevent rule cycles that lead to timeouts and OOMs.
+		int(opt.EliminateProject),
+		int(opt.EliminateSelect),
 	)
 
 	for i := opt.RuleName(1); i < opt.NumRuleNames; i++ {


### PR DESCRIPTION
This commit marks the `EliminateProject` and `EliminateSelect`
normalization rules as essential during disabled-rule testing. This is
necessary to prevent cycles with other rules that can cause testing
timeouts and OOMs.

Fixes #85319
Fixes #85616

Release note: None

Release justification: non-production code change