### PR TITLE
eventpb: allow encoding of zero values

### DIFF
--- a/pkg/util/log/eventpb/event_test.go
+++ b/pkg/util/log/eventpb/event_test.go
@@ -52,6 +52,12 @@ func TestEventJSON(t *testing.T) {
 
 		// Integer and boolean fields are not redactable in any case.
 		{&UnsafeDeleteDescriptor{ParentID: 123, Force: true}, `"ParentID":123,"Force":true`},
+
+		// Primitive fields without an `includeempty` annotation will NOT emit their
+		// zero value. In this case, `SnapshotID` and `NumRecords` do not have the
+		// `includeempty` annotation, so nothing is emitted, despite the presence of
+		// zero values.
+		{&SchemaSnapshotMetadata{SnapshotID: "", NumRecords: 0}, ""},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Currently, the JSON encoder unconditionally elides zero values, due the
presence of a `if m.{{.FieldName}} != 0 {` rule in the template. There
are situations where a zero value should still be emitted, despite it
being the default value.

Update the encoder to use the absence of the `omitempty` proto
annotation as an indication that a zero value should be emitted.
Boolean, string, and numerical native types take this annotation into
account.

Release note: None.

Release justification: Low risk, high benefit changes to existing functionality.