### PR TITLE
ui, obsservice: add feature flags to db console

### DIFF
--- a/pkg/obsservice/obslib/httpproxy/BUILD.bazel
+++ b/pkg/obsservice/obslib/httpproxy/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli/exit",
+        "//pkg/server/serverpb",
         "//pkg/ui",
         "//pkg/util/log",
         "//pkg/util/stop",

--- a/pkg/obsservice/obslib/httpproxy/reverseproxy.go
+++ b/pkg/obsservice/obslib/httpproxy/reverseproxy.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -141,6 +142,9 @@ func (p *ReverseHTTPProxy) Start(ctx context.Context, stop *stop.Stopper) {
 			return &u
 		},
 		OIDC: &noOIDCConfigured{},
+		Flags: serverpb.FeatureFlags{
+			IsObservabilityService: true,
+		},
 	}))
 	for _, path := range CRDBProxyPaths {
 		mux.Handle(path, p.proxy)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -804,7 +804,7 @@ Binary built without web UI.
 			respBytes, err = io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			expected := fmt.Sprintf(
-				`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":""}`,
+				`{"ExperimentalUseLogin":false,"LoginEnabled":false,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 				build.GetInfo().Tag,
 				build.BinaryVersionPrefix(),
 				1,
@@ -832,7 +832,7 @@ Binary built without web UI.
 			{
 				loggedInClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":""}`,
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":"authentic_user","Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,
@@ -841,7 +841,7 @@ Binary built without web UI.
 			{
 				loggedOutClient,
 				fmt.Sprintf(
-					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":""}`,
+					`{"ExperimentalUseLogin":true,"LoginEnabled":true,"LoggedInUser":null,"Tag":"%s","Version":"%s","NodeID":"%d","OIDCAutoLogin":false,"OIDCLoginEnabled":false,"OIDCButtonText":"","FeatureFlags":{}}`,
 					build.GetInfo().Tag,
 					build.BinaryVersionPrefix(),
 					1,

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1239,3 +1239,8 @@ message SetTraceRecordingTypeRequest {
 // SetTraceRecordingTypeRequest is the response for SetTraceRecordingType.
 message SetTraceRecordingTypeResponse{}
 
+// FeatureFlags within this struct are used within back-end/front-end code to show/hide features.
+message FeatureFlags {
+  // Whether the server is an instance of the Observability Service
+  bool is_observability_service = 1;
+}

--- a/pkg/ui/BUILD.bazel
+++ b/pkg/ui/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/build",
+        "//pkg/server/serverpb",
         "//pkg/util/httputil",
         "//pkg/util/log",
     ],

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -67,6 +68,7 @@ type indexHTMLArgs struct {
 	OIDCAutoLogin        bool
 	OIDCLoginEnabled     bool
 	OIDCButtonText       string
+	FeatureFlags         serverpb.FeatureFlags
 }
 
 // OIDCUIConf is a variable that stores data required by the
@@ -102,6 +104,7 @@ type Config struct {
 	NodeID               *base.NodeIDContainer
 	GetUser              func(ctx context.Context) *string
 	OIDC                 OIDCUI
+	Flags                serverpb.FeatureFlags
 }
 
 var uiConfigPath = regexp.MustCompile("^/uiconfig$")
@@ -141,6 +144,7 @@ func Handler(cfg Config) http.Handler {
 			OIDCAutoLogin:        oidcConf.AutoLogin,
 			OIDCLoginEnabled:     oidcConf.Enabled,
 			OIDCButtonText:       oidcConf.ButtonText,
+			FeatureFlags:         cfg.Flags,
 		}
 		if cfg.NodeID != nil {
 			args.NodeID = cfg.NodeID.String()

--- a/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/dataFromServer.ts
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
+
 export interface DataFromServer {
   ExperimentalUseLogin: boolean;
   LoginEnabled: boolean;
@@ -18,6 +21,7 @@ export interface DataFromServer {
   OIDCAutoLogin: boolean;
   OIDCLoginEnabled: boolean;
   OIDCButtonText: string;
+  FeatureFlags: IFeatureFlags;
 }
 
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
@@ -30,5 +34,10 @@ declare global {
 }
 
 export function getDataFromServer(): DataFromServer {
-  return window.dataFromServer || ({} as DataFromServer);
+  return (
+    window.dataFromServer ||
+    ({
+      FeatureFlags: {},
+    } as DataFromServer)
+  );
 }

--- a/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
+++ b/pkg/ui/workspaces/db-console/src/util/dataFromServer.ts
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import IFeatureFlags = cockroach.server.serverpb.IFeatureFlags;
+
 export interface DataFromServer {
   ExperimentalUseLogin: boolean;
   LoginEnabled: boolean;
@@ -18,6 +21,7 @@ export interface DataFromServer {
   OIDCAutoLogin: boolean;
   OIDCLoginEnabled: boolean;
   OIDCButtonText: string;
+  FeatureFlags: IFeatureFlags;
 }
 // Tell TypeScript about `window.dataFromServer`, which is set in a script
 // tag in index.html, the contents of which are generated in a Go template
@@ -44,7 +48,12 @@ export function fetchDataFromServer(): Promise<DataFromServer> {
 }
 
 export function getDataFromServer(): DataFromServer {
-  return window.dataFromServer || ({} as DataFromServer);
+  return (
+    window.dataFromServer ||
+    ({
+      FeatureFlags: {},
+    } as DataFromServer)
+  );
 }
 
 export function setDataFromServer(d: DataFromServer) {

--- a/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/containers/layout/index.tsx
@@ -39,6 +39,7 @@ import { Badge } from "@cockroachlabs/cluster-ui";
 
 import "./layout.styl";
 import "./layoutPanel.styl";
+import { getDataFromServer } from "src/util/dataFromServer";
 
 export interface LayoutProps {
   clusterName: string;
@@ -92,6 +93,9 @@ class Layout extends React.Component<LayoutProps & RouteComponentProps> {
           <div className="layout-panel__navigation-bar">
             <PageHeader>
               <Text textType={TextTypes.Heading2} noWrap>
+                {getDataFromServer().FeatureFlags.is_observability_service
+                  ? "(Obs Service) "
+                  : ""}
                 {clusterName || `Cluster id: ${clusterId || ""}`}
               </Text>
               <Badge text={clusterVersion} />


### PR DESCRIPTION
This commit adds feature flags to the initial data that DB Console loads from
the backend server. The purpose of this is to enable development on `master` of
features that can be deployed prior to the release of a DB version, and to
allow for the UI to run against various backends (primarily: obs service) with
different capabilities and be able to selectively enable UI components to
match.

The feature flags are defined in `admin.proto` using the same pattern that's
implemented in our managed service, and are available via a Typescript
interface from the compiled protobuf. This couples us a little bit to the
relevant backend via the protobuf. However, if we treat the flag list as
append-only the UI should always remain backwards compatible with this payload.

Resolves #84299

Release note: None