### PR TITLE
storage: implement `RangeKeyChanged()` for `MVCCIncrementalIterator`

### DIFF
--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -93,16 +93,14 @@ type MVCCIncrementalIterator struct {
 	// or range key from the underlying iterator. If true, this implies that the
 	// underlying iterator returns true as well. This can be used to hide point or
 	// range keys where one key kind satisfies the time predicate but the other
-	// one doesn't.
+	// one doesn't. Ignored following IgnoringTime() calls.
 	hasPoint, hasRange bool
 
-	// rangeKeysStart contains the last seen range key start bound. It is used
-	// to detect changes to range keys.
-	//
-	// TODO(erikgrinaker): This pattern keeps coming up, and involves one
-	// comparison for every covered point key. Consider exposing this from Pebble,
-	// who has presumably already done these comparisons, so we can avoid them.
-	rangeKeysStart roachpb.Key
+	// rangeKeys contains the filtered range keys at the current location.
+	rangeKeys MVCCRangeKeyStack
+
+	// rangeKeysIgnoringTime contains the complete range keys at the current location.
+	rangeKeysIgnoringTime MVCCRangeKeyStack
 
 	// ignoringTime is true if the iterator is currently ignoring time bounds,
 	// i.e. following a call to NextIgnoringTime().
@@ -246,8 +244,7 @@ func (i *MVCCIncrementalIterator) SeekGE(startKey MVCCKey) {
 		}
 	}
 	i.iter.SeekGE(startKey)
-	i.rangeKeysStart = nil
-	i.advance()
+	i.advance(true /* seeked */)
 }
 
 // Close implements SimpleMVCCIterator.
@@ -261,7 +258,7 @@ func (i *MVCCIncrementalIterator) Close() {
 // Next implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) Next() {
 	i.iter.Next()
-	i.advance()
+	i.advance(false /* seeked */)
 }
 
 // updateValid updates i.valid and i.err based on the underlying iterator, and
@@ -275,14 +272,17 @@ func (i *MVCCIncrementalIterator) updateValid() bool {
 // NextKey implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) NextKey() {
 	i.iter.NextKey()
-	i.advance()
+	i.advance(false /* seeked */)
 }
 
 // maybeSkipKeys checks if any keys can be skipped by using a time-bound
 // iterator. If keys can be skipped, it will update the main iterator to point
-// to the earliest version of the next candidate key.
-// It is expected (but not required) that TBI is at a key <= main iterator key
-// when calling maybeSkipKeys().
+// to the earliest version of the next candidate key. It is expected (but not
+// required) that TBI is at a key <= main iterator key when calling
+// maybeSkipKeys().
+//
+// Returns true if any of the iter positioning operations caused the range keys
+// to change.
 //
 // NB: This logic will not handle TBI range key filtering properly -- the TBI
 // may see different range key fragmentation than the regular iterator, causing
@@ -290,10 +290,10 @@ func (i *MVCCIncrementalIterator) NextKey() {
 // disabled in pebbleMVCCIterator, since the performance gains are expected to
 // be marginal, and the necessary seeks/processing here would likely negate it.
 // See: https://github.com/cockroachdb/cockroach/issues/86260
-func (i *MVCCIncrementalIterator) maybeSkipKeys() {
+func (i *MVCCIncrementalIterator) maybeSkipKeys() (rangeKeyChanged bool) {
 	if i.timeBoundIter == nil {
 		// If there is no time bound iterator, we cannot skip any keys.
-		return
+		return false
 	}
 	tbiKey := i.timeBoundIter.UnsafeKey().Key
 	iterKey := i.iter.UnsafeKey().Key
@@ -312,7 +312,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 		i.timeBoundIter.NextKey()
 		if ok, err := i.timeBoundIter.Valid(); !ok {
 			i.valid, i.err = false, err
-			return
+			return false
 		}
 		tbiKey = i.timeBoundIter.UnsafeKey().Key
 
@@ -327,7 +327,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 			i.timeBoundIter.SeekGE(seekKey)
 			if ok, err := i.timeBoundIter.Valid(); !ok {
 				i.valid, i.err = false, err
-				return
+				return false
 			}
 			tbiKey = i.timeBoundIter.UnsafeKey().Key
 
@@ -338,7 +338,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 					i.timeBoundIter.Next()
 					if ok, err := i.timeBoundIter.Valid(); !ok {
 						i.valid, i.err = false, err
-						return
+						return false
 					}
 					tbiKey = i.timeBoundIter.UnsafeKey().Key
 				}
@@ -357,8 +357,9 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 			seekKey := MakeMVCCMetadataKey(tbiKey)
 			i.iter.SeekGE(seekKey)
 			if !i.updateValid() {
-				return
+				return false
 			}
+			rangeKeyChanged := i.iter.RangeKeyChanged()
 
 			// The seek may have landed in the middle of a bare range key, in which
 			// case we should move on to the next key.
@@ -366,12 +367,15 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 				if !i.iter.RangeBounds().Key.Equal(i.iter.UnsafeKey().Key) {
 					i.iter.Next()
 					if !i.updateValid() {
-						return
+						return false
 					}
+					rangeKeyChanged = rangeKeyChanged || i.iter.RangeKeyChanged()
 				}
 			}
+			return rangeKeyChanged
 		}
 	}
+	return false
 }
 
 // updateMeta initializes i.meta. It sets i.err and returns an error on any
@@ -433,57 +437,78 @@ func (i *MVCCIncrementalIterator) updateMeta() error {
 	return nil
 }
 
+// updateRangeKeys updates the iterator with the current range keys, filtered by
+// time span, and returns whether the position has point and/or range keys.
+func (i *MVCCIncrementalIterator) updateRangeKeys() (bool, bool) {
+	hasPoint, hasRange := i.iter.HasPointAndRange()
+	if hasRange {
+		// Clone full set of range keys into i.rangeKeysIgnoringTime.
+		rangeKeys := i.iter.RangeKeys()
+		rangeKeys.CloneInto(&i.rangeKeysIgnoringTime)
+
+		// Keep trimmed subset in i.rangeKeys.
+		i.rangeKeys = i.rangeKeysIgnoringTime
+		i.rangeKeys.Trim(i.startTime.Next(), i.endTime)
+		if i.rangeKeys.IsEmpty() {
+			i.rangeKeys.Clear()
+			hasRange = false
+		}
+	} else {
+		i.rangeKeys.Clear()
+		i.rangeKeysIgnoringTime.Clear()
+	}
+	return hasPoint, hasRange
+}
+
 // advance advances the main iterator until it is referencing a key within
-// (start_time, end_time].
+// (start_time, end_time]. If seeked is true, the caller is a SeekGE operation,
+// in which case we should emit the current range key position even if
+// RangeKeyChanged() doesn't trigger.
 //
 // It populates i.err with an error if it encountered an inline value or an
 // intent with a timestamp within the incremental iterator's bounds when the
 // intent policy is MVCCIncrementalIterIntentPolicyError.
-func (i *MVCCIncrementalIterator) advance() {
+func (i *MVCCIncrementalIterator) advance(seeked bool) {
 	i.ignoringTime = false
 	for {
 		if !i.updateValid() {
 			return
 		}
-		i.maybeSkipKeys()
+
+		// If the caller was a SeekGE operation, process the initial range key (if
+		// any) even if RangeKeyChanged() does not fire.
+		rangeKeyChanged := seeked || i.iter.RangeKeyChanged()
+		seeked = false
+
+		if i.maybeSkipKeys() {
+			rangeKeyChanged = true
+		}
 		if !i.valid {
 			return
 		}
 
-		// NB: Don't update i.hasRange directly -- we only change it when
-		// i.rangeKeysStart changes, which allows us to retain i.hasRange=false if
-		// we've already determined that the current range keys are outside of the
-		// time bounds.
-		hasPoint, hasRange := i.iter.HasPointAndRange()
-		i.hasPoint = hasPoint
-
 		// Process range keys.
-		//
-		// TODO(erikgrinaker): This needs to be optimized. For example, range keys
-		// only change on unversioned keys (except after a SeekGE), which can save a
-		// bunch of comparisons here. HasPointAndRange() has also been seen to have
-		// a non-negligible cost even without any range keys.
 		var newRangeKey bool
-		if hasRange {
-			if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
-				i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
-				i.hasRange = i.iter.RangeKeys().HasBetween(i.startTime.Next(), i.endTime)
-				newRangeKey = i.hasRange
-			}
-			// Else: keep i.hasRange from last i.rangeKeysStart change.
-		} else {
-			i.hasRange = false
-		}
+		if rangeKeyChanged {
+			i.hasPoint, i.hasRange = i.updateRangeKeys()
+			newRangeKey = i.hasRange
 
-		// If we're on a visible, bare range key then we're done. If the range key
-		// isn't visible either, then we keep going.
-		if !i.hasPoint {
-			if !i.hasRange {
-				i.iter.Next()
-				continue
+			// If we're on a visible, bare range key then we're done. If the range key
+			// was filtered out by the time bounds (the !hasPoint && !hasRange case),
+			// then we move on to the next key.
+			if !i.hasPoint {
+				if !i.hasRange {
+					i.iter.Next()
+					continue
+				}
+				i.meta.Reset()
+				return
 			}
-			i.meta.Reset()
-			return
+
+		} else if !i.hasPoint {
+			// If the range key didn't change, and this wasn't a seek, then we must be
+			// on a point key since the iterator won't surface anything else.
+			i.hasPoint = true
 		}
 
 		// Process point keys.
@@ -548,30 +573,26 @@ func (i *MVCCIncrementalIterator) UnsafeKey() MVCCKey {
 
 // HasPointAndRange implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) HasPointAndRange() (bool, bool) {
+	if i.ignoringTime {
+		return i.iter.HasPointAndRange()
+	}
 	return i.hasPoint, i.hasRange
 }
 
 // RangeBounds implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) RangeBounds() roachpb.Span {
-	if !i.hasRange {
-		return roachpb.Span{}
+	if i.ignoringTime {
+		return i.rangeKeysIgnoringTime.Bounds
 	}
-	return i.iter.RangeBounds()
+	return i.rangeKeys.Bounds
 }
 
 // RangeKeys implements SimpleMVCCIterator.
 func (i *MVCCIncrementalIterator) RangeKeys() MVCCRangeKeyStack {
-	if !i.hasRange {
-		return MVCCRangeKeyStack{}
+	if i.ignoringTime {
+		return i.rangeKeysIgnoringTime
 	}
-	// TODO(erikgrinaker): It may be worthwhile to clone and memoize this result
-	// for the same range key. However, callers may avoid calling RangeKeys()
-	// unnecessarily, and we may optimize parent iterators, so let's measure.
-	rangeKeys := i.iter.RangeKeys()
-	if !i.ignoringTime {
-		rangeKeys.Trim(i.startTime.Next(), i.endTime)
-	}
-	return rangeKeys
+	return i.rangeKeys
 }
 
 // RangeKeyChanged implements SimpleMVCCIterator.
@@ -596,17 +617,12 @@ func (i *MVCCIncrementalIterator) updateIgnoreTime() {
 			return
 		}
 
-		i.hasPoint, i.hasRange = i.iter.HasPointAndRange()
-		if i.hasRange {
-			// Make sure we update rangeKeysStart appropriately so that switching back
-			// to regular iteration won't emit bare range keys twice.
-			if rangeStart := i.iter.RangeBounds().Key; !rangeStart.Equal(i.rangeKeysStart) {
-				i.rangeKeysStart = append(i.rangeKeysStart[:0], rangeStart...)
+		if i.iter.RangeKeyChanged() {
+			if i.hasPoint, i.hasRange = i.updateRangeKeys(); !i.hasPoint {
+				return
 			}
-		}
-
-		if !i.hasPoint {
-			return
+		} else {
+			i.hasPoint = true
 		}
 
 		if err := i.updateMeta(); err != nil {

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
@@ -121,36 +121,36 @@ iter_new_incremental types=pointsAndRanges intents=emit
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -159,15 +159,15 @@ iter_new_incremental types=rangesOnly intents=emit
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 # Iterate across the span while moving StartTime upwards.
@@ -181,30 +181,30 @@ iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "a"/7.000000000,0=/BYTES/a7
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: "a"/2.000000000,0=/BYTES/a2
-iter_scan: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty>]
-iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/4.000000000,0=/<empty> !
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -217,28 +217,28 @@ iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000
 iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "a"/7.000000000,0=/BYTES/a7
 iter_scan: "a"/4.000000000,0=/<empty>
-iter_scan: {b-c}/[3.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
-iter_scan: "h"/4.000000000,0=/<empty>
+iter_scan: "h"/4.000000000,0=/<empty> !
 iter_scan: "h"/3.000000000,0=/BYTES/h3
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -252,14 +252,14 @@ iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000
 iter_scan: "a"/7.000000000,0=/BYTES/a7
 iter_scan: "a"/4.000000000,0=/<empty>
 iter_scan: "b"/4.000000000,0=/<empty>
-iter_scan: {c-d}/[5.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty>]
-iter_scan: "g"/4.000000000,0=/BYTES/g4
+iter_scan: "g"/4.000000000,0=/BYTES/g4 !
 iter_scan: "h"/4.000000000,0=/<empty>
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "j"/7.000000000,0=/BYTES/j7
@@ -280,12 +280,12 @@ iter_scan
 iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "a"/7.000000000,0=/BYTES/a7
-iter_scan: {c-d}/[5.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty>]
-iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "j"/7.000000000,0=/BYTES/j7
 iter_scan: "k"/5.000000000,0=/BYTES/k5
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -363,36 +363,36 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=8
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -401,34 +401,34 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=7
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -437,28 +437,28 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=6
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -466,27 +466,27 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=5
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -494,26 +494,26 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=4
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[1.000000000,0=/<empty>]
-iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -521,20 +521,20 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=3
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[1.000000000,0=/<empty>] !
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[1.000000000,0=/<empty>]
-iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -542,17 +542,17 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=2
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[1.000000000,0=/<empty>]
-iter_scan: {c-d}/[1.000000000,0=/<empty>]
-iter_scan: {d-f}/[1.000000000,0=/<empty>]
-iter_scan: {f-g}/[1.000000000,0=/<empty>]
+iter_scan: {b-c}/[1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[1.000000000,0=/<empty>] !
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[1.000000000,0=/<empty>]
-iter_scan: {g-h}/[1.000000000,0=/<empty>]
+iter_scan: {g-h}/[1.000000000,0=/<empty>] !
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: .
 
 run ok
@@ -560,14 +560,14 @@ iter_new_incremental types=pointsAndRanges intents=emit endTs=1
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[1.000000000,0=/<empty>]
-iter_scan: {c-d}/[1.000000000,0=/<empty>]
-iter_scan: {d-f}/[1.000000000,0=/<empty>]
-iter_scan: {f-g}/[1.000000000,0=/<empty>]
-iter_scan: {g-h}/[1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {b-c}/[1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[1.000000000,0=/<empty>] !
+iter_scan: {g-h}/[1.000000000,0=/<empty>] !
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: .
 
 # Run a scan of a single timestamp going upwards.
@@ -576,14 +576,14 @@ iter_new_incremental types=pointsAndRanges intents=emit startTs=0 endTs=1
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[1.000000000,0=/<empty>]
-iter_scan: {c-d}/[1.000000000,0=/<empty>]
-iter_scan: {d-f}/[1.000000000,0=/<empty>]
-iter_scan: {f-g}/[1.000000000,0=/<empty>]
-iter_scan: {g-h}/[1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {b-c}/[1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[1.000000000,0=/<empty>] !
+iter_scan: {g-h}/[1.000000000,0=/<empty>] !
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: .
 
 run ok
@@ -602,14 +602,14 @@ iter_new_incremental types=pointsAndRanges intents=emit startTs=2 endTs=3
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty>]
-iter_scan: {c-d}/[3.000000000,0=/<empty>]
-iter_scan: "e"/3.000000000,0=/BYTES/e3
-iter_scan: {f-g}/[3.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty>]
-iter_scan: "h"/3.000000000,0=/BYTES/h3
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>] !
+iter_scan: {b-c}/[3.000000000,0=/<empty>] !
+iter_scan: {c-d}/[3.000000000,0=/<empty>] !
+iter_scan: "e"/3.000000000,0=/BYTES/e3 !
+iter_scan: {f-g}/[3.000000000,0=/<empty>] !
+iter_scan: {g-h}/[3.000000000,0=/<empty>] !
+iter_scan: "h"/3.000000000,0=/BYTES/h3 !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -631,11 +631,11 @@ iter_new_incremental types=pointsAndRanges intents=emit startTs=4 endTs=5
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty>] !
+iter_scan: {c-d}/[5.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty>] !
+iter_scan: {f-g}/[5.000000000,0=/<empty>] !
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: .
 
 run ok
@@ -689,12 +689,12 @@ iter_new_incremental types=pointsAndRanges k=ccc end=fff intents=emit startTs=1 
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty>]
+iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_scan: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
-iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_scan: "f"/4.000000000,0=/BYTES/f4 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 iter_scan: .
@@ -717,19 +717,19 @@ iter_next_key
 iter_next_key
 iter_next_key
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_next_key: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key: {h-k}/[1.000000000,0=/<empty>] !
 iter_next_key: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
-iter_next_key: "k"/5.000000000,0=/BYTES/k5
+iter_next_key: "k"/5.000000000,0=/BYTES/k5 !
 iter_next_key: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_next_key: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_next_key: .
 
 run ok
@@ -740,10 +740,10 @@ iter_next_key
 iter_next_key
 iter_next_key
 ----
-iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_next_key: {d-f}/[5.000000000,0=/<empty>]
+iter_seek_ge: {ccc-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_next_key: {d-f}/[5.000000000,0=/<empty>] !
 iter_next_key: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty>]
-iter_next_key: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_next_key: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_key: .
 
 # Seek to every point location.
@@ -765,14 +765,14 @@ iter_seek_ge k=m
 iter_seek_ge k=n
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
-iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
-iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>] !
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4 !
 iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
-iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
-iter_seek_ge: {g-h}/[3.000000000,0=/<empty>]
-iter_seek_ge: "h"/4.000000000,0=/<empty>
-iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>] !
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty>] !
+iter_seek_ge: "h"/4.000000000,0=/<empty> !
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
@@ -798,14 +798,14 @@ iter_seek_ge k=m ts=5
 iter_seek_ge k=n ts=5
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_seek_ge: {b-c}/[3.000000000,0=/<empty>]
-iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
-iter_seek_ge: "d"/4.000000000,0=/BYTES/d4
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty>] !
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
+iter_seek_ge: "d"/4.000000000,0=/BYTES/d4 !
 iter_seek_ge: "e"/3.000000000,0=/BYTES/e3
-iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
-iter_seek_ge: {g-h}/[3.000000000,0=/<empty>]
-iter_seek_ge: "h"/4.000000000,0=/<empty>
-iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>] !
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty>] !
+iter_seek_ge: "h"/4.000000000,0=/<empty> !
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
@@ -830,12 +830,12 @@ iter_seek_ge k=m ts=3
 iter_seek_ge k=n ts=3
 ----
 iter_seek_ge: "b"/4.000000000,0=/<empty>
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty>] !
 iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
-iter_seek_ge: {c-d}/[5.000000000,0=/<empty>]
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty>] !
 iter_seek_ge: {d-f}/[5.000000000,0=/<empty>]
-iter_seek_ge: {d-f}/[5.000000000,0=/<empty>]
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
-iter_seek_ge: "h"/4.000000000,0=/<empty>
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
+iter_seek_ge: "h"/4.000000000,0=/<empty> !
 iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
 iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
 iter_seek_ge: "k"/5.000000000,0=/BYTES/k5
@@ -851,7 +851,7 @@ iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=e
 iter_seek_ge k=f ts=6
 iter_next
 ----
-iter_seek_ge: {f-g}/[3.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[3.000000000,0=/<empty>] !
 iter_next: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>]
 
 # Seeking twice to within the same range key must emit the bare range key both
@@ -881,34 +881,34 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=aggregate
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
 error: (*roachpb.WriteIntentError:) conflicting intents on "a", "d", "j", "l", "m", "o"
 
@@ -917,32 +917,32 @@ iter_new_incremental types=pointsAndRanges k=a end=z endTs=7 intents=aggregate
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/7.000000000,0=/BYTES/o7
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_scan: "o"/7.000000000,0=/BYTES/o7 !
 iter_scan: .
 error: (*roachpb.WriteIntentError:) conflicting intents on "a", "j", "l", "o"
 
@@ -951,28 +951,28 @@ iter_new_incremental types=pointsAndRanges k=a end=z endTs=6 intents=aggregate
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -980,17 +980,17 @@ iter_new_incremental types=pointsAndRanges k=e end=j intents=aggregate
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {e-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-j}/[1.000000000,0=/<empty>]
+iter_scan: {h-j}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-j}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-j}/[1.000000000,0=/<empty>]
 iter_scan: .
@@ -1002,15 +1002,15 @@ iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=e
 iter_seek_ge k=c
 iter_next_ignoring_time
 ----
-iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
-iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
+iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
 iter_seek_ge k=c
 iter_next_ignoring_time
 ----
-iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_ignoring_time: err=conflicting intents on "d"
 error: (*roachpb.WriteIntentError:) conflicting intents on "d"
 
@@ -1019,15 +1019,15 @@ iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=e
 iter_seek_ge k=c
 iter_next_key_ignoring_time
 ----
-iter_seek_ge: {c-d}/[3.000000000,0=/<empty>]
-iter_next_key_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
 iter_seek_ge k=c
 iter_next_key_ignoring_time
 ----
-iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_next_key_ignoring_time: err=conflicting intents on "d"
 error: (*roachpb.WriteIntentError:) conflicting intents on "d"
 
@@ -1037,15 +1037,15 @@ iter_new_incremental types=rangesOnly k=a end=z intents=error
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 # Test NextIgnoringTime().
@@ -1082,21 +1082,21 @@ iter_next_ignoring_time
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_next_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_next_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
@@ -1104,9 +1104,9 @@ iter_next_ignoring_time: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empt
 iter_next_ignoring_time: "k"/5.000000000,0=/BYTES/k5
 iter_next_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next_ignoring_time: "l"/7.000000000,0=/BYTES/l7
-iter_next_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_next_ignoring_time: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_next_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_next_ignoring_time: "o"/7.000000000,0=/BYTES/o7
 
 # Switch from ignoring to respecting time at point key.
@@ -1118,7 +1118,7 @@ iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next: {b-c}/[3.000000000,0=/<empty>] !
 
 # Switch from ignoring to respecting time at range key.
 run ok
@@ -1130,10 +1130,10 @@ iter_next_ignoring_time
 iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next: {b-c}/[3.000000000,0=/<empty>] !
 iter_next: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
-iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: "d"/4.000000000,0=/BYTES/d4
+iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next: "d"/4.000000000,0=/BYTES/d4 !
 
 # Switch between ignoring and respecting time with NextIgnoringTime across span.
 run ok
@@ -1158,21 +1158,21 @@ iter_next_ignoring_time
 iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next: {b-c}/[3.000000000,0=/<empty>] !
 iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: {c-d}/[3.000000000,0=/<empty>]
-iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {c-d}/[3.000000000,0=/<empty>] !
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next: "d"/4.000000000,0=/BYTES/d4
 iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: {f-g}/[3.000000000,0=/<empty>]
+iter_next: {f-g}/[3.000000000,0=/<empty>] !
 iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>]
 iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: {g-h}/[3.000000000,0=/<empty>]
+iter_next: {g-h}/[3.000000000,0=/<empty>] !
 iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: "h"/4.000000000,0=/<empty>
+iter_next: "h"/4.000000000,0=/<empty> !
 iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_next_ignoring_time: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next: .
 
@@ -1182,8 +1182,8 @@ iter_new_incremental types=rangesOnly k=a end=z startTs=4 endTs=5 intents=emit
 iter_seek_ge k=f
 iter_next_ignoring_time
 ----
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 
 # Test NextKeyIgnoringTime().
 run ok
@@ -1204,18 +1204,18 @@ iter_next_key_ignoring_time
 iter_next_key_ignoring_time
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next_key_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
 iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_next_key_ignoring_time: "k"/5.000000000,0=/BYTES/k5
 iter_next_key_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
-iter_next_key_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_next_key_ignoring_time: .
 
 # Switch between ignoring and respecting time with NextKeyIgnoringTime across span.
@@ -1237,18 +1237,18 @@ iter_next_key_ignoring_time
 iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next: {b-c}/[3.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: "d"/4.000000000,0=/BYTES/d4
+iter_next: {b-c}/[3.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next: "d"/4.000000000,0=/BYTES/d4 !
 iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next: {f-g}/[3.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {f-g}/[3.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
 iter_next: "h"/4.000000000,0=/<empty>
 iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
-iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
+iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_next: .
 
 # NextKeyIgnoringTime with only range keys.
@@ -1257,8 +1257,8 @@ iter_new_incremental types=rangesOnly k=a end=z startTs=4 endTs=5 intents=emit
 iter_seek_ge k=f
 iter_next_key_ignoring_time
 ----
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 
 # Try some scans, bounded and unbounded, with only point keys.
 run ok
@@ -1355,15 +1355,15 @@ iter_new_incremental types=rangesOnly k=a end=z endTs=8 intents=emit
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
-iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
+iter_scan: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: .
 
 run ok
@@ -1371,11 +1371,11 @@ iter_new_incremental types=rangesOnly k=bbb end=fff startTs=2 endTs=5 intents=em
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: {bbb-c}/[3.000000000,0=/<empty>]
-iter_scan: {bbb-c}/[3.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-iter_scan: {d-f}/[5.000000000,0=/<empty>]
-iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+iter_seek_ge: {bbb-c}/[3.000000000,0=/<empty>] !
+iter_scan: {bbb-c}/[3.000000000,0=/<empty>] !
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
+iter_scan: {d-f}/[5.000000000,0=/<empty>] !
+iter_scan: f{-ff}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>] !
 iter_scan: .
 
 run ok
@@ -1392,17 +1392,17 @@ iter_seek_ge k=i
 iter_seek_ge k=j
 iter_seek_ge k=k
 ----
-iter_seek_ge: {a-b}/[1.000000000,0=/<empty>]
-iter_seek_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {a-b}/[1.000000000,0=/<empty>] !
+iter_seek_ge: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_seek_ge: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_seek_ge: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_seek_ge: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_seek_ge: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_seek_ge: {h-k}/[1.000000000,0=/<empty>] !
 iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
 iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
-iter_seek_ge: {h-k}/[1.000000000,0=/<empty>]
-iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_seek_ge: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 
 run ok
 iter_new_incremental types=rangesOnly k=a end=z endTs=8 intents=emit
@@ -1414,7 +1414,7 @@ iter_seek_ge k=f ts=3
 iter_seek_ge k=f ts=2
 iter_seek_ge k=f ts=1
 ----
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -1428,36 +1428,36 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=1
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1466,36 +1466,36 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=2
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1504,34 +1504,34 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=3
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1540,34 +1540,34 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=4
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_scan: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1576,31 +1576,31 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=5
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1609,31 +1609,31 @@ iter_new_incremental types=pointsAndRanges k=a end=z intents=emit maskBelow=6
 iter_seek_ge k=a
 iter_scan
 ----
-iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
-iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>]
+iter_seek_ge: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
+iter_scan: "a"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {a-b}/[1.000000000,0=/<empty>] !
 iter_scan: "a"/7.000000000,0=/BYTES/a7 {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/4.000000000,0=/<empty> {a-b}/[1.000000000,0=/<empty>]
 iter_scan: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_scan: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_scan: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_scan: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_scan: {h-k}/[1.000000000,0=/<empty>]
+iter_scan: {h-k}/[1.000000000,0=/<empty>] !
 iter_scan: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
 iter_scan: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
-iter_scan: "k"/5.000000000,0=/BYTES/k5
+iter_scan: "k"/5.000000000,0=/BYTES/k5 !
 iter_scan: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_scan: "l"/7.000000000,0=/BYTES/l7
-iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_scan: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_scan: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
-iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_scan: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_scan: "o"/7.000000000,0=/BYTES/o7
 iter_scan: .
 
@@ -1646,8 +1646,8 @@ iter_next_ignoring_time
 iter_next_ignoring_time
 iter_next_ignoring_time
 ----
-iter_seek_ge: {f-g}/[5.000000000,0=/<empty>]
+iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
 iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
 iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
@@ -1135,6 +1135,47 @@ iter_next: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
 iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 iter_next: "d"/4.000000000,0=/BYTES/d4
 
+# Switch between ignoring and respecting time with NextIgnoringTime across span.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+iter_next_ignoring_time
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {c-d}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4
+iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {f-g}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {g-h}/[3.000000000,0=/<empty>]
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "h"/4.000000000,0=/<empty>
+iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_ignoring_time: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next: .
+
 # NextIgnoringTime with only range keys.
 run ok
 iter_new_incremental types=rangesOnly k=a end=z startTs=4 endTs=5 intents=emit
@@ -1148,6 +1189,7 @@ iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 run ok
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
 iter_seek_ge k=a
+iter_next_key_ignoring_time
 iter_next_key_ignoring_time
 iter_next_key_ignoring_time
 iter_next_key_ignoring_time
@@ -1174,6 +1216,40 @@ iter_next_key_ignoring_time: "k"/5.000000000,0=/BYTES/k5
 iter_next_key_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next_key_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key_ignoring_time: .
+
+# Switch between ignoring and respecting time with NextKeyIgnoringTime across span.
+run ok
+iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=4 intents=emit
+iter_seek_ge k=a
+iter_next
+iter_next_key_ignoring_time
+iter_next
+iter_next_key_ignoring_time
+iter_next
+iter_next_key_ignoring_time
+iter_next
+iter_next_key_ignoring_time
+iter_next
+iter_next_key_ignoring_time
+iter_next
+iter_next_key_ignoring_time
+iter_next
+----
+iter_seek_ge: "a"/4.000000000,0=/<empty>
+iter_next: {b-c}/[3.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "d"/4.000000000,0=/BYTES/d4
+iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: {f-g}/[3.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next: "h"/4.000000000,0=/<empty>
+iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
+iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next: .
 
 # NextKeyIgnoringTime with only range keys.
 run ok

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_incremental
@@ -1003,7 +1003,7 @@ iter_seek_ge k=c
 iter_next_ignoring_time
 ----
 iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
-iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
@@ -1020,7 +1020,7 @@ iter_seek_ge k=c
 iter_next_key_ignoring_time
 ----
 iter_seek_ge: {c-d}/[3.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: "d"/8.000000000,0=/BYTES/d8 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 
 run error
 iter_new_incremental types=pointsAndRanges k=a end=z startTs=2 endTs=10 intents=error
@@ -1081,26 +1081,26 @@ iter_next_ignoring_time
 iter_next_ignoring_time
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
-iter_next_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "d"/4.000000000,0=/BYTES/d4 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "f"/4.000000000,0=/BYTES/f4 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "h"/4.000000000,0=/<empty> {h-k}/[1.000000000,0=/<empty>]
-iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
-iter_next_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
-iter_next_ignoring_time: "j"/7.000000000,0=/BYTES/j7 {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 (+{a-b}/[1.000000000,0=/<empty>])
+iter_next_ignoring_time: {b-c}/[3.000000000,0=/<empty>] (+{b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>] (+{b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: {c-d}/[3.000000000,0=/<empty>] (+{c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "d"/8.000000000,0=/BYTES/d8 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: "d"/4.000000000,0=/BYTES/d4 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: "g"/2.000000000,0=/BYTES/g2 {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: (+{h-k}/[1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "h"/4.000000000,0=/<empty> (+{h-k}/[1.000000000,0=/<empty>])
+iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 (+{h-k}/[1.000000000,0=/<empty>])
+iter_next_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{h-k}/[1.000000000,0=/<empty>])
+iter_next_ignoring_time: "j"/7.000000000,0=/BYTES/j7 (+{h-k}/[1.000000000,0=/<empty>])
 iter_next_ignoring_time: "k"/5.000000000,0=/BYTES/k5
 iter_next_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next_ignoring_time: "l"/7.000000000,0=/BYTES/l7
@@ -1117,7 +1117,7 @@ iter_next_ignoring_time
 iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 {a-b}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "a"/2.000000000,0=/BYTES/a2 (+{a-b}/[1.000000000,0=/<empty>])
 iter_next: {b-c}/[3.000000000,0=/<empty>] !
 
 # Switch from ignoring to respecting time at range key.
@@ -1132,7 +1132,7 @@ iter_next
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_next: {b-c}/[3.000000000,0=/<empty>] !
 iter_next: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>]
-iter_next_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_ignoring_time: {c-d}/[3.000000000,0=/<empty>] (+{c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 iter_next: "d"/4.000000000,0=/BYTES/d4 !
 
 # Switch between ignoring and respecting time with NextIgnoringTime across span.
@@ -1159,19 +1159,19 @@ iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_next: {b-c}/[3.000000000,0=/<empty>] !
-iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "b"/4.000000000,0=/<empty> {b-c}/[3.000000000,0=/<empty>] (+{b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: {c-d}/[3.000000000,0=/<empty>] !
-iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 iter_next: "d"/4.000000000,0=/BYTES/d4
-iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "e"/3.000000000,0=/BYTES/e3 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: {f-g}/[3.000000000,0=/<empty>] !
-iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: "f"/4.000000000,0=/BYTES/f4 {f-g}/[3.000000000,0=/<empty>]
-iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/2.000000000,0=/BYTES/f2 {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: {g-h}/[3.000000000,0=/<empty>] !
-iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: "h"/4.000000000,0=/<empty> !
-iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "h"/3.000000000,0=/BYTES/h3 (+{h-k}/[1.000000000,0=/<empty>])
 iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_next_ignoring_time: "m"/8.000000000,0=/BYTES/m8 {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>]
 iter_next: .
@@ -1183,7 +1183,7 @@ iter_seek_ge k=f
 iter_next_ignoring_time
 ----
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_ignoring_time: (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 
 # Test NextKeyIgnoringTime().
 run ok
@@ -1204,14 +1204,14 @@ iter_next_key_ignoring_time
 iter_next_key_ignoring_time
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
-iter_next_key_ignoring_time: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: {b-c}/[3.000000000,0=/<empty>] (+{b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: {c-d}/[3.000000000,0=/<empty>] (+{c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_key_ignoring_time: {f-g}/[3.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: (+{h-k}/[1.000000000,0=/<empty>] !) !
+iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{h-k}/[1.000000000,0=/<empty>])
 iter_next_key_ignoring_time: "k"/5.000000000,0=/BYTES/k5
 iter_next_key_ignoring_time: "l"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 iter_next_key_ignoring_time: "m"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
@@ -1238,15 +1238,15 @@ iter_next
 ----
 iter_seek_ge: "a"/4.000000000,0=/<empty>
 iter_next: {b-c}/[3.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {c-d}/[3.000000000,0=/<empty>] (+{c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 iter_next: "d"/4.000000000,0=/BYTES/d4 !
-iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "e"/3.000000000,0=/BYTES/e3 (+{d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>])
 iter_next: {f-g}/[3.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty>] (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 iter_next: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty>]
-iter_next_key_ignoring_time: {h-k}/[1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: (+{h-k}/[1.000000000,0=/<empty>] !) !
 iter_next: "h"/4.000000000,0=/<empty>
-iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true {h-k}/[1.000000000,0=/<empty>]
+iter_next_key_ignoring_time: "j"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true (+{h-k}/[1.000000000,0=/<empty>])
 iter_next: {m-n}/[3.000000000,0={localTs=2.000000000,0}/<empty>] !
 iter_next_key_ignoring_time: "o"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true !
 iter_next: .
@@ -1258,7 +1258,7 @@ iter_seek_ge k=f
 iter_next_key_ignoring_time
 ----
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
-iter_next_key_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
+iter_next_key_ignoring_time: (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
 
 # Try some scans, bounded and unbounded, with only point keys.
 run ok
@@ -1647,7 +1647,7 @@ iter_next_ignoring_time
 iter_next_ignoring_time
 ----
 iter_seek_ge: {f-g}/[5.000000000,0=/<empty>] !
-iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !
-iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 {g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
-iter_next_ignoring_time: {h-k}/[1.000000000,0=/<empty>]
+iter_next_ignoring_time: "f"/6.000000000,0=/BYTES/f6 {f-g}/[5.000000000,0=/<empty>] (+{f-g}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>] !) !
+iter_next_ignoring_time: "g"/4.000000000,0=/BYTES/g4 (+{g-h}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>])
+iter_next_ignoring_time: (+{h-k}/[1.000000000,0=/<empty>] !)


### PR DESCRIPTION
**storage: use `RangeKeyChanged()` in `MVCCIncrementalIterator`**

This patch uses `RangeKeyChanged()` to detect changes to range keys in
`MVCCIncrementalIterator`. There are no functional changes.

Some quick benchmarks, using catchup scans:

```
name                                                                 old time/op  new time/op  delta
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=0-24      538ms ± 1%   535ms ± 1%     ~     (p=0.211 n=10+9)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=1-24      690ms ± 0%   590ms ± 1%  -14.56%  (p=0.000 n=9+10)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=100-24    743ms ± 1%   646ms ± 1%  -13.13%  (p=0.000 n=9+9)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=0-24     794ms ± 1%   794ms ± 0%     ~     (p=0.579 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=1-24     966ms ± 0%   911ms ± 1%   -5.72%  (p=0.000 n=10+10)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=100-24   974ms ± 0%   920ms ± 0%   -5.51%  (p=0.000 n=10+10)
```

Release justification: bug fixes and low-risk updates to new functionality.

Release note: None

**storage: implement `RangeKeyChanged()` for `MVCCIncrementalIterator`**

This patch implements `RangeKeyChanged()` for `MVCCIncrementalIterator`.
It only fires if the time bound range keys change, not if a
`Next(Key)IgnoringTime()` operation reveals additional range keys.

Resolves #86105.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None
  
**storage: add `MVCCIncrementalIterator.RangeKeysIgnoringTime()`**

This patch changes `MVCCIncrementalIterator` range key behavior
following a `Next(Key)IgnoringTime()` call. Previously, range key
methods would then expose unfiltered range keys. Now, the standard range
key methods only apply to filtered range keys, and an additional
`RangeKeysIgnoringTime()` method provides access to unfiltered range
keys.

This implies that if such a call steps onto a range key that's entirely
outside of the time bounds then:

* `HasPointAndRange()` will return `false`,`false` if on a bare range
  key.

* `RangeKeyChanged()` will not fire, unless stepping off of a range key
  within the time bounds.

* `RangeBounds()` and `RangeKeys()` will return empty results.

This is done to avoid conditional range key handling following these
calls, except for the exact sites where the caller is interested in
the unfiltered range keys.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None