### PR TITLE
ui, server: prevent decommissioned nodes from displaying in ui as live

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2035,9 +2035,12 @@ func (s *adminServer) checkReadinessForHealthCheck(ctx context.Context) error {
 //
 // getLivenessStatusMap() includes removed nodes (dead + decommissioned).
 func getLivenessStatusMap(
-	nl *liveness.NodeLiveness, now time.Time, st *cluster.Settings,
-) map[roachpb.NodeID]livenesspb.NodeLivenessStatus {
-	livenesses := nl.GetLivenesses()
+	ctx context.Context, nl *liveness.NodeLiveness, now time.Time, st *cluster.Settings,
+) (map[roachpb.NodeID]livenesspb.NodeLivenessStatus, error) {
+	livenesses, err := nl.GetLivenessesFromKV(ctx)
+	if err != nil {
+		return nil, err
+	}
 	threshold := storepool.TimeUntilStoreDead.Get(&st.SV)
 
 	statusMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus, len(livenesses))
@@ -2045,23 +2048,41 @@ func getLivenessStatusMap(
 		status := storepool.LivenessStatus(liveness, now, threshold)
 		statusMap[liveness.NodeID] = status
 	}
-	return statusMap
+	return statusMap, nil
 }
 
-// Liveness returns the liveness state of all nodes on the cluster
-// known to gossip. To reach all nodes in the cluster, consider
-// using (statusServer).NodesWithLiveness instead.
-func (s *adminServer) Liveness(
-	context.Context, *serverpb.LivenessRequest,
+// getLivenessResponse returns LivenessResponse: a map from NodeID to LivenessStatus and
+// a slice containing the liveness record of all nodes that have ever been a part of the
+// cluster.
+func getLivenessResponse(
+	ctx context.Context, nl *liveness.NodeLiveness, now time.Time, st *cluster.Settings,
 ) (*serverpb.LivenessResponse, error) {
-	clock := s.server.clock
-	statusMap := getLivenessStatusMap(
-		s.server.nodeLiveness, clock.Now().GoTime(), s.server.st)
-	livenesses := s.server.nodeLiveness.GetLivenesses()
+	livenesses, err := nl.GetLivenessesFromKV(ctx)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+
+	threshold := storepool.TimeUntilStoreDead.Get(&st.SV)
+
+	statusMap := make(map[roachpb.NodeID]livenesspb.NodeLivenessStatus, len(livenesses))
+	for _, liveness := range livenesses {
+		status := storepool.LivenessStatus(liveness, now, threshold)
+		statusMap[liveness.NodeID] = status
+	}
 	return &serverpb.LivenessResponse{
 		Livenesses: livenesses,
 		Statuses:   statusMap,
 	}, nil
+}
+
+// Liveness returns the liveness state of all nodes on the cluster
+// based on a KV transaction. To reach all nodes in the cluster, consider
+// using (statusServer).NodesWithLiveness instead.
+func (s *adminServer) Liveness(
+	ctx context.Context, _ *serverpb.LivenessRequest,
+) (*serverpb.LivenessResponse, error) {
+	clock := s.server.clock
+	return getLivenessResponse(ctx, s.server.nodeLiveness, clock.Now().GoTime(), s.server.st)
 }
 
 func (s *adminServer) Jobs(

--- a/pkg/server/admin_test.go
+++ b/pkg/server/admin_test.go
@@ -2692,7 +2692,7 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 			_, err := c.Jobs(ctx, &serverpb.JobsRequest{})
 			return err
 		}},
-		{"Liveness", codes.OK, func(c serverpb.AdminClient) error {
+		{"Liveness", codes.Internal, func(c serverpb.AdminClient) error {
 			_, err := c.Liveness(ctx, &serverpb.LivenessRequest{})
 			return err
 		}},

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -1664,7 +1664,10 @@ func (s *statusServer) nodesHelper(
 	}
 
 	clock := s.admin.server.clock
-	resp.LivenessByNodeID = getLivenessStatusMap(s.nodeLiveness, clock.Now().GoTime(), s.st)
+	resp.LivenessByNodeID, err = getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now().GoTime(), s.st)
+	if err != nil {
+		return nil, 0, err
+	}
 	return &resp, next, nil
 }
 
@@ -1681,7 +1684,10 @@ func (s *statusServer) nodesStatusWithLiveness(
 		return nil, err
 	}
 	clock := s.admin.server.clock
-	statusMap := getLivenessStatusMap(s.nodeLiveness, clock.Now().GoTime(), s.st)
+	statusMap, err := getLivenessStatusMap(ctx, s.nodeLiveness, clock.Now().GoTime(), s.st)
+	if err != nil {
+		return nil, err
+	}
 	ret := make(map[roachpb.NodeID]nodeStatusWithLiveness)
 	for _, node := range nodes.Nodes {
 		nodeID := node.Desc.NodeID

--- a/pkg/ui/workspaces/db-console/src/redux/nodes.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/nodes.ts
@@ -539,13 +539,11 @@ export const partitionedStatuses = createSelector(
   nodesSummarySelector,
   summary => {
     return _.groupBy(summary.nodeStatuses, ns => {
-      switch (summary.livenessStatusByNodeID[ns.desc.node_id]) {
-        case LivenessStatus.NODE_STATUS_LIVE:
-        case LivenessStatus.NODE_STATUS_UNAVAILABLE:
-        case LivenessStatus.NODE_STATUS_DEAD:
-        case LivenessStatus.NODE_STATUS_DECOMMISSIONING:
+      switch (summary.livenessByNodeID[ns.desc.node_id]) {
+        case MembershipStatus.ACTIVE:
+        case MembershipStatus.DECOMMISSIONING:
           return "live";
-        case LivenessStatus.NODE_STATUS_DECOMMISSIONED:
+        case MembershipStatus.DECOMMISSIONED:
           return "decommissioned";
         default:
           // TODO (koorosh): "live" has to be renamed to some partition which


### PR DESCRIPTION
This change resolves an issue where decommissioned nodes would
in rare cases display as live in the admin ui. The changes
are on both the frontend and backend:
- The ui has been changed so that the way live nodes are
filtered is now based on MembershipStatus which matches
the way decommissioned nodes are filtered.
- The server now uses GetLivenessesFromKV instead of
GetLivenesses because the latter retrieves livenesses
known to gossip which could be stale reads from in-memory cache
while the former is read directly from the KV layer.

Part of #85445

Release justification: low risk, high benefit changes to existing functionality.

Release note (ui change, api change): Filter live nodes based on
MembershipStatus and retrieve livenesses directly from kv.