### PR TITLE
backupccl: make more attributes of backup schedules alterable.

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -1,0 +1,96 @@
+new-server name=s1 allow-implicit-access
+----
+
+# Create test schedules.
+
+exec-sql
+create schedule datatest for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached"
+
+# Can't use the same command twice.
+
+exec-sql expect-error-ignore
+alter backup schedule $fullID set recurring '0 0 1 * *', set recurring '@weekly';
+----
+ignoring expected error
+
+exec-sql expect-error-ignore
+alter backup schedule $fullID set full backup '0 0 1 * *', set recurring '0 0 1 * *', set full backup '@weekly';
+----
+ignoring expected error
+
+# Set an option
+
+exec-sql
+alter backup schedule $incID set with revision_history = false;
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = false, detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = false, detached"
+
+# Change an option and set another.
+
+exec-sql
+alter backup schedule $incID set with revision_history = true, set with encryption_passphrase = 'abc';
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
+
+# Add a list-option
+
+exec-sql
+alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///key2?region=r2'), set with incremental_location = 'inc';
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
+
+# Set options to empty (unset).
+
+exec-sql
+alter backup schedule $incID set with kms = '', set with incremental_location = (''), set with encryption_passphrase = '';
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+
+# Setting DETACHED throws an error.
+
+exec-sql expect-error-ignore
+alter backup schedule $incID set with detached = true;
+----
+ignoring expected error
+
+exec-sql expect-error-ignore
+alter backup schedule $incID set with detached = false;
+----
+ignoring expected error
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached"

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/recurrence
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/recurrence
@@ -175,6 +175,13 @@ with schedules as (show schedules) select id, state, recurrence, owner, command 
 $fullID <nil> 0 0 1 * * root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
 $incID Waiting for initial backup to complete @weekly root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
 
+# Can't set incremental schedule to be slower than full.
+
+exec-sql expect-error-ignore
+alter backup schedule $fullID set recurring '@weekly', set full backup '@daily';
+----
+ignoring expected error
+
 # Remove incremental backup and change full cadence in the same command.
 
 exec-sql
@@ -198,15 +205,3 @@ query-sql
 with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
 ----
 $fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
-
-# Can't use the same command twice.
-
-exec-sql expect-error-ignore
-alter backup schedule $incID set recurring '0 0 1 * *', set recurring '@weekly';
-----
-ignoring expected error
-
-exec-sql expect-error-ignore
-alter backup schedule $incID set full backup '0 0 1 * *', set recurring '0 0 1 * *', set full backup '@weekly';
-----
-ignoring expected error

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
@@ -1,0 +1,81 @@
+new-server name=s1 allow-implicit-access
+----
+
+# Create test schedules.
+
+exec-sql
+create schedule datatest for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, label from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+----
+$fullID datatest
+$incID datatest
+
+exec-sql
+alter backup schedule $fullID set label 'datatest2'
+----
+
+query-sql
+with schedules as (show schedules) select id, label from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+----
+$fullID datatest2
+$incID datatest2
+
+exec-sql
+alter backup schedule $fullID set into 'nodelocal://1/example-schedule-2'
+----
+
+query-sql
+with schedules as (show schedules) select id, command->'backup_statement' from schedules where id in ($fullID, $incID) order by command->>'backup_type' asc;
+----
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule-2' WITH detached"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule-2' WITH detached"
+
+# Hard to validate these, so settle for checking they execute without errors.
+
+exec-sql
+alter backup schedule $fullID set schedule option on_previous_running='skip', set schedule option on_execution_failure = 'pause';
+----
+
+exec-sql
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = '1';
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = '0';
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'TRUE';
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'False';
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 't';
+----
+
+exec-sql expect-error-ignore
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'yeah for sure true';
+----
+ignoring expected error
+
+exec-sql
+create user testuser;
+grant admin to testuser;
+----
+
+# Cluster backup as a non-admin user should fail.
+exec-sql user=testuser
+create schedule datatest3 for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+exec-sql
+revoke admin from testuser;
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest3' order by command->>'backup_type' asc;
+----
+
+exec-sql user=testuser expect-error-ignore
+alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = '1';
+----
+ignoring expected error
+


### PR DESCRIPTION
Release note (enterprise change): ALTER BACKUP now supports additional commands like
SET WITH, SET SCHEDULE OPTION, SET LABEL, and SET INTO

Release justification: low risk, medium benefit

Informs https://github.com/cockroachdb/cockroach/issues/84033