### PR TITLE
testccl/sqlccl: deflake TestTenantTempTableCleanup

### DIFF
--- a/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
+++ b/pkg/ccl/testccl/sqlccl/temp_table_clean_test.go
@@ -142,7 +142,7 @@ func TestTenantTempTableCleanup(t *testing.T) {
 	// two clean up cycles just in case, so that we have
 	// stable timing.
 	waitForCleanup()
-	tenantSQL.CheckQueryResults(t, "SELECT table_name FROM [SHOW TABLES]",
+	tenantSQL.CheckQueryResultsRetry(t, "SELECT table_name FROM [SHOW TABLES]",
 		[][]string{
 			{"temp_table"},
 		})


### PR DESCRIPTION
Fixes #85657

I don't know why we miss this, I guess it has something to do
with not detecting the session is dead on time. A retry works just
fine.

Release justification: testing only change

Release note: None