### PR TITLE
sql: fix temporary schema cleaner to use transaction correctly

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -29,8 +29,6 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
-        "//pkg/sql/sqlutil",
         "//pkg/storage",
         "//pkg/util",
         "//pkg/util/contextutil",

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -29,8 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -92,7 +90,6 @@ func New(
 		settings:          cfg.Settings,
 		targets:           targets,
 		leaseMgr:          cfg.LeaseManager.(*lease.Manager),
-		ie:                cfg.InternalExecutorFactory.NewInternalExecutor(&sessiondata.SessionData{}),
 		collectionFactory: cfg.CollectionFactory,
 		metrics:           metrics,
 		tolerances:        tolerances,
@@ -119,7 +116,6 @@ type schemaFeed struct {
 	clock      *hlc.Clock
 	settings   *cluster.Settings
 	targets    changefeedbase.Targets
-	ie         sqlutil.InternalExecutor
 	metrics    *Metrics
 	tolerances changefeedbase.CanHandle
 
@@ -295,9 +291,7 @@ func (tf *schemaFeed) primeInitialTableDescs(ctx context.Context) error {
 		})
 	}
 
-	if err := tf.collectionFactory.Txn(
-		ctx, tf.ie, tf.db, initialTableDescsFn,
-	); err != nil {
+	if err := tf.collectionFactory.Txn(ctx, tf.db, initialTableDescsFn); err != nil {
 		return err
 	}
 

--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -710,7 +710,7 @@ func TestDBDecommissionedOperations(t *testing.T) {
 	}
 }
 
-// TestGenerateForcedRetryableError verifies that GenerateForcedRetryableError
+// TestGenerateForcedRetryableError verifies that GenerateRetryableAbortedError
 // returns an error with a transaction that had the epoch bumped (and not epoch 0).
 func TestGenerateForcedRetryableError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -720,7 +720,7 @@ func TestGenerateForcedRetryableError(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	txn := db.NewTxn(ctx, "test: TestGenerateForcedRetryableError")
 	require.Equal(t, 0, int(txn.Epoch()))
-	err := txn.GenerateForcedRetryableError(ctx, "testing TestGenerateForcedRetryableError")
+	err := txn.GenerateRetryableAbortedError(ctx, "testing TestGenerateForcedRetryableError")
 	var retryErr *roachpb.TransactionRetryWithProtoRefreshError
 	require.True(t, errors.As(err, &retryErr))
 	require.Equal(t, 1, int(retryErr.Transaction.Epoch))

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
@@ -100,7 +100,7 @@ func TestSavepoints(t *testing.T) {
 
 			case "retry":
 				epochBefore := txn.Epoch()
-				retryErr := txn.GenerateForcedRetryableError(ctx, "forced retry")
+				retryErr := txn.GenerateRetryableAbortedError(ctx, "forced retry")
 				epochAfter := txn.Epoch()
 				fmt.Fprintf(&buf, "synthetic error: %v\n", retryErr)
 				fmt.Fprintf(&buf, "epoch: %d -> %d\n", epochBefore, epochAfter)

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -179,7 +179,8 @@ func (m *MockTransactionalSender) DisablePipelining() error { return nil }
 
 // PrepareRetryableError is part of the client.TxnSender interface.
 func (m *MockTransactionalSender) PrepareRetryableError(ctx context.Context, msg string) error {
-	return roachpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
+	retryErr := roachpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
+	return retryErr
 }
 
 // Step is part of the TxnSender interface.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -254,7 +254,9 @@ type TxnSender interface {
 
 	// PrepareRetryableError generates a
 	// TransactionRetryWithProtoRefreshError with a payload initialized
-	// from this txn.
+	// from this txn. The method also moves the transaction into the
+	// txnRestart state, forcing the client to handle the error before
+	// being able to use the transaction again.
 	PrepareRetryableError(ctx context.Context, msg string) error
 
 	// TestingCloneTxn returns a clone of the transaction's current

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1454,12 +1454,12 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 	return txn.mu.sender.SetFixedTimestamp(ctx, ts)
 }
 
-// GenerateForcedRetryableError returns a TransactionRetryWithProtoRefreshError that will
+// GenerateRetryableAbortedError returns a TransactionRetryWithProtoRefreshError that will
 // cause the txn to be aborted and retried.
 //
 // The transaction's epoch is bumped, simulating to an extent what the
 // TxnCoordSender does on aborted errors.
-func (txn *Txn) GenerateForcedRetryableError(ctx context.Context, msg string) error {
+func (txn *Txn) GenerateRetryableAbortedError(ctx context.Context, msg string) error {
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	txn.resetDeadlineLocked()

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1449,8 +1449,9 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 // cause the txn to be retried.
 //
 // The transaction's epoch is bumped, simulating to an extent what the
-// TxnCoordSender does on retriable errors. The transaction's timestamp is only
-// bumped to the extent that txn.ReadTimestamp is racheted up to txn.WriteTimestamp.
+// TxnCoordSender does on retriable errors. The transaction's timestamp is
+// bumped to the current clock timestamp.
+//
 // TODO(andrei): This method should take in an up-to-date timestamp, but
 // unfortunately its callers don't currently have that handy.
 func (txn *Txn) GenerateForcedRetryableError(ctx context.Context, msg string) error {

--- a/pkg/kv/txn_external_test.go
+++ b/pkg/kv/txn_external_test.go
@@ -84,13 +84,11 @@ func TestGenerateForcedRetryableErrorInTxn(t *testing.T) {
 		// not cleaning up the first time to make sure the transaction's writes
 		// are no longer visible.
 		if i++; i < 3 {
+			retryErr := txn.GenerateRetryableAbortedError(ctx, "force retry")
 			if i == 1 {
-				if err := txn.Rollback(ctx); err != nil {
-					return err
-				}
+				txn.CleanupOnError(ctx, retryErr)
 			}
-
-			return txn.GenerateForcedRetryableError(ctx, "force retry")
+			return retryErr
 		}
 		return txn.Put(ctx, mkKey("b"), 2)
 	}))

--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -360,13 +361,27 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 	// runner is the function that will execute all the statements as a group.
 	// If there's just one statement, we execute them with an implicit,
 	// auto-commit transaction.
-	runner := func(ctx context.Context, fn func(context.Context, *kv.Txn) error) error { return fn(ctx, nil) }
+
+	type (
+		txnFunc    = func(context.Context, *kv.Txn, sqlutil.InternalExecutor) error
+		runnerFunc = func(ctx context.Context, fn txnFunc) error
+	)
+	var runner runnerFunc
 	if len(requestPayload.Statements) > 1 {
 		// We need a transaction to group the statements together.
 		// We use TxnWithSteppingEnabled here even though we don't
 		// use stepping below, because that buys us admission control.
-		runner = func(ctx context.Context, fn func(context.Context, *kv.Txn) error) error {
-			return a.admin.server.db.TxnWithSteppingEnabled(ctx, sessiondatapb.Normal, fn)
+		cf := a.admin.server.sqlServer.execCfg.CollectionFactory
+		runner = func(ctx context.Context, fn txnFunc) error {
+			return cf.TxnWithExecutor(ctx, a.admin.server.db, nil, func(
+				ctx context.Context, txn *kv.Txn, _ *descs.Collection, ie sqlutil.InternalExecutor,
+			) error {
+				return fn(ctx, txn, ie)
+			})
+		}
+	} else {
+		runner = func(ctx context.Context, fn func(context.Context, *kv.Txn, sqlutil.InternalExecutor) error) error {
+			return fn(ctx, nil, a.admin.ie)
 		}
 	}
 
@@ -376,7 +391,7 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 	err = contextutil.RunWithTimeout(ctx, "run-sql-via-api", timeout, func(ctx context.Context) error {
 		retryNum := 0
 
-		return runner(ctx, func(ctx context.Context, txn *kv.Txn) error {
+		return runner(ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
 			result.Execution.TxnResults = result.Execution.TxnResults[:0]
 			result.Execution.Retries = retryNum
 			retryNum++
@@ -413,7 +428,7 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 						}
 					}()
 
-					it, err := a.admin.ie.QueryIteratorEx(ctx, "run-query-via-api", txn,
+					it, err := ie.QueryIteratorEx(ctx, "run-query-via-api", txn,
 						sessiondata.InternalExecutorOverride{
 							User:            username,
 							Database:        requestPayload.Database,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -829,7 +829,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		GCJobNotifier:              gcJobNotifier,
 		RangeFeedFactory:           cfg.rangeFeedFactory,
 		CollectionFactory:          collectionFactory,
-		SystemTableIDResolver:      descs.MakeSystemTableIDResolver(collectionFactory, cfg.circularInternalExecutor, cfg.db),
+		SystemTableIDResolver:      descs.MakeSystemTableIDResolver(collectionFactory, cfg.db),
 		ConsistencyChecker:         consistencychecker.NewConsistencyChecker(cfg.db),
 		RangeProber:                rangeprober.NewRangeProber(cfg.db),
 		DescIDGenerator:            descidgen.NewGenerator(codec, cfg.db),

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2367,16 +2367,16 @@ func (s *statusServer) HotRangesV2(
 	rangeReportMetas := make(map[uint32]hotRangeReportMeta)
 	var descrs []catalog.Descriptor
 	var err error
-	if err := s.sqlServer.distSQLServer.CollectionFactory.Txn(
-		ctx, s.sqlServer.internalExecutor, s.db,
-		func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
-			all, err := descriptors.GetAllDescriptors(ctx, txn)
-			if err != nil {
-				return err
-			}
-			descrs = all.OrderedDescriptors()
-			return nil
-		}); err != nil {
+	if err := s.sqlServer.distSQLServer.CollectionFactory.Txn(ctx, s.db, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+	) error {
+		all, err := descriptors.GetAllDescriptors(ctx, txn)
+		if err != nil {
+			return err
+		}
+		descrs = all.OrderedDescriptors()
+		return nil
+	}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -271,3 +271,186 @@ sql admin expect-error
 }
 ----
 XXUUU|parsing statement 1: expected 1 placeholder(s), got 2
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [{"sql": "CREATE TABLE foo (i INT PRIMARY KEY, j INT UNIQUE)"}]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "CREATE TABLE"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "ALTER TABLE foo RENAME TO bar"},
+    {"sql": "INSERT INTO bar (i) VALUES (1), (2)"},
+    {"sql": "ALTER TABLE bar DROP COLUMN j"},
+    {"sql": "ALTER TABLE bar ADD COLUMN k INT DEFAULT 42"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "ALTER TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 2,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 2,
+    "tag": "INSERT"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 3,
+    "tag": "ALTER TABLE"
+   },
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 4,
+    "tag": "ALTER TABLE"
+   }
+  ]
+ },
+ "num_statements": 4
+}
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "SELECT * FROM bar"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "i",
+      "oid": 20,
+      "type": "INT8"
+     },
+     {
+      "name": "k",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows": [
+     {
+      "i": 1,
+      "k": 42
+     },
+     {
+      "i": 2,
+      "k": 42
+     }
+    ],
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "SELECT"
+   }
+  ]
+ },
+ "num_statements": 1
+}
+
+
+sql admin
+{
+  "database": "mydb",
+  "execute": true,
+  "statements": [
+    {"sql": "DROP TABLE bar"}
+  ]
+}
+----
+{
+ "execution": {
+  "txn_results": [
+   {
+    "columns": [
+     {
+      "name": "rows_affected",
+      "oid": 20,
+      "type": "INT8"
+     }
+    ],
+    "end": "1970-01-01T00:00:00Z",
+    "rows_affected": 0,
+    "start": "1970-01-01T00:00:00Z",
+    "statement": 1,
+    "tag": "DROP TABLE"
+   }
+  ]
+ },
+ "num_statements": 1
+}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -203,7 +203,9 @@ func (sc *SchemaChanger) fixedTimestampTxnWithExecutor(
 	) error,
 ) error {
 	sd := NewFakeSessionData(sc.execCfg.SV())
-	return sc.txnWithExecutor(ctx, sd, func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor) error {
+	return sc.txnWithExecutor(ctx, sd, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor,
+	) error {
 		if err := txn.SetFixedTimestamp(ctx, readAsOf); err != nil {
 			return err
 		}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -438,6 +438,13 @@ func (tc *Collection) SetSession(session sqlliveness.Session) {
 	tc.sqlLivenessSession = session
 }
 
+// SetTemporarySchema is used to set the temporary schema provider for the
+// collection. This is a low-level operation exposed only for use in the
+// temporary schema cleaner.
+func (tc *Collection) SetTemporarySchema(provider TemporarySchemaProvider) {
+	tc.temporary = makeTemporaryDescriptors(tc.settings, tc.codec(), provider)
+}
+
 // MakeTestCollection makes a Collection that can be used for tests.
 func MakeTestCollection(ctx context.Context, leaseManager *lease.Manager) Collection {
 	settings := cluster.MakeTestingClusterSettings()

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -50,6 +50,8 @@ type InternalExecutorFactoryWithTxn interface {
 		txn *kv.Txn,
 		descCol *Collection,
 	) (sqlutil.InternalExecutor, sqlutil.InternalExecutorCommitTxnFunc)
+
+	Monitor() *mon.BytesMonitor
 }
 
 // NewCollectionFactory constructs a new CollectionFactory which holds onto

--- a/pkg/sql/catalog/descs/system_table.go
+++ b/pkg/sql/catalog/descs/system_table.go
@@ -17,13 +17,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 )
 
 // systemTableIDResolver is the implementation for catalog.SystemTableIDResolver.
 type systemTableIDResolver struct {
 	collectionFactory *CollectionFactory
-	ie                sqlutil.InternalExecutor
 	db                *kv.DB
 }
 
@@ -31,11 +29,10 @@ var _ catalog.SystemTableIDResolver = (*systemTableIDResolver)(nil)
 
 // MakeSystemTableIDResolver creates an object that implements catalog.SystemTableIDResolver.
 func MakeSystemTableIDResolver(
-	collectionFactory *CollectionFactory, ie sqlutil.InternalExecutor, db *kv.DB,
+	collectionFactory *CollectionFactory, db *kv.DB,
 ) catalog.SystemTableIDResolver {
 	return &systemTableIDResolver{
 		collectionFactory: collectionFactory,
-		ie:                ie,
 		db:                db,
 	}
 }
@@ -46,7 +43,7 @@ func (r *systemTableIDResolver) LookupSystemTableID(
 ) (descpb.ID, error) {
 
 	var id descpb.ID
-	if err := r.collectionFactory.Txn(ctx, r.ie, r.db, func(
+	if err := r.collectionFactory.Txn(ctx, r.db, func(
 		ctx context.Context, txn *kv.Txn, descriptors *Collection,
 	) (err error) {
 		id, err = descriptors.stored.lookupName(

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -54,6 +54,15 @@ func (cf *CollectionFactory) Txn(
 	})
 }
 
+// TxnWithExecutorFunc is used to run a transaction in the context of a
+// Collection and an InternalExecutor.
+type TxnWithExecutorFunc = func(
+	ctx context.Context,
+	txn *kv.Txn,
+	descriptors *Collection,
+	ie sqlutil.InternalExecutor,
+) error
+
 // TxnWithExecutor enables callers to run transactions with a *Collection such that all
 // retrieved immutable descriptors are properly leased and all mutable
 // descriptors are handled. The function deals with verifying the two version
@@ -66,10 +75,7 @@ func (cf *CollectionFactory) Txn(
 // The passed transaction is pre-emptively anchored to the system config key on
 // the system tenant.
 func (cf *CollectionFactory) TxnWithExecutor(
-	ctx context.Context,
-	db *kv.DB,
-	sd *sessiondata.SessionData,
-	f func(ctx context.Context, txn *kv.Txn, descriptors *Collection, ie sqlutil.InternalExecutor) error,
+	ctx context.Context, db *kv.DB, sd *sessiondata.SessionData, f TxnWithExecutorFunc,
 ) error {
 	// Waits for descriptors that were modified, skipping
 	// over ones that had their descriptor wiped.

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -227,7 +227,7 @@ func CheckTwoVersionInvariant(
 			onRetryBackoff()
 		}
 	}
-	return true, txn.GenerateForcedRetryableError(ctx,
+	return true, txn.GenerateRetryableAbortedError(ctx,
 		fmt.Sprintf(
 			`cannot publish new versions for descriptors: %v, old versions still in use`,
 			descs))

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1095,17 +1095,12 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 
 	ex.resetExtraTxnState(ctx, txnEvent{eventType: txnEvType})
 	if ex.hasCreatedTemporarySchema && !ex.server.cfg.TestingKnobs.DisableTempObjectsCleanupOnSessionExit {
-		ieMon := MakeInternalExecutorMemMonitor(MemoryMetrics{}, ex.server.cfg.Settings)
-		ieMon.StartNoReserved(ctx, ex.server.GetBytesMonitor())
-		defer ieMon.Stop(ctx)
-		ie := MakeInternalExecutor(ex.server, MemoryMetrics{}, ieMon)
 		err := cleanupSessionTempObjects(
 			ctx,
 			ex.server.cfg.Settings,
 			ex.server.cfg.CollectionFactory,
 			ex.server.cfg.DB,
 			ex.server.cfg.Codec,
-			&ie,
 			ex.sessionID,
 		)
 		if err != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -986,6 +986,7 @@ func (s *Server) newConnExecutor(
 	}
 	ex.extraTxnState.prepStmtsNamespaceMemAcc = ex.sessionMon.MakeBoundAccount()
 	ex.extraTxnState.descCollection = s.cfg.CollectionFactory.NewCollection(ctx, descs.NewTemporarySchemaProvider(sdMutIterator.sds), ex.sessionMon)
+	ex.extraTxnState.jobs = new(jobsCollection)
 	ex.extraTxnState.txnRewindPos = -1
 	ex.extraTxnState.schemaChangeJobRecords = make(map[descpb.ID]*jobs.Record)
 	ex.extraTxnState.schemaChangerState = &SchemaChangerState{
@@ -1238,7 +1239,7 @@ type connExecutor struct {
 		// job. The jobs are staged via the function QueueJob in
 		// pkg/sql/planner.go. The staged jobs are executed once the transaction
 		// that staged them commits.
-		jobs jobsCollection
+		jobs *jobsCollection
 
 		// schemaChangeJobRecords is a map of descriptor IDs to job Records.
 		// Used in createOrUpdateSchemaChangeJob so we can check if a job has been
@@ -1651,7 +1652,7 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent) {
 		for k := range ex.extraTxnState.schemaChangeJobRecords {
 			delete(ex.extraTxnState.schemaChangeJobRecords, k)
 		}
-		ex.extraTxnState.jobs = nil
+		ex.extraTxnState.jobs.reset()
 		ex.extraTxnState.schemaChangerState = &SchemaChangerState{
 			mode: ex.sessionData().NewSchemaChangerMode,
 		}
@@ -2702,7 +2703,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		MemMetrics:             &ex.memMetrics,
 		Descs:                  ex.extraTxnState.descCollection,
 		TxnModesSetter:         ex,
-		Jobs:                   &ex.extraTxnState.jobs,
+		Jobs:                   ex.extraTxnState.jobs,
 		SchemaChangeJobRecords: ex.extraTxnState.schemaChangeJobRecords,
 		statsProvider:          ex.server.sqlStats,
 		indexUsageStats:        ex.indexUsageStats,
@@ -2972,7 +2973,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		if err := ex.server.cfg.JobRegistry.Run(
 			ex.ctxHolder.connCtx,
 			ex.server.cfg.InternalExecutor,
-			ex.extraTxnState.jobs,
+			*ex.extraTxnState.jobs,
 		); err != nil {
 			handleErr(err)
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -714,9 +714,8 @@ func (ex *connExecutor) execStmtInOpenState(
 				IsCommit:     fsm.FromBool(isCommit(ast)),
 				CanAutoRetry: fsm.FromBool(canAutoRetry),
 			}
-			txn.ManualRestart(ctx, ex.server.cfg.Clock.Now())
 			payload := eventRetriableErrPayload{
-				err:    txn.PrepareRetryableError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
+				err:    txn.GenerateForcedRetryableError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
 				rewCap: rc,
 			}
 			return ev, payload, nil

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -715,7 +715,7 @@ func (ex *connExecutor) execStmtInOpenState(
 				CanAutoRetry: fsm.FromBool(canAutoRetry),
 			}
 			payload := eventRetriableErrPayload{
-				err:    txn.GenerateForcedRetryableError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
+				err:    txn.GenerateRetryableAbortedError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
 				rewCap: rc,
 			}
 			return ev, payload, nil
@@ -1162,7 +1162,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		if ex.sessionData().InjectRetryErrorsEnabled && !isSetOrShow &&
 			planner.Txn().Sender().TxnStatus() == roachpb.PENDING {
 			if planner.Txn().Epoch() < ex.state.lastEpoch+numTxnRetryErrors {
-				retryErr := planner.Txn().GenerateForcedRetryableError(
+				retryErr := planner.Txn().GenerateRetryableAbortedError(
 					ctx, "injected by `inject_retry_errors_enabled` session variable")
 				res.SetError(retryErr)
 			} else {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3438,7 +3438,7 @@ func DescsTxn(
 	execCfg *ExecutorConfig,
 	f func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error,
 ) error {
-	return execCfg.CollectionFactory.Txn(ctx, execCfg.InternalExecutor, execCfg.DB, f)
+	return execCfg.CollectionFactory.Txn(ctx, execCfg.DB, f)
 }
 
 // TestingDescsTxn is a convenience function for running a transaction on

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2144,6 +2144,10 @@ func (jc *jobsCollection) add(ids ...jobspb.JobID) {
 	*jc = append(*jc, ids...)
 }
 
+func (jc *jobsCollection) reset() {
+	*jc = nil
+}
+
 // truncateStatementStringForTelemetry truncates the string
 // representation of a statement to a maximum length, so as to not
 // create unduly large logging and error payloads.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1286,3 +1286,8 @@ func (ief *InternalExecutorFactory) RunWithoutTxn(
 	ie := ief.NewInternalExecutor(nil /* sessionData */)
 	return run(ctx, ie)
 }
+
+// Monitor returns the BytesMonitor for use with the constructed InternalExecutor.
+func (ief *InternalExecutorFactory) Monitor() *mon.BytesMonitor {
+	return ief.monitor
+}

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -12,6 +12,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -115,10 +116,10 @@ func (p *planner) waitForDescriptorSchemaChanges(
 
 	// Drop all leases and locks due to the current transaction, and, in the
 	// process, abort the transaction.
+	retryErr := p.txn.GenerateRetryableAbortedError(ctx,
+		fmt.Sprintf("schema change waiting for concurrent schema changes on descriptor %d", descID))
+	p.txn.CleanupOnError(ctx, retryErr)
 	p.Descriptors().ReleaseAll(ctx)
-	if err := p.txn.Rollback(ctx); err != nil {
-		return err
-	}
 
 	// Wait for the descriptor to no longer be claimed by a schema change.
 	start := timeutil.Now()

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -132,23 +132,23 @@ func (p *planner) waitForDescriptorSchemaChanges(
 			)
 		}
 		blocked := false
-		if err := p.ExecCfg().CollectionFactory.Txn(
-			ctx, p.ExecCfg().InternalExecutor, p.ExecCfg().DB,
-			func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error {
-				if err := txn.SetFixedTimestamp(ctx, now); err != nil {
-					return err
-				}
-				desc, err := descriptors.GetImmutableDescriptorByID(ctx, txn, descID,
-					tree.CommonLookupFlags{
-						Required:    true,
-						AvoidLeased: true,
-					})
-				if err != nil {
-					return err
-				}
-				blocked = desc.HasConcurrentSchemaChanges()
-				return nil
-			}); err != nil {
+		if err := p.ExecCfg().CollectionFactory.Txn(ctx, p.ExecCfg().DB, func(
+			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
+		) error {
+			if err := txn.SetFixedTimestamp(ctx, now); err != nil {
+				return err
+			}
+			desc, err := descriptors.GetImmutableDescriptorByID(ctx, txn, descID,
+				tree.CommonLookupFlags{
+					Required:    true,
+					AvoidLeased: true,
+				})
+			if err != nil {
+				return err
+			}
+			blocked = desc.HasConcurrentSchemaChanges()
+			return nil
+		}); err != nil {
 			return err
 		}
 		if !blocked {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1354,7 +1354,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 	var didUpdate bool
 	var depMutationJobs []jobspb.JobID
 	var otherJobIDs []jobspb.JobID
-	err := sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutor, sc.db, func(
+	err := sc.execCfg.CollectionFactory.Txn(ctx, sc.db, func(
 		ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
 	) error {
 		depMutationJobs = depMutationJobs[:0]
@@ -2474,7 +2474,7 @@ func (sc *SchemaChanger) txn(
 			return err
 		}
 	}
-	return sc.execCfg.CollectionFactory.Txn(ctx, sc.execCfg.InternalExecutor, sc.db, f)
+	return sc.execCfg.CollectionFactory.Txn(ctx, sc.db, f)
 }
 
 // txnWithExecutor is to run internal executor within a txn.

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -88,7 +88,6 @@ go_test(
         "//pkg/sql/sem/catid",  # keep
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/schemachanger/scexec/executor_external_test.go
+++ b/pkg/sql/schemachanger/scexec/executor_external_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
@@ -52,7 +51,6 @@ import (
 type testInfra struct {
 	tc       *testcluster.TestCluster
 	settings *cluster.Settings
-	ie       sqlutil.InternalExecutor
 	db       *kv.DB
 	lm       *lease.Manager
 	tsql     *sqlutils.SQLRunner
@@ -93,7 +91,6 @@ func setupTestInfra(t testing.TB) *testInfra {
 	return &testInfra{
 		tc:       tc,
 		settings: tc.Server(0).ClusterSettings(),
-		ie:       tc.Server(0).InternalExecutor().(sqlutil.InternalExecutor),
 		db:       tc.Server(0).DB(),
 		lm:       tc.Server(0).LeaseManager().(*lease.Manager),
 		cf:       tc.Server(0).ExecutorConfig().(sql.ExecutorConfig).CollectionFactory,
@@ -105,7 +102,7 @@ func (ti *testInfra) txn(
 	ctx context.Context,
 	f func(ctx context.Context, txn *kv.Txn, descriptors *descs.Collection) error,
 ) error {
-	return ti.cf.Txn(ctx, ti.ie, ti.db, f)
+	return ti.cf.Txn(ctx, ti.db, f)
 }
 
 func TestExecutorDescriptorMutationOps(t *testing.T) {

--- a/pkg/sql/schemachanger/scjob/job.go
+++ b/pkg/sql/schemachanger/scjob/job.go
@@ -70,7 +70,6 @@ func (n *newSchemaChangeResumer) run(ctx context.Context, execCtxI interface{}) 
 	deps := scdeps.NewJobRunDependencies(
 		execCfg.CollectionFactory,
 		execCfg.DB,
-		execCfg.InternalExecutor,
 		execCfg.IndexBackfiller,
 		execCfg.IndexMerger,
 		NewRangeCounter(execCfg.DB, execCfg.DistSQLPlanner),

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5161,7 +5161,7 @@ value if you rely on the HLC for accuracy.`,
 				minDuration := args[0].(*tree.DInterval).Duration
 				elapsed := duration.MakeDuration(int64(ctx.StmtTimestamp.Sub(ctx.TxnTimestamp)), 0, 0)
 				if elapsed.Compare(minDuration) < 0 {
-					return nil, ctx.Txn.GenerateForcedRetryableError(
+					return nil, ctx.Txn.GenerateRetryableAbortedError(
 						ctx.Ctx(), "forced by crdb_internal.force_retry()")
 				}
 				return tree.DZero, nil

--- a/pkg/sql/sessioninit/cache.go
+++ b/pkg/sql/sessioninit/cache.go
@@ -125,7 +125,7 @@ func (a *Cache) GetAuthInfo(
 
 	var usersTableDesc catalog.TableDescriptor
 	var roleOptionsTableDesc catalog.TableDescriptor
-	err = f.Txn(ctx, ie, db, func(
+	err = f.Txn(ctx, db, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) error {
 		_, usersTableDesc, err = descriptors.GetImmutableTableByName(
@@ -297,7 +297,7 @@ func (a *Cache) GetDefaultSettings(
 ) (settingsEntries []SettingsCacheEntry, err error) {
 	var dbRoleSettingsTableDesc catalog.TableDescriptor
 	var databaseID descpb.ID
-	err = f.Txn(ctx, ie, db, func(
+	err = f.Txn(ctx, db, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) error {
 		_, dbRoleSettingsTableDesc, err = descriptors.GetImmutableTableByName(

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -352,7 +352,7 @@ func (r *Refresher) autoStatsFractionStaleRows(explicitSettings *catpb.AutoStats
 func (r *Refresher) getTableDescriptor(
 	ctx context.Context, tableID descpb.ID,
 ) (desc catalog.TableDescriptor) {
-	if err := r.cache.collectionFactory.Txn(ctx, r.cache.SQLExecutor, r.cache.ClientDB, func(
+	if err := r.cache.collectionFactory.Txn(ctx, r.cache.ClientDB, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) (err error) {
 		flags := tree.ObjectLookupFlagsWithRequired()

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -581,7 +581,7 @@ func (sc *TableStatisticsCache) parseStats(
 			// TypeDescriptor's with the timestamp that the stats were recorded with.
 			//
 			// TODO(ajwerner): We now do delete members from enum types. See #67050.
-			if err := sc.collectionFactory.Txn(ctx, sc.SQLExecutor, sc.ClientDB, func(
+			if err := sc.collectionFactory.Txn(ctx, sc.ClientDB, func(
 				ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 			) error {
 				resolver := descs.NewDistSQLTypeResolver(descriptors, txn)

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -412,7 +412,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -436,7 +436,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -462,7 +462,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -487,7 +487,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -511,7 +511,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -536,7 +536,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -565,7 +565,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.True}, b
@@ -605,7 +605,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -412,7 +412,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -436,7 +436,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -462,7 +462,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -487,7 +487,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -511,7 +511,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -536,7 +536,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -565,7 +565,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.True}, b
@@ -605,7 +605,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateRetryableAbortedError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -133,25 +133,23 @@ func GetUserSessionInitInfo(
 		}
 
 		// Find whether the user is an admin.
-		return execCfg.CollectionFactory.Txn(
-			ctx,
-			ie,
-			execCfg.DB,
-			func(ctx context.Context, txn *kv.Txn, descsCol *descs.Collection) error {
-				memberships, err := MemberOfWithAdminOption(
-					ctx,
-					execCfg,
-					ie,
-					descsCol,
-					txn,
-					user,
-				)
-				if err != nil {
-					return err
-				}
-				_, isSuperuser = memberships[username.AdminRoleName()]
-				return nil
-			},
+		return execCfg.CollectionFactory.Txn(ctx, execCfg.DB, func(
+			ctx context.Context, txn *kv.Txn, descsCol *descs.Collection,
+		) error {
+			memberships, err := MemberOfWithAdminOption(
+				ctx,
+				execCfg,
+				ie,
+				descsCol,
+				txn,
+				user,
+			)
+			if err != nil {
+				return err
+			}
+			_, isSuperuser = memberships[username.AdminRoleName()]
+			return nil
+		},
 		)
 	}); err != nil {
 		log.Warningf(ctx, "user membership lookup for %q failed: %v", user, err)

--- a/pkg/upgrade/upgrades/BUILD.bazel
+++ b/pkg/upgrade/upgrades/BUILD.bazel
@@ -108,7 +108,6 @@ go_test(
         "//pkg/sql/sem/builtins/builtinconstants",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sqlutil",
         "//pkg/sql/types",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/upgrade/upgrades/descriptor_utils.go
+++ b/pkg/upgrade/upgrades/descriptor_utils.go
@@ -88,7 +88,7 @@ func runPostDeserializationChangesOnAllDescriptors(
 	maybeUpgradeDescriptors := func(
 		ctx context.Context, d upgrade.TenantDeps, toUpgrade []descpb.ID,
 	) error {
-		return d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
+		return d.CollectionFactory.Txn(ctx, d.DB, func(
 			ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 		) error {
 			descs, err := descriptors.GetMutableDescriptorsByID(ctx, txn, toUpgrade...)

--- a/pkg/upgrade/upgrades/schema_changes.go
+++ b/pkg/upgrade/upgrades/schema_changes.go
@@ -138,7 +138,7 @@ func readTableDescriptor(
 ) (catalog.TableDescriptor, error) {
 	var t catalog.TableDescriptor
 
-	if err := d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
+	if err := d.CollectionFactory.Txn(ctx, d.DB, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) (err error) {
 		t, err = descriptors.GetImmutableTableByID(ctx, txn, tableID, tree.ObjectLookupFlags{

--- a/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID.go
+++ b/pkg/upgrade/upgrades/upgrade_sequence_to_be_referenced_by_ID.go
@@ -98,7 +98,7 @@ func findNextTableOrViewToUpgrade(
 func maybeUpgradeSeqReferencesInTableOrView(
 	ctx context.Context, idToUpgrade descpb.ID, d upgrade.TenantDeps,
 ) error {
-	return d.CollectionFactory.Txn(ctx, d.InternalExecutor, d.DB, func(
+	return d.CollectionFactory.Txn(ctx, d.DB, func(
 		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection,
 	) error {
 		// Set up: retrieve table desc for `idToUpgrade` and a schema resolver


### PR DESCRIPTION
This thing before was buggy in some way I don't really understand.

Release justification: Fixes tests and improves code.

Release note: None