### PR TITLE
docker: fix the test

### DIFF
--- a/build/teamcity/cockroach/ci/tests/docker_image.sh
+++ b/build/teamcity/cockroach/ci/tests/docker_image.sh
@@ -10,9 +10,9 @@ tc_prepare
 tc_start_block "Run docker image tests"
 
 # Skip for now: #82747
-#bazel run \
-#  //pkg/testutils/docker:docker_test \
-#  --config=crosslinux --config=test \
-#  --test_timeout=3000
+bazel run \
+  //pkg/testutils/docker:docker_test \
+  --config=crosslinux --config=test \
+  --test_timeout=3000
 
 tc_end_block "Run docker image tests"

--- a/pkg/testutils/docker/single_node_docker_test.go
+++ b/pkg/testutils/docker/single_node_docker_test.go
@@ -40,8 +40,6 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
-const fsnotifyBinName = "docker-fsnotify-bin"
-
 // sqlQuery consists of a sql query and the expected result.
 type sqlQuery struct {
 	query          string
@@ -79,7 +77,7 @@ func TestSingleNodeDocker(t *testing.T) {
 		t.Fatal(errors.NewAssertionErrorWithWrappedErrf(err, "cannot get pwd"))
 	}
 
-	fsnotifyPath := filepath.Join(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(filepath.Dir(pwd)))))), "docker-fsnotify")
+	fsnotifyBinPath := filepath.Join(pwd, "docker-fsnotify/docker-fsnotify-bin")
 
 	var dockerTests = []singleNodeDockerTest{
 		{
@@ -93,7 +91,7 @@ func TestSingleNodeDocker(t *testing.T) {
 				},
 				volSetting: []string{
 					fmt.Sprintf("%s/testdata/single-node-test/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d", pwd),
-					fmt.Sprintf("%s/docker-fsnotify-bin:/cockroach/docker-fsnotify", fsnotifyPath),
+					fmt.Sprintf("%s:/cockroach/docker-fsnotify", fsnotifyBinPath),
 				},
 				cmd: []string{"start-single-node", "--certs-dir=certs"},
 			},
@@ -119,7 +117,7 @@ func TestSingleNodeDocker(t *testing.T) {
 				},
 				volSetting: []string{
 					fmt.Sprintf("%s/testdata/single-node-test/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d", pwd),
-					fmt.Sprintf("%s/docker-fsnotify-bin:/cockroach/docker-fsnotify", fsnotifyPath),
+					fmt.Sprintf("%s:/cockroach/docker-fsnotify", fsnotifyBinPath),
 				},
 				cmd: []string{"start-single-node", "--insecure"},
 			},
@@ -146,7 +144,7 @@ func TestSingleNodeDocker(t *testing.T) {
 				},
 				volSetting: []string{
 					fmt.Sprintf("%s/testdata/single-node-test/docker-entrypoint-initdb.d/:/docker-entrypoint-initdb.d", pwd),
-					fmt.Sprintf("%s/docker-fsnotify-bin:/cockroach/docker-fsnotify", fsnotifyPath),
+					fmt.Sprintf("%s:/cockroach/docker-fsnotify", fsnotifyBinPath),
 				},
 				cmd: []string{"start-single-node", "--insecure", "--store=type=mem,size=0.25"},
 			},


### PR DESCRIPTION
fixes #82747 

We now update the path of the fsnotify binary to mount on the docker.

Release justification: bug fix
Release note: none