### PR TITLE
scplan: make EXPLAIN target output stable

### DIFF
--- a/pkg/sql/schemachanger/scplan/plan_explain.go
+++ b/pkg/sql/schemachanger/scplan/plan_explain.go
@@ -190,8 +190,11 @@ func (p Plan) explainTargets(s scstage.Stage, sn treeprinter.Node, style treepri
 	// Generate format string for printing element status transition.
 	fmtCompactTransition := fmt.Sprintf("%%-%ds → %%-%ds %%s", beforeMaxLen, afterMaxLen)
 	// Go over each target grouping.
-	targetTypeMap.ForEach(func(key, numTransitions int) {
-		ts := scpb.TargetStatus(key)
+	for _, ts := range []scpb.TargetStatus{scpb.ToPublic, scpb.Transient, scpb.ToAbsent} {
+		numTransitions := targetTypeMap.GetDefault(int(ts))
+		if numTransitions == 0 {
+			continue
+		}
 		plural := "s"
 		if numTransitions == 1 {
 			plural = ""
@@ -233,7 +236,7 @@ func (p Plan) explainTargets(s scstage.Stage, sn treeprinter.Node, style treepri
 				}
 			}
 		}
-	})
+	}
 	return nil
 }
 

--- a/pkg/sql/schemachanger/testdata/explain/add_column
+++ b/pkg/sql/schemachanger/testdata/explain/add_column
@@ -87,10 +87,6 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              └── ValidateUniqueIndex {"IndexID":2,"TableID":106}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
-      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
       │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC                Column:{DescID: 106, ColumnID: 2}
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -99,6 +95,10 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
@@ -110,10 +110,10 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    └── 5 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
@@ -93,10 +93,6 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │              └── ValidateUniqueIndex {"IndexID":2,"TableID":106}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
-      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
       │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC                Column:{DescID: 106, ColumnID: 2}
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -105,6 +101,10 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 3}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
@@ -117,10 +117,10 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │         ├── SetJobStateOnDescriptor {"DescriptorID":107}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    └── 6 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── CreateGcJobForIndex {"IndexID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid
@@ -7,9 +7,6 @@ EXPLAIN (ddl) alter table t add primary key (a);
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›); 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -20,6 +17,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
  │         └── 11 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -82,14 +82,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    └── 1 Validation operation
  │    │         └── ValidateUniqueIndex {"IndexID":2,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
  │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
  │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+ │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    └── 8 Mutation operations
  │    │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -144,17 +144,17 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              └── ValidateUniqueIndex {"IndexID":4,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-      │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+      │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 6 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
@@ -163,8 +163,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── DELETE_ONLY           → ABSENT               PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC               PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── ABSENT                → PUBLIC               IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
@@ -175,6 +173,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT     IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT     TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT     TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── DELETE_ONLY           → ABSENT               PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 12 Mutation operations
       │         ├── CreateGcJobForIndex {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
@@ -196,12 +196,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_ABSENT
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            ├── 3 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 2}
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
            │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-           ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
+           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
            ├── 8 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           ├── 2 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
-           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
            └── 11 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
                 ├── MakeColumnPublic {"ColumnID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ADD PRIMARY KEY (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 14 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid
@@ -7,9 +7,6 @@ EXPLAIN (ddl) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
@@ -20,6 +17,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
  │         └── 11 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -82,14 +82,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    └── 1 Validation operation
  │    │         └── ValidateUniqueIndex {"IndexID":2,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
  │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
  │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+ │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    └── 8 Mutation operations
  │    │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -144,17 +144,17 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              └── ValidateUniqueIndex {"IndexID":4,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-      │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+      │    │    └── VALIDATED  → DELETE_ONLY           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 6 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}
@@ -163,8 +163,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── DELETE_ONLY           → ABSENT               PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC               PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── ABSENT                → PUBLIC               IndexName:{DescID: 104, Name: t_pkey, IndexID: 4}
@@ -175,6 +173,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT     IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT     TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT     TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── DELETE_ONLY           → ABSENT               PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 12 Mutation operations
       │         ├── CreateGcJobForIndex {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
@@ -196,12 +196,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_ABSENT
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            ├── 3 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 2}
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
            │    └── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-           ├── 1 element transitioning toward TRANSIENT_ABSENT
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            └── 6 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":2,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
+           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
            ├── 8 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           ├── 2 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
-           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
            └── 11 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
                 ├── MakeColumnPublic {"ColumnID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -8,6 +8,9 @@ EXPLAIN (ddl) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
@@ -17,9 +20,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -8,6 +8,11 @@ EXPLAIN (ddl) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› ALTER PRIMARY KEY USING COLUMNS (‹a›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → WRITE_ONLY  PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -20,11 +25,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› A
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-      │    ├── 4 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 14 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"rowid","TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain/alter_table_alter_primary_key_vanilla
@@ -99,11 +99,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              └── ValidateUniqueIndex {"IndexID":4,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
@@ -114,6 +109,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -126,11 +126,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 7 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic
@@ -7,15 +7,15 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
  │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
  │         └── 7 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -75,18 +75,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":2,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
       │    └── 8 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
@@ -97,10 +97,10 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    └── 5 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── CreateGcJobForIndex {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_1_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
+           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            ├── 4 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
            │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           ├── 2 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
-           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            └── 9 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── MakeColumnPublic {"ColumnID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_2_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_3_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_4_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_5_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_6_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":3,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_basic.rollback_7_of_7
@@ -8,14 +8,14 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index
@@ -7,6 +7,12 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j CASCADE;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         ├── 6 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
  │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -14,12 +20,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
  │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
  │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
- │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
- │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         └── 12 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -84,6 +84,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 9 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 3}
@@ -94,12 +100,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -112,13 +112,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 3}
       │    │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 3}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_1_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            ├── 6 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
            │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            │    └── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            └── 14 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_2_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_3_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_4_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_5_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_6_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_computed_index.rollback_7_of_7
@@ -8,11 +8,6 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
@@ -20,6 +15,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 3}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 19 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 19 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED   → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 19 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 17 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 17 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED  → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 17 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 6 elements transitioning toward ABSENT
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            ├── 6 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
            │    └── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 14 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 13 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -9,13 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 8 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 6 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 4}
@@ -23,6 +16,13 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -9,6 +9,15 @@ EXPLAIN (ddl) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.public.‹t› (‹k›); 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
+      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    ├── 13 elements transitioning toward ABSENT
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
@@ -23,15 +32,6 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── DELETE_ONLY   → ABSENT      TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-      │    ├── 8 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 4}
-      │    │    ├── VALIDATED     → PUBLIC      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-      │    │    ├── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-      │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-      │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
       │    └── 20 Mutation operations
       │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_1_of_2
@@ -7,13 +7,6 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j CASCADE;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 4}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
- │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
  │         ├── 3 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -22,6 +15,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+ │         ├── 6 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 4}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+ │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
  │         └── 14 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -88,6 +88,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 4}
@@ -100,13 +107,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -119,13 +119,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 4}
       │    │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_create_index_separate_statements.statement_2_of_2
@@ -56,9 +56,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    └── 1 Validation operation
  │    │         └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    ├── 7 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
@@ -69,6 +66,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
  │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+ │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
  │    │    └── 12 Mutation operations
  │    │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -127,6 +127,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":5,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: idx, IndexID: 5}
+      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    ├── 10 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 4}
@@ -138,14 +146,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: idx, IndexID: 5}
-      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -158,6 +158,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
            ├── 6 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 2}
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
@@ -165,9 +168,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
            │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
            │    ├── DELETE_ONLY           → ABSENT           PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
            │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-           ├── 2 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-           │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
            └── 13 Mutation operations
                 ├── CreateGcJobForIndex {"IndexID":1,"TableID":104}
                 ├── MakeIndexAbsent {"IndexID":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index
@@ -10,9 +10,6 @@ EXPLAIN (ddl) ALTER TABLE t.test DROP pi;
 Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN ‹pi›; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 2 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 106, ColumnID: 3}
- │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
  │         ├── 4 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -23,6 +20,9 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 106, ColumnID: 3}
+ │         │    └── PUBLIC → ABSENT        ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
  │         └── 11 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":3,"TableID":106}
  │              ├── LogEvent {"TargetStatus":1}
@@ -86,14 +86,6 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
  │              └── ValidateUniqueIndex {"IndexID":4,"TableID":106}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 106, ColumnID: 3}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 1}
-      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: test_pkey, IndexID: 1}
       │    ├── 2 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
@@ -102,6 +94,14 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 106, ColumnID: 3}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 1}
+      │    │    ├── PUBLIC     → WRITE_ONLY            PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+      │    │    └── PUBLIC     → ABSENT                IndexName:{DescID: 106, Name: test_pkey, IndexID: 1}
       │    └── 8 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":106}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":106}
@@ -112,10 +112,10 @@ Schema change plan for ALTER TABLE ‹t›.‹public›.‹test› DROP COLUMN �
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    ├── 1 element transitioning toward TRANSIENT_ABSENT
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
       │    └── 5 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── CreateGcJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_1_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 106, ColumnID: 3}
+           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
            ├── 8 elements transitioning toward ABSENT
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
            │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-           ├── 2 elements transitioning toward PUBLIC
-           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 106, ColumnID: 3}
-           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
            └── 9 Mutation operations
                 ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
                 ├── MakeColumnPublic {"ColumnID":3,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_2_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_3_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_4_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT      → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT      → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 8 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_5_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_6_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_unique_index.rollback_7_of_7
@@ -11,6 +11,9 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP COLUMN ‹pi›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
@@ -20,9 +23,6 @@ Schema change plan for rolling back ALTER TABLE ‹t›.public.‹test› DROP C
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
       │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
       │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 106, ColumnID: 3}
-      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
       │    └── 7 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"pi","TableID":106}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":4,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index
@@ -7,17 +7,17 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j›; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 4 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
- │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
  │         ├── 2 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
  │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+ │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
  │         └── 9 Mutation operations
  │              ├── MakeDroppedNonPrimaryIndexDeleteAndWriteOnly {"IndexID":2,"TableID":104}
  │              ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -79,6 +79,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 8 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
@@ -88,12 +94,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedPrimaryIndexDeleteAndWriteOnly {"IndexID":1,"TableID":104}
@@ -105,11 +105,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 2 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 8 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_1_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            ├── 4 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 2}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
            │    └── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
            └── 11 Mutation operations
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
                 ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_2_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_3_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_4_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_5_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_6_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_column_with_index.rollback_7_of_7
@@ -8,16 +8,16 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j›; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    └── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
       │    └── 9 Mutation operations
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"t_j_idx","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 1 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       └── Stage 1 of 1 in PostCommitNonRevertiblePhase
-           ├── 4 elements transitioning toward ABSENT
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            ├── 8 elements transitioning toward PUBLIC
            │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104, ColumnID: 3}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
            │    ├── ABSENT        → PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
            │    └── ABSENT        → PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
            └── 17 Mutation operations
                 ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
                 ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 2 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 16 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 3 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT        → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT        → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 16 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 4 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT      → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT      → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 16 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 5 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 15 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 6 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 15 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -9,11 +9,6 @@ EXPLAIN (ddl) rollback at post-commit stage 7 of 7;
 Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹j› CASCADE; ALTER TABLE ‹defaultdb›.public.‹t› DROP COLUMN ‹k› CASCADE; 
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 8 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104, ColumnID: 3}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: k, ColumnID: 3}
@@ -23,6 +18,11 @@ Schema change plan for rolling back ALTER TABLE ‹defaultdb›.public.‹t› D
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: j, ColumnID: 2}
       │    │    ├── ABSENT     → PUBLIC      ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
       │    │    └── ABSENT     → PUBLIC      IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 15 Mutation operations
       │         ├── SetColumnName {"ColumnID":3,"Name":"k","TableID":104}
       │         ├── SetColumnName {"ColumnID":2,"Name":"j","TableID":104}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -7,13 +7,6 @@ EXPLAIN (ddl) ALTER TABLE t DROP COLUMN j CASCADE;
 Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE; 
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 6 elements transitioning toward ABSENT
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
- │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 4}
- │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
- │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
- │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
  │         ├── 3 elements transitioning toward PUBLIC
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -22,6 +15,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+ │         ├── 6 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 2}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+ │         │    ├── PUBLIC → WRITE_ONLY    Column:{DescID: 104, ColumnID: 4}
+ │         │    ├── PUBLIC → ABSENT        ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+ │         │    ├── PUBLIC → VALIDATED     SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+ │         │    └── PUBLIC → ABSENT        IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
  │         └── 14 Mutation operations
  │              ├── MakeDroppedColumnDeleteAndWriteOnly {"ColumnID":2,"TableID":104}
  │              ├── LogEvent {"TargetStatus":1}
@@ -88,6 +88,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 4}
@@ -100,13 +107,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
       │    │    └── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
       │    └── 10 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":4,"TableID":104}
@@ -119,13 +119,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 4}
       │    │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}

--- a/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -66,6 +66,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │              └── ValidateUniqueIndex {"IndexID":3,"TableID":104}
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 14 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 3}
       │    │    ├── WRITE_ONLY → DELETE_ONLY           Column:{DescID: 104, ColumnID: 2}
@@ -81,12 +87,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │    │    ├── VALIDATED  → DELETE_ONLY           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
       │    │    ├── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
       │    │    └── PUBLIC     → ABSENT                IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED  → PUBLIC                PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-      │    │    └── ABSENT     → PUBLIC                IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-      │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 12 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":2,"TableID":104}
@@ -101,13 +101,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    ├── 4 elements transitioning toward ABSENT
       │    │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104, ColumnID: 4}
       │    │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
       │    │    └── DELETE_ONLY           → ABSENT           SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-      │    ├── 1 element transitioning toward TRANSIENT_ABSENT
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
       │    └── 9 Mutation operations
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── LogEvent {"TargetStatus":1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column
@@ -347,26 +347,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   └── • IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │             rule: "index no longer public before dependents"
-    │   │
     │   ├── • 3 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 106, ColumnID: 2}
@@ -429,6 +409,26 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
+    │   ├── • 3 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   └── • IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │             rule: "index no longer public before dependents"
+    │   │
     │   └── • 9 Mutation operations
     │       │
     │       ├── • MakeDroppedPrimaryIndexDeleteAndWriteOnly
@@ -488,11 +488,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -503,6 +498,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN j INT NOT NULL DEFAU
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 5 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -372,26 +372,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 3 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   └── • IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │             rule: "index no longer public before dependents"
-    │   │
     │   ├── • 3 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 106, ColumnID: 2}
@@ -453,6 +433,26 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │   │       │
     │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
+    │   │
+    │   ├── • 3 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   └── • IndexName:{DescID: 106, Name: tbl_pkey, IndexID: 1}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │             rule: "index no longer public before dependents"
     │   │
     │   └── • 10 Mutation operations
     │       │
@@ -516,11 +516,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -531,6 +526,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 3}
     │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 6 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid
@@ -10,17 +10,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 2 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │             rule: "column no longer public before dependents"
-│       │
 │       ├── • 2 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
@@ -63,6 +52,17 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │             rule: "column no longer public before dependents"
 │       │
 │       └── • 11 Mutation operations
 │           │
@@ -307,17 +307,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
 │   │
 │   ├── • Stage 8 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 2 elements transitioning toward ABSENT
-│   │   │   │
-│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │   │     PUBLIC → VALIDATED
-│   │   │   │
-│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-│   │   │       │ PUBLIC → ABSENT
-│   │   │       │
-│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │             rule: "index no longer public before dependents"
-│   │   │
 │   │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -353,6 +342,17 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
 │   │   │       │
 │   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "temp index existence precedes index dependents"
+│   │   │
+│   │   ├── • 2 elements transitioning toward ABSENT
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   │     PUBLIC → VALIDATED
+│   │   │   │
+│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+│   │   │       │ PUBLIC → ABSENT
+│   │   │       │
+│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │             rule: "index no longer public before dependents"
 │   │   │
 │   │   └── • 8 Mutation operations
 │   │       │
@@ -536,35 +536,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │
     ├── • Stage 1 of 4 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column no longer public before dependents"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │         VALIDATED → DELETE_ONLY
-    │   │
     │   ├── • 5 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -594,6 +565,35 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │         VALIDATED → DELETE_ONLY
+    │   │
     │   └── • 6 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -622,20 +622,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │               pending
     │
     ├── • Stage 2 of 4 in PostCommitNonRevertiblePhase
-    │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │       │ DELETE_ONLY → ABSENT
-    │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │             rule: "dependents removed before index"
     │   │
     │   ├── • 2 elements transitioning toward PUBLIC
     │   │   │
@@ -706,6 +692,20 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │       │ DELETE_ONLY → ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 12 Mutation operations
@@ -801,6 +801,20 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
     │
     └── • Stage 4 of 4 in PostCommitNonRevertiblePhase
         │
+        ├── • 1 element transitioning toward TRANSIENT_ABSENT
+        │   │
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+        │       │
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │             rule: "dependents removed before index"
+        │
         ├── • 3 elements transitioning toward ABSENT
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -845,20 +859,6 @@ EXPLAIN (ddl, verbose) alter table t add primary key (a);
         │       │
         │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
         │             rule: "column no longer public before dependents"
-        │
-        ├── • 1 element transitioning toward TRANSIENT_ABSENT
-        │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-        │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-        │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-        │       │     rule: "dependents removed before index"
-        │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-        │       │     rule: "dependents removed before index"
-        │       │
-        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-        │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_10_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_11_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_12_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_13_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_14_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_15_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_1_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │         ABSENT → PUBLIC
+        │
         ├── • 8 elements transitioning toward ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,26 +92,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
         │       │
         │       └── • skip PUBLIC → ABSENT operations
         │             rule: "skip index-column removal ops on index removal"
-        │
-        ├── • 2 elements transitioning toward PUBLIC
-        │   │
-        │   ├── • Column:{DescID: 104, ColumnID: 2}
-        │   │   │ WRITE_ONLY → PUBLIC
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-        │   │         rule: "column dependents exist before column becomes public"
-        │   │
-        │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-        │         ABSENT → PUBLIC
         │
         └── • 11 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_2_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_3_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_4_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_5_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_6_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_7_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_8_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_add_primary_key_drop_rowid.rollback_9_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -81,45 +120,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 14 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid
@@ -10,17 +10,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 2 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │             rule: "column no longer public before dependents"
-│       │
 │       ├── • 2 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 2}
@@ -63,6 +52,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │             rule: "column no longer public before dependents"
 │       │
 │       └── • 11 Mutation operations
 │           │
@@ -309,17 +309,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │
 │   ├── • Stage 8 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 2 elements transitioning toward ABSENT
-│   │   │   │
-│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │   │     PUBLIC → VALIDATED
-│   │   │   │
-│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-│   │   │       │ PUBLIC → ABSENT
-│   │   │       │
-│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │             rule: "index no longer public before dependents"
-│   │   │
 │   │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
 │   │   │   │
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -355,6 +344,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 │   │   │       │
 │   │   │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}
 │   │   │             rule: "temp index existence precedes index dependents"
+│   │   │
+│   │   ├── • 2 elements transitioning toward ABSENT
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   │     PUBLIC → VALIDATED
+│   │   │   │
+│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+│   │   │       │ PUBLIC → ABSENT
+│   │   │       │
+│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │             rule: "index no longer public before dependents"
 │   │   │
 │   │   └── • 8 Mutation operations
 │   │       │
@@ -539,35 +539,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │
     ├── • Stage 1 of 4 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column no longer public before dependents"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │         VALIDATED → DELETE_ONLY
-    │   │
     │   ├── • 5 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -597,6 +568,35 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column no longer public before dependents"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │         VALIDATED → DELETE_ONLY
+    │   │
     │   └── • 6 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -625,20 +625,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │               pending
     │
     ├── • Stage 2 of 4 in PostCommitNonRevertiblePhase
-    │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │       │ DELETE_ONLY → ABSENT
-    │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │             rule: "dependents removed before index"
     │   │
     │   ├── • 2 elements transitioning toward PUBLIC
     │   │   │
@@ -709,6 +695,20 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │       │ DELETE_ONLY → ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 12 Mutation operations
@@ -806,6 +806,20 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
     │
     └── • Stage 4 of 4 in PostCommitNonRevertiblePhase
         │
+        ├── • 1 element transitioning toward TRANSIENT_ABSENT
+        │   │
+        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+        │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+        │       │
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
+        │             rule: "dependents removed before index"
+        │
         ├── • 3 elements transitioning toward ABSENT
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -850,20 +864,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
         │       │
         │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
         │             rule: "column no longer public before dependents"
-        │
-        ├── • 1 element transitioning toward TRANSIENT_ABSENT
-        │   │
-        │   └── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-        │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-        │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-        │       │     rule: "dependents removed before index"
-        │       │
-        │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-        │       │     rule: "dependents removed before index"
-        │       │
-        │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}
-        │             rule: "dependents removed before index"
         │
         └── • 6 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_10_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_11_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_12_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -78,45 +117,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_13_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_14_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_15_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,45 +111,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_1_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+        │         ABSENT → PUBLIC
+        │
         ├── • 8 elements transitioning toward ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -72,26 +92,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
         │       │
         │       └── • skip PUBLIC → ABSENT operations
         │             rule: "skip index-column removal ops on index removal"
-        │
-        ├── • 2 elements transitioning toward PUBLIC
-        │   │
-        │   ├── • Column:{DescID: 104, ColumnID: 2}
-        │   │   │ WRITE_ONLY → PUBLIC
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-        │   │         rule: "column dependents exist before column becomes public"
-        │   │
-        │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-        │         ABSENT → PUBLIC
         │
         └── • 11 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_2_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_3_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_4_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -66,26 +86,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_5_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_6_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_7_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_8_of_15
@@ -11,6 +11,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_drop_rowid.rollback_9_of_15
@@ -11,6 +11,45 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 4 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -81,45 +120,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 4 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: rowid, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 14 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/alter_table_alter_primary_key_vanilla
@@ -381,35 +381,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │             rule: "index no longer public before dependents"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -473,6 +444,35 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
     │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │             rule: "index no longer public before dependents"
+    │   │
     │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeDroppedPrimaryIndexDeleteAndWriteOnly
@@ -529,11 +529,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -547,6 +542,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j);
     │   │   │
     │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}
     │   │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic
@@ -10,17 +10,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 2 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │             rule: "column no longer public before dependents"
-│       │
 │       ├── • 2 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -42,6 +31,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │             rule: "column no longer public before dependents"
 │       │
 │       └── • 7 Mutation operations
 │           │
@@ -255,6 +255,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 5 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -289,38 +321,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       │
     │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
     │   │             rule: "index no longer public before dependents"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 2}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 8 Mutation operations
     │       │
@@ -368,11 +368,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
@@ -380,6 +375,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
     │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 5 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_1_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 104, ColumnID: 2}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+        │         ABSENT → PUBLIC
+        │
         ├── • 4 elements transitioning toward ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -39,23 +56,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │       │
         │       └── • skip PUBLIC → ABSENT operations
         │             rule: "skip index-column removal ops on index removal"
-        │
-        ├── • 2 elements transitioning toward PUBLIC
-        │   │
-        │   ├── • Column:{DescID: 104, ColumnID: 2}
-        │   │   │ WRITE_ONLY → PUBLIC
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-        │   │         rule: "column dependents exist before column becomes public"
-        │   │
-        │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-        │         ABSENT → PUBLIC
         │
         └── • 9 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_2_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -36,23 +53,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_3_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -36,23 +53,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_4_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -36,23 +53,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_5_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -30,23 +47,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_6_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -30,23 +47,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_basic.rollback_7_of_7
@@ -11,6 +11,23 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -30,23 +47,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index
@@ -10,6 +10,28 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
+│       ├── • 2 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │     ABSENT → BACKFILL_ONLY
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │             rule: "index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+│       │   │     ABSENT → DELETE_ONLY
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+│       │             rule: "temp index existence precedes index dependents"
+│       │
 │       ├── • 6 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -41,28 +63,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │       │
 │       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │             rule: "index no longer public before dependents"
-│       │
-│       ├── • 2 elements transitioning toward PUBLIC
-│       │   │
-│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-│       │   │     ABSENT → BACKFILL_ONLY
-│       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-│       │       │ ABSENT → PUBLIC
-│       │       │
-│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-│       │             rule: "index existence precedes index dependents"
-│       │
-│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-│       │   │
-│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-│       │   │     ABSENT → DELETE_ONLY
-│       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-│       │       │ ABSENT → PUBLIC
-│       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-│       │             rule: "temp index existence precedes index dependents"
 │       │
 │       └── • 12 Mutation operations
 │           │
@@ -311,6 +311,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 9 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -373,38 +405,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │         VALIDATED → DELETE_ONLY
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -459,6 +459,14 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -496,14 +504,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │       │     rule: "dependents removed before index"
     │   │       │
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
-    │   │             rule: "dependents removed before index"
-    │   │
-    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 9 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_1_of_7
@@ -11,35 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 4 elements transitioning toward ABSENT
-        │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-        │   │   │ BACKFILL_ONLY → ABSENT
-        │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-        │   │   │ DELETE_ONLY → ABSENT
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │       │ PUBLIC → ABSENT
-        │       │
-        │       └── • skip PUBLIC → ABSENT operations
-        │             rule: "skip index-column removal ops on index removal"
-        │
         ├── • 6 elements transitioning toward PUBLIC
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -90,6 +61,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │
         │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
         │         ABSENT → PUBLIC
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       └── • skip PUBLIC → ABSENT operations
+        │             rule: "skip index-column removal ops on index removal"
         │
         └── • 14 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_2_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -87,6 +61,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_3_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -87,6 +61,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_4_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ DELETE_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -87,6 +61,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_5_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -81,6 +61,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_6_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -81,6 +61,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_computed_index.rollback_7_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -81,6 +61,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_10_of_15
@@ -12,6 +12,82 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 8 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 13 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,82 +170,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 10 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 8 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "ensure columns are in increasing order"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 19 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_11_of_15
@@ -12,6 +12,82 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 8 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 13 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,82 +170,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 11 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 8 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "ensure columns are in increasing order"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 19 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_12_of_15
@@ -12,6 +12,82 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 8 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 13 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -94,82 +170,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 12 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 8 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "ensure columns are in increasing order"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 19 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_13_of_15
@@ -12,80 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 13 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "index no longer public before dependents"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -161,6 +87,80 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 13 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 13 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 17 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_14_of_15
@@ -12,80 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 13 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "index no longer public before dependents"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -161,6 +87,80 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 14 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 13 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 17 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_15_of_15
@@ -12,80 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 13 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │     rule: "index no longer public before dependents"
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     PUBLIC → WRITE_ONLY
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "index no longer public before dependents"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -161,6 +87,80 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 15 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 13 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │     rule: "index no longer public before dependents"
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     PUBLIC → WRITE_ONLY
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "index no longer public before dependents"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 6}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 17 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_1_of_15
@@ -12,53 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 6 elements transitioning toward ABSENT
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-        │   │   │ BACKFILL_ONLY → ABSENT
-        │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-        │       │ DELETE_ONLY → ABSENT
-        │       │
-        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │       │     rule: "dependents removed before index"
-        │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-        │             rule: "dependents removed before index"
-        │
         ├── • 6 elements transitioning toward PUBLIC
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -112,6 +65,53 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 15;
         │   │
         │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │         ABSENT → PUBLIC
+        │
+        ├── • 6 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │       │     rule: "dependents removed before index"
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+        │             rule: "dependents removed before index"
         │
         └── • 14 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_2_of_15
@@ -12,47 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -106,6 +65,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_3_of_15
@@ -12,47 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -106,6 +65,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_4_of_15
@@ -12,47 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ DELETE_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -106,6 +65,47 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 13 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_5_of_15
@@ -12,38 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -97,6 +65,38 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_6_of_15
@@ -12,38 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -97,6 +65,38 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_7_of_15
@@ -12,38 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -97,6 +65,38 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_8_of_15
@@ -12,38 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 6 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 6 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -97,6 +65,38 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 8 of 15;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 6 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 12 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.rollback_9_of_15
@@ -12,6 +12,82 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 8 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
+    │   │   │   │     rule: "ensure columns are in increasing order"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │         rule: "primary index swap"
+    │   │   │
+    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+    │   │   │     ABSENT → PUBLIC
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 13 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
@@ -100,82 +176,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 9 of 15;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 8 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • Column:{DescID: 104, ColumnID: 4}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC Column:{DescID: 104, ColumnID: 2}
-    │   │   │   │     rule: "ensure columns are in increasing order"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │         rule: "primary index swap"
-    │   │   │
-    │   │   ├── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 4, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-    │   │   │     ABSENT → PUBLIC
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 20 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_1_of_2
@@ -10,38 +10,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 6 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-│       │   │   │ PUBLIC → ABSENT
-│       │   │   │
-│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │   │         rule: "column no longer public before dependents"
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 4}
-│       │   │   │ PUBLIC → WRITE_ONLY
-│       │   │   │
-│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
-│       │   │
-│       │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-│       │   │   │ PUBLIC → ABSENT
-│       │   │   │
-│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 4}
-│       │   │         rule: "column no longer public before dependents"
-│       │   │
-│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │   │     PUBLIC → VALIDATED
-│       │   │
-│       │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │             rule: "index no longer public before dependents"
-│       │
 │       ├── • 3 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -75,6 +43,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 6 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 4}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 4}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │     PUBLIC → VALIDATED
+│       │   │
+│       │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │             rule: "index no longer public before dependents"
 │       │
 │       └── • 14 Mutation operations
 │           │
@@ -341,6 +341,47 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -421,47 +462,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │         VALIDATED → DELETE_ONLY
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -516,6 +516,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 4}
@@ -556,17 +567,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │       │     rule: "dependents removed before index"
     │   │       │
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │             rule: "dependents removed before index"
-    │   │
-    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-    │   │       │
-    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 9 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_create_index_separate_statements.statement_2_of_2
@@ -172,17 +172,6 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │
 │   ├── • Stage 8 of 15 in PostCommitPhase
 │   │   │
-│   │   ├── • 2 elements transitioning toward ABSENT
-│   │   │   │
-│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │   │     PUBLIC → VALIDATED
-│   │   │   │
-│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
-│   │   │       │ PUBLIC → ABSENT
-│   │   │       │
-│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-│   │   │             rule: "index no longer public before dependents"
-│   │   │
 │   │   ├── • 7 elements transitioning toward PUBLIC
 │   │   │   │
 │   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -244,6 +233,17 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
 │   │   │       │
 │   │   │       └── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
 │   │   │             rule: "primary index with new columns should exist before temp indexes"
+│   │   │
+│   │   ├── • 2 elements transitioning toward ABSENT
+│   │   │   │
+│   │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │   │     PUBLIC → VALIDATED
+│   │   │   │
+│   │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 1}
+│   │   │       │ PUBLIC → ABSENT
+│   │   │       │
+│   │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+│   │   │             rule: "index no longer public before dependents"
 │   │   │
 │   │   └── • 12 Mutation operations
 │   │       │
@@ -455,6 +455,47 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx, IndexID: 5}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: idx, IndexID: 5}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+    │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │
     │   ├── • 10 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -529,47 +570,6 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │         VALIDATED → DELETE_ONLY
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 5}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 5}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: idx, IndexID: 5}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: idx, IndexID: 5}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY SecondaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
-    │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │
     │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -615,6 +615,20 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
     │               pending
     │
     └── • Stage 2 of 2 in PostCommitNonRevertiblePhase
+        │
+        ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+        │   │   │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
+        │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         ├── • 6 elements transitioning toward ABSENT
         │   │
@@ -691,20 +705,6 @@ EXPLAIN (ddl, verbose) CREATE UNIQUE INDEX idx ON t(k);
         │       │
         │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │             rule: "dependents removed before index"
-        │
-        ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-        │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-        │   │   │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-        │   │   │
-        │   │   ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 4, SourceIndexID: 3}
-        │         TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
         │
         └── • 13 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index
@@ -13,17 +13,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 2 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 106, ColumnID: 3}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
-│       │             rule: "column no longer public before dependents"
-│       │
 │       ├── • 4 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -69,6 +58,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 106, ColumnID: 3}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 3}
+│       │             rule: "column no longer public before dependents"
 │       │
 │       └── • 11 Mutation operations
 │           │
@@ -320,6 +320,56 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 7 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 106, ColumnID: 3}
@@ -373,56 +423,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │   │       └── • Precedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
     │   │             rule: "index no longer public before dependents"
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 4}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 4}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 4}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 106, Name: test_pkey, IndexID: 4}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 4 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 5}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 5}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   └── • 8 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -469,11 +469,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 1 element transitioning toward ABSENT
-    │   │   │
-    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
     │   │   │
     │   │   └── • TemporaryIndex:{DescID: 106, IndexID: 5, ConstraintID: 6, SourceIndexID: 1}
@@ -487,6 +482,11 @@ EXPLAIN (ddl, verbose) ALTER TABLE t.test DROP pi;
     │   │       │
     │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 106, ColumnID: 4, IndexID: 5}
     │   │             rule: "dependents removed before index"
+    │   │
+    │   ├── • 1 element transitioning toward ABSENT
+    │   │   │
+    │   │   └── • PrimaryIndex:{DescID: 106, IndexID: 1, ConstraintID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 5 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_1_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
+        ├── • 2 elements transitioning toward PUBLIC
+        │   │
+        │   ├── • Column:{DescID: 106, ColumnID: 3}
+        │   │   │ WRITE_ONLY → PUBLIC
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+        │   │   │     rule: "column dependents exist before column becomes public"
+        │   │   │
+        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+        │   │         rule: "column dependents exist before column becomes public"
+        │   │
+        │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+        │         ABSENT → PUBLIC
+        │
         ├── • 8 elements transitioning toward ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -78,26 +98,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │       │
         │       └── • skip PUBLIC → ABSENT operations
         │             rule: "skip index-column removal ops on index removal"
-        │
-        ├── • 2 elements transitioning toward PUBLIC
-        │   │
-        │   ├── • Column:{DescID: 106, ColumnID: 3}
-        │   │   │ WRITE_ONLY → PUBLIC
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-        │   │   │     rule: "column dependents exist before column becomes public"
-        │   │   │
-        │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-        │   │         rule: "column dependents exist before column becomes public"
-        │   │
-        │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-        │         ABSENT → PUBLIC
         │
         └── • 9 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_2_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -69,26 +89,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_3_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -69,26 +89,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_4_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -69,26 +89,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 8 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_5_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_6_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_unique_index.rollback_7_of_7
@@ -14,6 +14,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
+    │   │   │   │ WRITE_ONLY → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
+    │   │   │   │     rule: "column dependents exist before column becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
+    │   │   │         rule: "column dependents exist before column becomes public"
+    │   │   │
+    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
+    │   │         ABSENT → PUBLIC
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 106, IndexID: 4, ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1}
@@ -57,26 +77,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │       │
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
-    │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • Column:{DescID: 106, ColumnID: 3}
-    │   │   │   │ WRITE_ONLY → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 3}
-    │   │   │   │     rule: "column dependents exist before column becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 106, ColumnID: 3, IndexID: 1}
-    │   │   │         rule: "column dependents exist before column becomes public"
-    │   │   │
-    │   │   └── • ColumnName:{DescID: 106, Name: pi, ColumnID: 3}
-    │   │         ABSENT → PUBLIC
     │   │
     │   └── • 7 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index
@@ -10,6 +10,28 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
+│       ├── • 2 elements transitioning toward PUBLIC
+│       │   │
+│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │   │     ABSENT → BACKFILL_ONLY
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+│       │             rule: "index existence precedes index dependents"
+│       │
+│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+│       │   │
+│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+│       │   │     ABSENT → DELETE_ONLY
+│       │   │
+│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+│       │       │ ABSENT → PUBLIC
+│       │       │
+│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+│       │             rule: "temp index existence precedes index dependents"
+│       │
 │       ├── • 4 elements transitioning toward ABSENT
 │       │   │
 │       │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -32,28 +54,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
 │       │       │
 │       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
 │       │             rule: "index no longer public before dependents"
-│       │
-│       ├── • 2 elements transitioning toward PUBLIC
-│       │   │
-│       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-│       │   │     ABSENT → BACKFILL_ONLY
-│       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-│       │       │ ABSENT → PUBLIC
-│       │       │
-│       │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-│       │             rule: "index existence precedes index dependents"
-│       │
-│       ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-│       │   │
-│       │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-│       │   │     ABSENT → DELETE_ONLY
-│       │   │
-│       │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-│       │       │ ABSENT → PUBLIC
-│       │       │
-│       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-│       │             rule: "temp index existence precedes index dependents"
 │       │
 │       └── • 9 Mutation operations
 │           │
@@ -276,6 +276,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 8 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -335,38 +367,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │         VALIDATED → DELETE_ONLY
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   └── • 9 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -417,6 +417,14 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
     │   ├── • 2 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
@@ -432,14 +440,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j;
     │   │       │     rule: "dependents removed before index"
     │   │       │
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
-    │   │             rule: "dependents removed before index"
-    │   │
-    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 8 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_1_of_7
@@ -11,35 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 4 elements transitioning toward ABSENT
-        │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-        │   │   │ BACKFILL_ONLY → ABSENT
-        │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-        │   │   │ DELETE_ONLY → ABSENT
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │       │ PUBLIC → ABSENT
-        │       │
-        │       └── • skip PUBLIC → ABSENT operations
-        │             rule: "skip index-column removal ops on index removal"
-        │
         ├── • 4 elements transitioning toward PUBLIC
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -75,6 +46,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │
         │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
         │         ABSENT → PUBLIC
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+        │   │   │ DELETE_ONLY → ABSENT
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │       │ PUBLIC → ABSENT
+        │       │
+        │       └── • skip PUBLIC → ABSENT operations
+        │             rule: "skip index-column removal ops on index removal"
         │
         └── • 11 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_2_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -72,6 +46,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_3_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -72,6 +46,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_4_of_7
@@ -11,32 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ DELETE_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -72,6 +46,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 10 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_5_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -66,6 +46,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_6_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -66,6 +46,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_column_with_index.rollback_7_of_7
@@ -11,26 +11,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │ PUBLIC → ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   ├── • 4 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -66,6 +46,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_j_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │ PUBLIC → ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
     │   │
     │   └── • 9 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_1_of_7
@@ -12,35 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
     │
     └── • Stage 1 of 1 in PostCommitNonRevertiblePhase
         │
-        ├── • 4 elements transitioning toward ABSENT
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │   │   │ PUBLIC → ABSENT
-        │   │   │
-        │   │   └── • skip PUBLIC → ABSENT operations
-        │   │         rule: "skip index-column removal ops on index removal"
-        │   │
-        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-        │   │   │ BACKFILL_ONLY → ABSENT
-        │   │   │
-        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-        │   │   │     rule: "dependents removed before index"
-        │   │   │
-        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-        │   │         rule: "dependents removed before index"
-        │   │
-        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-        │       │ DELETE_ONLY → ABSENT
-        │       │
-        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-        │             rule: "dependents removed before index"
-        │
         ├── • 8 elements transitioning toward PUBLIC
         │   │
         │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -130,6 +101,35 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │
         │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
         │         ABSENT → PUBLIC
+        │
+        ├── • 4 elements transitioning toward ABSENT
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │   │   │ PUBLIC → ABSENT
+        │   │   │
+        │   │   └── • skip PUBLIC → ABSENT operations
+        │   │         rule: "skip index-column removal ops on index removal"
+        │   │
+        │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+        │   │   │ BACKFILL_ONLY → ABSENT
+        │   │   │
+        │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+        │   │   │     rule: "dependents removed before index"
+        │   │   │
+        │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+        │   │         rule: "dependents removed before index"
+        │   │
+        │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+        │       │ DELETE_ONLY → ABSENT
+        │       │
+        │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+        │             rule: "dependents removed before index"
         │
         └── • 17 Mutation operations
             │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_2_of_7
@@ -12,32 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -127,6 +101,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_3_of_7
@@ -12,32 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ BACKFILL_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -127,6 +101,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ BACKFILL_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_4_of_7
@@ -12,32 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ DELETE_ONLY → ABSENT
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "dependents removed before index"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "dependents removed before index"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -127,6 +101,32 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ DELETE_ONLY → ABSENT
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "dependents removed before index"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "dependents removed before index"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 16 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_5_of_7
@@ -12,26 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -121,6 +101,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 15 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_6_of_7
@@ -12,26 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     MERGE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -121,6 +101,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     MERGE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 15 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.rollback_7_of_7
@@ -12,26 +12,6 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │
     ├── • Stage 1 of 2 in PostCommitNonRevertiblePhase
     │   │
-    │   ├── • 4 elements transitioning toward ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → DELETE_ONLY
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → DELETE_ONLY
-    │   │
     │   ├── • 8 elements transitioning toward PUBLIC
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -121,6 +101,26 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
     │   │   │
     │   │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
     │   │         ABSENT → PUBLIC
+    │   │
+    │   ├── • 4 elements transitioning toward ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → DELETE_ONLY
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → DELETE_ONLY
     │   │
     │   └── • 15 Mutation operations
     │       │

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_1_of_2
@@ -10,38 +10,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │   │
 │   └── • Stage 1 of 1 in StatementPhase
 │       │
-│       ├── • 6 elements transitioning toward ABSENT
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 2}
-│       │   │     PUBLIC → WRITE_ONLY
-│       │   │
-│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
-│       │   │   │ PUBLIC → ABSENT
-│       │   │   │
-│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
-│       │   │         rule: "column no longer public before dependents"
-│       │   │
-│       │   ├── • Column:{DescID: 104, ColumnID: 4}
-│       │   │   │ PUBLIC → WRITE_ONLY
-│       │   │   │
-│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
-│       │   │
-│       │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
-│       │   │   │ PUBLIC → ABSENT
-│       │   │   │
-│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 4}
-│       │   │         rule: "column no longer public before dependents"
-│       │   │
-│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │   │     PUBLIC → VALIDATED
-│       │   │
-│       │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-│       │       │ PUBLIC → ABSENT
-│       │       │
-│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
-│       │             rule: "index no longer public before dependents"
-│       │
 │       ├── • 3 elements transitioning toward PUBLIC
 │       │   │
 │       │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
@@ -75,6 +43,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
 │       │       │
 │       │       └── • Precedence dependency from DELETE_ONLY TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
 │       │             rule: "temp index existence precedes index dependents"
+│       │
+│       ├── • 6 elements transitioning toward ABSENT
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 2}
+│       │   │     PUBLIC → WRITE_ONLY
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: j, ColumnID: 2}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 2}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • Column:{DescID: 104, ColumnID: 4}
+│       │   │   │ PUBLIC → WRITE_ONLY
+│       │   │   │
+│       │   │   └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │         rule: "secondary indexes containing column as key reach write-only before column"
+│       │   │
+│       │   ├── • ColumnName:{DescID: 104, Name: crdb_internal_idx_expr, ColumnID: 4}
+│       │   │   │ PUBLIC → ABSENT
+│       │   │   │
+│       │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 104, ColumnID: 4}
+│       │   │         rule: "column no longer public before dependents"
+│       │   │
+│       │   ├── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │   │     PUBLIC → VALIDATED
+│       │   │
+│       │   └── • IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
+│       │       │ PUBLIC → ABSENT
+│       │       │
+│       │       └── • Precedence dependency from VALIDATED SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
+│       │             rule: "index no longer public before dependents"
 │       │
 │       └── • 14 Mutation operations
 │           │
@@ -341,6 +341,47 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │     rule: "index named right before index becomes public"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │       │ PUBLIC → TRANSIENT_ABSENT
+    │   │       │
+    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │             rule: "skip index-column removal ops on index removal"
+    │   │
     │   ├── • 11 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 2}
@@ -421,47 +462,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │   └── • SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0}
     │   │         VALIDATED → DELETE_ONLY
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │     rule: "index named right before index becomes public"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 3 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │   │     WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
-    │   │       │ PUBLIC → TRANSIENT_ABSENT
-    │   │       │
-    │   │       └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │             rule: "skip index-column removal ops on index removal"
-    │   │
     │   └── • 10 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -516,6 +516,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 4}
@@ -556,17 +567,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN j CASCADE;
     │   │       │     rule: "dependents removed before index"
     │   │       │
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │             rule: "dependents removed before index"
-    │   │
-    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-    │   │       │
-    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       └── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 9 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_multiple_columns_separate_statements.statement_2_of_2
@@ -214,6 +214,38 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │
     ├── • Stage 1 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 2 elements transitioning toward PUBLIC
+    │   │   │
+    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │   │   │ VALIDATED → PUBLIC
+    │   │   │   │
+    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
+    │   │   │   │     rule: "primary index swap"
+    │   │   │   │
+    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
+    │   │   │   │     rule: "index dependents exist before index becomes public"
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │   │         rule: "index dependents exist before index becomes public"
+    │   │   │         rule: "index named right before index becomes public"
+    │   │   │
+    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
+    │   │       │ ABSENT → PUBLIC
+    │   │       │
+    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
+    │   │             rule: "index existence precedes index dependents"
+    │   │
+    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
+    │   │   │   │
+    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
+    │   │   │         rule: "skip index-column removal ops on index removal"
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
+    │   │
     │   ├── • 14 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 3}
@@ -318,38 +350,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │   │       └── • skip PUBLIC → ABSENT operations
     │   │             rule: "skip index-column removal ops on index removal"
     │   │
-    │   ├── • 2 elements transitioning toward PUBLIC
-    │   │   │
-    │   │   ├── • PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │   │   │ VALIDATED → PUBLIC
-    │   │   │   │
-    │   │   │   ├── • SameStagePrecedence dependency from VALIDATED PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}
-    │   │   │   │     rule: "primary index swap"
-    │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}
-    │   │   │   │     rule: "index dependents exist before index becomes public"
-    │   │   │   │
-    │   │   │   └── • SameStagePrecedence dependency from PUBLIC IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │   │         rule: "index dependents exist before index becomes public"
-    │   │   │         rule: "index named right before index becomes public"
-    │   │   │
-    │   │   └── • IndexName:{DescID: 104, Name: t_pkey, IndexID: 3}
-    │   │       │ ABSENT → PUBLIC
-    │   │       │
-    │   │       └── • Precedence dependency from BACKFILL_ONLY PrimaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 2, TemporaryIndexID: 4, SourceIndexID: 1}
-    │   │             rule: "index existence precedes index dependents"
-    │   │
-    │   ├── • 2 elements transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   ├── • IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │   │   │ PUBLIC → TRANSIENT_ABSENT
-    │   │   │   │
-    │   │   │   └── • skip PUBLIC → TRANSIENT_ABSENT operations
-    │   │   │         rule: "skip index-column removal ops on index removal"
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │         WRITE_ONLY → TRANSIENT_DELETE_ONLY
-    │   │
     │   └── • 12 Mutation operations
     │       │
     │       ├── • MakeDroppedColumnDeleteOnly
@@ -414,6 +414,17 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │
     ├── • Stage 2 of 3 in PostCommitNonRevertiblePhase
     │   │
+    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
+    │   │   │
+    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
+    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
+    │   │       │
+    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
+    │   │       │     rule: "dependents removed before index"
+    │   │       │
+    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
+    │   │             rule: "dependents removed before index"
+    │   │
     │   ├── • 4 elements transitioning toward ABSENT
     │   │   │
     │   │   ├── • Column:{DescID: 104, ColumnID: 4}
@@ -454,17 +465,6 @@ EXPLAIN (ddl, verbose) ALTER TABLE t DROP COLUMN k CASCADE;
     │   │       │     rule: "dependents removed before index"
     │   │       │
     │   │       └── • Precedence dependency from ABSENT IndexName:{DescID: 104, Name: t_expr_k_idx, IndexID: 2}
-    │   │             rule: "dependents removed before index"
-    │   │
-    │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
-    │   │   │
-    │   │   └── • TemporaryIndex:{DescID: 104, IndexID: 4, ConstraintID: 3, SourceIndexID: 1}
-    │   │       │ TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT
-    │   │       │
-    │   │       ├── • Precedence dependency from TRANSIENT_ABSENT IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 4}
-    │   │       │     rule: "dependents removed before index"
-    │   │       │
-    │   │       └── • Precedence dependency from ABSENT IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 4}
     │   │             rule: "dependents removed before index"
     │   │
     │   └── • 9 Mutation operations


### PR DESCRIPTION
This commit does not make any functional changes. It merely ensures that
the diagrams generated by an EXPLAIN (DDL) statement list the schema
change targets in a predefined order: first the to-public targets, then
the transient targets, and finally the to-absent targets.

This helps readability and makes the declarative schema changer
data-driven test output more stable.

Release justification: low-impact, test-only change
Release note: None