### PR TITLE
sql: deflake TestRoleOptionsMigration15000User

### DIFF
--- a/pkg/upgrade/upgrades/role_options_migration_test.go
+++ b/pkg/upgrade/upgrades/role_options_migration_test.go
@@ -102,7 +102,11 @@ func runTestRoleOptionsMigration(t *testing.T, numUsers int) {
 	}
 
 	if numUsers > 100 {
-		id := uint32(100)
+		var id uint32
+		// We're not guaranteed that the ID of the first created
+		// user is 100.
+		idRow := tdb.QueryRow(t, `SELECT last_value - 1 FROM system.role_id_seq`)
+		idRow.Scan(&id)
 		var wg sync.WaitGroup
 		wg.Add(100)
 		// Parallelize user creation.


### PR DESCRIPTION
Previously it was flakey because we always assumed the first user created
had ID 100, however this is not the case due to transaction failures.

Release note: None

Release justification: test only