### PR TITLE
sql: remove leftovers

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -488,7 +488,6 @@ func (ds *ServerImpl) newFlowContext(
 		DiskMonitor: execinfra.NewMonitor(
 			ctx, ds.ParentDiskMonitor, "flow-disk-monitor",
 		),
-		PreserveFlowSpecs: localState.PreserveFlowSpecs,
 	}
 
 	if localState.IsLocal && localState.Collection != nil {
@@ -551,10 +550,6 @@ type LocalState struct {
 	// LocalProcs is an array of planNodeToRowSource processors. It's in order and
 	// will be indexed into by the RowSourceIdx field in LocalPlanNodeSpec.
 	LocalProcs []execinfra.LocalProcessor
-
-	// PreserveFlowSpecs is true when the flow setup code needs to be careful
-	// when modifying the specifications of processors.
-	PreserveFlowSpecs bool
 }
 
 // MustUseLeafTxn returns true if a LeafTxn must be used. It is valid to call

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -518,9 +518,6 @@ func (dsp *DistSQLPlanner) Run(
 	localState.IsLocal = planCtx.isLocal
 	localState.Txn = txn
 	localState.LocalProcs = plan.LocalProcessors
-	// If we need to perform some operation on the flow specs, we want to
-	// preserve the specs during the flow setup.
-	localState.PreserveFlowSpecs = planCtx.saveFlows != nil
 	// If we have access to a planner and are currently being used to plan
 	// statements in a user transaction, then take the descs.Collection to resolve
 	// types with during flow execution. This is necessary to do in the case of

--- a/pkg/sql/execinfra/flow_context.go
+++ b/pkg/sql/execinfra/flow_context.go
@@ -95,10 +95,6 @@ type FlowCtx struct {
 	// DiskMonitor is this flow's disk monitor. All disk usage for this flow must
 	// be registered through this monitor.
 	DiskMonitor *mon.BytesMonitor
-
-	// PreserveFlowSpecs is true when the flow setup code needs to be careful
-	// when modifying the specifications of processors.
-	PreserveFlowSpecs bool
 }
 
 // NewEvalCtx returns a modifiable copy of the FlowCtx's EvalContext.


### PR DESCRIPTION
This commit removes some of the fields that are no longer used. It is
a continuation of 5aa72c3cb4b2b182725465810d8cceb0962432e5 in spirit.

Release justification: non-production code changes.

Release note: None