### PR TITLE
storage/metamorphic: unskip TestPebbleEquivalence

### DIFF
--- a/pkg/storage/metamorphic/meta_test.go
+++ b/pkg/storage/metamorphic/meta_test.go
@@ -169,7 +169,6 @@ func TestPebbleEquivalence(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 86102)
 	skip.UnderRace(t)
 	runPebbleEquivalenceTest(t)
 }


### PR DESCRIPTION
The vendor bump which fixed a couple of Pebble iterator issues has seemed to
stabilize this test.

We may see additional failures in nightly stress since we still have an
outstanding Pebble metamorphic test failure (cockroachdb/pebble#1893), but the
test should be stable.

Release justification: Non-production code changes
Release note: None