### PR TITLE
jobsprotectedtsccl: deflake TestJobsProtectedTimestamp

### DIFF
--- a/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
+++ b/pkg/ccl/jobsccl/jobsprotectedtsccl/jobs_protected_ts_test.go
@@ -117,16 +117,14 @@ func testJobsProtectedTimestamp(
 
 	// Verify that the two jobs we just observed as removed were recorded in the
 	// metrics.
-	var removed int
-	runner.QueryRow(t, `
+	runner.CheckQueryResultsRetry(t, `
 SELECT
-    value
+    value >= 2 -- we expect 2, but with retries it can be higher
 FROM
     crdb_internal.node_metrics
 WHERE
     name = 'kv.protectedts.reconciliation.records_removed';
-`).Scan(&removed)
-	require.Equal(t, 2, removed)
+`, [][]string{{"true"}})
 }
 
 // TestJobsProtectedTimestamp is an end-to-end test of protected timestamp


### PR DESCRIPTION
Sometimes the counter would be incremented an extra time due to
restarts or something else.

Fixes #86115

Release justification: testing only fix.

Release note: None