### PR TITLE
sql: fix type hydration in some cases

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -716,6 +716,9 @@ func NewColOperator(
 			if err := checkNumIn(inputs, 0); err != nil {
 				return r, err
 			}
+			if err := execinfra.HydrateTypesInDatumInfo(ctx, args.TypeResolver, core.Values.Columns); err != nil {
+				return r, err
+			}
 			if core.Values.NumRows == 0 || len(core.Values.Columns) == 0 {
 				// To simplify valuesOp we handle some special cases with
 				// fixedNumTuplesNoInputOp.
@@ -747,7 +750,7 @@ func NewColOperator(
 			estimatedRowCount := spec.EstimatedRowCount
 			scanOp, err := colfetcher.NewColBatchScan(
 				ctx, colmem.NewAllocator(ctx, cFetcherMemAcc, factory), kvFetcherMemAcc,
-				flowCtx, core.TableReader, post, estimatedRowCount,
+				flowCtx, core.TableReader, post, estimatedRowCount, args.TypeResolver,
 			)
 			if err != nil {
 				return r, err
@@ -785,7 +788,8 @@ func NewColOperator(
 				ctx, getStreamingAllocator(ctx, args),
 				colmem.NewAllocator(ctx, cFetcherMemAcc, factory),
 				kvFetcherMemAcc, streamerBudgetAcc, flowCtx,
-				inputs[0].Root, core.JoinReader, post, inputTypes, streamerDiskMonitor,
+				inputs[0].Root, core.JoinReader, post, inputTypes,
+				streamerDiskMonitor, args.TypeResolver,
 			)
 			if err != nil {
 				return r, err

--- a/pkg/sql/colexec/colexecargs/BUILD.bazel
+++ b/pkg/sql/colexec/colexecargs/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/col/coldata",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/colcontainer",
         "//pkg/sql/colexecerror",
         "//pkg/sql/colexecop",

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -65,6 +66,7 @@ type NewColOperatorArgs struct {
 	ExprHelper             *ExprHelper
 	Factory                coldata.ColumnFactory
 	MonitorRegistry        *MonitorRegistry
+	TypeResolver           *descs.DistSQLTypeResolver
 	TestingKnobs           struct {
 		// SpillingCallbackFn will be called when the spilling from an in-memory
 		// to disk-backed operator occurs. It should only be set in tests.

--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/colconv",
         "//pkg/sql/colencoding",

--- a/pkg/sql/colfetcher/cfetcher_setup.go
+++ b/pkg/sql/colfetcher/cfetcher_setup.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -61,7 +61,7 @@ func (a *cFetcherTableArgs) populateTypes(cols []descpb.IndexFetchSpec_Column) {
 
 // populateTableArgs fills in cFetcherTableArgs.
 func populateTableArgs(
-	ctx context.Context, flowCtx *execinfra.FlowCtx, fetchSpec *descpb.IndexFetchSpec,
+	ctx context.Context, fetchSpec *descpb.IndexFetchSpec, typeResolver *descs.DistSQLTypeResolver,
 ) (_ *cFetcherTableArgs, _ error) {
 	args := cFetcherTableArgsPool.Get().(*cFetcherTableArgs)
 
@@ -73,14 +73,13 @@ func populateTableArgs(
 	// they are hydrated. In row execution engine it is done during the processor
 	// initialization, but neither ColBatchScan nor cFetcher are processors, so we
 	// need to do the hydration ourselves.
-	resolver := flowCtx.NewTypeResolver(flowCtx.Txn)
 	for i := range args.spec.FetchedColumns {
-		if err := typedesc.EnsureTypeIsHydrated(ctx, args.spec.FetchedColumns[i].Type, &resolver); err != nil {
+		if err := typedesc.EnsureTypeIsHydrated(ctx, args.spec.FetchedColumns[i].Type, typeResolver); err != nil {
 			return nil, err
 		}
 	}
 	for i := range args.spec.KeyAndSuffixColumns {
-		if err := typedesc.EnsureTypeIsHydrated(ctx, args.spec.KeyAndSuffixColumns[i].Type, &resolver); err != nil {
+		if err := typedesc.EnsureTypeIsHydrated(ctx, args.spec.KeyAndSuffixColumns[i].Type, typeResolver); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -189,6 +190,7 @@ func NewColBatchScan(
 	spec *execinfrapb.TableReaderSpec,
 	post *execinfrapb.PostProcessSpec,
 	estimatedRowCount uint64,
+	typeResolver *descs.DistSQLTypeResolver,
 ) (*ColBatchScan, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); nodeID == 0 && ok {
@@ -212,7 +214,7 @@ func NewColBatchScan(
 	}
 
 	limitHint := rowinfra.RowLimit(execinfra.LimitHint(spec.LimitHint, post))
-	tableArgs, err := populateTableArgs(ctx, flowCtx, &spec.FetchSpec)
+	tableArgs, err := populateTableArgs(ctx, &spec.FetchSpec, typeResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/typeconv"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecspan"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
@@ -459,6 +460,7 @@ func NewColIndexJoin(
 	post *execinfrapb.PostProcessSpec,
 	inputTypes []*types.T,
 	diskMonitor *mon.BytesMonitor,
+	typeResolver *descs.DistSQLTypeResolver,
 ) (*ColIndexJoin, error) {
 	// NB: we hit this with a zero NodeID (but !ok) with multi-tenancy.
 	if nodeID, ok := flowCtx.NodeID.OptionalNodeID(); nodeID == 0 && ok {
@@ -474,7 +476,7 @@ func NewColIndexJoin(
 		return nil, errors.AssertionFailedf("non-empty ON expressions are not supported for index joins")
 	}
 
-	tableArgs, err := populateTableArgs(ctx, flowCtx, &spec.FetchSpec)
+	tableArgs, err := populateTableArgs(ctx, &spec.FetchSpec, typeResolver)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colflow/BUILD.bazel
+++ b/pkg/sql/colflow/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowexec",
+        "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/types",
         "//pkg/util",

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -1183,10 +1184,13 @@ func (s *vectorizedFlowCreator) setupFlow(
 				ExprHelper:           s.exprHelper,
 				Factory:              factory,
 				MonitorRegistry:      &s.monitorRegistry,
+				TypeResolver:         &s.typeResolver,
 			}
 			numOldMonitors := len(s.monitorRegistry.GetMonitors())
 			if args.ExprHelper.SemaCtx == nil {
-				args.ExprHelper.SemaCtx = flowCtx.NewSemaContext(flowCtx.Txn)
+				semaCtx := tree.MakeSemaContext()
+				semaCtx.TypeResolver = &s.typeResolver
+				args.ExprHelper.SemaCtx = &semaCtx
 			}
 			var result *colexecargs.NewColOperatorResult
 			result, err = colbuilder.NewColOperator(ctx, flowCtx, args)

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -112,7 +112,10 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	consumer := distsqlutils.NewRowBuffer(types.OneIntCol, nil /* rows */, distsqlutils.RowBufferArgs{})
 	connectionInfo := map[execinfrapb.StreamID]*flowinfra.InboundStreamInfo{
 		streamID: flowinfra.NewInboundStreamInfo(
-			flowinfra.RowInboundStreamHandler{RowReceiver: consumer},
+			flowinfra.RowInboundStreamHandler{
+				RowReceiver: consumer,
+				Types:       types.OneIntCol,
+			},
 			wg,
 		),
 	}

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/evalcatalog",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/rowenc",

--- a/pkg/sql/execinfra/utils.go
+++ b/pkg/sql/execinfra/utils.go
@@ -11,6 +11,11 @@
 package execinfra
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -31,4 +36,17 @@ func DecodeDatum(datumAlloc *tree.DatumAlloc, typ *types.T, data []byte) (tree.D
 			"%d trailing bytes in encoded value", errors.Safe(len(rem)))
 	}
 	return datum, nil
+}
+
+// HydrateTypesInDatumInfo hydrates all user-defined types in the provided
+// DatumInfo slice.
+func HydrateTypesInDatumInfo(
+	ctx context.Context, resolver *descs.DistSQLTypeResolver, info []execinfrapb.DatumInfo,
+) error {
+	for i := range info {
+		if err := typedesc.EnsureTypeIsHydrated(ctx, info[i].Type, resolver); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/sql/execinfra/version.go
+++ b/pkg/sql/execinfra/version.go
@@ -64,17 +64,20 @@ import "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 //
 // ATTENTION: When updating these fields, add a brief description of what
 // changed to the version history below.
-const Version execinfrapb.DistSQLVersion = 68
+const Version execinfrapb.DistSQLVersion = 69
 
 // MinAcceptedVersion is the oldest version that the server is compatible with.
 // A server will not accept flows with older versions.
-const MinAcceptedVersion execinfrapb.DistSQLVersion = 68
+const MinAcceptedVersion execinfrapb.DistSQLVersion = 69
 
 /*
 
 **  VERSION HISTORY **
 
 Please add new entries at the top.
+
+- Version: 69 (MinAcceptedVersion: 69)
+  - ProducerMessage no longer includes the typing information.
 
 - Version: 68 (MinAcceptedVersion: 68)
   - ZigzagJoinerSpec now uses descpb.IndexFetchSpec instead of table and

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -231,16 +231,17 @@ message ProducerData {
 message ProducerMessage {
   optional ProducerHeader header = 1;
 
-  // Typing information. There will be one DatumInfo for each element in a row.
-  // This field has to be populated on, or before, a ProducerMessage with data
-  // in it, and can only be populated once. It can be nil if only zero length
-  // rows will be sent.
-  // TODO(andrei): It'd be nice if the typing information for streams would be
-  // configured statically at plan creation time, instead of being discovered
-  // dynamically through the first rows that flow.
-  repeated DatumInfo typing = 2 [(gogoproto.nullable) = false];
-
   optional ProducerData data = 3 [(gogoproto.nullable) = false];
+
+  // Encoding information. There will be one DatumEncoding for each element in a
+  // row. This field has to be populated on, or before, a ProducerMessage with
+  // data in it, and can only be populated once. It can be nil if only zero
+  // length rows will be sent.
+  // TODO(yuzefovich): it should be possible to determine this information
+  // statically instead of passing in the first message.
+  repeated sqlbase.DatumEncoding encoding = 4 [(gogoproto.nullable) = false];
+
+  reserved 2;
 }
 
 // RemoteProducerMetadata represents records that a producer wants to pass to

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -218,7 +218,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
-		streamID1: {receiver: RowInboundStreamHandler{consumer}, onFinish: wg.Done},
+		streamID1: {receiver: RowInboundStreamHandler{consumer, nil /* types */}, onFinish: wg.Done},
 	}
 	if err := reg.RegisterFlow(
 		context.Background(), id1, f1, inboundStreams, jiffy,
@@ -317,7 +317,7 @@ func TestHandshake(t *testing.T) {
 				wg := &sync.WaitGroup{}
 				wg.Add(1)
 				inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
-					streamID: {receiver: RowInboundStreamHandler{consumer}, onFinish: wg.Done},
+					streamID: {receiver: RowInboundStreamHandler{consumer, nil /* types */}, onFinish: wg.Done},
 				}
 				if err := reg.RegisterFlow(
 					context.Background(), flowID, f1, inboundStreams, time.Hour, /* timeout */
@@ -525,7 +525,7 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 	rc.InitWithBufSizeAndNumSenders(types.OneIntCol, 1 /* chanBufSize */, 1 /* numSenders */)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver: RowInboundStreamHandler{rc},
+			receiver: RowInboundStreamHandler{rc, types.OneIntCol},
 			onFinish: wg.Done,
 		},
 	}
@@ -568,7 +568,7 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	wg.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver: RowInboundStreamHandler{rc},
+			receiver: RowInboundStreamHandler{rc, types.OneIntCol},
 			onFinish: wg.Done,
 		},
 	}
@@ -616,11 +616,11 @@ func TestFlowCancelPartiallyBlocked(t *testing.T) {
 	wgRight.Add(1)
 	inboundStreams := map[execinfrapb.StreamID]*InboundStreamInfo{
 		0: {
-			receiver: RowInboundStreamHandler{left},
+			receiver: RowInboundStreamHandler{left, nil /* types */},
 			onFinish: wgLeft.Done,
 		},
 		1: {
-			receiver: RowInboundStreamHandler{right},
+			receiver: RowInboundStreamHandler{right, nil /* types */},
 			onFinish: wgRight.Done,
 		},
 	}

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -141,6 +141,7 @@ func TestOutbox(t *testing.T) {
 
 	// Consume everything that the outbox sends on the stream.
 	var decoder flowinfra.StreamDecoder
+	decoder.Init(types.OneIntCol)
 	var rows rowenc.EncDatumRows
 	var metas []execinfrapb.ProducerMetadata
 	drainSignalSent := false

--- a/pkg/sql/flowinfra/stream_data_test.go
+++ b/pkg/sql/flowinfra/stream_data_test.go
@@ -62,6 +62,7 @@ func testRowStream(tb testing.TB, rng *rand.Rand, types []*types.T, records []ro
 	numMeta := 0
 
 	se.Init(types)
+	sd.Init(types)
 
 	for rowIdx := 0; rowIdx <= len(records); rowIdx++ {
 		if rowIdx < len(records) {
@@ -220,6 +221,7 @@ func BenchmarkStreamDecoder(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				var sd flowinfra.StreamDecoder
+				sd.Init(colTypes)
 				if err := sd.AddMessage(ctx, msg); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/sql/flowinfra/stream_decoder.go
+++ b/pkg/sql/flowinfra/stream_decoder.go
@@ -13,6 +13,7 @@ package flowinfra
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -43,14 +44,21 @@ import (
 // AddMessage can be called multiple times before getting the rows, but this
 // will cause data to accumulate internally.
 type StreamDecoder struct {
-	typing       []execinfrapb.DatumInfo
+	types []*types.T
+	// TODO(yuzefovich): move descpb.DatumEncoding into execinfrapb.
+	encoding     []descpb.DatumEncoding
 	data         []byte
 	numEmptyRows int
 	metadata     []execinfrapb.ProducerMetadata
 	rowAlloc     rowenc.EncDatumRowAlloc
 
-	headerReceived bool
-	typingReceived bool
+	headerReceived   bool
+	encodingReceived bool
+}
+
+// Init initializes the decoder.
+func (sd *StreamDecoder) Init(types []*types.T) {
+	sd.types = types
 }
 
 // AddMessage adds the data in a ProducerMessage to the decoder.
@@ -66,17 +74,17 @@ func (sd *StreamDecoder) AddMessage(ctx context.Context, msg *execinfrapb.Produc
 		}
 		sd.headerReceived = true
 	}
-	if msg.Typing != nil {
-		if sd.typingReceived {
-			return errors.Errorf("typing information received multiple times")
+	if msg.Encoding != nil {
+		if sd.encodingReceived {
+			return errors.Errorf("encoding information received multiple times")
 		}
-		sd.typingReceived = true
-		sd.typing = msg.Typing
+		sd.encodingReceived = true
+		sd.encoding = msg.Encoding
 	}
 
 	if len(msg.Data.RawBytes) > 0 {
-		if !sd.headerReceived || !sd.typingReceived {
-			return errors.Errorf("received data before header and/or typing info")
+		if !sd.headerReceived || !sd.encodingReceived {
+			return errors.Errorf("received data before header and/or encoding info")
 		}
 
 		if len(sd.data) == 0 {
@@ -136,7 +144,7 @@ func (sd *StreamDecoder) GetRow(
 	if len(sd.data) == 0 {
 		return nil, nil, nil
 	}
-	rowLen := len(sd.typing)
+	rowLen := len(sd.types)
 	if cap(rowBuf) >= rowLen {
 		rowBuf = rowBuf[:rowLen]
 	} else {
@@ -145,7 +153,7 @@ func (sd *StreamDecoder) GetRow(
 	for i := range rowBuf {
 		var err error
 		rowBuf[i], sd.data, err = rowenc.EncDatumFromBuffer(
-			sd.typing[i].Type, sd.typing[i].Encoding, sd.data,
+			sd.types[i], sd.encoding[i], sd.data,
 		)
 		if err != nil {
 			// Reset sd because it is no longer usable.
@@ -154,14 +162,4 @@ func (sd *StreamDecoder) GetRow(
 		}
 	}
 	return rowBuf, nil, nil
-}
-
-// Types returns the types of the columns; can only be used after we received at
-// least one row.
-func (sd *StreamDecoder) Types() []*types.T {
-	types := make([]*types.T, len(sd.typing))
-	for i := range types {
-		types[i] = sd.typing[i].Type
-	}
-	return types
 }

--- a/pkg/sql/flowinfra/stream_encoder.go
+++ b/pkg/sql/flowinfra/stream_encoder.go
@@ -41,9 +41,10 @@ const PreferredEncoding = descpb.DatumEncoding_ASCENDING_KEY
 //       ...
 //   }
 type StreamEncoder struct {
-	// infos is fully initialized when the first row is received.
-	infos            []execinfrapb.DatumInfo
-	infosInitialized bool
+	types []*types.T
+	// encodings is fully initialized when the first row is received.
+	encodings            []descpb.DatumEncoding
+	encodingsInitialized bool
 
 	rowBuf       []byte
 	numEmptyRows int
@@ -52,10 +53,10 @@ type StreamEncoder struct {
 	// headerSent is set after the first message (which contains the header) has
 	// been sent.
 	headerSent bool
-	// typingSent is set after the first message that contains any rows has been
-	// sent.
-	typingSent bool
-	alloc      tree.DatumAlloc
+	// encodingSent is set after the first message that contains any rows has
+	// been sent.
+	encodingSent bool
+	alloc        tree.DatumAlloc
 
 	// Preallocated structures to avoid allocations.
 	msg    execinfrapb.ProducerMessage
@@ -75,10 +76,8 @@ func (se *StreamEncoder) SetHeaderFields(flowID execinfrapb.FlowID, streamID exe
 
 // Init initializes the encoder.
 func (se *StreamEncoder) Init(types []*types.T) {
-	se.infos = make([]execinfrapb.DatumInfo, len(types))
-	for i := range types {
-		se.infos[i].Type = types[i]
-	}
+	se.types = types
+	se.encodings = make([]descpb.DatumEncoding, len(types))
 }
 
 // AddMetadata encodes a metadata message. Unlike AddRow(), it cannot fail. This
@@ -95,28 +94,28 @@ func (se *StreamEncoder) AddMetadata(ctx context.Context, meta execinfrapb.Produ
 
 // AddRow encodes a message.
 func (se *StreamEncoder) AddRow(row rowenc.EncDatumRow) error {
-	if se.infos == nil {
+	if se.encodings == nil {
 		panic("Init not called")
 	}
-	if len(se.infos) != len(row) {
-		return errors.Errorf("inconsistent row length: expected %d, got %d", len(se.infos), len(row))
+	if len(se.encodings) != len(row) {
+		return errors.Errorf("inconsistent row length: expected %d, got %d", len(se.encodings), len(row))
 	}
-	if !se.infosInitialized {
+	if !se.encodingsInitialized {
 		// First row. Initialize encodings.
 		for i := range row {
 			enc, ok := row[i].Encoding()
 			if !ok {
 				enc = PreferredEncoding
 			}
-			sType := se.infos[i].Type
+			sType := se.types[i]
 			if enc != descpb.DatumEncoding_VALUE &&
 				(colinfo.CanHaveCompositeKeyEncoding(sType) || colinfo.MustBeValueEncoded(sType)) {
 				// Force VALUE encoding for composite types (key encodings may lose data).
 				enc = descpb.DatumEncoding_VALUE
 			}
-			se.infos[i].Encoding = enc
+			se.encodings[i] = enc
 		}
-		se.infosInitialized = true
+		se.encodingsInitialized = true
 	}
 	if len(row) == 0 {
 		se.numEmptyRows++
@@ -124,7 +123,7 @@ func (se *StreamEncoder) AddRow(row rowenc.EncDatumRow) error {
 	}
 	for i := range row {
 		var err error
-		se.rowBuf, err = row[i].Encode(se.infos[i].Type, &se.alloc, se.infos[i].Encoding, se.rowBuf)
+		se.rowBuf, err = row[i].Encode(se.types[i], &se.alloc, se.encodings[i], se.rowBuf)
 		if err != nil {
 			return err
 		}
@@ -147,13 +146,13 @@ func (se *StreamEncoder) FormMessage(ctx context.Context) *execinfrapb.ProducerM
 		msg.Header = &se.msgHdr
 		se.headerSent = true
 	}
-	if !se.typingSent {
-		if se.infosInitialized {
-			msg.Typing = se.infos
-			se.typingSent = true
+	if !se.encodingSent {
+		if se.encodingsInitialized {
+			msg.Encoding = se.encodings
+			se.encodingSent = true
 		}
 	} else {
-		msg.Typing = nil
+		msg.Encoding = nil
 	}
 
 	se.rowBuf = se.rowBuf[:0]

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -342,7 +342,11 @@ func newZigzagJoiner(
 			// the spec itself.
 			z.infos[i].fixedValues = fixedValues[i]
 		} else {
-			z.infos[i].fixedValues, err = valuesSpecToEncDatum(&spec.Sides[i].FixedValues)
+			fv := &spec.Sides[i].FixedValues
+			if err = execinfra.HydrateTypesInDatumInfo(flowCtx.EvalCtx.Ctx(), &resolver, fv.Columns); err != nil {
+				return nil, err
+			}
+			z.infos[i].fixedValues, err = valuesSpecToEncDatum(fv)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**flowinfra: fix type hydration for row-based inbound streams**

This commit fixes the usage of unhydrated types in the inbound streams
of the row-based flows which could only occur with high verbosity on
`inbound` file. This is achieved by no longer propagating the unhydrated
types through the wire as part of the first `ProducerMessage` and,
instead, using the types that are hydrated when setting up the input
synchronizers. As a result, `ProducerMessage` is changed slightly which
required the bump to the DistSQL version.

Fixes: #86079.

Release justification: bug fix.

Release note: None

**sql: hydrate types in some edge cases**

This commit fixes a couple of bugs in the edge cases where we forgot to
hydrate the types that could be received over the wire. These spots are:
- when setting up a values operator in the vectorized engine (this case
is correctly handled in the row-by-row engine)
- when using the fixed values of the zigzag joiner.

Additionally, this commit removes some of the allocations in order to
reuse the same type resolver in the vectorized flow setup.

Release justification: bug fix.

Release note: None