### PR TITLE
api: update database parameter name

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -15,7 +15,7 @@ export type SqlExecutionRequest = {
   execute?: boolean;
   timeout?: string; // Default 5s
   application_name?: string; // Defaults to '$ api-v2-sql'
-  database_name?: string; // Defaults to defaultDb
+  database?: string; // Defaults to defaultDb
   max_result_size?: number; // Default 10kib
 };
 


### PR DESCRIPTION
Previously, we were calling the database parameter
in `SqlExecutionRequest` as `database_name`, instead
of the correct `database`.
This commit updates the parameter name to the
correct one.

Release note (bug fix): Use proper parameter name for database
on SQL api

Release justification: bug fix