### PR TITLE
sql: avoid running lint tests under race/deadlock/stress

### DIFF
--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -962,6 +963,10 @@ func TestShowSessionPrivileges(t *testing.T) {
 func TestLintClusterSettingNames(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "lint only test")
+	skip.UnderDeadlock(t, "lint only test")
+	skip.UnderStress(t, "lint only test")
 
 	params, _ := tests.CreateTestServerParams()
 	s, sqlDB, _ := serverutils.StartServer(t, params)


### PR DESCRIPTION
Release justification: changes to test-only code

Release note: None