### PR TITLE
sqlsmith: skip crdb_internal.set_compaction_concurrency

### DIFF
--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -517,6 +517,7 @@ var functions = func() map[tree.FunctionClass]map[oid.Oid][]function {
 			"crdb_internal.complete_replication_stream",
 			"crdb_internal.revalidate_unique_constraint",
 			"crdb_internal.request_statement_bundle",
+			"crdb_internal.set_compaction_concurrency",
 		} {
 			skip = skip || strings.Contains(def.Name, substr)
 		}


### PR DESCRIPTION
Fixes: #86201

Release justification: test-only change.

Release note: None