### PR TITLE
rangefeed: skip `BenchmarkCatchUpScan` under short

### DIFF
--- a/pkg/kv/kvserver/rangefeed/BUILD.bazel
+++ b/pkg/kv/kvserver/rangefeed/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
+        "//pkg/testutils/skip",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan_bench_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -75,6 +76,7 @@ func runCatchUpBenchmark(b *testing.B, emk engineMaker, opts benchOptions) (numE
 
 func BenchmarkCatchUpScan(b *testing.B) {
 	defer log.Scope(b).Close(b)
+	skip.UnderShort(b)
 
 	numKeys := 1_000_000
 	valueBytes := 64


### PR DESCRIPTION
Otherwise this test may time out in CI.

Release justification: non-production code changes.

Release note: None