### PR TITLE
sql: Support DISCARD SEQUENCES

### DIFF
--- a/docs/generated/sql/bnf/discard_stmt.bnf
+++ b/docs/generated/sql/bnf/discard_stmt.bnf
@@ -1,2 +1,3 @@
 discard_stmt ::=
 	'DISCARD' 'ALL'
+	| 'DISCARD' 'SEQUENCES'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -83,6 +83,7 @@ deallocate_stmt ::=
 
 discard_stmt ::=
 	'DISCARD' 'ALL'
+	| 'DISCARD' 'SEQUENCES'
 
 grant_stmt ::=
 	'GRANT' privileges 'ON' grant_targets 'TO' role_spec_list opt_with_grant_option

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -54,3 +54,63 @@ BEGIN
 
 statement error DISCARD ALL cannot run inside a transaction block
 DISCARD ALL
+
+statement ok
+ROLLBACK
+
+statement ok
+CREATE SEQUENCE discard_seq_test START WITH 10
+
+query I
+SELECT nextval('discard_seq_test')
+----
+10
+
+query I
+SELECT lastval()
+----
+10
+
+query I
+SELECT currval('discard_seq_test')
+----
+10
+
+statement ok
+DISCARD SEQUENCES
+
+statement error pgcode 55000 pq: lastval\(\): lastval is not yet defined in this session
+SELECT lastval()
+
+statement error pgcode 55000 pq: currval\(\): currval of sequence "test.public.discard_seq_test" is not yet defined in this session
+SELECT currval('discard_seq_test')
+
+statement ok
+CREATE SEQUENCE discard_seq_test_2 START WITH 10
+
+query I
+SELECT nextval('discard_seq_test_2')
+----
+10
+
+statement ok
+DISCARD ALL
+
+statement error pgcode 55000 pq: lastval\(\): lastval is not yet defined in this session
+SELECT lastval()
+
+statement ok
+CREATE SEQUENCE S2 CACHE 10
+
+query I
+SELECT nextval('s2')
+----
+1
+
+statement ok
+DISCARD SEQUENCES
+
+query I
+SELECT nextval('s2')
+----
+11

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -450,7 +450,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`DROP TRIGGER a`, 28296, `drop`, ``},
 
 		{`DISCARD PLANS`, 0, `discard plans`, ``},
-		{`DISCARD SEQUENCES`, 0, `discard sequences`, ``},
 		{`DISCARD TEMP`, 0, `discard temp`, ``},
 		{`DISCARD TEMPORARY`, 0, `discard temp`, ``},
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4805,7 +4805,10 @@ discard_stmt:
     $$.val = &tree.Discard{Mode: tree.DiscardModeAll}
   }
 | DISCARD PLANS { return unimplemented(sqllex, "discard plans") }
-| DISCARD SEQUENCES { return unimplemented(sqllex, "discard sequences") }
+| DISCARD SEQUENCES
+  {
+    $$.val = &tree.Discard{Mode: tree.DiscardModeSequences}
+  }
 | DISCARD TEMP { return unimplemented(sqllex, "discard temp") }
 | DISCARD TEMPORARY { return unimplemented(sqllex, "discard temp") }
 | DISCARD error // SHOW HELP: DISCARD

--- a/pkg/sql/sem/tree/discard.go
+++ b/pkg/sql/sem/tree/discard.go
@@ -23,6 +23,9 @@ type DiscardMode int
 const (
 	// DiscardModeAll represents a DISCARD ALL statement.
 	DiscardModeAll DiscardMode = iota
+
+	// DiscardModeSequences represents a DISCARD SEQUENCES statement
+	DiscardModeSequences
 )
 
 // Format implements the NodeFormatter interface.
@@ -30,6 +33,8 @@ func (node *Discard) Format(ctx *FmtCtx) {
 	switch node.Mode {
 	case DiscardModeAll:
 		ctx.WriteString("DISCARD ALL")
+	case DiscardModeSequences:
+		ctx.WriteString("DISCARD SEQUENCES")
 	}
 }
 


### PR DESCRIPTION
Refs #83061

Release note (sql change): We now support DISCARD SEQUENCES, which discards
all sequence-related state such as currval/lastval information. DISCARD ALL
now also discards sequence-related state.

Release justification: Low risk, high benefit changes to existing functionality(DISCARD ALL)