### PR TITLE
storage/metamorphic: skip TestPebbleEquivalence

### DIFF
--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -169,6 +169,7 @@ func TestPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 86102)
 	skip.UnderRace(t)
 	runPebbleEquivalenceTest(t)
 }


### PR DESCRIPTION
Skip TestPebbleEquivalence until #86102/#86088 is resolved.

Release note: None
Release justification: Non-production code changes.