### PR TITLE
changefeedccl: make core changefeeds more resilient

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -191,6 +191,11 @@ func changefeedPlanHook(
 		}
 
 		if details.SinkURI == `` {
+
+			p.ExtendedEvalContext().ChangefeedState = &coreChangefeedProgress{
+				progress: progress,
+			}
+
 			// If this is a sinkless changefeed, then we should not hold on to the
 			// descriptor leases accessed to plan the changefeed. If changes happen
 			// to descriptors, they will be addressed during the execution.
@@ -220,18 +225,7 @@ func changefeedPlanHook(
 					return err
 				}
 
-				// Check for a schemachange boundary timestamp returned via a
-				// retryable error. Retrying without updating the changefeed progress
-				// will result in the changefeed performing the schema change again,
-				// causing an infinite loop.
-				if ts, ok := changefeedbase.MaybeGetRetryableErrorTimestamp(err); ok {
-					progress = jobspb.Progress{
-						Progress: &jobspb.Progress_HighWater{HighWater: &ts},
-						Details: &jobspb.Progress_Changefeed{
-							Changefeed: &jobspb.ChangefeedProgress{},
-						},
-					}
-				}
+				progress = p.ExtendedEvalContext().ChangefeedState.(*coreChangefeedProgress).progress
 			}
 			telemetry.Count(`changefeed.core.error`)
 			return changefeedbase.MaybeStripRetryableErrorMarker(err)

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
-        "//pkg/util/hlc",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -45,6 +45,8 @@ type TestingKnobs struct {
 	OnDistflowSpec func(aggregatorSpecs []*execinfrapb.ChangeAggregatorSpec, frontierSpec *execinfrapb.ChangeFrontierSpec)
 	// ShouldReplan is used to see if a replan for a changefeed should be triggered
 	ShouldReplan func(ctx context.Context, oldPlan, newPlan *sql.PhysicalPlan) bool
+	// RaiseRetryableError is a knob used to possibly return an error.
+	RaiseRetryableError func() error
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -230,6 +230,9 @@ type Context struct {
 
 	// RangeStatsFetcher is used to fetch RangeStats.
 	RangeStatsFetcher RangeStatsFetcher
+
+	// ChangefeedState stores the state (progress) of core changefeeds.
+	ChangefeedState ChangefeedState
 }
 
 // DescIDGenerator generates unique descriptor IDs.

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -500,6 +501,17 @@ type SequenceOperators interface {
 	// `newVal + seqOpts.Increment`.
 	// Takes in a sequence ID rather than a name, unlike SetSequenceValue.
 	SetSequenceValueByID(ctx context.Context, seqID uint32, newVal int64, isCalled bool) error
+}
+
+// ChangefeedState is used to track progress and checkpointing for sinkless/core changefeeds.
+// Because a CREATE CHANGEFEED statement for a sinkless changefeed will hang and return data
+// over the SQL connection, this state belongs in the EvalCtx.
+type ChangefeedState interface {
+	// SetHighwater sets the frontier timestamp for the changefeed.
+	SetHighwater(frontier *hlc.Timestamp)
+
+	// SetCheckpoint sets the checkpoint for the changefeed.
+	SetCheckpoint(spans []roachpb.Span, timestamp hlc.Timestamp)
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL


### PR DESCRIPTION
This change updates core changefeeds to save checkpoints
inside the EvalCtx. With this change, core changefeeds
can retry from the last checkpoint instead of restarting
from the beginning.

Fixes: https://github.com/cockroachdb/cockroach/issues/84511

Release note (general change): This change updates core/experimental
changefeeds to be more resilient to transient errors
(ex. network blips) by adding checkpointing.

Previously, transient errors would result in a core changefeed
stopping and terminating the underlying SQL statement. This
would require the SQL statement to be restarted by a user.
Furtheremore, if the core changefeed were restarted during an
inital scan, the initial scan would start from the beginning.
For large initial scans, transient errors are more likely,
so restarting from the beginning would likely see more transient
errors and restarts which would not progress the changefeed.

Now, an experimental changefeed will automatically take
frequent checkpoints and retry from the last checkpoint
when a transient errors occurs.

Release justification: This change updates an experimental
feature.