### PR TITLE
sql/schemachanger: fixed a ordial number bug in ALTER PRIMARY KEY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1742,3 +1742,32 @@ SELECT column_name FROM [SHOW COLUMNS FROM t_rowid] ORDER BY column_name;
 ----
 k
 v
+
+# The following subtest tests the case when the new primary key
+# intersects with the old primary key.
+subtest regression_85877
+
+statement ok
+CREATE TABLE t_85877(i INT NOT NULL, j INT NOT NULL, PRIMARY KEY (i))
+
+statement ok
+ALTER TABLE t_85877 ALTER PRIMARY KEY USING COLUMNS (i, j)
+
+statement ok
+DROP TABLE t_85877
+
+statement ok
+CREATE TABLE t_85877 (i INT NOT NULL, j INT NOT NULL, PRIMARY KEY (i, j))
+
+statement ok
+ALTER TABLE t_85877 ALTER PRIMARY KEY USING COLUMNS (i)
+
+statement ok
+DROP TABLE t_85877
+
+statement ok
+CREATE TABLE t_85877 (i INT NOT NULL, j INT NOT NULL, k INT NOT NULL, PRIMARY KEY (i, j))
+
+statement ok
+ALTER TABLE t_85877 ALTER PRIMARY KEY USING COLUMNS (j, k)
+

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -617,13 +617,14 @@ func addIndexColumnsForNewUniqueSecondaryIndexAndTempIndex(
 	}
 
 	// Add each column that is not in the old primary key as a SUFFIX_KEY column.
+	var ord uint32 = 0
 	for i, keyColIDInNewPrimaryIndex := range newPrimaryIndexKeyColumnIDs {
 		if !descpb.ColumnIDs(oldPrimaryIndexKeyColumnIDs).Contains(keyColIDInNewPrimaryIndex) {
 			b.Add(&scpb.IndexColumn{
 				TableID:       tbl.TableID,
 				IndexID:       newUniqueSecondaryIndexID,
 				ColumnID:      keyColIDInNewPrimaryIndex,
-				OrdinalInKind: uint32(i),
+				OrdinalInKind: ord,
 				Kind:          scpb.IndexColumn_KEY_SUFFIX,
 				Direction:     newPrimaryIndexKeyColumnDirs[i],
 			})
@@ -631,10 +632,11 @@ func addIndexColumnsForNewUniqueSecondaryIndexAndTempIndex(
 				TableID:       tbl.TableID,
 				IndexID:       temporaryIndexIDForNewUniqueSecondaryIndex,
 				ColumnID:      keyColIDInNewPrimaryIndex,
-				OrdinalInKind: uint32(i),
+				OrdinalInKind: ord,
 				Kind:          scpb.IndexColumn_KEY_SUFFIX,
 				Direction:     newPrimaryIndexKeyColumnDirs[i],
 			})
+			ord++
 		}
 	}
 }


### PR DESCRIPTION
Previously, we had a bug in ALTER PRIMARY KEY such that when the new
primary key is a superset of the old primary key, we incorrectly gave
ordinal numbers to IndexColumn elements. This PR fixed it and added
a few logic tests for cases when the new primary key intersects with
the old primary key.

Fixes: #85877

Release note: None

Release justification: fixed a bug that was revealed in roachtest
failure (issue #85877)