### PR TITLE
tracing: re-use childrenMetadata map across trace spans

### DIFF
--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -674,7 +674,7 @@ func (sp *Span) reset(
 			recording: recordingState{
 				logs:             makeSizeLimitedBuffer(maxLogBytesPerSpan, nil /* scratch */),
 				structured:       makeSizeLimitedBuffer(maxStructuredBytesPerSpan, h.structuredEventsAlloc[:]),
-				childrenMetadata: make(map[string]tracingpb.OperationMetadata),
+				childrenMetadata: h.childrenMetadataAlloc,
 			},
 			tags: h.tagsAlloc[:0],
 		}


### PR DESCRIPTION
This commit pools the `childrenMetadata` hash map across trace spans,
to avoid a source of per-span heap allocations. This hash map was
added in 4ddc350, after prior optimization passes were made over the
`util/tracing` package.

This should help close the performance gap between v22.1 and v22.2.

```
name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-10    41.7µs ± 2%    41.4µs ± 1%  -0.72%  (p=0.026 n=20+18)
KV/Insert/SQL/rows=1-10        123µs ± 2%     124µs ± 2%    ~     (p=0.665 n=19+19)
KV/Update/Native/rows=1-10    66.0µs ± 2%    65.8µs ± 1%    ~     (p=0.258 n=20+19)
KV/Update/SQL/rows=1-10        170µs ± 3%     170µs ± 4%    ~     (p=0.851 n=18+20)
KV/Delete/Native/rows=1-10    41.5µs ± 2%    41.4µs ± 1%    ~     (p=0.740 n=20+18)
KV/Delete/SQL/rows=1-10        137µs ± 2%     137µs ± 2%    ~     (p=0.377 n=20+18)
KV/Scan/Native/rows=1-10      17.2µs ± 2%    17.2µs ± 3%    ~     (p=0.920 n=20+20)
KV/Scan/SQL/rows=1-10         92.2µs ± 1%    92.2µs ± 2%    ~     (p=0.667 n=20+19)

name                        old alloc/op   new alloc/op   delta
KV/Scan/SQL/rows=1-10         24.8kB ± 0%    24.3kB ± 0%  -2.00%  (p=0.000 n=19+19)
KV/Scan/Native/rows=1-10      7.80kB ± 0%    7.65kB ± 0%  -1.86%  (p=0.000 n=20+18)
KV/Delete/Native/rows=1-10    15.9kB ± 1%    15.6kB ± 0%  -1.48%  (p=0.000 n=20+17)
KV/Update/Native/rows=1-10    22.8kB ± 0%    22.5kB ± 0%  -1.44%  (p=0.000 n=17+19)
KV/Update/SQL/rows=1-10       52.4kB ± 0%    51.8kB ± 0%  -1.16%  (p=0.000 n=20+20)
KV/Insert/Native/rows=1-10    16.1kB ± 0%    15.9kB ± 0%  -1.15%  (p=0.000 n=20+20)
KV/Insert/SQL/rows=1-10       45.2kB ± 0%    44.8kB ± 0%  -0.85%  (p=0.000 n=20+20)
KV/Delete/SQL/rows=1-10       52.2kB ± 0%    51.8kB ± 0%  -0.72%  (p=0.000 n=19+19)

name                        old allocs/op  new allocs/op  delta
KV/Scan/Native/rows=1-10        57.0 ± 0%      54.0 ± 0%  -5.26%  (p=0.000 n=20+18)
KV/Update/Native/rows=1-10       189 ± 0%       182 ± 0%  -3.66%  (p=0.000 n=20+19)
KV/Scan/SQL/rows=1-10            289 ± 0%       279 ± 0%  -3.46%  (p=0.000 n=17+19)
KV/Delete/Native/rows=1-10       131 ± 0%       127 ± 0%  -3.05%  (p=0.000 n=20+20)
KV/Insert/Native/rows=1-10       132 ± 0%       128 ± 0%  -3.03%  (p=0.000 n=20+20)
KV/Insert/SQL/rows=1-10          367 ± 0%       359 ± 0%  -2.32%  (p=0.000 n=16+20)
KV/Update/SQL/rows=1-10          533 ± 0%       520 ± 0%  -2.30%  (p=0.000 n=20+20)
KV/Delete/SQL/rows=1-10          394 ± 0%       386 ± 0%  -2.03%  (p=0.000 n=20+18)
```

Release justification: avoids performance regression.

cc. @erikgrinaker 