### PR TITLE
generate-logictest: tell bazel about cpu needs of logictests

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 3,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -12,6 +12,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 5,
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 3,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 3,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 4,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-21.2-22.1/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 3,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 15,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-15node-5region-3azs/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 4,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-3node-3superlongregions/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-no-los/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-tenant/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 13,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 7,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/ccl",

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -24,11 +24,16 @@ import (
 )
 
 type testFileTemplateConfig struct {
-	LogicTest, CclLogicTest, ExecBuildLogicTest, SqliteLogicTest bool
-	Ccl, ForceProductionValues                                   bool
-	Package, TestRuleName, RelDir                                string
-	ConfigIdx                                                    int
-	TestCount                                                    int
+	LogicTest                     bool
+	CclLogicTest                  bool
+	ExecBuildLogicTest            bool
+	SqliteLogicTest               bool
+	Ccl                           bool
+	ForceProductionValues         bool
+	Package, TestRuleName, RelDir string
+	ConfigIdx                     int
+	TestCount                     int
+	NumCPU                        int
 }
 
 var outDir = flag.String("out-dir", "", "path to the root of the cockroach workspace")
@@ -155,6 +160,10 @@ func (t *testdir) dump() error {
 		tplCfg.Package = strings.ReplaceAll(strings.ReplaceAll(cfg.Name, "-", "_"), ".", "")
 		tplCfg.RelDir = t.relPathToParent
 		tplCfg.TestCount = testCount
+		// The NumCPU calculation is a guess pulled out of thin air to
+		// allocate the tests which use 3-node clusters 2 vCPUs, and
+		// the ones which use more a bit more.
+		tplCfg.NumCPU = (cfg.NumNodes / 2) + 1
 		subdir := filepath.Join(t.dir, cfg.Name)
 		f, buildF, cleanup, err := openTestSubdir(subdir)
 		if err != nil {

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -258,6 +258,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
     shard_count = {{ if gt .TestCount 16 }}16{{ else }}{{ .TestCount }}{{end}},
+    tags = ["cpu:{{ if gt .NumCPU 4 }}4{{ else }}{{ .NumCPU }}{{ end }}"],
     deps = [
         "//pkg/build/bazel",{{ if .Ccl }}
         "//pkg/ccl",

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 13,
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/logictest/tests/fakedist/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local-mixed-21.2-22.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-21.2-22.1/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local-udf/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-udf/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-v1.1-at-v1.0-noupgrade/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 2,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/local/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:4"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/5node/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/fakedist/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-udf/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-udf/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 1,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",

--- a/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
+++ b/pkg/sql/sqlitelogictest/tests/local/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep
     ],
     shard_count = 16,
+    tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",
         "//pkg/security/securityassets",


### PR DESCRIPTION
The logictests run servers and clients and those things use cores more or
less in parallel. We should allocate these CPU cores in bazel to try to
overload the CI server a bit less.

Release justification: testing only change

Release note: None