### PR TITLE
sql/logictest: attempt to deflake retry errors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -1204,6 +1204,8 @@ CREATE TYPE fakedb.typ AS ENUM ('schema')
 
 # Test the behavior of dropping a not-null enum colums
 
+skip_on_retry
+
 subtest drop_not_null
 
 statement ok


### PR DESCRIPTION
When we run transactions in logictests, they can be exposed to retry errors.
The framework does not have tools to retry whole blocks. In #58217 we added
a mechanism to skip tests which hit such errors. Apply that logic here.

(hopefully)
Fixes #86215

Release justification: testing only change

Release note: None