### PR TITLE
sql: Implement DISCARD TEMP

### DIFF
--- a/docs/generated/sql/bnf/discard_stmt.bnf
+++ b/docs/generated/sql/bnf/discard_stmt.bnf
@@ -1,3 +1,5 @@
 discard_stmt ::=
 	'DISCARD' 'ALL'
 	| 'DISCARD' 'SEQUENCES'
+	| 'DISCARD' 'TEMP'
+	| 'DISCARD' 'TEMPORARY'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -84,6 +84,8 @@ deallocate_stmt ::=
 discard_stmt ::=
 	'DISCARD' 'ALL'
 	| 'DISCARD' 'SEQUENCES'
+	| 'DISCARD' 'TEMP'
+	| 'DISCARD' 'TEMPORARY'
 
 grant_stmt ::=
 	'GRANT' privileges 'ON' grant_targets 'TO' role_spec_list opt_with_grant_option

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -48,6 +48,7 @@ func (n *discardNode) startExec(params runParams) error {
 
 		// RESET ALL
 		if err := params.p.resetAllSessionVars(params.ctx); err != nil {
+
 			return err
 		}
 
@@ -59,13 +60,44 @@ func (n *discardNode) startExec(params runParams) error {
 			m.data.SequenceState = sessiondata.NewSequenceState()
 			m.initSequenceCache()
 		})
+
+		// DISCARD TEMP
+		err := deleteTempTables(params.ctx, params.p)
+		if err != nil {
+			return err
+		}
+
 	case tree.DiscardModeSequences:
 		params.p.sessionDataMutatorIterator.applyOnEachMutator(func(m sessionDataMutator) {
 			m.data.SequenceState = sessiondata.NewSequenceState()
 			m.initSequenceCache()
 		})
+	case tree.DiscardModeTemp:
+		err := deleteTempTables(params.ctx, params.p)
+		if err != nil {
+			return err
+		}
 	default:
 		return errors.AssertionFailedf("unknown mode for DISCARD: %d", n.mode)
+	}
+	return nil
+}
+
+func deleteTempTables(ctx context.Context, p *planner) error {
+	codec := p.execCfg.Codec
+	descCol := p.Descriptors()
+	allDbDescs, err := descCol.GetAllDatabaseDescriptors(ctx, p.Txn())
+	if err != nil {
+		return err
+	}
+	ie := p.execCfg.InternalExecutor
+
+	for _, dbDesc := range allDbDescs {
+		schemaName := p.TemporarySchemaName()
+		err = cleanupSchemaObjects(ctx, p.execCfg.Settings, p.Txn(), descCol, codec, ie, dbDesc, schemaName)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -114,3 +114,44 @@ query I
 SELECT nextval('s2')
 ----
 11
+
+statement ok
+SET experimental_enable_temp_tables=on
+
+query I
+SELECT count(*) FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%'
+----
+0
+
+statement ok
+DISCARD TEMP;
+
+query I
+SELECT count(*) FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%'
+----
+0
+
+statement ok
+CREATE TEMP TABLE test (a int);
+
+statement ok
+CREATE TEMP TABLE test2 (a uuid);
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----
+test
+test2
+
+statement ok
+DISCARD TEMP;
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----
+
+#Ensure temp schema is not deleted
+query I
+SELECT count(*) FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%'
+----
+1

--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -450,8 +450,6 @@ func TestUnimplementedSyntax(t *testing.T) {
 		{`DROP TRIGGER a`, 28296, `drop`, ``},
 
 		{`DISCARD PLANS`, 0, `discard plans`, ``},
-		{`DISCARD TEMP`, 0, `discard temp`, ``},
-		{`DISCARD TEMPORARY`, 0, `discard temp`, ``},
 
 		{`SET CONSTRAINTS foo`, 0, `set constraints`, ``},
 		{`SET foo FROM CURRENT`, 0, `set from current`, ``},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4816,8 +4816,14 @@ discard_stmt:
   {
     $$.val = &tree.Discard{Mode: tree.DiscardModeSequences}
   }
-| DISCARD TEMP { return unimplemented(sqllex, "discard temp") }
-| DISCARD TEMPORARY { return unimplemented(sqllex, "discard temp") }
+| DISCARD TEMP
+  {
+    $$.val = &tree.Discard{Mode: tree.DiscardModeTemp}
+  }
+| DISCARD TEMPORARY
+  {
+    $$.val = &tree.Discard{Mode: tree.DiscardModeTemp}
+  }
 | DISCARD error // SHOW HELP: DISCARD
 
 // %Help: DROP

--- a/pkg/sql/sem/tree/discard.go
+++ b/pkg/sql/sem/tree/discard.go
@@ -26,6 +26,9 @@ const (
 
 	// DiscardModeSequences represents a DISCARD SEQUENCES statement
 	DiscardModeSequences
+
+	// DiscardModeTemp represents a DISCARD TEMPORARY statement
+	DiscardModeTemp
 )
 
 // Format implements the NodeFormatter interface.
@@ -35,6 +38,8 @@ func (node *Discard) Format(ctx *FmtCtx) {
 		ctx.WriteString("DISCARD ALL")
 	case DiscardModeSequences:
 		ctx.WriteString("DISCARD SEQUENCES")
+	case DiscardModeTemp:
+		ctx.WriteString("DISCARD TEMPORARY")
 	}
 }
 


### PR DESCRIPTION
Refs #83061

Release note (sql change): We now support DISCARD TEMP/TEMPORARY, which drops all temporary tables created in the current session. The command does not drop temporary schemas.

Release note (bug fix): DISCARD ALL now deletes temporary tables

Release justification: Low risk, high benefit changes to existing functionality(DISCARD ALL)