### PR TITLE
Revert "flowinfra: hydrate types for the inbound streams"

### DIFF
--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
-        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfra/execopnode",
         "//pkg/sql/execinfra/execreleasable",

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -192,7 +192,7 @@ func processProducerMessage(
 	draining *bool,
 	msg *execinfrapb.ProducerMessage,
 ) processMessageResult {
-	err := sd.AddMessage(ctx, msg, &flowBase.FlowCtx)
+	err := sd.AddMessage(ctx, msg)
 	if err != nil {
 		return processMessageResult{
 			err: errors.Wrapf(err, "%s",
@@ -225,7 +225,7 @@ func processProducerMessage(
 
 		if log.V(3) && row != nil {
 			if types == nil {
-				types = sd.types()
+				types = sd.Types()
 			}
 			log.Infof(ctx, "inbound stream pushing row %s", row.String(types))
 		}

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -152,7 +152,7 @@ func TestOutbox(t *testing.T) {
 			}
 			t.Fatal(err)
 		}
-		err = decoder.AddMessage(context.Background(), msg, &flowCtx)
+		err = decoder.AddMessage(context.Background(), msg)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -81,7 +81,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []*types.T, records []ro
 			msg := se.FormMessage(context.Background())
 			// Make a copy of the data buffer.
 			msg.Data.RawBytes = append([]byte(nil), msg.Data.RawBytes...)
-			err := sd.AddMessage(context.Background(), msg, nil /* flowCtx */)
+			err := sd.AddMessage(context.Background(), msg)
 			if err != nil {
 				tb.Fatal(err)
 			}
@@ -138,7 +138,7 @@ func TestEmptyStreamEncodeDecode(t *testing.T) {
 	var se flowinfra.StreamEncoder
 	var sd flowinfra.StreamDecoder
 	msg := se.FormMessage(context.Background())
-	if err := sd.AddMessage(context.Background(), msg, nil /* flowCtx */); err != nil {
+	if err := sd.AddMessage(context.Background(), msg); err != nil {
 		t.Fatal(err)
 	}
 	if msg.Header == nil {
@@ -220,7 +220,7 @@ func BenchmarkStreamDecoder(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var sd flowinfra.StreamDecoder
-				if err := sd.AddMessage(ctx, msg, nil /* flowCtx */); err != nil {
+				if err := sd.AddMessage(ctx, msg); err != nil {
 					b.Fatal(err)
 				}
 				for j := 0; j < flowinfra.OutboxBufRows; j++ {


### PR DESCRIPTION
This reverts commit e06c2db4977e2dd8ce772a9ad863f1ae9e0f5a61.

The rationale for the revert is that the commit is broken - it
introduced a concurrent access to `FlowCtx.Descriptors`, but that field
is not concurrency-safe. I'll work on a more involved but proper fix
separately.

Fixes: #86213.

Release justification: bug fix.

Release note: None