### PR TITLE
opt: use only required columns in provided ordering for project

### DIFF
--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2845,3 +2845,57 @@ sort (segmented)
       │    ├── key: (1-3)
       │    └── ordering: +1,+2,+3
       └── filters (true)
+
+# Regression test for #85393 - use only columns from the required ordering when
+# building the provided ordering for Project operators.
+exec-ddl
+CREATE TABLE t0_85393 (c0 INT);
+----
+
+exec-ddl
+CREATE TABLE t1_85393 (c0 INT);
+----
+
+opt
+SELECT *
+FROM t0_85393 CROSS JOIN t1_85393
+WHERE (t0_85393.rowid IS NULL) OR (t1_85393.rowid IN (t0_85393.rowid))
+ORDER BY t1_85393.rowid;
+----
+project
+ ├── columns: c0:1 c0:5  [hidden: t1_85393.rowid:6!null]
+ ├── fd: (6)-->(5)
+ ├── ordering: +6
+ └── project
+      ├── columns: t0_85393.c0:1 t0_85393.rowid:2!null t1_85393.c0:5 t1_85393.rowid:6!null
+      ├── key: (2,6)
+      ├── fd: (2)-->(1), (6)-->(5)
+      ├── ordering: +6
+      └── project
+           ├── columns: t0_85393.c0:1 t0_85393.rowid:2!null t1_85393.c0:5 t1_85393.rowid:6!null
+           ├── key: (6)
+           ├── fd: (2)==(6), (6)==(2), (2)-->(1,5)
+           ├── ordering: +(2|6) [actual: +2]
+           ├── inner-join (merge)
+           │    ├── columns: t0_85393.c0:9 t0_85393.rowid:10!null t1_85393.c0:13 t1_85393.rowid:14!null
+           │    ├── left ordering: +10
+           │    ├── right ordering: +14
+           │    ├── key: (14)
+           │    ├── fd: (10)-->(9), (14)-->(13), (10)==(14), (14)==(10)
+           │    ├── ordering: +(10|14) [actual: +10]
+           │    ├── scan t0_85393
+           │    │    ├── columns: t0_85393.c0:9 t0_85393.rowid:10!null
+           │    │    ├── key: (10)
+           │    │    ├── fd: (10)-->(9)
+           │    │    └── ordering: +10
+           │    ├── scan t1_85393
+           │    │    ├── columns: t1_85393.c0:13 t1_85393.rowid:14!null
+           │    │    ├── key: (14)
+           │    │    ├── fd: (14)-->(13)
+           │    │    └── ordering: +14
+           │    └── filters (true)
+           └── projections
+                ├── t0_85393.c0:9 [as=t0_85393.c0:1, outer=(9)]
+                ├── t0_85393.rowid:10 [as=t0_85393.rowid:2, outer=(10)]
+                ├── t1_85393.c0:13 [as=t1_85393.c0:5, outer=(13)]
+                └── t1_85393.rowid:14 [as=t1_85393.rowid:6, outer=(14)]


### PR DESCRIPTION
Project operators can only pass through their input ordering.
However, the provided ordering may have to be remapped in order to
ensure it only refers to output columns, since the `Project` can add
and remove columns. The `Project` uses its `internalFDs` field to
accomplish the remapping; these are constructed when the `Project`
is added to the memo by combining the functional dependencies of the
input and the projections.

The problem occurs when transformation rules cause the input of the
`Project` to "reveal" additional functional dependencies. For example,
one side of a union may be eliminated and the FDs of the remaining side
used in the result. This can cause the `Project` to output an ordering
that is equivalent to the required ordering according to its own FDs,
but which a parent operator cannot tell is equivalent because its FDs
were calculated before the tranformation rule fired. This can cause
panics later down the line when the provided ordering does not match
up with the required ordering.

In the following example, an exploration rule transforms the join into
two joins unioned together, one over each disjunct. After the
transformation, a normalization rule fires that removes the
`t0.rowid IS NULL` side because rowids are non-null. This reveals the
`t1.rowid = t0.rowid` FD, which later causes `t0.rowid` to be used in
a provided ordering rather than `t1.rowid`. For the reasons mentioned
above, this later causes a panic when a `Project` attempts to remap to
the required `t1.rowid` ordering.
```
CREATE TABLE t0 (c0 INT);
CREATE TABLE t1 (c0 INT);

SELECT * FROM t0 CROSS JOIN t1
WHERE (t0.rowid IS NULL) OR (t1.rowid IN (t0.rowid))
ORDER BY t1.rowid;
```

This commit prevents the panic by making `Project` operators remap the
input provided ordering to use columns from the required ordering
(which are a subset of the output columns). This prevents the disparity
between required and provided orderings that can cause panics down the
line. In the example given above, the `t1.rowid` column would be chosen
for the provided ordering because it is in the required ordering.

Fixes #85393

Release note (bug fix): fixed a vulnerability in the optimizer that could
cause a panic in rare cases when planning complex queries with `ORDER BY`.

Release justification: fixes release blocker