### PR TITLE
ttl: validate ttl_expiration_expression is a TIMESTAMPTZ

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -78,6 +78,9 @@ func AlterColumnType(
 			)
 		}
 	}
+	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, col); err != nil {
+		return err
+	}
 
 	typ, err := tree.ResolveType(ctx, t.ToType, params.p.semaCtx.GetTypeResolver())
 	if err != nil {

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -699,6 +699,17 @@ func RenameColumnInTable(
 		}
 	}
 
+	// Rename the column in the TTL expiration expression.
+	if tableDesc.HasRowLevelTTL() {
+		if expirationExpr := tableDesc.GetRowLevelTTL().ExpirationExpr; expirationExpr != "" {
+			expirationExprStr := string(expirationExpr)
+			if err := renameInExpr(&expirationExprStr); err != nil {
+				return err
+			}
+			tableDesc.GetRowLevelTTL().ExpirationExpr = catpb.Expression(expirationExprStr)
+		}
+	}
+
 	// Do all of the above renames inside check constraints, computed expressions,
 	// and idx predicates that are in mutations.
 	for i := range tableDesc.Mutations {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -784,6 +784,16 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	})
 
 	vea.Report(ValidateRowLevelTTL(desc.GetRowLevelTTL()))
+	if desc.HasRowLevelTTL() {
+		// ValidateTTLExpirationExpr is called separately from ValidateRowLevelTTL
+		// because it can only be called on an initialized table descriptor.
+		// ValidateRowLevelTTL is also used before the table descriptor is fully
+		// initialized to validate the storage parameters.
+		if err := ValidateTTLExpirationExpr(desc, desc.GetRowLevelTTL().ExpirationExpr); err != nil {
+			vea.Report(err)
+			return
+		}
+	}
 
 	// Validate that there are no column with both a foreign key ON UPDATE and an
 	// ON UPDATE expression. This check is made to ensure that we know which ON

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -213,51 +213,8 @@ func (desc *wrapper) ValidateCrossReferences(
 		}
 	}
 
-	// For row-level TTL, only ascending PKs are permitted.
+	// For row-level TTL, no FKs are allowed.
 	if desc.HasRowLevelTTL() {
-		rowLevelTTL := desc.RowLevelTTL
-		if rowLevelTTL.HasDurationExpr() {
-			if col, err := desc.FindColumnWithName(colinfo.TTLDefaultExpirationColumnName); err != nil {
-				vea.Report(errors.Wrapf(err, "expected column %s", colinfo.TTLDefaultExpirationColumnName))
-			} else {
-				intervalExpr := desc.GetRowLevelTTL().DurationExpr
-				expectedStr := `current_timestamp():::TIMESTAMPTZ + ` + string(intervalExpr)
-				if col.GetDefaultExpr() != expectedStr {
-					vea.Report(pgerror.Newf(
-						pgcode.InvalidTableDefinition,
-						"expected DEFAULT expression of %s to be %s",
-						colinfo.TTLDefaultExpirationColumnName,
-						expectedStr,
-					))
-				}
-				if col.GetOnUpdateExpr() != expectedStr {
-					vea.Report(pgerror.Newf(
-						pgcode.InvalidTableDefinition,
-						"expected ON UPDATE expression of %s to be %s",
-						colinfo.TTLDefaultExpirationColumnName,
-						expectedStr,
-					))
-				}
-			}
-		}
-
-		if rowLevelTTL.HasExpirationExpr() {
-			_, err := parser.ParseExpr(string(rowLevelTTL.ExpirationExpr))
-			if err != nil {
-				vea.Report(errors.Wrapf(err, "value of 'ttl_expiration_expression' must be a valid expression"))
-			}
-		}
-
-		pk := desc.GetPrimaryIndex()
-		for i := 0; i < pk.NumKeyColumns(); i++ {
-			dir := pk.GetKeyColumnDirection(i)
-			if dir != catpb.IndexColumn_ASC {
-				vea.Report(unimplemented.NewWithIssuef(
-					76912,
-					`non-ascending ordering on PRIMARY KEYs are not supported`,
-				))
-			}
-		}
 		if len(desc.OutboundFKs) > 0 || len(desc.InboundFKs) > 0 {
 			vea.Report(unimplemented.NewWithIssuef(
 				76407,
@@ -784,15 +741,17 @@ func (desc *wrapper) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 	})
 
 	vea.Report(ValidateRowLevelTTL(desc.GetRowLevelTTL()))
-	if desc.HasRowLevelTTL() {
-		// ValidateTTLExpirationExpr is called separately from ValidateRowLevelTTL
-		// because it can only be called on an initialized table descriptor.
-		// ValidateRowLevelTTL is also used before the table descriptor is fully
-		// initialized to validate the storage parameters.
-		if err := ValidateTTLExpirationExpr(desc, desc.GetRowLevelTTL().ExpirationExpr); err != nil {
-			vea.Report(err)
-			return
-		}
+	// The remaining validation is called separately from ValidateRowLevelTTL
+	// because it can only be called on an initialized table descriptor.
+	// ValidateRowLevelTTL is also used before the table descriptor is fully
+	// initialized to validate the storage parameters.
+	if err := ValidateTTLExpirationExpr(desc); err != nil {
+		vea.Report(err)
+		return
+	}
+	if err := ValidateTTLExpirationColumn(desc); err != nil {
+		vea.Report(err)
+		return
 	}
 
 	// Validate that there are no column with both a foreign key ON UPDATE and an

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2340,7 +2340,7 @@ func newTableDesc(
 			creationTime,
 			privileges,
 			affected,
-			&params.p.semaCtx,
+			params.p.SemaCtx(),
 			params.EvalContext(),
 			params.SessionData(),
 			n.Persistence,
@@ -2363,6 +2363,10 @@ func newTableDesc(
 
 	// Row level TTL tables require a scheduled job to be created as well.
 	if ttl := ret.RowLevelTTL; ttl != nil {
+		if err := schemaexpr.ValidateTTLExpirationExpression(params.ctx, ret, params.p.SemaCtx(), &n.Table); err != nil {
+			return nil, err
+		}
+
 		j, err := CreateRowLevelTTLScheduledJob(
 			params.ctx,
 			params.ExecCfg(),

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -9,8 +9,11 @@ CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = '-10 m
 statement error parameter "ttl_expiration_expression" requires a string value
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 0)
 
-statement error value of "ttl_expiration_expression" must be a valid expression: at or near "EOF": syntax error
+statement error ttl_expiration_expression "; DROP DATABASE defaultdb" must be a valid expression: at or near "EOF": syntax error
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = '; DROP DATABASE defaultdb')
+
+statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
+CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 'text')
 
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl = 'on')
@@ -473,7 +476,7 @@ subtest create_table_ttl_expiration_expression
 statement ok
 CREATE TABLE tbl_create_table_ttl_expiration_expression (
   id INT PRIMARY KEY,
-  expire_at TIMESTAMP,
+  expire_at TIMESTAMPTZ,
   FAMILY (id, expire_at)
 ) WITH (ttl_expiration_expression = 'expire_at')
 
@@ -482,7 +485,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
                                                                                         id INT8 NOT NULL,
-                                                                                        expire_at TIMESTAMP NULL,
+                                                                                        expire_at TIMESTAMPTZ NULL,
                                                                                         CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
                                                                                         FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
@@ -495,7 +498,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
    id INT8 NOT NULL,
-   expire_at TIMESTAMP NULL,
+   expire_at TIMESTAMPTZ NULL,
    CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
    FAMILY fam_0_id_expire_at (id, expire_at)
 )
@@ -507,19 +510,19 @@ subtest create_table_ttl_expiration_expression_escape_sql
 statement ok
 CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql (
   id INT PRIMARY KEY,
-  expire_at TIMESTAMP,
+  expire_at TIMESTAMPTZ,
   FAMILY (id, expire_at)
-) WITH (ttl_expiration_expression = 'IF(expire_at > ''2020-01-01 00:00:00'':::TIMESTAMP, expire_at, NULL)')
+) WITH (ttl_expiration_expression = 'IF(expire_at > parse_timestamp(''2020-01-01 00:00:00'') AT TIME ZONE ''UTC'', expire_at, NULL)')
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql]
 ----
 CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
-                                                                                                                                                   id INT8 NOT NULL,
-                                                                                                                                                   expire_at TIMESTAMP NULL,
-                                                                                                                                                   CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                   FAMILY fam_0_id_expire_at (id, expire_at)
-) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > \'2020-01-01 00:00:00\':::TIMESTAMP, expire_at, NULL)', ttl_job_cron = '@hourly')
+                                                                                                                                                                              id INT8 NOT NULL,
+                                                                                                                                                                              expire_at TIMESTAMPTZ NULL,
+                                                                                                                                                                              CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
+                                                                                                                                                                              FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > parse_timestamp(\'2020-01-01 00:00:00\') AT TIME ZONE \'UTC\', expire_at, NULL)', ttl_job_cron = '@hourly')
 
 
 subtest end
@@ -529,36 +532,63 @@ subtest alter_table_ttl_expiration_expression
 statement ok
 CREATE TABLE tbl_alter_table_ttl_expiration_expression (
   id INT PRIMARY KEY,
-  expire_at TIMESTAMP,
-  FAMILY (id, expire_at)
+  text TEXT,
+  expire_at TIMESTAMPTZ,
+  FAMILY (id, text, expire_at)
 )
+
+statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'text')
 
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at')
+
+statement error cannot drop column "expire_at" referenced by row-level TTL expiration expression "expire_at"
+ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
+
+statement ok
+SET use_declarative_schema_changer = 'off'
+
+statement error column "expire_at" is referenced by row-level TTL expiration expression "expire_at"
+ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
+
+statement ok
+SET use_declarative_schema_changer = 'on'
+
+statement ok
+SET enable_experimental_alter_column_type_general = 'on'
+
+statement error column "expire_at" is referenced by row-level TTL expiration expression "expire_at"
+ALTER TABLE tbl_alter_table_ttl_expiration_expression ALTER expire_at TYPE TIMESTAMP USING (expire_at AT TIME ZONE 'UTC')
+
+statement ok
+SET enable_experimental_alter_column_type_general = 'off'
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
                                                                                         id INT8 NOT NULL,
-                                                                                        expire_at TIMESTAMP NULL,
+                                                                                        text STRING NULL,
+                                                                                        expire_at TIMESTAMPTZ NULL,
                                                                                         CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                        FAMILY fam_0_id_expire_at (id, expire_at)
+                                                                                        FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
 
 # try setting it again
 statement ok
-ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at + ''5 minutes'':::INTERVAL')
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = '((expire_at AT TIME ZONE ''UTC'') + ''5 minutes'':::INTERVAL) AT TIME ZONE ''UTC''')
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
-                                                                                                                    id INT8 NOT NULL,
-                                                                                                                    expire_at TIMESTAMP NULL,
-                                                                                                                    CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-                                                                                                                    FAMILY fam_0_id_expire_at (id, expire_at)
-) WITH (ttl = 'on', ttl_expiration_expression = e'expire_at + \'5 minutes\':::INTERVAL', ttl_job_cron = '@hourly')
+                                                                                                                                                                  id INT8 NOT NULL,
+                                                                                                                                                                  text STRING NULL,
+                                                                                                                                                                  expire_at TIMESTAMPTZ NULL,
+                                                                                                                                                                  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                                                                                                  FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'((expire_at AT TIME ZONE \'UTC\') + \'5 minutes\':::INTERVAL) AT TIME ZONE \'UTC\'', ttl_job_cron = '@hourly')
 
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expiration_expression RESET (ttl)
@@ -568,9 +598,10 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_e
 ----
 CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
    id INT8 NOT NULL,
-   expire_at TIMESTAMP NULL,
+   text STRING NULL,
+   expire_at TIMESTAMPTZ NULL,
    CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
-   FAMILY fam_0_id_expire_at (id, expire_at)
+   FAMILY fam_0_id_text_expire_at (id, text, expire_at)
 )
 
 subtest end
@@ -580,7 +611,7 @@ subtest add_ttl_expiration_expression_to_ttl_expire_after
 statement ok
 CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after (
   id INT PRIMARY KEY,
-  expire_at TIMESTAMP,
+  expire_at TIMESTAMPTZ,
   FAMILY (id, expire_at)
 ) WITH (ttl_expire_after = '10 minutes')
 
@@ -592,7 +623,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expressio
 ----
 CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
                                                                                                                                                  id INT8 NOT NULL,
-                                                                                                                                                 expire_at TIMESTAMP NULL,
+                                                                                                                                                 expire_at TIMESTAMPTZ NULL,
                                                                                                                                                  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
                                                                                                                                                  CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
                                                                                                                                                  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
@@ -606,7 +637,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expressio
 ----
 CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
                                                                                          id INT8 NOT NULL,
-                                                                                         expire_at TIMESTAMP NULL,
+                                                                                         expire_at TIMESTAMPTZ NULL,
                                                                                          crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
                                                                                          CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
                                                                                          FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
@@ -619,7 +650,7 @@ subtest add_ttl_expire_after_to_ttl_expiration_expression
 statement ok
 CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression (
   id INT PRIMARY KEY,
-  expire_at TIMESTAMP,
+  expire_at TIMESTAMPTZ,
   FAMILY (id, expire_at)
 ) WITH (ttl_expiration_expression = 'expire_at')
 
@@ -631,7 +662,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_
 ----
 CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
                                                                                                                                   id INT8 NOT NULL,
-                                                                                                                                  expire_at TIMESTAMP NULL,
+                                                                                                                                  expire_at TIMESTAMPTZ NULL,
                                                                                                                                   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
                                                                                                                                   CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
                                                                                                                                   FAMILY fam_0_id_expire_at (id, expire_at, crdb_internal_expiration)
@@ -645,7 +676,7 @@ SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expire_after_to_ttl_
 ----
 CREATE TABLE public.tbl_add_ttl_expire_after_to_ttl_expiration_expression (
    id INT8 NOT NULL,
-   expire_at TIMESTAMP NULL,
+   expire_at TIMESTAMPTZ NULL,
    CONSTRAINT tbl_add_ttl_expire_after_to_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
    FAMILY fam_0_id_expire_at (id, expire_at)
 )
@@ -710,6 +741,30 @@ CREATE TABLE public.tbl_alter_table_ttl_expire_after_and_ttl_expiration_expressi
    id INT8 NOT NULL,
    CONSTRAINT tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 )
+
+subtest end
+
+subtest ttl_expiration_expression_rename
+
+statement ok
+CREATE TABLE tbl_ttl_expiration_expression_renamed (
+  id INT PRIMARY KEY,
+  expires_at TIMESTAMPTZ,
+  FAMILY fam (id, expires_at)
+) WITH (ttl_expiration_expression = 'expires_at')
+
+statement ok
+ALTER TABLE tbl_ttl_expiration_expression_renamed RENAME expires_at TO expires_at_renamed
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_expiration_expression_renamed]
+----
+CREATE TABLE public.tbl_ttl_expiration_expression_renamed (
+                                                                                                 id INT8 NOT NULL,
+                                                                                                 expires_at_renamed TIMESTAMPTZ NULL,
+                                                                                                 CONSTRAINT tbl_ttl_expiration_expression_renamed_pkey PRIMARY KEY (id ASC),
+                                                                                                 FAMILY fam (id, expires_at_renamed)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expires_at_renamed', ttl_job_cron = '@hourly')
 
 subtest end
 

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_add_column
@@ -105,7 +105,7 @@ ALTER TABLE defaultdb.foo ADD COLUMN a INT AS (i+1) STORED
 - [[ColumnName:{DescID: 104, Name: a, ColumnID: 2}, PUBLIC], ABSENT]
   {columnId: 2, name: a, tableId: 104}
 - [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}, PUBLIC], ABSENT]
-  {columnId: 2, computeExpr: {expr: 'i + 1:::INT8'}, isNullable: true, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}}
+  {columnId: 2, computeExpr: {expr: 'i + 1:::INT8', referencedColumnIds: [1]}, isNullable: true, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}}
 - [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT]
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
 - [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT]

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -85,7 +85,7 @@ CREATE INDEX id4
 - [[ColumnName:{DescID: 104, Name: crdb_internal_id_name_shard_8, ColumnID: 4}, PUBLIC], ABSENT]
   {columnId: 4, name: crdb_internal_id_name_shard_8, tableId: 104}
 - [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}, PUBLIC], ABSENT]
-  {columnId: 4, computeExpr: {expr: 'mod(fnv32(crdb_internal.datums_to_bytes(id, name)), 8:::INT8)'}, isVirtual: true, tableId: 104, type: {family: IntFamily, oid: 23, width: 32}}
+  {columnId: 4, computeExpr: {expr: 'mod(fnv32(crdb_internal.datums_to_bytes(id, name)), 8:::INT8)', referencedColumnIds: [1, 2]}, isVirtual: true, tableId: 104, type: {family: IntFamily, oid: 23, width: 32}}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 2, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT]

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -820,6 +820,8 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
         ColumnID: 2
         ComputeExpr:
           expr: i + 1:::INT8
+          referencedColumnIds:
+          - 1
         IsNullable: true
         TableID: 104
         TypeT:

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/paramparse",
-        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
+++ b/pkg/sql/storageparam/tablestorageparam/table_storage_param.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -238,17 +237,6 @@ var tableParams = map[string]tableParam{
 			stringVal, err := paramparse.DatumAsString(evalCtx, key, datum)
 			if err != nil {
 				return err
-			}
-			stringVal = strings.TrimSpace(stringVal)
-			// todo(wall): add type checking https://github.com/cockroachdb/cockroach/issues/76916
-			_, err = parser.ParseExpr(stringVal)
-			if err != nil {
-				return pgerror.Wrapf(
-					err,
-					pgcode.InvalidParameterValue,
-					`value of %q must be a valid expression`,
-					key,
-				)
 			}
 			rowLevelTTL := po.getOrCreateRowLevelTTL()
 			rowLevelTTL.ExpirationExpr = catpb.Expression(stringVal)

--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -379,7 +379,7 @@ func TestRowLevelTTLJobMultipleNodes(t *testing.T) {
 	sqlDB.Exec(t, fmt.Sprintf(
 		`CREATE TABLE %s (
 			id INT PRIMARY KEY,
-			expire_at TIMESTAMP
+			expire_at TIMESTAMPTZ
 			) WITH (ttl_expiration_expression = '%s')`,
 		tableName, expirationExpr,
 	))
@@ -583,7 +583,7 @@ func TestRowLevelTTLJobRandomEntries(t *testing.T) {
 			desc: "ttl expiration expression",
 			createTable: `CREATE TABLE tbl (
 	id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  expire_at TIMESTAMP
+  expire_at TIMESTAMPTZ
 ) WITH (ttl_expiration_expression = 'expire_at')`,
 			numExpiredRows:       1001,
 			numNonExpiredRows:    5,


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/86410
fixes https://github.com/cockroachdb/cockroach/issues/85531
fixes https://github.com/cockroachdb/cockroach/issues/84725

Previously the only validation is that the expression is valid SQL
syntax. Now the expression must also be a TIMESTAMPTZ which will
prevent errors in the TTL job when comparing to the cutoff.

Validation is also added so that a column cannot be dropped or altered
in type if it is used in the TTL expression. If the column is renamed, the
expression is automatically updated.

Release note: None

Release justification: low risk changes to validation