### PR TITLE
scbuildstmt: add secondary index support for ALTER PK

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/testdata/alter_primary_key
+++ b/pkg/ccl/changefeedccl/schemafeed/testdata/alter_primary_key
@@ -35,3 +35,7 @@ t 13->14: Unknown
 t 14->15: PrimaryKeyChange
 t 15->16: Unknown
 t 16->17: Unknown
+t 17->18: Unknown
+t 18->19: Unknown
+t 19->20: Unknown
+t 20->21: Unknown

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1143,7 +1143,10 @@ statement ok
 create table t1(id integer not null, id2 integer not null, name varchar(32));
 
 query TTT
-select index_name,column_name,direction from [show indexes from t1] where index_name like 'primary%';
+SELECT index_name, column_name, direction
+  FROM [SHOW INDEXES FROM t1]
+  WHERE index_name LIKE 'primary%'
+  ORDER BY 1,2,3;
 ----
 
 statement ok
@@ -1152,21 +1155,19 @@ alter table t1 alter primary key using columns(id, id2);
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
 t1_pkey  id    ASC
 t1_pkey  id2   ASC
 t1_pkey  name  N/A
 
-
 statement ok
 alter table t1 alter primary key using columns(id, id2);
-
 
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
 t1_pkey  id    ASC
 t1_pkey  id2   ASC
@@ -1179,7 +1180,7 @@ alter table t1 drop constraint t1_pkey, alter primary key using columns(id, id2)
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
 t1_pkey  id    ASC
 t1_pkey  id2   ASC
@@ -1191,13 +1192,13 @@ alter table t1 alter primary key using columns(id);
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
+t1_id_id2_key  id    ASC
+t1_id_id2_key  id2   ASC
 t1_pkey        id    ASC
 t1_pkey        id2   N/A
 t1_pkey        name  N/A
-t1_id_id2_key  id    ASC
-t1_id_id2_key  id2   ASC
 
 statement ok
 alter table t1 alter primary key using columns(id desc);
@@ -1205,14 +1206,14 @@ alter table t1 alter primary key using columns(id desc);
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
+t1_id_id2_key  id    ASC
+t1_id_id2_key  id2   ASC
+t1_id_key      id    ASC
 t1_pkey        id    DESC
 t1_pkey        id2   N/A
 t1_pkey        name  N/A
-t1_id_key      id    ASC
-t1_id_id2_key  id    ASC
-t1_id_id2_key  id2   ASC
 
 
 statement ok
@@ -1221,14 +1222,14 @@ alter table t1 alter primary key using columns(id desc);
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
+t1_id_id2_key  id    ASC
+t1_id_id2_key  id2   ASC
+t1_id_key      id    ASC
 t1_pkey        id    DESC
 t1_pkey        id2   N/A
 t1_pkey        name  N/A
-t1_id_key      id    ASC
-t1_id_id2_key  id    ASC
-t1_id_id2_key  id2   ASC
 
 statement ok
 alter table t1 alter primary key using columns(id desc);
@@ -1236,14 +1237,14 @@ alter table t1 alter primary key using columns(id desc);
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
+t1_id_id2_key  id    ASC
+t1_id_id2_key  id2   ASC
+t1_id_key      id    ASC
 t1_pkey        id    DESC
 t1_pkey        id2   N/A
 t1_pkey        name  N/A
-t1_id_key      id    ASC
-t1_id_id2_key  id    ASC
-t1_id_id2_key  id2   ASC
 
 statement ok
 alter table t1 alter primary key using columns(id) USING HASH WITH (bucket_count=10)
@@ -1251,19 +1252,19 @@ alter table t1 alter primary key using columns(id) USING HASH WITH (bucket_count
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
 query TTT
-select index_name,column_name,direction from [show indexes from t1];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t1] ORDER BY 1,2,3
 ----
+t1_id_id2_key  crdb_internal_id_shard_10  ASC
+t1_id_id2_key  id                         ASC
+t1_id_id2_key  id2                        ASC
+t1_id_key      crdb_internal_id_shard_10  ASC
+t1_id_key      id                         ASC
+t1_id_key1     crdb_internal_id_shard_10  ASC
+t1_id_key1     id                         DESC
 t1_pkey        crdb_internal_id_shard_10  ASC
 t1_pkey        id                         ASC
 t1_pkey        id2                        N/A
 t1_pkey        name                       N/A
-t1_id_key1     id                         DESC
-t1_id_key1     crdb_internal_id_shard_10  ASC
-t1_id_key      id                         ASC
-t1_id_key      crdb_internal_id_shard_10  ASC
-t1_id_id2_key  id                         ASC
-t1_id_id2_key  id2                        ASC
-t1_id_id2_key  crdb_internal_id_shard_10  ASC
 
 statement ok
 CREATE TABLE table_with_virtual_cols (
@@ -1555,7 +1556,7 @@ CREATE TABLE public.t_test_param (
    FAMILY fam_0_a_b (a, b)
 )
 
-subtest pkey-comment-drop
+subtest pkey-comment-carry-over
 
 # Create a table with a primary key and add a comment on it.
 statement ok
@@ -1572,7 +1573,6 @@ statement ok
 COMMENT ON INDEX i2 IS 'idx2';
 COMMENT ON CONSTRAINT i2 ON pkey_comment IS 'idx3';
 
-
 # Comment should exist inside the create statement, so filter it out
 query T
 SELECT substring(@2, strpos(@2, 'COMMENT')) FROM [SHOW CREATE pkey_comment];
@@ -1582,18 +1582,18 @@ COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2';
 COMMENT ON CONSTRAINT pkey ON public.pkey_comment IS 'const';
 COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3'
 
-
-# Altering the primary key should clean up the comment.
+# Altering the primary key should carry over the comment.
 statement ok
 ALTER TABLE pkey_comment ALTER PRIMARY KEY USING COLUMNS (b);
 
-
 # No comment exists inside the CREATE statement
+skipif config local-legacy-schema-changer
 query T
 SELECT substring(@2, strpos(@2, 'COMMENT')) FROM [SHOW CREATE pkey_comment];
 ----
+COMMENT ON INDEX public.pkey_comment@pkey IS 'idx';
 COMMENT ON INDEX public.pkey_comment@i2 IS 'idx2';
-COMMENT ON CONSTRAINT pkey_comment_a_b_key ON public.pkey_comment IS 'const';
+COMMENT ON CONSTRAINT pkey ON public.pkey_comment IS 'const';
 COMMENT ON CONSTRAINT i2 ON public.pkey_comment IS 'idx3'
 
 subtest test-index-deduplication
@@ -1635,14 +1635,14 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b);
 # even if they both have columns (a, b) in the sense that one enforces uniqueness
 # on only (a) but the other on (a, b).
 query TTTB
-SELECT index_name, column_name, direction, storing FROM [SHOW INDEXES FROM t]
+SELECT index_name, column_name, direction, storing FROM [SHOW INDEXES FROM t] ORDER BY 1,2,3,4;
 ----
-t_pkey     b  ASC  false
-t_pkey     a  N/A  true
 t_a_b_key  a  ASC  false
 t_a_b_key  b  ASC  false
 t_a_key    a  ASC  false
 t_a_key    b  ASC  true
+t_pkey     a  N/A  true
+t_pkey     b  ASC  false
 
 # The following regression test makes sure that when the new PK columns
 # is a (strict) subset of the old PK columns, all existing secondary indexes
@@ -1669,12 +1669,12 @@ statement ok
 ALTER TABLE t DROP COLUMN b
 
 query TTT
-select index_name,column_name,direction from [show indexes from t];
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t] ORDER BY 1,2,3
 ----
 t_pkey    a  ASC
 t_pkey    c  N/A
-uniq_idx  c  ASC
 uniq_idx  a  ASC
+uniq_idx  c  ASC
 
 # Alter primary key on a hash-sharded primary key to be non-hash-sharded.
 # This had unexpectedly caused all unique indexes to be dropped silently on v21.2.
@@ -1690,14 +1690,14 @@ CREATE TABLE t (
 
 # Assert that the primary key is hash-sharded and the unique index is created.
 query TTT
-SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
+SELECT index_name, column_name, direction FROM [SHOW INDEXES FROM t] ORDER BY 1,2,3
 ----
-t_pkey      crdb_internal_i_shard_7  ASC
-t_pkey      i                        ASC
-t_pkey      j                        N/A
-t_j_key     j                        ASC
-t_j_key     crdb_internal_i_shard_7  ASC
-t_j_key     i                        ASC
+t_j_key  crdb_internal_i_shard_7  ASC
+t_j_key  i                        ASC
+t_j_key  j                        ASC
+t_pkey   crdb_internal_i_shard_7  ASC
+t_pkey   i                        ASC
+t_pkey   j                        N/A
 
 # Alter the primary key to be no longer hash-sharded.
 statement ok
@@ -1706,12 +1706,12 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (i)
 # Now assert that the primary key has been modified to non-hash-sharded,
 # and the unique index still exists.
 query TTT
-SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t]
+SELECT index_name,column_name,direction FROM [SHOW INDEXES FROM t] ORDER BY 1,2,3
 ----
-t_pkey      i            ASC
-t_pkey      j            N/A
-t_j_key     j            ASC
-t_j_key     i            ASC
+t_j_key  i  ASC
+t_j_key  j  ASC
+t_pkey   i  ASC
+t_pkey   j  N/A
 
 
 subtest alter_primary_key_with_more_than_one_column_families

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2493,6 +2493,7 @@ func TestVisibilityDuringPrimaryKeyChange(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	if _, err := sqlDB.Exec(`
+SET use_declarative_schema_changer = 'off';
 CREATE DATABASE t;
 CREATE TABLE t.test (x INT PRIMARY KEY, y INT NOT NULL, z INT, INDEX i (z));
 INSERT INTO t.test VALUES (1, 1, 1), (2, 2, 2), (3, 3, 3);

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
@@ -3,6 +3,7 @@ CREATE TABLE defaultdb.foo (i INT NOT NULL, j INT NOT NULL, CONSTRAINT pkey PRIM
 COMMENT ON INDEX pkey IS 'pkey is an index';
 COMMENT ON CONSTRAINT pkey ON defaultdb.foo IS 'pkey is a constraint';
 CREATE TABLE defaultdb.bar (i INT NOT NULL);
+CREATE TABLE defaultdb.baz (i INT NOT NULL, j INT NOT NULL UNIQUE);
 ----
 
 build
@@ -96,3 +97,79 @@ ALTER TABLE defaultdb.bar ALTER PRIMARY KEY USING COLUMNS (i)
   {constraintId: 5, indexId: 5, isUnique: true, sourceIndexId: 2, tableId: 105}
 - [[IndexColumn:{DescID: 105, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT]
   {columnId: 1, indexId: 5, tableId: 105}
+
+build
+ALTER TABLE defaultdb.baz ALTER PRIMARY KEY USING COLUMNS (i)
+----
+- [[Column:{DescID: 106, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, isHidden: true, pgAttributeNum: 3, tableId: 106}
+- [[ColumnName:{DescID: 106, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, name: rowid, tableId: 106}
+- [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, tableId: 106, type: {family: IntFamily, oid: 20, width: 64}}
+- [[ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT], PUBLIC]
+  {columnId: 3, expr: unique_rowid(), tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 3, indexId: 1, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 1, indexId: 1, kind: STORED, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC]
+  {columnId: 2, indexId: 1, kind: STORED, ordinalInKind: 1, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 2}, ABSENT], PUBLIC]
+  {constraintId: 2, indexId: 1, isUnique: true, tableId: 106}
+- [[IndexName:{DescID: 106, Name: baz_pkey, IndexID: 1}, ABSENT], PUBLIC]
+  {indexId: 1, name: baz_pkey, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC]
+  {columnId: 2, indexId: 2, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 2}, ABSENT], PUBLIC]
+  {columnId: 3, indexId: 2, kind: KEY_SUFFIX, tableId: 106}
+- [[SecondaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 1}, ABSENT], PUBLIC]
+  {constraintId: 1, indexId: 2, isUnique: true, tableId: 106}
+- [[IndexName:{DescID: 106, Name: baz_j_key, IndexID: 2}, ABSENT], PUBLIC]
+  {indexId: 2, name: baz_j_key, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 106, temporaryIndexId: 4}
+- [[IndexName:{DescID: 106, Name: baz_pkey, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {indexId: 3, name: baz_pkey, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 3, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 2, indexId: 3, kind: STORED, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 3, indexId: 3, kind: STORED, ordinalInKind: 1, tableId: 106}
+- [[TemporaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 4, indexId: 4, isUnique: true, sourceIndexId: 1, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 4, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 2, indexId: 4, kind: STORED, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 3, indexId: 4, kind: STORED, ordinalInKind: 1, tableId: 106}
+- [[PrimaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], ABSENT]
+  {constraintId: 5, indexId: 5, isUnique: true, sourceIndexId: 3, tableId: 106, temporaryIndexId: 6}
+- [[IndexName:{DescID: 106, Name: baz_pkey, IndexID: 5}, PUBLIC], ABSENT]
+  {indexId: 5, name: baz_pkey, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 5, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 5, kind: STORED, tableId: 106}
+- [[TemporaryIndex:{DescID: 106, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 6, indexId: 6, isUnique: true, sourceIndexId: 3, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 6}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 6, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 6}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 2, indexId: 6, kind: STORED, tableId: 106}
+- [[SecondaryIndex:{DescID: 106, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], ABSENT]
+  {constraintId: 7, indexId: 7, isUnique: true, sourceIndexId: 3, tableId: 106, temporaryIndexId: 8}
+- [[IndexName:{DescID: 106, Name: baz_j_key, IndexID: 7}, PUBLIC], ABSENT]
+  {indexId: 7, name: baz_j_key, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 7}, PUBLIC], ABSENT]
+  {columnId: 2, indexId: 7, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 7}, PUBLIC], ABSENT]
+  {columnId: 1, indexId: 7, kind: KEY_SUFFIX, tableId: 106}
+- [[TemporaryIndex:{DescID: 106, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT], ABSENT]
+  {constraintId: 8, indexId: 8, isUnique: true, isUsingSecondaryEncoding: true, sourceIndexId: 3, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 8}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 2, indexId: 8, tableId: 106}
+- [[IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 8}, TRANSIENT_ABSENT], ABSENT]
+  {columnId: 1, indexId: 8, kind: KEY_SUFFIX, tableId: 106}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -115,7 +115,3 @@ ALTER TABLE defaultdb.foo PARTITION BY NOTHING
 unimplemented
 ALTER TABLE defaultdb.foo INJECT STATISTICS '[]'
 ----
-
-unimplemented
-ALTER TABLE defaultdb.foo ALTER PRIMARY KEY USING COLUMNS (l)
-----

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -1,25 +1,27 @@
 setup
-CREATE TABLE t (k INT NOT NULL, v STRING);
+CREATE TABLE t (k INT NOT NULL, v STRING NOT NULL UNIQUE);
 ----
 
 ops
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
 ----
-StatementPhase stage 1 of 1 with 14 MutationType ops
+StatementPhase stage 1 of 1 with 16 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> BACKFILL_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 104, Name: t_v_key, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> BACKFILL_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], ABSENT] -> BACKFILL_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.MakePublicColumnWriteOnly
       ColumnID: 3
@@ -44,36 +46,21 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
       ColumnID: 3
       Name: crdb_internal_column_3_name_placeholder
       TableID: 104
+    *scop.MakePublicSecondaryIndexWriteOnly
+      IndexID: 2
+      TableID: 104
+    *scop.SetIndexName
+      IndexID: 2
+      Name: crdb_internal_index_2_name_placeholder
+      TableID: 104
     *scop.MakeAbsentIndexBackfilling
-      Index:
-        ConstraintID: 2
-        IndexID: 2
-        IsUnique: true
-        SourceIndexID: 1
-        TableID: 104
-        TemporaryIndexID: 3
-    *scop.AddColumnToIndex
-      ColumnID: 1
-      IndexID: 2
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 2
-      IndexID: 2
-      Kind: 2
-      TableID: 104
-    *scop.AddColumnToIndex
-      ColumnID: 3
-      IndexID: 2
-      Kind: 2
-      Ordinal: 1
-      TableID: 104
-    *scop.MakeAbsentTempIndexDeleteOnly
       Index:
         ConstraintID: 3
         IndexID: 3
         IsUnique: true
         SourceIndexID: 1
         TableID: 104
+        TemporaryIndexID: 4
     *scop.AddColumnToIndex
       ColumnID: 1
       IndexID: 3
@@ -89,14 +76,13 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
       Kind: 2
       Ordinal: 1
       TableID: 104
-    *scop.MakeAbsentIndexBackfilling
+    *scop.MakeAbsentTempIndexDeleteOnly
       Index:
         ConstraintID: 4
         IndexID: 4
         IsUnique: true
-        SourceIndexID: 2
+        SourceIndexID: 1
         TableID: 104
-        TemporaryIndexID: 5
     *scop.AddColumnToIndex
       ColumnID: 1
       IndexID: 4
@@ -104,6 +90,29 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
     *scop.AddColumnToIndex
       ColumnID: 2
       IndexID: 4
+      Kind: 2
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 3
+      IndexID: 4
+      Kind: 2
+      Ordinal: 1
+      TableID: 104
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 5
+        IndexID: 5
+        IsUnique: true
+        SourceIndexID: 3
+        TableID: 104
+        TemporaryIndexID: 6
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 5
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 5
       Kind: 2
       TableID: 104
 PreCommitPhase stage 1 of 1 with 2 MutationType ops
@@ -126,10 +135,10 @@ PreCommitPhase stage 1 of 1 with 2 MutationType ops
         statementtag: ALTER TABLE
 PostCommitPhase stage 1 of 15 with 3 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeDeleteOnlyIndexWriteOnly
-      IndexID: 3
+      IndexID: 4
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -137,18 +146,18 @@ PostCommitPhase stage 1 of 15 with 3 MutationType ops
       JobID: 1
 PostCommitPhase stage 2 of 15 with 1 BackfillType op
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], BACKFILL_ONLY] -> BACKFILLED
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], BACKFILL_ONLY] -> BACKFILLED
   ops:
     *scop.BackfillIndex
-      IndexID: 2
+      IndexID: 3
       SourceIndexID: 1
       TableID: 104
 PostCommitPhase stage 3 of 15 with 3 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], BACKFILLED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], BACKFILLED] -> DELETE_ONLY
   ops:
     *scop.MakeBackfillingIndexDeleteOnly
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -156,10 +165,10 @@ PostCommitPhase stage 3 of 15 with 3 MutationType ops
       JobID: 1
 PostCommitPhase stage 4 of 15 with 3 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> MERGE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], DELETE_ONLY] -> MERGE_ONLY
   ops:
     *scop.MakeBackfilledIndexMerging
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -167,18 +176,18 @@ PostCommitPhase stage 4 of 15 with 3 MutationType ops
       JobID: 1
 PostCommitPhase stage 5 of 15 with 1 BackfillType op
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], MERGE_ONLY] -> MERGED
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], MERGE_ONLY] -> MERGED
   ops:
     *scop.MergeIndex
-      BackfilledIndexID: 2
+      BackfilledIndexID: 3
       TableID: 104
-      TemporaryIndexID: 3
+      TemporaryIndexID: 4
 PostCommitPhase stage 6 of 15 with 3 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], MERGED] -> WRITE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], MERGED] -> WRITE_ONLY
   ops:
     *scop.MakeMergedIndexWriteOnly
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -186,20 +195,26 @@ PostCommitPhase stage 6 of 15 with 3 MutationType ops
       JobID: 1
 PostCommitPhase stage 7 of 15 with 1 ValidationType op
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> VALIDATED
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> VALIDATED
   ops:
     *scop.ValidateIndex
-      IndexID: 2
+      IndexID: 3
       TableID: 104
-PostCommitPhase stage 8 of 15 with 9 MutationType ops
+PostCommitPhase stage 8 of 15 with 15 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT], PUBLIC] -> VALIDATED
     [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], ABSENT] -> BACKFILL_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}, PUBLIC], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
   ops:
     *scop.MakePublicPrimaryIndexWriteOnly
       IndexID: 1
@@ -209,7 +224,7 @@ PostCommitPhase stage 8 of 15 with 9 MutationType ops
       Name: crdb_internal_index_1_name_placeholder
       TableID: 104
     *scop.SetIndexName
-      IndexID: 2
+      IndexID: 3
       Name: t_pkey
       TableID: 104
     *scop.MakeValidatedPrimaryIndexPublic
@@ -221,139 +236,227 @@ PostCommitPhase stage 8 of 15 with 9 MutationType ops
         TargetMetadata:
           SourceElementID: 1
           SubWorkID: 1
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
-        ConstraintID: 5
-        IndexID: 5
+        ConstraintID: 6
+        IndexID: 6
         IsUnique: true
-        SourceIndexID: 2
+        SourceIndexID: 3
         TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 1
-      IndexID: 5
+      IndexID: 6
       TableID: 104
     *scop.AddColumnToIndex
       ColumnID: 2
-      IndexID: 5
+      IndexID: 6
       Kind: 2
       TableID: 104
+    *scop.MakeAbsentIndexBackfilling
+      Index:
+        ConstraintID: 7
+        IndexID: 7
+        IsUnique: true
+        SourceIndexID: 3
+        TableID: 104
+        TemporaryIndexID: 8
+      IsSecondaryIndex: true
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 7
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 7
+      Kind: 1
+      TableID: 104
+    *scop.MakeAbsentTempIndexDeleteOnly
+      Index:
+        ConstraintID: 8
+        IndexID: 8
+        IsUnique: true
+        SourceIndexID: 3
+        TableID: 104
+      IsSecondaryIndex: true
+    *scop.AddColumnToIndex
+      ColumnID: 2
+      IndexID: 8
+      TableID: 104
+    *scop.AddColumnToIndex
+      ColumnID: 1
+      IndexID: 8
+      Kind: 1
+      TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 9 of 15 with 3 MutationType ops
+PostCommitPhase stage 9 of 15 with 4 MutationType ops
   transitions:
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT], DELETE_ONLY] -> WRITE_ONLY
   ops:
     *scop.MakeDeleteOnlyIndexWriteOnly
-      IndexID: 5
+      IndexID: 6
+      TableID: 104
+    *scop.MakeDeleteOnlyIndexWriteOnly
+      IndexID: 8
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 10 of 15 with 1 BackfillType op
+PostCommitPhase stage 10 of 15 with 2 BackfillType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], BACKFILL_ONLY] -> BACKFILLED
   ops:
     *scop.BackfillIndex
-      IndexID: 4
-      SourceIndexID: 2
+      IndexID: 5
+      SourceIndexID: 3
       TableID: 104
-PostCommitPhase stage 11 of 15 with 3 MutationType ops
+    *scop.BackfillIndex
+      IndexID: 7
+      SourceIndexID: 3
+      TableID: 104
+PostCommitPhase stage 11 of 15 with 4 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], BACKFILLED] -> DELETE_ONLY
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], BACKFILLED] -> DELETE_ONLY
   ops:
     *scop.MakeBackfillingIndexDeleteOnly
-      IndexID: 4
+      IndexID: 5
+      TableID: 104
+    *scop.MakeBackfillingIndexDeleteOnly
+      IndexID: 7
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 12 of 15 with 3 MutationType ops
+PostCommitPhase stage 12 of 15 with 4 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], DELETE_ONLY] -> MERGE_ONLY
   ops:
     *scop.MakeBackfilledIndexMerging
-      IndexID: 4
+      IndexID: 5
+      TableID: 104
+    *scop.MakeBackfilledIndexMerging
+      IndexID: 7
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 13 of 15 with 1 BackfillType op
+PostCommitPhase stage 13 of 15 with 2 BackfillType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], MERGE_ONLY] -> MERGED
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], MERGE_ONLY] -> MERGED
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], MERGE_ONLY] -> MERGED
   ops:
     *scop.MergeIndex
-      BackfilledIndexID: 4
+      BackfilledIndexID: 5
       TableID: 104
-      TemporaryIndexID: 5
-PostCommitPhase stage 14 of 15 with 3 MutationType ops
+      TemporaryIndexID: 6
+    *scop.MergeIndex
+      BackfilledIndexID: 7
+      TableID: 104
+      TemporaryIndexID: 8
+PostCommitPhase stage 14 of 15 with 4 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], MERGED] -> WRITE_ONLY
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], MERGED] -> WRITE_ONLY
   ops:
     *scop.MakeMergedIndexWriteOnly
-      IndexID: 4
+      IndexID: 5
+      TableID: 104
+    *scop.MakeMergedIndexWriteOnly
+      IndexID: 7
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       JobID: 1
-PostCommitPhase stage 15 of 15 with 1 ValidationType op
+PostCommitPhase stage 15 of 15 with 2 ValidationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], WRITE_ONLY] -> VALIDATED
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], WRITE_ONLY] -> VALIDATED
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], WRITE_ONLY] -> VALIDATED
   ops:
     *scop.ValidateIndex
-      IndexID: 4
+      IndexID: 5
       TableID: 104
-PostCommitNonRevertiblePhase stage 1 of 4 with 6 MutationType ops
+    *scop.ValidateIndex
+      IndexID: 7
+      TableID: 104
+PostCommitNonRevertiblePhase stage 1 of 4 with 10 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_v_key, IndexID: 7}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT], WRITE_ONLY] -> TRANSIENT_DELETE_ONLY
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
   ops:
     *scop.MakeWriteOnlyColumnDeleteOnly
       ColumnID: 3
       TableID: 104
     *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 3
+      IndexID: 4
       TableID: 104
     *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 5
+      IndexID: 6
+      TableID: 104
+    *scop.SetIndexName
+      IndexID: 7
+      Name: t_v_key
+      TableID: 104
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 8
       TableID: 104
     *scop.MakeWriteOnlyIndexDeleteOnly
       IndexID: 1
+      TableID: 104
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 2
+      TableID: 104
+    *scop.MakeValidatedSecondaryIndexPublic
+      IndexID: 7
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
+PostCommitNonRevertiblePhase stage 2 of 4 with 17 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_VALIDATED
-    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
-    [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
-    [[TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_VALIDATED
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}, PUBLIC], ABSENT] -> PUBLIC
+    [[TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGCJobForIndex
       IndexID: 1
@@ -372,34 +475,68 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
           SubWorkID: 1
       IndexID: 1
       TableID: 104
-    *scop.MakePublicPrimaryIndexWriteOnly
+    *scop.LogEvent
+      Element:
+        SecondaryIndex:
+          constraintId: 1
+          indexId: 2
+          isUnique: true
+          tableId: 104
+      EventBase:
+        Authorization:
+          UserName: root
+        Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹k›)
+        StatementTag: ALTER TABLE
+        TargetMetadata:
+          SourceElementID: 1
+          SubWorkID: 1
+      TargetStatus: 1
+    *scop.CreateGCJobForIndex
       IndexID: 2
+      StatementForDropJob:
+        Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (k)
+      TableID: 104
+    *scop.MakeIndexAbsent
+      IndexID: 2
+      TableID: 104
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 3
       TableID: 104
     *scop.SetIndexName
-      IndexID: 2
-      Name: crdb_internal_index_2_name_placeholder
+      IndexID: 3
+      Name: crdb_internal_index_3_name_placeholder
       TableID: 104
     *scop.CreateGCJobForIndex
-      IndexID: 3
+      IndexID: 4
       StatementForDropJob:
         Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
           KEY USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
-      IndexID: 3
+      IndexID: 4
       TableID: 104
     *scop.SetIndexName
-      IndexID: 4
+      IndexID: 5
       Name: t_pkey
       TableID: 104
     *scop.CreateGCJobForIndex
-      IndexID: 5
+      IndexID: 6
       StatementForDropJob:
         Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
           KEY USING COLUMNS (k)
       TableID: 104
     *scop.MakeIndexAbsent
-      IndexID: 5
+      IndexID: 6
+      TableID: 104
+    *scop.CreateGCJobForIndex
+      IndexID: 8
+      StatementForDropJob:
+        Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+          KEY USING COLUMNS (k)
+      TableID: 104
+    *scop.MakeIndexAbsent
+      IndexID: 8
       TableID: 104
     *scop.MakeValidatedPrimaryIndexPublic
       EventBase:
@@ -410,7 +547,7 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
         TargetMetadata:
           SourceElementID: 1
           SubWorkID: 1
-      IndexID: 4
+      IndexID: 5
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -419,10 +556,10 @@ PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
       JobID: 1
 PostCommitNonRevertiblePhase stage 3 of 4 with 3 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_VALIDATED] -> TRANSIENT_DELETE_ONLY
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_VALIDATED] -> TRANSIENT_DELETE_ONLY
   ops:
     *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -434,10 +571,10 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
     [[Column:{DescID: 104, ColumnID: 3}, ABSENT], DELETE_ONLY] -> ABSENT
     [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnDefaultExpression:{DescID: 104, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
+    [[PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
     *scop.CreateGCJobForIndex
-      IndexID: 2
+      IndexID: 3
       StatementForDropJob:
         Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
           USING COLUMNS (k)
@@ -451,7 +588,7 @@ PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops
         TargetMetadata:
           SourceElementID: 1
           SubWorkID: 1
-      IndexID: 2
+      IndexID: 3
       TableID: 104
     *scop.RemoveColumnDefaultExpression
       ColumnID: 3
@@ -508,11 +645,15 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: column no longer public before dependents
+- from: [Column:{DescID: 104, ColumnID: 3}, WRITE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [ColumnDefaultExpression:{DescID: 104, ColumnID: 3}, ABSENT]
@@ -532,366 +673,526 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: SameStagePrecedence
   rules: [dependents removed before column; column type removed right before column when not dropping relation]
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before index
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
-  kind: Precedence
-  rule: index-column added to index before index is backfilled
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  kind: Precedence
-  rule: index dependents exist before index becomes public
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, TRANSIENT_ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
-  rule: index-column added to index before temp index receives writes
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
-  kind: Precedence
-  rule: index-column added to index before index is backfilled
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
-  kind: Precedence
-  rule: index dependents exist before index becomes public
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
-- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT]
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
-  kind: Precedence
-  rule: index-column added to index before index is backfilled
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  kind: Precedence
-  rule: index dependents exist before index becomes public
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, TRANSIENT_ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
-  rule: index-column added to index before temp index receives writes
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
-  kind: Precedence
-  rule: index-column added to index before index is backfilled
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
-  kind: Precedence
-  rule: index dependents exist before index becomes public
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
   rule: index-column added to index before temp index receives writes
-- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT]
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT]
-  to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before index
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT]
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILLED]
+  kind: Precedence
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT]
   to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, ABSENT]
+  to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
-  rule: index-column added to index before temp index receives writes
+  rule: index-column added to index before index is backfilled
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: index dependents exist before index becomes public
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT]
   to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  kind: Precedence
+  rule: index-column added to index before temp index receives writes
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT]
+  to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, TRANSIENT_ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
+- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: SameStagePrecedence
   rules: [index dependents exist before index becomes public; index named right before index becomes public]
-- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, TRANSIENT_ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, TRANSIENT_ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
-- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
+- from: [IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
   kind: SameStagePrecedence
   rules: [index dependents exist before index becomes public; index named right before index becomes public]
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
+- from: [IndexName:{DescID: 104, Name: t_v_key, IndexID: 2}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before index
+- from: [IndexName:{DescID: 104, Name: t_v_key, IndexID: 7}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC]
+  kind: SameStagePrecedence
+  rules: [index dependents exist before index becomes public; index named right before index becomes public]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
   to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: indexes containing column reach absent before column
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
   kind: Precedence
   rule: old index absent before new index public when swapping with transient
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, DELETE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, ABSENT]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
   to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
   to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}, ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, WRITE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, WRITE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: SameStagePrecedence
   rule: primary index swap
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->BACKFILL_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
-  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, PUBLIC]
   kind: Precedence
   rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILL_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILL_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, MERGE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, MERGE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, MERGED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, MERGED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGED->WRITE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, MERGE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, MERGED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, MERGE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, MERGED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGE_ONLY->MERGED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: PUBLIC->TRANSIENT_VALIDATED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should exist before secondary indexes
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, DELETE_ONLY]
   kind: Precedence
   rule: primary index with new columns should exist before temp indexes
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should exist before temp indexes
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: indexes containing column reach absent before column
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}, TRANSIENT_ABSENT]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: index no longer public before dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_WRITE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_WRITE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->TRANSIENT_WRITE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, TRANSIENT_VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
   kind: SameStagePrecedence
   rule: primary index swap
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: VALIDATED->PUBLIC
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, VALIDATED]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, VALIDATED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, ABSENT]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILL_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, ABSENT]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILL_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, DELETE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILLED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILL_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC]
-  kind: Precedence
-  rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILL_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC]
-  kind: Precedence
-  rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILL_ONLY]
-  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}, PUBLIC]
-  kind: Precedence
-  rule: index existence precedes index dependents
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILL_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, DELETE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, MERGE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, MERGED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, WRITE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, MERGE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, MERGED]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, VALIDATED]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, PUBLIC]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
-- from: [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, WRITE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, VALIDATED]
-  kind: PreviousTransactionPrecedence
-  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
-  kind: Precedence
-  rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
-  kind: Precedence
-  rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
-  kind: Precedence
-  rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
-  kind: PreviousTransactionPrecedence
-  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
-  kind: Precedence
-  rule: temp index is WRITE_ONLY before backfill
-- from: [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, ABSENT]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
-  kind: PreviousTransactionPrecedence
-  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}, PUBLIC]
   kind: Precedence
-  rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILL_ONLY]
   to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}, PUBLIC]
   kind: Precedence
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILLED]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, MERGE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, MERGED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, MERGE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, MERGED]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, PUBLIC]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, VALIDATED]
+  kind: PreviousTransactionPrecedence
+  rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT]
+  to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
+  kind: Precedence
+  rule: indexes containing column reach absent before column
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, DELETE_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, ABSENT]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, PUBLIC]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, VALIDATED]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, VALIDATED]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, VALIDATED]
+  to:   [IndexName:{DescID: 104, Name: t_v_key, IndexID: 2}, ABSENT]
+  kind: Precedence
+  rule: index no longer public before dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, VALIDATED]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}, WRITE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, ABSENT]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILLED]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [IndexName:{DescID: 104, Name: t_v_key, IndexID: 7}, PUBLIC]
+  kind: Precedence
+  rule: index existence precedes index dependents
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILL_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILLED]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, MERGE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, MERGED]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, MERGE_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, MERGED]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, VALIDATED]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, PUBLIC]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, VALIDATED]
+  kind: PreviousTransactionPrecedence
+  rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}, PUBLIC]
+  kind: Precedence
   rule: temp index existence precedes index dependents
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_ABSENT]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
-  to:   [PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}, BACKFILLED]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: temp index is WRITE_ONLY before backfill
-- from: [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, WRITE_ONLY]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, TRANSIENT_DELETE_ONLY]
+- from: [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, TRANSIENT_DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_ABSENT]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, TemporaryIndexID: 6, SourceIndexID: 3}, BACKFILLED]
+  kind: Precedence
+  rule: temp index is WRITE_ONLY before backfill
+- from: [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 6, SourceIndexID: 3}, TRANSIENT_DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, ABSENT]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}, PUBLIC]
+  kind: Precedence
+  rule: temp index existence precedes index dependents
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_DELETE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_ABSENT]
+  kind: PreviousTransactionPrecedence
+  rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [SecondaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 7, TemporaryIndexID: 8, SourceIndexID: 3}, BACKFILLED]
+  kind: Precedence
+  rule: temp index is WRITE_ONLY before backfill
+- from: [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, WRITE_ONLY]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 8, SourceIndexID: 3}, TRANSIENT_DELETE_ONLY]
   kind: PreviousTransactionPrecedence
   rule: TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
@@ -1,5 +1,6 @@
 setup
-CREATE TABLE t (a INT NOT NULL)
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 ----
 ...
 +object {100 101 t} -> 104
@@ -12,14 +13,14 @@ begin transaction #1
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.alter_primary_key
-## StatementPhase stage 1 of 1 with 11 MutationType ops
+## StatementPhase stage 1 of 1 with 18 MutationType ops
 upsert descriptor #104
   ...
-         oid: 20
-         width: 64
+         family: StringFamily
+         oid: 25
   -  - defaultExpr: unique_rowid()
   -    hidden: true
-  -    id: 2
+  -    id: 3
   -    name: rowid
   -    type:
   -      family: IntFamily
@@ -28,33 +29,71 @@ upsert descriptor #104
      createAsOfTime:
        wallTime: "1640995200000000000"
   ...
-       columnNames:
        - a
+       - b
   -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
+  +    - crdb_internal_column_3_name_placeholder
        name: primary
-  ...
+     formatVersion: 3
      id: 104
+  -  indexes:
+  -  - constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 2
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    keyColumnIds:
+  -    - 2
+  -    keyColumnNames:
+  -    - b
+  -    keySuffixColumnIds:
+  -    - 3
+  -    name: t_b_key
+  -    partitioning: {}
+  -    sharded: {}
+  -    unique: true
+  -    version: 3
+  -  - createdAtNanos: "1640995200000000000"
+  -    createdExplicitly: true
+  -    foreignKey: {}
+  -    geoConfig: {}
+  -    id: 3
+  -    interleave: {}
+  -    keyColumnDirections:
+  -    - ASC
+  -    keyColumnIds:
+  -    - 2
+  -    keyColumnNames:
+  -    - b
+  -    keySuffixColumnIds:
+  -    - 3
+  -    name: idx1
+  -    partitioning: {}
+  -    predicate: b = 'a':::STRING
+  -    sharded: {}
+  -    version: 3
+  +  indexes: []
      modificationTime: {}
   +  mutations:
   +  - column:
   +      defaultExpr: unique_rowid()
   +      hidden: true
-  +      id: 2
-  +      name: crdb_internal_column_2_name_placeholder
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
   +      type:
   +        family: IntFamily
   +        oid: 20
   +        width: 64
   +    direction: DROP
-  +    mutationId: 1
+  +    mutationId: 2
   +    state: WRITE_ONLY
-  +  - direction: ADD
+  +  - direction: DROP
   +    index:
-  +      constraintId: 2
-  +      createdExplicitly: true
-  +      encodingType: 1
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
   +      foreignKey: {}
   +      geoConfig: {}
   +      id: 2
@@ -62,25 +101,22 @@ upsert descriptor #104
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-  +      - 1
+  +      - 2
   +      keyColumnNames:
-  +      - a
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 3
   +      name: crdb_internal_index_2_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnIds:
-  +      - 2
-  +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
   +      unique: true
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: ADD
+  +      version: 3
+  +    mutationId: 2
+  +    state: WRITE_ONLY
+  +  - direction: DROP
   +    index:
-  +      constraintId: 3
+  +      createdAtNanos: "1640995200000000000"
   +      createdExplicitly: true
-  +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
   +      id: 3
@@ -88,29 +124,26 @@ upsert descriptor #104
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-  +      - 1
+  +      - 2
   +      keyColumnNames:
-  +      - a
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 3
   +      name: crdb_internal_index_3_name_placeholder
   +      partitioning: {}
+  +      predicate: b = 'a':::STRING
   +      sharded: {}
-  +      storeColumnIds:
-  +      - 2
-  +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
-  +      unique: true
-  +      useDeletePreservingEncoding: true
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
+  +      version: 3
+  +    mutationId: 2
+  +    state: WRITE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 3
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 4
+  +      id: 5
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
@@ -118,35 +151,95 @@ upsert descriptor #104
   +      - 1
   +      keyColumnNames:
   +      - a
-  +      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_5_name_placeholder
   +      partitioning: {}
   +      sharded: {}
-  +      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - b
+  +      - crdb_internal_column_3_name_placeholder
   +      unique: true
   +      version: 4
-  +    mutationId: 1
+  +    mutationId: 2
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - a
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - b
+  +      - crdb_internal_column_3_name_placeholder
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 2
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - a
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      storeColumnNames:
+  +      - b
+  +      unique: true
+  +      version: 4
+  +    mutationId: 2
   +    state: BACKFILLING
      name: t
-     nextColumnId: 3
-  -  nextConstraintId: 2
-  +  nextConstraintId: 5
+     nextColumnId: 4
+  -  nextConstraintId: 3
+  +  nextConstraintId: 6
      nextFamilyId: 1
-  -  nextIndexId: 2
-  +  nextIndexId: 5
-     nextMutationId: 1
+  -  nextIndexId: 5
+  +  nextIndexId: 8
+     nextMutationId: 2
      parentId: 100
   ...
-       - 2
+       - 3
        keyColumnNames:
   -    - rowid
-  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_3_name_placeholder
        name: t_pkey
        partitioning: {}
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "1"
-  +  version: "2"
+  -  version: "7"
+  +  version: "8"
 write *eventpb.AlterTable to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
 # end StatementPhase
 # begin PreCommitPhase
@@ -174,8 +267,8 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "1"
-  +  version: "2"
+  -  version: "7"
+  +  version: "8"
 create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]
 # end PreCommitPhase
@@ -189,7 +282,7 @@ begin transaction #3
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      - direction: ADD
@@ -197,20 +290,20 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "2"
-  +  version: "3"
+  -  version: "8"
+  +  version: "9"
 update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
 commit transaction #3
 begin transaction #4
 ## PostCommitPhase stage 2 of 15 with 1 BackfillType op
-backfill indexes [2] from index #1 in table #104
+backfill indexes [5] from index #1 in table #104
 commit transaction #4
 begin transaction #5
 ## PostCommitPhase stage 3 of 15 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: BACKFILLING
   +    state: DELETE_ONLY
      - direction: ADD
@@ -218,8 +311,8 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "3"
-  +  version: "4"
+  -  version: "9"
+  +  version: "10"
 update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
 commit transaction #5
 begin transaction #6
@@ -227,7 +320,7 @@ begin transaction #6
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: DELETE_ONLY
   +    state: MERGING
      - direction: ADD
@@ -235,20 +328,20 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "4"
-  +  version: "5"
+  -  version: "10"
+  +  version: "11"
 update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
 commit transaction #6
 begin transaction #7
 ## PostCommitPhase stage 5 of 15 with 1 BackfillType op
-merge temporary indexes [3] into backfilled indexes [2] in table #104
+merge temporary indexes [6] into backfilled indexes [5] in table #104
 commit transaction #7
 begin transaction #8
 ## PostCommitPhase stage 6 of 15 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: MERGING
   +    state: WRITE_ONLY
      - direction: ADD
@@ -256,43 +349,17 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "5"
-  +  version: "6"
+  -  version: "11"
+  +  version: "12"
 update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
 commit transaction #8
 begin transaction #9
 ## PostCommitPhase stage 7 of 15 with 1 ValidationType op
-validate forward indexes [2] in table #104
+validate forward indexes [5] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 8 MutationType ops
+## PostCommitPhase stage 8 of 15 with 23 MutationType ops
 upsert descriptor #104
-  ...
-     - direction: ADD
-       index:
-  -      constraintId: 2
-  +      constraintId: 3
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 2
-  +      id: 3
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - a
-  -      name: crdb_internal_index_2_name_placeholder
-  +      name: crdb_internal_index_3_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         - crdb_internal_column_2_name_placeholder
-         unique: true
-  +      useDeletePreservingEncoding: true
-         version: 4
-       mutationId: 1
   ...
      - direction: ADD
        index:
@@ -302,50 +369,23 @@ upsert descriptor #104
          encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 3
-  +      id: 4
+  -      id: 5
+  +      id: 6
          interleave: {}
          keyColumnDirections:
   ...
          keyColumnNames:
          - a
-  -      name: crdb_internal_index_3_name_placeholder
-  +      name: crdb_internal_index_4_name_placeholder
+  -      name: crdb_internal_index_5_name_placeholder
+  +      name: crdb_internal_index_6_name_placeholder
          partitioning: {}
          sharded: {}
-  -      storeColumnIds:
-  +      storeColumnNames: []
-  +      unique: true
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: DROP
-  +    index:
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 1
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-         - 2
-  -      storeColumnNames:
-  +      keyColumnNames:
-         - crdb_internal_column_2_name_placeholder
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 1
-  +      storeColumnNames:
-  +      - a
+  ...
+         - crdb_internal_column_3_name_placeholder
          unique: true
-  -      useDeletePreservingEncoding: true
+  +      useDeletePreservingEncoding: true
          version: 4
-       mutationId: 1
+       mutationId: 2
   ...
      - direction: ADD
        index:
@@ -355,152 +395,369 @@ upsert descriptor #104
          encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 4
-  +      id: 5
+  -      id: 6
+  +      id: 7
          interleave: {}
          keyColumnDirections:
   ...
          keyColumnNames:
          - a
-  -      name: crdb_internal_index_4_name_placeholder
-  +      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_6_name_placeholder
+  +      name: crdb_internal_index_7_name_placeholder
          partitioning: {}
          sharded: {}
-         storeColumnNames: []
+         storeColumnIds:
+         - 2
+  -      - 3
+         storeColumnNames:
+         - b
+  +      unique: true
+  +      version: 4
+  +    mutationId: 2
+  +    state: BACKFILLING
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 1
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+         - crdb_internal_column_3_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      storeColumnNames:
+  +      - a
+  +      - b
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 2
+  ...
+     - direction: ADD
+       index:
+  -      constraintId: 5
+  +      constraintId: 6
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 7
+  +      id: 8
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - a
+  -      name: crdb_internal_index_7_name_placeholder
+  +      name: crdb_internal_index_8_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - b
          unique: true
   +      useDeletePreservingEncoding: true
          version: 4
-       mutationId: 1
-  -    state: BACKFILLING
+       mutationId: 2
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 9
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      version: 4
+  +    mutationId: 2
+       state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 10
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_10_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 2
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 9
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 11
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      predicate: b = 'a':::STRING
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      version: 4
+  +    mutationId: 2
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 10
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 12
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_12_name_placeholder
+  +      partitioning: {}
+  +      predicate: b = 'a':::STRING
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 2
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
-  -  nextConstraintId: 5
-  +  nextConstraintId: 6
+     nextColumnId: 4
+  -  nextConstraintId: 6
+  +  nextConstraintId: 11
      nextFamilyId: 1
-  -  nextIndexId: 5
-  +  nextIndexId: 6
-     nextMutationId: 1
+  -  nextIndexId: 8
+  +  nextIndexId: 13
+     nextMutationId: 2
      parentId: 100
      primaryIndex:
-  -    constraintId: 1
+  -    constraintId: 2
   -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 2
+  +    constraintId: 3
   +    createdExplicitly: true
        encodingType: 1
        foreignKey: {}
        geoConfig: {}
   -    id: 1
-  +    id: 2
+  +    id: 5
        interleave: {}
        keyColumnDirections:
        - ASC
        keyColumnIds:
-  -    - 2
+  -    - 3
   +    - 1
        keyColumnNames:
-  -    - crdb_internal_column_2_name_placeholder
+  -    - crdb_internal_column_3_name_placeholder
   +    - a
        name: t_pkey
        partitioning: {}
        sharded: {}
        storeColumnIds:
   -    - 1
-  +    - 2
+       - 2
+  +    - 3
        storeColumnNames:
   -    - a
-  +    - crdb_internal_column_2_name_placeholder
+       - b
+  +    - crdb_internal_column_3_name_placeholder
        unique: true
        version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "6"
-  +  version: "7"
-update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 1 MutationType op pending"
+  -  version: "12"
+  +  version: "13"
+update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 3 MutationType ops pending"
 commit transaction #10
 begin transaction #11
-## PostCommitPhase stage 9 of 15 with 3 MutationType ops
+## PostCommitPhase stage 9 of 15 with 5 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 2
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 2
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "7"
-  +  version: "8"
-update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 1 BackfillType op pending"
+  -  version: "13"
+  +  version: "14"
+update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 3 BackfillType ops pending"
 commit transaction #11
 begin transaction #12
-## PostCommitPhase stage 10 of 15 with 1 BackfillType op
-backfill indexes [4] from index #2 in table #104
+## PostCommitPhase stage 10 of 15 with 3 BackfillType ops
+backfill indexes [7 9 11] from index #5 in table #104
 commit transaction #12
 begin transaction #13
-## PostCommitPhase stage 11 of 15 with 3 MutationType ops
+## PostCommitPhase stage 11 of 15 with 5 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: BACKFILLING
   +    state: DELETE_ONLY
      - direction: DROP
        index:
   ...
+         version: 4
+       mutationId: 2
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 2
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "8"
-  +  version: "9"
-update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 1 MutationType op pending"
+  -  version: "14"
+  +  version: "15"
+update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 3 MutationType ops pending"
 commit transaction #13
 begin transaction #14
-## PostCommitPhase stage 12 of 15 with 3 MutationType ops
+## PostCommitPhase stage 12 of 15 with 5 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: DELETE_ONLY
   +    state: MERGING
      - direction: DROP
        index:
   ...
+         version: 4
+       mutationId: 2
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 2
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "9"
-  +  version: "10"
-update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 1 BackfillType op pending"
+  -  version: "15"
+  +  version: "16"
+update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 3 BackfillType ops pending"
 commit transaction #14
 begin transaction #15
-## PostCommitPhase stage 13 of 15 with 1 BackfillType op
-merge temporary indexes [5] into backfilled indexes [4] in table #104
+## PostCommitPhase stage 13 of 15 with 3 BackfillType ops
+merge temporary indexes [8 10 12] into backfilled indexes [7 9 11] in table #104
 commit transaction #15
 begin transaction #16
-## PostCommitPhase stage 14 of 15 with 3 MutationType ops
+## PostCommitPhase stage 14 of 15 with 5 MutationType ops
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: MERGING
   +    state: WRITE_ONLY
      - direction: DROP
        index:
   ...
+         version: 4
+       mutationId: 2
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 2
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "10"
-  +  version: "11"
-update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 1 ValidationType op pending"
+  -  version: "16"
+  +  version: "17"
+update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 3 ValidationType ops pending"
 commit transaction #16
 begin transaction #17
-## PostCommitPhase stage 15 of 15 with 1 ValidationType op
-validate forward indexes [4] in table #104
+## PostCommitPhase stage 15 of 15 with 3 ValidationType ops
+validate forward indexes [7] in table #104
+validate forward indexes [9] in table #104
+validate forward indexes [11] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 4 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 4 with 15 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a)
@@ -509,83 +766,268 @@ upsert descriptor #104
        targetRanks: <redacted>
        targets: <redacted>
   ...
+     formatVersion: 3
+     id: 104
+  -  indexes: []
+  +  indexes:
+  +  - constraintId: 7
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 9
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 2
+  +    keyColumnNames:
+  +    - b
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: t_b_key
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    version: 4
+  +  - constraintId: 9
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 11
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 2
+  +    keyColumnNames:
+  +    - b
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: idx1
+  +    partitioning: {}
+  +    predicate: b = 'a':::STRING
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    version: 4
+     modificationTime: {}
+     mutations:
+  ...
        direction: DROP
-       mutationId: 1
+       mutationId: 2
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         version: 3
+       mutationId: 2
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         version: 3
+       mutationId: 2
   -    state: WRITE_ONLY
   -  - direction: ADD
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 3
+         constraintId: 4
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      - direction: ADD
        index:
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: WRITE_ONLY
   -  - direction: ADD
   +    state: DELETE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 5
+         constraintId: 6
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 7
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 9
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      version: 4
+  -    mutationId: 2
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+         constraintId: 8
+         createdExplicitly: true
+  ...
+         version: 4
+       mutationId: 2
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 9
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 11
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_11_name_placeholder
+  -      partitioning: {}
+  -      predicate: b = 'a':::STRING
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      version: 4
+  -    mutationId: 2
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+         constraintId: 10
+         createdExplicitly: true
+  ...
+         name: crdb_internal_index_12_name_placeholder
+         partitioning: {}
+  -      predicate: b = 'a':::STRING
+         sharded: {}
+         storeColumnNames: []
+  ...
+         version: 4
+       mutationId: 2
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "11"
-  +  version: "12"
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 10 MutationType ops pending"
+  -  version: "17"
+  +  version: "18"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 21 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 4 with 23 MutationType ops
 upsert descriptor #104
   ...
      - direction: DROP
        index:
-  -      constraintId: 3
-  +      constraintId: 2
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 3
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      unique: true
+  -      version: 3
+  -    mutationId: 2
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  +      constraintId: 3
          createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 3
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning: {}
+  -      predicate: b = 'a':::STRING
+  -      sharded: {}
+  -      version: 3
+  -    mutationId: 2
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 4
+  -      createdExplicitly: true
          encodingType: 1
          foreignKey: {}
          geoConfig: {}
-  -      id: 3
-  +      id: 2
+  -      id: 6
+  +      id: 5
          interleave: {}
          keyColumnDirections:
   ...
          keyColumnNames:
          - a
-  -      name: crdb_internal_index_3_name_placeholder
-  +      name: crdb_internal_index_2_name_placeholder
+  -      name: crdb_internal_index_6_name_placeholder
+  +      name: crdb_internal_index_5_name_placeholder
          partitioning: {}
          sharded: {}
   ...
-         - crdb_internal_column_2_name_placeholder
+         - crdb_internal_column_3_name_placeholder
          unique: true
   -      useDeletePreservingEncoding: true
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: DELETE_ONLY
   -  - direction: ADD
   -    index:
-  -      constraintId: 4
+  -      constraintId: 5
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 4
+  -      id: 7
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -593,17 +1035,20 @@ upsert descriptor #104
   -      - 1
   -      keyColumnNames:
   -      - a
-  -      name: crdb_internal_index_4_name_placeholder
+  -      name: crdb_internal_index_7_name_placeholder
   -      partitioning: {}
   -      sharded: {}
-  -      storeColumnNames: []
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - b
   -      unique: true
   -      version: 4
-  -    mutationId: 1
+  -    mutationId: 2
        state: WRITE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 1
+  -      constraintId: 2
   -      createdAtNanos: "1640995200000000000"
   -      encodingType: 1
   -      foreignKey: {}
@@ -613,28 +1058,30 @@ upsert descriptor #104
   -      keyColumnDirections:
   -      - ASC
   -      keyColumnIds:
-  -      - 2
+  -      - 3
   -      keyColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
+  -      - crdb_internal_column_3_name_placeholder
   -      name: crdb_internal_index_1_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
   -      - 1
+  -      - 2
   -      storeColumnNames:
   -      - a
+  -      - b
   -      unique: true
   -      version: 4
-  -    mutationId: 1
+  -    mutationId: 2
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 5
+  -      constraintId: 6
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 5
+  -      id: 8
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -642,45 +1089,97 @@ upsert descriptor #104
   -      - 1
   -      keyColumnNames:
   -      - a
-  -      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_8_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - b
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 2
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 8
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 10
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_10_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnNames: []
   -      unique: true
   -      useDeletePreservingEncoding: true
   -      version: 4
-  -    mutationId: 1
+  -    mutationId: 2
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 10
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 12
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_12_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+  -      version: 4
+  -    mutationId: 2
   -    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
      parentId: 100
      primaryIndex:
-  -    constraintId: 2
-  +    constraintId: 4
+  -    constraintId: 3
+  +    constraintId: 5
        createdExplicitly: true
        encodingType: 1
        foreignKey: {}
        geoConfig: {}
-  -    id: 2
-  +    id: 4
+  -    id: 5
+  +    id: 7
        interleave: {}
        keyColumnDirections:
   ...
-       partitioning: {}
-       sharded: {}
-  -    storeColumnIds:
-  -    - 2
-  -    storeColumnNames:
-  -    - crdb_internal_column_2_name_placeholder
-  +    storeColumnNames: []
+       storeColumnIds:
+       - 2
+  -    - 3
+       storeColumnNames:
+       - b
+  -    - crdb_internal_column_3_name_placeholder
        unique: true
        version: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "12"
-  +  version: "13"
+  -  version: "18"
+  +  version: "19"
+write *eventpb.DropIndex to event log: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
 create job #2 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 1 MutationType op pending"
@@ -691,16 +1190,16 @@ begin transaction #20
 upsert descriptor #104
   ...
          version: 4
-       mutationId: 1
+       mutationId: 2
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "13"
-  +  version: "14"
+  -  version: "19"
+  +  version: "20"
 update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 4 MutationType ops pending"
 commit transaction #20
 begin transaction #21
@@ -725,36 +1224,38 @@ upsert descriptor #104
      families:
      - columnIds:
        - 1
-  -    - 2
+       - 2
+  -    - 3
        columnNames:
        - a
-  -    - crdb_internal_column_2_name_placeholder
-       defaultColumnId: 1
+       - b
+  -    - crdb_internal_column_3_name_placeholder
        name: primary
+     formatVersion: 3
   ...
-     id: 104
+       version: 4
      modificationTime: {}
   -  mutations:
   -  - column:
   -      defaultExpr: unique_rowid()
   -      hidden: true
-  -      id: 2
-  -      name: crdb_internal_column_2_name_placeholder
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
   -      type:
   -        family: IntFamily
   -        oid: 20
   -        width: 64
   -    direction: DROP
-  -    mutationId: 1
+  -    mutationId: 2
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 2
+  -      constraintId: 3
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 2
+  -      id: 5
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -762,25 +1263,27 @@ upsert descriptor #104
   -      - 1
   -      keyColumnNames:
   -      - a
-  -      name: crdb_internal_index_2_name_placeholder
+  -      name: crdb_internal_index_5_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
+  -      - 3
   -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
+  -      - b
+  -      - crdb_internal_column_3_name_placeholder
   -      unique: true
   -      version: 4
-  -    mutationId: 1
+  -    mutationId: 2
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
-     nextColumnId: 3
+     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "14"
-  +  version: "15"
+  -  version: "20"
+  +  version: "21"
 write *eventpb.FinishSchemaChange to event log
 create job #3 (non-cancelable: true): "GC for removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (a)"
   descriptor IDs: [104]

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 EXPLAIN (ddl) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -7,31 +8,45 @@ EXPLAIN (ddl) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
- │         ├── 6 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
- │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
- │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
- │         └── 11 Mutation operations
- │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":104}
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+ │         ├── 8 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+ │         ├── 6 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 3}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+ │         │    ├── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+ │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+ │         └── 18 Mutation operations
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
- │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
- │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":4,"IsUnique":true,"SourceIndexID":2,"TableID":104,"TemporaryIndexID":5}}
- │              └── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":3,"TableID":104}
+ │              ├── SetIndexName {"IndexID":3,"Name":"crdb_internal_in...","TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":3,"IndexID":5,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":6}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":4,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":7,"IsUnique":true,"SourceIndexID":5,"TableID":104,"TemporaryIndexID":8}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":104}
  ├── PreCommitPhase
  │    └── Stage 1 of 1 in PreCommitPhase
  │         └── 2 Mutation operations
@@ -40,172 +55,278 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  ├── PostCommitPhase
  │    ├── Stage 1 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 2 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":5,"SourceIndexID":1,"TableID":104}
  │    ├── Stage 3 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 4 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 5 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    │         └── MergeIndex {"BackfilledIndexID":5,"TableID":104,"TemporaryIndexID":6}
  │    ├── Stage 6 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 3 Mutation operations
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 7 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
  │    │    └── 1 Validation operation
- │    │         └── ValidateIndex {"IndexID":2,"TableID":104}
+ │    │         └── ValidateIndex {"IndexID":5,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
- │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
- │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
- │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+ │    │    ├── 7 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+ │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC        SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+ │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+ │    │    ├── 12 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+ │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+ │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+ │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+ │    │    │    ├── ABSENT    → PUBLIC        SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+ │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+ │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
  │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
- │    │    └── 8 Mutation operations
+ │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+ │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+ │    │    └── 23 Mutation operations
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":5,"Name":"t_pkey","TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":5,"TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":8,"IsUnique":true,"SourceIndexID":5,"TableID":104}}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Kind":1,"TableID":104}
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── SetAddedIndexPartialPredicate {"Expr":"b = 'a':::STRING","IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Kind":1,"TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── SetAddedIndexPartialPredicate {"Expr":"b = 'a':::STRING","IndexID":12,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":12,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Kind":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":104}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":8,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":12,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 10 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │    │    └── 1 Backfill operation
- │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":2,"TableID":104}
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    └── 3 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":7,"SourceIndexID":5,"TableID":104}
+ │    │         ├── BackfillIndex {"IndexID":9,"SourceIndexID":5,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":11,"SourceIndexID":5,"TableID":104}
  │    ├── Stage 11 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":7,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":11,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 12 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":7,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":9,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":11,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 13 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │    │    └── 1 Backfill operation
- │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    └── 3 Backfill operations
+ │    │         ├── MergeIndex {"BackfilledIndexID":7,"TableID":104,"TemporaryIndexID":8}
+ │    │         ├── MergeIndex {"BackfilledIndexID":9,"TableID":104,"TemporaryIndexID":10}
+ │    │         └── MergeIndex {"BackfilledIndexID":11,"TableID":104,"TemporaryIndexID":12}
  │    ├── Stage 14 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │    │    └── 3 Mutation operations
- │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED → WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │    │    │    ├── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │    │    │    └── MERGED → WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":7,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":11,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    └── Stage 15 of 15 in PostCommitPhase
- │         ├── 1 element transitioning toward PUBLIC
- │         │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
- │         └── 1 Validation operation
- │              └── ValidateIndex {"IndexID":4,"TableID":104}
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+ │         │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+ │         └── 3 Validation operations
+ │              ├── ValidateIndex {"IndexID":7,"TableID":104}
+ │              ├── ValidateIndex {"IndexID":9,"TableID":104}
+ │              └── ValidateIndex {"IndexID":11,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+      │    ├── 14 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-      │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    └── 6 Mutation operations
-      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+      │    │    ├── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    └── 15 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":9,"Name":"t_b_key","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── SetIndexName {"IndexID":11,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":9,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC              PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── ABSENT                → PUBLIC              IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
-      │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── PUBLIC                → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── DELETE_ONLY           → ABSENT              PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    └── 12 Mutation operations
+      │    │    ├── VALIDATED             → PUBLIC              PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    └── ABSENT                → PUBLIC              IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
+      │    ├── 9 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── PUBLIC                → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY           → ABSENT              PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── DELETE_ONLY           → ABSENT              SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT              SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+      │    │    └── DELETE_ONLY           → ABSENT              SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    └── 23 Mutation operations
       │         ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":3,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
       │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"t_pkey","TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":7,"Name":"t_pkey","TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+      │    │    └── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
       │    └── 3 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 4 of 4 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            ├── 3 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 2}
-           │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-           │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+           │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 3}
+           │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
+           │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
            └── 6 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":104}
-                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,55 +9,97 @@ EXPLAIN (ddl) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 13 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 27 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 7 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 11 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,55 +9,97 @@ EXPLAIN (ddl) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 13 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 27 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 7 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 11 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,55 +9,97 @@ EXPLAIN (ddl) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 13 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 27 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 7 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 11 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,57 +9,103 @@ EXPLAIN (ddl) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 12 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 28 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 21 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 9 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 20 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,57 +9,103 @@ EXPLAIN (ddl) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 12 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 28 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 21 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 9 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 20 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,57 +9,103 @@ EXPLAIN (ddl) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 12 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 28 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC     → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 21 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":12,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    └── 9 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC      → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    └── 20 Mutation operations
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,27 +9,38 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 2 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
-           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-           ├── 8 elements transitioning toward ABSENT
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           └── 11 Mutation operations
-                ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+           ├── 6 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 3}
+           │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+           │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+           │    ├── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+           │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+           │    └── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+           └── 15 Mutation operations
+                ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+                ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+                ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
                 ├── RefreshStats {"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,34 +9,45 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 10 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 14 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,34 +9,45 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 10 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 14 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,34 +9,45 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 10 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 14 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,36 +9,47 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 9 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 6 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,36 +9,47 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 9 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 6 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,36 +9,47 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 9 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 6 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,36 +9,47 @@ EXPLAIN (ddl) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    └── 9 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 11 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    └── 13 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
            └── 6 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -8,53 +9,91 @@ EXPLAIN (ddl) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    ├── 11 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    └── 14 Mutation operations
-      │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+      │    │    ├── BACKFILL_ONLY → ABSENT      SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+      │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+      │    │    ├── PUBLIC        → ABSENT      SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+      │    └── 30 Mutation operations
+      │         ├── SetColumnName {"ColumnID":3,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_b_key","TableID":104}
+      │         ├── SetIndexName {"IndexID":3,"Name":"idx1","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":5,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":12,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":3,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":11,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":12,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":12,"TableID":104}
+      │         ├── LogEvent {"TargetStatus":1}
+      │         ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
       │    ├── 2 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
       │    └── 5 Mutation operations
-      │         ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 1 element transitioning toward ABSENT
-           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
            └── 4 Mutation operations
-                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -10,84 +11,126 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 2 elements transitioning toward PUBLIC
+│       ├── • 3 elements transitioning toward PUBLIC
 │       │   │
-│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
 │       │   │   │ ABSENT → BACKFILL_ONLY
 │       │   │   │
-│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
 │       │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
 │       │             rule: "index existence precedes index dependents"
 │       │
-│       ├── • 6 elements transitioning toward TRANSIENT_ABSENT
+│       ├── • 8 elements transitioning toward TRANSIENT_ABSENT
 │       │   │
-│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │       │   │   │ ABSENT → BACKFILL_ONLY
 │       │   │   │
-│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │       │   │         rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
 │       │   │
-│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │       │   │         rule: "index existence precedes index dependents"
 │       │   │
-│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │       │   │         rule: "index existence precedes index dependents"
 │       │   │
-│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+│       │   │         rule: "index existence precedes index dependents"
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │       │   │   │ ABSENT → DELETE_ONLY
 │       │   │   │
-│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │       │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │       │   │
-│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
-│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │       │   │         rule: "temp index existence precedes index dependents"
 │       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+│       │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+│       │   │   │ ABSENT → PUBLIC
+│       │   │   │
+│       │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
+│       │   │         rule: "temp index existence precedes index dependents"
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
 │       │       │ ABSENT → PUBLIC
 │       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
 │       │
-│       ├── • 2 elements transitioning toward ABSENT
+│       ├── • 6 elements transitioning toward ABSENT
 │       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   ├── • Column:{DescID: 104, ColumnID: 3}
 │       │   │   │ PUBLIC → WRITE_ONLY
 │       │   │   │
-│       │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+│       │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 3}
 │       │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: PUBLIC->WRITE_ONLY"
 │       │   │
-│       │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+│       │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+│       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+│       │   │         rule: "index no longer public before dependents"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+│       │   │   │ PUBLIC → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+│       │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
+│       │   │
+│       │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
 │       │       │ PUBLIC → ABSENT
 │       │       │
-│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │             rule: "column no longer public before dependents"
+│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+│       │             rule: "index no longer public before dependents"
 │       │
-│       └── • 11 Mutation operations
+│       └── • 18 Mutation operations
 │           │
 │           ├── • MakePublicColumnWriteOnly
-│           │     ColumnID: 2
+│           │     ColumnID: 3
 │           │     TableID: 104
 │           │
 │           ├── • LogEvent
 │           │     Element:
 │           │       Column:
-│           │         columnId: 2
+│           │         columnId: 3
 │           │         isHidden: true
-│           │         pgAttributeNum: 2
+│           │         pgAttributeNum: 3
 │           │         tableId: 104
 │           │     EventBase:
 │           │       Authorization:
@@ -101,61 +144,99 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │           │     TargetStatus: 1
 │           │
 │           ├── • SetColumnName
-│           │     ColumnID: 2
-│           │     Name: crdb_internal_column_2_name_placeholder
+│           │     ColumnID: 3
+│           │     Name: crdb_internal_column_3_name_placeholder
+│           │     TableID: 104
+│           │
+│           ├── • MakePublicSecondaryIndexWriteOnly
+│           │     IndexID: 2
+│           │     TableID: 104
+│           │
+│           ├── • SetIndexName
+│           │     IndexID: 2
+│           │     Name: crdb_internal_index_2_name_placeholder
+│           │     TableID: 104
+│           │
+│           ├── • MakePublicSecondaryIndexWriteOnly
+│           │     IndexID: 3
+│           │     TableID: 104
+│           │
+│           ├── • SetIndexName
+│           │     IndexID: 3
+│           │     Name: crdb_internal_index_3_name_placeholder
 │           │     TableID: 104
 │           │
 │           ├── • MakeAbsentIndexBackfilling
 │           │     Index:
-│           │       ConstraintID: 2
-│           │       IndexID: 2
+│           │       ConstraintID: 3
+│           │       IndexID: 5
 │           │       IsUnique: true
 │           │       SourceIndexID: 1
 │           │       TableID: 104
-│           │       TemporaryIndexID: 3
+│           │       TemporaryIndexID: 6
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 1
-│           │     IndexID: 2
+│           │     IndexID: 5
 │           │     TableID: 104
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 2
-│           │     IndexID: 2
+│           │     IndexID: 5
 │           │     Kind: 2
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 5
+│           │     Kind: 2
+│           │     Ordinal: 1
 │           │     TableID: 104
 │           │
 │           ├── • MakeAbsentTempIndexDeleteOnly
 │           │     Index:
-│           │       ConstraintID: 3
-│           │       IndexID: 3
+│           │       ConstraintID: 4
+│           │       IndexID: 6
 │           │       IsUnique: true
 │           │       SourceIndexID: 1
 │           │       TableID: 104
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 1
-│           │     IndexID: 3
+│           │     IndexID: 6
 │           │     TableID: 104
 │           │
 │           ├── • AddColumnToIndex
 │           │     ColumnID: 2
-│           │     IndexID: 3
+│           │     IndexID: 6
 │           │     Kind: 2
+│           │     TableID: 104
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 3
+│           │     IndexID: 6
+│           │     Kind: 2
+│           │     Ordinal: 1
 │           │     TableID: 104
 │           │
 │           ├── • MakeAbsentIndexBackfilling
 │           │     Index:
-│           │       ConstraintID: 4
-│           │       IndexID: 4
+│           │       ConstraintID: 5
+│           │       IndexID: 7
 │           │       IsUnique: true
-│           │       SourceIndexID: 2
+│           │       SourceIndexID: 5
 │           │       TableID: 104
-│           │       TemporaryIndexID: 5
+│           │       TemporaryIndexID: 8
+│           │
+│           ├── • AddColumnToIndex
+│           │     ColumnID: 1
+│           │     IndexID: 7
+│           │     TableID: 104
 │           │
 │           └── • AddColumnToIndex
-│                 ColumnID: 1
-│                 IndexID: 4
+│                 ColumnID: 2
+│                 IndexID: 7
+│                 Kind: 2
 │                 TableID: 104
 │
 ├── • PreCommitPhase
@@ -187,22 +268,25 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
-│   │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│   │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │   │   │       │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │       │
-│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
 │   │   │       │     rule: "index-column added to index before temp index receives writes"
 │   │   │       │
-│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+│   │   │       │     rule: "index-column added to index before temp index receives writes"
+│   │   │       │
+│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
 │   │   │             rule: "index-column added to index before temp index receives writes"
 │   │   │
 │   │   └── • 3 Mutation operations
 │   │       │
 │   │       ├── • MakeDeleteOnlyIndexWriteOnly
-│   │       │     IndexID: 3
+│   │       │     IndexID: 6
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -216,25 +300,28 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ BACKFILL_ONLY → BACKFILLED
 │   │   │       │
-│   │   │       ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │     rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
 │   │   │       │
-│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
 │   │   └── • 1 Backfill operation
 │   │       │
 │   │       └── • BackfillIndex
-│   │             IndexID: 2
+│   │             IndexID: 5
 │   │             SourceIndexID: 1
 │   │             TableID: 104
 │   │
@@ -242,16 +329,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ BACKFILLED → DELETE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       └── • PreviousTransactionPrecedence dependency from BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
 │   │   │
 │   │   └── • 3 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfillingIndexDeleteOnly
-│   │       │     IndexID: 2
+│   │       │     IndexID: 5
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -265,16 +352,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ DELETE_ONLY → MERGE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
 │   │   │
 │   │   └── • 3 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfilledIndexMerging
-│   │       │     IndexID: 2
+│   │       │     IndexID: 5
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -288,33 +375,33 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ MERGE_ONLY → MERGED
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGE_ONLY->MERGED"
 │   │   │
 │   │   └── • 1 Backfill operation
 │   │       │
 │   │       └── • MergeIndex
-│   │             BackfilledIndexID: 2
+│   │             BackfilledIndexID: 5
 │   │             TableID: 104
-│   │             TemporaryIndexID: 3
+│   │             TemporaryIndexID: 6
 │   │
 │   ├── • Stage 6 of 15 in PostCommitPhase
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ MERGED → WRITE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from MERGED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       └── • PreviousTransactionPrecedence dependency from MERGED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: MERGED->WRITE_ONLY"
 │   │   │
 │   │   └── • 3 Mutation operations
 │   │       │
 │   │       ├── • MakeMergedIndexWriteOnly
-│   │       │     IndexID: 2
+│   │       │     IndexID: 5
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -328,77 +415,184 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │       │ WRITE_ONLY → VALIDATED
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->VALIDATED"
 │   │   │
 │   │   └── • 1 Validation operation
 │   │       │
 │   │       └── • ValidateIndex
-│   │             IndexID: 2
+│   │             IndexID: 5
 │   │             TableID: 104
 │   │
 │   ├── • Stage 8 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
+│   │   ├── • 7 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ ABSENT → BACKFILL_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+│   │   │   │   │     rule: "primary index with new columns should exist before secondary indexes"
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │   │   │ ABSENT → BACKFILL_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+│   │   │   │   │     rule: "primary index with new columns should exist before secondary indexes"
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: ABSENT->BACKFILL_ONLY"
+│   │   │   │
+│   │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │   │         rule: "index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │   │         rule: "index existence precedes index dependents"
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+│   │   │       │ ABSENT → PUBLIC
+│   │   │       │
+│   │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │             rule: "index existence precedes index dependents"
+│   │   │
+│   │   ├── • 12 elements transitioning toward TRANSIENT_ABSENT
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │   │   │ VALIDATED → PUBLIC
 │   │   │   │   │
-│   │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
 │   │   │   │   │     rule: "primary index swap"
 │   │   │   │   │
-│   │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │   │   │     rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: VALIDATED->PUBLIC"
 │   │   │   │   │
-│   │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+│   │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
 │   │   │   │   │     rule: "index dependents exist before index becomes public"
 │   │   │   │   │     rule: "index named right before index becomes public"
 │   │   │   │   │
-│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
 │   │   │   │   │     rule: "index dependents exist before index becomes public"
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+│   │   │   │   │     rule: "index dependents exist before index becomes public"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
 │   │   │   │         rule: "index dependents exist before index becomes public"
 │   │   │   │
-│   │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+│   │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
 │   │   │   │   │ ABSENT → PUBLIC
 │   │   │   │   │
-│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │   └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │   │         rule: "index existence precedes index dependents"
 │   │   │   │
-│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
 │   │   │   │   │ ABSENT → DELETE_ONLY
 │   │   │   │   │
-│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
 │   │   │   │   │     rule: "primary index with new columns should exist before temp indexes"
 │   │   │   │   │
-│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
 │   │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
 │   │   │   │
-│   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │   │ ABSENT → DELETE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+│   │   │   │   │     rule: "primary index with new columns should exist before temp indexes"
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+│   │   │   │   │ ABSENT → DELETE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+│   │   │   │   │     rule: "primary index with new columns should exist before temp indexes"
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from ABSENT TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: ABSENT->DELETE_ONLY"
+│   │   │   │
+│   │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+│   │   │   │   │ ABSENT → PUBLIC
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "temp index existence precedes index dependents"
+│   │   │   │
+│   │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
 │   │   │       │ ABSENT → PUBLIC
 │   │   │       │
-│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
 │   │   │             rule: "temp index existence precedes index dependents"
 │   │   │
 │   │   ├── • 2 elements transitioning toward ABSENT
 │   │   │   │
-│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
 │   │   │   │   │ PUBLIC → VALIDATED
 │   │   │   │   │
-│   │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
 │   │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
 │   │   │   │
 │   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
 │   │   │       │ PUBLIC → ABSENT
 │   │   │       │
-│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
 │   │   │             rule: "index no longer public before dependents"
 │   │   │
-│   │   └── • 8 Mutation operations
+│   │   └── • 23 Mutation operations
 │   │       │
 │   │       ├── • MakePublicPrimaryIndexWriteOnly
 │   │       │     IndexID: 1
@@ -410,7 +604,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetIndexName
-│   │       │     IndexID: 2
+│   │       │     IndexID: 5
 │   │       │     Name: t_pkey
 │   │       │     TableID: 104
 │   │       │
@@ -424,20 +618,118 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │       TargetMetadata:
 │   │       │         SourceElementID: 1
 │   │       │         SubWorkID: 1
-│   │       │     IndexID: 2
+│   │       │     IndexID: 5
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • MakeAbsentTempIndexDeleteOnly
 │   │       │     Index:
-│   │       │       ConstraintID: 5
-│   │       │       IndexID: 5
+│   │       │       ConstraintID: 6
+│   │       │       IndexID: 8
 │   │       │       IsUnique: true
-│   │       │       SourceIndexID: 2
+│   │       │       SourceIndexID: 5
 │   │       │       TableID: 104
 │   │       │
 │   │       ├── • AddColumnToIndex
 │   │       │     ColumnID: 1
-│   │       │     IndexID: 5
+│   │       │     IndexID: 8
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 2
+│   │       │     IndexID: 8
+│   │       │     Kind: 2
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeAbsentIndexBackfilling
+│   │       │     Index:
+│   │       │       ConstraintID: 7
+│   │       │       IndexID: 9
+│   │       │       IsUnique: true
+│   │       │       SourceIndexID: 5
+│   │       │       TableID: 104
+│   │       │       TemporaryIndexID: 10
+│   │       │     IsSecondaryIndex: true
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 2
+│   │       │     IndexID: 9
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 1
+│   │       │     IndexID: 9
+│   │       │     Kind: 1
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeAbsentTempIndexDeleteOnly
+│   │       │     Index:
+│   │       │       ConstraintID: 8
+│   │       │       IndexID: 10
+│   │       │       IsUnique: true
+│   │       │       SourceIndexID: 5
+│   │       │       TableID: 104
+│   │       │     IsSecondaryIndex: true
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 2
+│   │       │     IndexID: 10
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 1
+│   │       │     IndexID: 10
+│   │       │     Kind: 1
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeAbsentIndexBackfilling
+│   │       │     Index:
+│   │       │       ConstraintID: 9
+│   │       │       IndexID: 11
+│   │       │       IsCreatedExplicitly: true
+│   │       │       SourceIndexID: 5
+│   │       │       TableID: 104
+│   │       │       TemporaryIndexID: 12
+│   │       │     IsSecondaryIndex: true
+│   │       │
+│   │       ├── • SetAddedIndexPartialPredicate
+│   │       │     Expr: b = 'a':::STRING
+│   │       │     IndexID: 11
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 2
+│   │       │     IndexID: 11
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 1
+│   │       │     IndexID: 11
+│   │       │     Kind: 1
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeAbsentTempIndexDeleteOnly
+│   │       │     Index:
+│   │       │       ConstraintID: 10
+│   │       │       IndexID: 12
+│   │       │       IsCreatedExplicitly: true
+│   │       │       SourceIndexID: 5
+│   │       │       TableID: 104
+│   │       │     IsSecondaryIndex: true
+│   │       │
+│   │       ├── • SetAddedIndexPartialPredicate
+│   │       │     Expr: b = 'a':::STRING
+│   │       │     IndexID: 12
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 2
+│   │       │     IndexID: 12
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • AddColumnToIndex
+│   │       │     ColumnID: 1
+│   │       │     IndexID: 12
+│   │       │     Kind: 1
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -445,25 +737,60 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │
 │   │       └── • UpdateSchemaChangerJob
 │   │             JobID: 1
-│   │             RunningStatus: PostCommitPhase stage 9 of 15 with 1 MutationType op pending
+│   │             RunningStatus: PostCommitPhase stage 9 of 15 with 3 MutationType ops pending
 │   │
 │   ├── • Stage 9 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+│   │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
-│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+│   │   │   │   │ DELETE_ONLY → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+│   │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+│   │   │   │   │     rule: "index-column added to index before temp index receives writes"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+│   │   │   │         rule: "index-column added to index before temp index receives writes"
+│   │   │   │
+│   │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │   │ DELETE_ONLY → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+│   │   │   │   │     rule: "index-column added to index before temp index receives writes"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+│   │   │   │         rule: "index-column added to index before temp index receives writes"
+│   │   │   │
+│   │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
 │   │   │       │ DELETE_ONLY → WRITE_ONLY
 │   │   │       │
-│   │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
 │   │   │       │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │       │
-│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+│   │   │       │     rule: "index-column added to index before temp index receives writes"
+│   │   │       │
+│   │   │       └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
 │   │   │             rule: "index-column added to index before temp index receives writes"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeDeleteOnlyIndexWriteOnly
-│   │       │     IndexID: 5
+│   │       │     IndexID: 8
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeDeleteOnlyIndexWriteOnly
+│   │       │     IndexID: 10
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeDeleteOnlyIndexWriteOnly
+│   │       │     IndexID: 12
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -471,45 +798,108 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │
 │   │       └── • UpdateSchemaChangerJob
 │   │             JobID: 1
-│   │             RunningStatus: PostCommitPhase stage 10 of 15 with 1 BackfillType op pending
+│   │             RunningStatus: PostCommitPhase stage 10 of 15 with 3 BackfillType ops pending
 │   │
 │   ├── • Stage 10 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   ├── • 3 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │ BACKFILL_ONLY → BACKFILLED
+│   │   │   │   │
+│   │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+│   │   │   │         rule: "temp index is WRITE_ONLY before backfill"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ BACKFILL_ONLY → BACKFILLED
+│   │   │   │   │
+│   │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+│   │   │   │   │     rule: "index-column added to index before index is backfilled"
+│   │   │   │   │
+│   │   │   │   └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "temp index is WRITE_ONLY before backfill"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │   │   │       │ BACKFILL_ONLY → BACKFILLED
 │   │   │       │
-│   │   │       ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│   │   │       │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
+│   │   │       ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │       │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILL_ONLY->BACKFILLED"
 │   │   │       │
-│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
 │   │   │       │     rule: "index-column added to index before index is backfilled"
 │   │   │       │
-│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+│   │   │       ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+│   │   │       │     rule: "index-column added to index before index is backfilled"
+│   │   │       │
+│   │   │       └── • Precedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
 │   │   │             rule: "temp index is WRITE_ONLY before backfill"
 │   │   │
-│   │   └── • 1 Backfill operation
+│   │   └── • 3 Backfill operations
+│   │       │
+│   │       ├── • BackfillIndex
+│   │       │     IndexID: 7
+│   │       │     SourceIndexID: 5
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • BackfillIndex
+│   │       │     IndexID: 9
+│   │       │     SourceIndexID: 5
+│   │       │     TableID: 104
 │   │       │
 │   │       └── • BackfillIndex
-│   │             IndexID: 4
-│   │             SourceIndexID: 2
+│   │             IndexID: 11
+│   │             SourceIndexID: 5
 │   │             TableID: 104
 │   │
 │   ├── • Stage 11 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   ├── • 3 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │ BACKFILLED → DELETE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ BACKFILLED → DELETE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │   │   │       │ BACKFILLED → DELETE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from BACKFILLED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
+│   │   │       └── • PreviousTransactionPrecedence dependency from BACKFILLED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: BACKFILLED->DELETE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfillingIndexDeleteOnly
-│   │       │     IndexID: 4
+│   │       │     IndexID: 7
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfillingIndexDeleteOnly
+│   │       │     IndexID: 9
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfillingIndexDeleteOnly
+│   │       │     IndexID: 11
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -517,22 +907,42 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │
 │   │       └── • UpdateSchemaChangerJob
 │   │             JobID: 1
-│   │             RunningStatus: PostCommitPhase stage 12 of 15 with 1 MutationType op pending
+│   │             RunningStatus: PostCommitPhase stage 12 of 15 with 3 MutationType ops pending
 │   │
 │   ├── • Stage 12 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   ├── • 3 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │ DELETE_ONLY → MERGE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ DELETE_ONLY → MERGE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │   │   │       │ DELETE_ONLY → MERGE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
+│   │   │       └── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->MERGE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeBackfilledIndexMerging
-│   │       │     IndexID: 4
+│   │       │     IndexID: 7
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfilledIndexMerging
+│   │       │     IndexID: 9
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeBackfilledIndexMerging
+│   │       │     IndexID: 11
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -540,39 +950,81 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │
 │   │       └── • UpdateSchemaChangerJob
 │   │             JobID: 1
-│   │             RunningStatus: PostCommitPhase stage 13 of 15 with 1 BackfillType op pending
+│   │             RunningStatus: PostCommitPhase stage 13 of 15 with 3 BackfillType ops pending
 │   │
 │   ├── • Stage 13 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   ├── • 3 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │ MERGE_ONLY → MERGED
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ MERGE_ONLY → MERGED
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │   │   │       │ MERGE_ONLY → MERGED
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED"
+│   │   │       └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED"
 │   │   │
-│   │   └── • 1 Backfill operation
+│   │   └── • 3 Backfill operations
+│   │       │
+│   │       ├── • MergeIndex
+│   │       │     BackfilledIndexID: 7
+│   │       │     TableID: 104
+│   │       │     TemporaryIndexID: 8
+│   │       │
+│   │       ├── • MergeIndex
+│   │       │     BackfilledIndexID: 9
+│   │       │     TableID: 104
+│   │       │     TemporaryIndexID: 10
 │   │       │
 │   │       └── • MergeIndex
-│   │             BackfilledIndexID: 4
+│   │             BackfilledIndexID: 11
 │   │             TableID: 104
-│   │             TemporaryIndexID: 5
+│   │             TemporaryIndexID: 12
 │   │
 │   ├── • Stage 14 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 1 element transitioning toward PUBLIC
+│   │   ├── • 3 elements transitioning toward PUBLIC
 │   │   │   │
-│   │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │   │ MERGED → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from MERGED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│   │   │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
+│   │   │   │
+│   │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │   │ MERGED → WRITE_ONLY
+│   │   │   │   │
+│   │   │   │   └── • PreviousTransactionPrecedence dependency from MERGED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│   │   │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
+│   │   │   │
+│   │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │   │   │       │ MERGED → WRITE_ONLY
 │   │   │       │
-│   │   │       └── • PreviousTransactionPrecedence dependency from MERGED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│   │   │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
+│   │   │       └── • PreviousTransactionPrecedence dependency from MERGED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│   │   │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGED->WRITE_ONLY"
 │   │   │
-│   │   └── • 3 Mutation operations
+│   │   └── • 5 Mutation operations
 │   │       │
 │   │       ├── • MakeMergedIndexWriteOnly
-│   │       │     IndexID: 4
+│   │       │     IndexID: 7
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeMergedIndexWriteOnly
+│   │       │     IndexID: 9
+│   │       │     TableID: 104
+│   │       │
+│   │       ├── • MakeMergedIndexWriteOnly
+│   │       │     IndexID: 11
 │   │       │     TableID: 104
 │   │       │
 │   │       ├── • SetJobStateOnDescriptor
@@ -580,78 +1032,198 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │       │
 │   │       └── • UpdateSchemaChangerJob
 │   │             JobID: 1
-│   │             RunningStatus: PostCommitPhase stage 15 of 15 with 1 ValidationType op pending
+│   │             RunningStatus: PostCommitPhase stage 15 of 15 with 3 ValidationType ops pending
 │   │
 │   └── • Stage 15 of 15 in PostCommitPhase
 │       │
-│       ├── • 1 element transitioning toward PUBLIC
+│       ├── • 3 elements transitioning toward PUBLIC
 │       │   │
-│       │   └── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│       │   │   │ WRITE_ONLY → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
+│       │   │         rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│       │   │   │ WRITE_ONLY → VALIDATED
+│       │   │   │
+│       │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+│       │   │         rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+│       │   │
+│       │   └── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
 │       │       │ WRITE_ONLY → VALIDATED
 │       │       │
-│       │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
-│       │             rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
+│       │       └── • PreviousTransactionPrecedence dependency from WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+│       │             rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->VALIDATED"
 │       │
-│       └── • 1 Validation operation
+│       └── • 3 Validation operations
+│           │
+│           ├── • ValidateIndex
+│           │     IndexID: 7
+│           │     TableID: 104
+│           │
+│           ├── • ValidateIndex
+│           │     IndexID: 9
+│           │     TableID: 104
 │           │
 │           └── • ValidateIndex
-│                 IndexID: 4
+│                 IndexID: 11
 │                 TableID: 104
 │
 └── • PostCommitNonRevertiblePhase
     │
     ├── • Stage 1 of 4 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 5 elements transitioning toward TRANSIENT_ABSENT
+    │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │ ABSENT → PUBLIC
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │         rule: "index existence precedes index dependents"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 14 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → TRANSIENT_ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → TRANSIENT_ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: WRITE_ONLY->TRANSIENT_DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → TRANSIENT_ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │         rule: "Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
@@ -660,34 +1232,135 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+    │   │   │   │ VALIDATED → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+    │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
     │   │       │ VALIDATED → DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │             rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
+    │   │       └── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │             rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │
-    │   └── • 6 Mutation operations
+    │   └── • 15 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyColumnDeleteOnly
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 9
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 11
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 2
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 5
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 9
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 1
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -696,112 +1369,200 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 4 with 10 MutationType ops
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 4 with 21 MutationType ops
     │               pending
     │
     ├── • Stage 2 of 4 in PostCommitNonRevertiblePhase
     │   │
     │   ├── • 2 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "old index absent before new index public when swapping with transient"
     │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • SameStagePrecedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "primary index swap"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "index dependents exist before index becomes public"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │       │ ABSENT → PUBLIC
     │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │             rule: "index existence precedes index dependents"
     │   │
-    │   ├── • 6 elements transitioning toward TRANSIENT_ABSENT
+    │   ├── • 9 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → TRANSIENT_VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: PUBLIC->TRANSIENT_VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → TRANSIENT_ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → TRANSIENT_ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → TRANSIENT_ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column no longer public before dependents"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
+    │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
+    │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │       ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │     rule: "partial predicate removed right before secondary index when not dropping relation"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │       │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 12 Mutation operations
+    │   └── • 23 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 1
@@ -823,19 +1584,60 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 1
+    │       │         indexId: 2
+    │       │         isUnique: true
+    │       │         tableId: 104
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS
+    │       │         (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 2
+    │       │     StatementForDropJob:
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
-    │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 3
     │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         indexId: 3
+    │       │         isCreatedExplicitly: true
+    │       │         tableId: 104
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS
+    │       │         (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
     │       │
     │       ├── • CreateGCJobForIndex
     │       │     IndexID: 3
     │       │     StatementForDropJob:
-    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
     │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
@@ -843,20 +1645,62 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       │     IndexID: 3
     │       │     TableID: 104
     │       │
+    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 4
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 6
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 7
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
     │       │         KEY USING COLUMNS (a)
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeValidatedPrimaryIndexPublic
@@ -869,7 +1713,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -884,16 +1728,16 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │       │ TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY
     │   │       │
-    │   │       └── • PreviousTransactionPrecedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │       └── • PreviousTransactionPrecedence dependency from TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │             rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_VALIDATED->TRANSIENT_WRITE_ONLY"
     │   │
     │   └── • 3 Mutation operations
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -908,73 +1752,88 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
         │
         ├── • 1 element transitioning toward TRANSIENT_ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: TRANSIENT_DELETE_ONLY->TRANSIENT_ABSENT"
         │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         ├── • 3 elements transitioning toward ABSENT
         │   │
-        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   ├── • Column:{DescID: 104, ColumnID: 3}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY Column:{DescID: 104, ColumnID: 2}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY Column:{DescID: 104, ColumnID: 3}
         │   │   │     rule: "Column transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • SameStagePrecedence dependency from ABSENT ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+        │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
         │   │   │     rule: "indexes containing column reach absent before column"
         │   │   │
-        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-        │   │   │     rule: "indexes containing column reach absent before column"
-        │   │   │
-        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+        │   │   │     rule: "indexes containing column reach absent before column"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+        │   │   │     rule: "dependents removed before column"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+        │   │   │     rule: "indexes containing column reach absent before column"
+        │   │   │
+        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+        │   │   │     rule: "indexes containing column reach absent before column"
+        │   │   │
+        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+        │   │   │     rule: "dependents removed before column"
+        │   │   │
+        │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │   │         rule: "dependents removed before column"
         │   │
-        │   ├── • ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   ├── • ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+        │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   └── • ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   └── • ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
         │       │ PUBLIC → ABSENT
         │       │
-        │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+        │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
         │             rule: "column no longer public before dependents"
         │
         └── • 6 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
             │         USING COLUMNS (a)
@@ -990,15 +1849,15 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveColumnDefaultExpression
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     TableID: 104
             │
             ├── • MakeDeleteOnlyColumnAbsent
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     EventBase:
             │       Authorization:
             │         UserName: root

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,135 +12,315 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 29 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 13 Mutation operations
+    │   └── • 27 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -148,25 +329,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -192,8 +395,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -209,7 +420,73 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -218,43 +495,76 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
+    │   ├── • 5 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 7 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -262,11 +572,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -274,11 +584,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -293,25 +627,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -327,7 +664,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,135 +12,315 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 29 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 13 Mutation operations
+    │   └── • 27 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -148,25 +329,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -192,8 +395,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -209,7 +420,73 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -218,43 +495,76 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
+    │   ├── • 5 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 7 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -262,11 +572,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -274,11 +584,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -293,25 +627,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -327,7 +664,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,135 +12,315 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 29 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 13 Mutation operations
+    │   └── • 27 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -148,25 +329,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -192,8 +395,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -209,7 +420,73 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -218,43 +495,76 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
+    │   ├── • 5 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 7 Mutation operations
+    │   └── • 11 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -262,11 +572,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -274,11 +584,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -293,25 +627,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -327,7 +664,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,129 +12,281 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 28 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 12 Mutation operations
+    │   └── • 21 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -142,25 +295,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -186,8 +361,24 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 4
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -196,55 +387,129 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 18 MutationType ops
+    │               pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 9 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 20 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -252,11 +517,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -272,11 +537,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -284,11 +549,101 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -303,25 +658,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -337,7 +695,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,129 +12,281 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 28 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ MERGE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 12 Mutation operations
+    │   └── • 21 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -142,25 +295,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -186,8 +361,24 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 4
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -196,55 +387,129 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 18 MutationType ops
+    │               pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 9 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 20 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -252,11 +517,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -272,11 +537,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -284,11 +549,101 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -303,25 +658,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -337,7 +695,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,129 +12,281 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 28 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │         rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ WRITE_ONLY → DELETE_ONLY
+    │   │   │   │
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 12 Mutation operations
+    │   └── • 21 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -142,29 +295,59 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
     │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 4
-    │       │     TableID: 104
-    │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakePublicPrimaryIndexWriteOnly
     │       │     IndexID: 5
     │       │     TableID: 104
     │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 7
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -190,61 +373,143 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • SetJobStateOnDescriptor
     │       │     DescriptorID: 104
     │       │
     │       └── • UpdateSchemaChangerJob
     │             IsNonCancelable: true
     │             JobID: 1
-    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops pending
+    │             RunningStatus: PostCommitNonRevertiblePhase stage 2 of 3 with 18 MutationType ops
+    │               pending
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
+    │   ├── • 9 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │       ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │             rule: "dependents removed before index"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 20 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -252,11 +517,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -272,11 +537,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -284,11 +549,101 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -303,25 +658,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -337,7 +695,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,109 +12,193 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 2 elements transitioning toward PUBLIC
+        ├── • 6 elements transitioning toward PUBLIC
         │   │
-        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   ├── • Column:{DescID: 104, ColumnID: 3}
         │   │   │ WRITE_ONLY → PUBLIC
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+        │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
         │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
         │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
         │   │   │     rule: "column dependents exist before column becomes public"
         │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
         │   │   │     rule: "column dependents exist before column becomes public"
         │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
         │   │   │     rule: "column dependents exist before column becomes public"
         │   │   │
-        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
         │   │         rule: "column dependents exist before column becomes public"
         │   │
-        │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+        │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+        │   │         rule: "index dependents exist before index becomes public"
+        │   │         rule: "index named right before index becomes public"
+        │   │
+        │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+        │   │     ABSENT → PUBLIC
+        │   │
+        │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+        │   │   │ VALIDATED → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+        │   │   │     rule: "index dependents exist before index becomes public"
+        │   │   │
+        │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+        │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+        │   │   │
+        │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+        │   │         rule: "index dependents exist before index becomes public"
+        │   │         rule: "index named right before index becomes public"
+        │   │
+        │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
         │         ABSENT → PUBLIC
         │
-        ├── • 8 elements transitioning toward ABSENT
+        ├── • 11 elements transitioning toward ABSENT
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │ BACKFILL_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • skip PUBLIC → ABSENT operations
         │   │         rule: "skip index-column removal ops on index removal"
         │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • skip PUBLIC → ABSENT operations
         │   │         rule: "skip index-column removal ops on index removal"
         │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │   │         rule: "dependents removed before index"
         │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • skip PUBLIC → ABSENT operations
         │   │         rule: "skip index-column removal ops on index removal"
         │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • skip PUBLIC → ABSENT operations
         │   │         rule: "skip index-column removal ops on index removal"
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
         │   │   │ BACKFILL_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+        │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
         │       │ PUBLIC → ABSENT
         │       │
         │       └── • skip PUBLIC → ABSENT operations
         │             rule: "skip index-column removal ops on index removal"
         │
-        └── • 11 Mutation operations
+        └── • 15 Mutation operations
             │
             ├── • SetColumnName
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     Name: rowid
             │     TableID: 104
             │
+            ├── • SetIndexName
+            │     IndexID: 2
+            │     Name: t_b_key
+            │     TableID: 104
+            │
+            ├── • SetIndexName
+            │     IndexID: 3
+            │     Name: idx1
+            │     TableID: 104
+            │
             ├── • MakeWriteOnlyColumnPublic
-            │     ColumnID: 2
+            │     ColumnID: 3
             │     EventBase:
             │       Authorization:
             │         UserName: root
@@ -127,8 +212,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             ├── • RefreshStats
             │     TableID: 104
             │
-            ├── • CreateGCJobForIndex
+            ├── • MakeValidatedSecondaryIndexPublic
             │     IndexID: 2
+            │     TableID: 104
+            │
+            ├── • MakeValidatedSecondaryIndexPublic
+            │     IndexID: 3
+            │     TableID: 104
+            │
+            ├── • CreateGCJobForIndex
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -144,11 +237,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -156,11 +249,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 4
+            │     IndexID: 7
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -176,7 +269,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 4
+            │     IndexID: 7
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,107 +12,188 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 14 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
     │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -125,8 +207,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
-    │       ├── • CreateGCJobForIndex
+    │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -142,11 +232,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -162,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -177,22 +267,25 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -200,7 +293,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,107 +12,188 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 14 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
     │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -125,8 +207,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
-    │       ├── • CreateGCJobForIndex
+    │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -142,11 +232,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -162,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -177,22 +267,25 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -200,7 +293,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,107 +12,188 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 10 Mutation operations
+    │   └── • 14 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
     │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -125,8 +207,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
-    │       ├── • CreateGCJobForIndex
+    │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 5
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -142,11 +232,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -162,7 +252,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -177,22 +267,25 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -200,7 +293,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,98 +12,176 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
     │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -116,12 +195,20 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -137,7 +224,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -152,37 +239,43 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -198,11 +291,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -210,7 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,98 +12,176 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ MERGE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from MERGE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: MERGE_ONLY->WRITE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
+    │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
     │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -116,12 +195,20 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • MakeValidatedSecondaryIndexPublic
     │       │     IndexID: 2
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -137,7 +224,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -152,37 +239,43 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -198,11 +291,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -210,7 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,102 +12,180 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 3
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -120,8 +199,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -137,7 +224,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -152,37 +239,43 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -198,11 +291,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -210,7 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,102 +12,180 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
+    │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 8 elements transitioning toward ABSENT
+    │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 9 Mutation operations
+    │   └── • 13 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
-    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 3
+    │       │     Name: idx1
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 3
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeWriteOnlyIndexDeleteOnly
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -120,8 +199,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │       ├── • RefreshStats
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -137,7 +224,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -152,37 +239,43 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
         │
         ├── • 2 elements transitioning toward ABSENT
         │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │ DELETE_ONLY → ABSENT
         │   │   │
-        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │   │   │     rule: "dependents removed before index"
         │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │   │         rule: "dependents removed before index"
         │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
         │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
         │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -198,11 +291,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 3
+            │     IndexID: 6
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -210,7 +303,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
             │     TableID: 104
             │
             ├── • MakeIndexAbsent
-            │     IndexID: 3
+            │     IndexID: 6
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -1,5 +1,6 @@
 /* setup */
-CREATE TABLE t (a INT NOT NULL);
+CREATE TABLE t (a INT NOT NULL, b STRING NOT NULL UNIQUE);
+CREATE INDEX idx1 ON t (b) WHERE (b = 'a');
 
 /* test */
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
@@ -11,138 +12,336 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
+    │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   ├── • Column:{DescID: 104, ColumnID: 3}
     │   │   │   │ WRITE_ONLY → PUBLIC
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "Column transitions to PUBLIC uphold 2-version invariant: WRITE_ONLY->PUBLIC"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 3}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
     │   │   │         rule: "column dependents exist before column becomes public"
     │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 3}
     │   │   │     ABSENT → PUBLIC
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │ VALIDATED → PUBLIC
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 2}
     │   │   │   │     rule: "PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
     │   │   │   │
     │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │   │   │     rule: "index dependents exist before index becomes public"
     │   │   │   │     rule: "index named right before index becomes public"
     │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "primary index swap"
     │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 1}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_b_key, IndexID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC SecondaryIndexPartial:{DescID: 104, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 0}
+    │   │   │   │     rule: "SecondaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx1, IndexID: 3}
     │   │         ABSENT → PUBLIC
     │   │
-    │   ├── • 11 elements transitioning toward ABSENT
+    │   ├── • 29 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ PUBLIC → VALIDATED
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: PUBLIC->VALIDATED"
     │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "index no longer public before dependents"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │     rule: "index no longer public before dependents"
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │   │ WRITE_ONLY → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from WRITE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │   │         rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │ BACKFILL_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 7, ConstraintID: 5, TemporaryIndexID: 8, SourceIndexID: 5}
     │   │   │   │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 7}
     │   │   │   │     rule: "dependents removed before index"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 7}
     │   │   │   │ PUBLIC → ABSENT
     │   │   │   │
     │   │   │   └── • skip PUBLIC → ABSENT operations
     │   │   │         rule: "skip index-column removal ops on index removal"
     │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 7}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │ DELETE_ONLY → ABSENT
     │   │   │   │
-    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 8, ConstraintID: 6, SourceIndexID: 5}
     │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
     │   │   │         rule: "dependents removed before index"
     │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 8}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 9, ConstraintID: 7, TemporaryIndexID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_b_key, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 9}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 10, ConstraintID: 8, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 10}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 11, ConstraintID: 9, TemporaryIndexID: 12, SourceIndexID: 5}
+    │   │   │   │     rule: "SecondaryIndex transitions to ABSENT uphold 2-version invariant: BACKFILL_ONLY->DELETE_ONLY"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: idx1, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │     rule: "partial predicate removed right before secondary index when not dropping relation"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 11}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 11}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 12, ConstraintID: 10, SourceIndexID: 5}
+    │   │   │   │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • SecondaryIndexPartial:{DescID: 104, IndexID: 12}
+    │   │   │     PUBLIC → ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 12}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 12}
     │   │       │ PUBLIC → ABSENT
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   └── • 14 Mutation operations
+    │   └── • 30 Mutation operations
     │       │
     │       ├── • SetColumnName
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     Name: rowid
     │       │     TableID: 104
     │       │
@@ -151,21 +350,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     Name: t_pkey
     │       │     TableID: 104
     │       │
-    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       ├── • SetIndexName
     │       │     IndexID: 2
+    │       │     Name: t_b_key
     │       │     TableID: 104
     │       │
     │       ├── • SetIndexName
-    │       │     IndexID: 2
-    │       │     Name: crdb_internal_index_2_name_placeholder
+    │       │     IndexID: 3
+    │       │     Name: idx1
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakePublicPrimaryIndexWriteOnly
+    │       │     IndexID: 5
+    │       │     TableID: 104
+    │       │
+    │       ├── • SetIndexName
+    │       │     IndexID: 5
+    │       │     Name: crdb_internal_index_5_name_placeholder
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 3
+    │       │     IndexID: 6
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 12
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyColumnPublic
-    │       │     ColumnID: 2
+    │       │     ColumnID: 3
     │       │     EventBase:
     │       │       Authorization:
     │       │         UserName: root
@@ -191,8 +404,16 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     IndexID: 1
     │       │     TableID: 104
     │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeValidatedSecondaryIndexPublic
+    │       │     IndexID: 3
+    │       │     TableID: 104
+    │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -208,11 +429,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │       TargetMetadata:
     │       │         SourceElementID: 1
     │       │         SubWorkID: 1
-    │       │     IndexID: 4
+    │       │     IndexID: 7
     │       │     TableID: 104
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 5
+    │       │     IndexID: 8
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -220,7 +441,97 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 5
+    │       │     IndexID: 8
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 7
+    │       │         indexId: 9
+    │       │         isUnique: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 10
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 9
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 9
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 10
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 10
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveDroppedIndexPartialPredicate
+    │       │     IndexID: 11
+    │       │     TableID: 104
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 12
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 12
+    │       │     TableID: 104
+    │       │
+    │       ├── • LogEvent
+    │       │     Element:
+    │       │       SecondaryIndex:
+    │       │         constraintId: 9
+    │       │         indexId: 11
+    │       │         isCreatedExplicitly: true
+    │       │         sourceIndexId: 5
+    │       │         tableId: 104
+    │       │         temporaryIndexId: 12
+    │       │     EventBase:
+    │       │       Authorization:
+    │       │         UserName: root
+    │       │       Statement: ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›)
+    │       │       StatementTag: ALTER TABLE
+    │       │       TargetMetadata:
+    │       │         SourceElementID: 1
+    │       │         SubWorkID: 1
+    │       │     TargetStatus: 1
+    │       │
+    │       ├── • CreateGCJobForIndex
+    │       │     IndexID: 11
+    │       │     StatementForDropJob:
+    │       │       Rollback: true
+    │       │       Statement: removed secondary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
+    │       │         KEY USING COLUMNS (a)
+    │       │     TableID: 104
+    │       │
+    │       ├── • MakeIndexAbsent
+    │       │     IndexID: 11
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -235,28 +546,31 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │
     │   ├── • 2 elements transitioning toward ABSENT
     │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │   │ VALIDATED → DELETE_ONLY
     │   │   │   │
-    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   └── • PreviousTransactionPrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
     │   │   │         rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: VALIDATED->WRITE_ONLY"
     │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │       │ DELETE_ONLY → ABSENT
     │   │       │
-    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 1}
     │   │       │     rule: "TemporaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
     │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
     │   │       │     rule: "dependents removed before index"
     │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 6}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 5 Mutation operations
     │       │
     │       ├── • CreateGCJobForIndex
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     StatementForDropJob:
     │       │       Rollback: true
     │       │       Statement: removed temporary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY
@@ -264,11 +578,11 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │       │     TableID: 104
     │       │
     │       ├── • MakeIndexAbsent
-    │       │     IndexID: 3
+    │       │     IndexID: 6
     │       │     TableID: 104
     │       │
     │       ├── • MakeWriteOnlyIndexDeleteOnly
-    │       │     IndexID: 2
+    │       │     IndexID: 5
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor
@@ -283,25 +597,28 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
         │
         ├── • 1 element transitioning toward ABSENT
         │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │ DELETE_ONLY → ABSENT
         │       │
-        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 3, TemporaryIndexID: 6, SourceIndexID: 1}
         │       │     rule: "PrimaryIndex transitions to ABSENT uphold 2-version invariant: DELETE_ONLY->ABSENT"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
         │       │     rule: "dependents removed before index"
         │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 5}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
         │             rule: "dependents removed before index"
         │
         └── • 4 Mutation operations
             │
             ├── • CreateGCJobForIndex
-            │     IndexID: 2
+            │     IndexID: 5
             │     StatementForDropJob:
             │       Rollback: true
             │       Statement: removed primary index; ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY
@@ -317,7 +634,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
             │       TargetMetadata:
             │         SourceElementID: 1
             │         SubWorkID: 1
-            │     IndexID: 2
+            │     IndexID: 5
             │     TableID: 104
             │
             ├── • RemoveJobStateFromDescriptor


### PR DESCRIPTION
    scbuildstmt: add secondary index support for ALTER PK
    
    Previously, we had limited support for ALTER PRIMARY KEY statements in
    the declarative schema changer. One of the limitations was that
    secondary indexes were not supported. This commit removes this limitation.
    
    Relates to #83932.
    
    Release note (sql change): declarative schema changer support for ALTER
    PRIMARY KEY statements now extends to tables which have secondary
    indexes.