### PR TITLE
ui: add workload insight details page v1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -13,7 +13,12 @@ import {
   SqlExecutionRequest,
   SqlExecutionResponse,
 } from "./sqlApi";
-import { InsightEvent, InsightExecEnum, InsightNameEnum } from "src/insights";
+import {
+  InsightEvent,
+  InsightEventDetails,
+  InsightExecEnum,
+  InsightNameEnum,
+} from "src/insights";
 import moment from "moment";
 
 export type InsightEventState = Omit<InsightEvent, "insights"> & {
@@ -22,13 +27,13 @@ export type InsightEventState = Omit<InsightEvent, "insights"> & {
 
 export type InsightEventsResponse = InsightEventState[];
 
-type InsightQuery<ResponseColumnType> = {
+type InsightQuery<ResponseColumnType, State> = {
   name: InsightNameEnum;
   query: string;
   toState: (
     response: SqlExecutionResponse<ResponseColumnType>,
-    results: Record<string, InsightEventState>,
-  ) => InsightEventState[];
+    results: Record<string, State>,
+  ) => State[];
 };
 
 // The only insight we currently report is "High Wait Time", which is the insight
@@ -68,7 +73,10 @@ function transactionContentionResultsToEventState(
   return Object.values(results);
 }
 
-const highWaitTimeQuery: InsightQuery<TransactionContentionResponseColumns> = {
+const highWaitTimeQuery: InsightQuery<
+  TransactionContentionResponseColumns,
+  InsightEventState
+> = {
   name: InsightNameEnum.highWaitTime,
   query: `SELECT
             blocking_txn_id,
@@ -96,7 +104,7 @@ const highWaitTimeQuery: InsightQuery<TransactionContentionResponseColumns> = {
 };
 
 // getInsightEventState is currently hardcoded to use the High Wait Time insight type
-// for transaction contention events
+// for transaction contention events.
 export function getInsightEventState(): Promise<InsightEventsResponse> {
   const request: SqlExecutionRequest = {
     statements: [
@@ -115,6 +123,140 @@ export function getInsightEventState(): Promise<InsightEventsResponse> {
 
       const results: Record<string, InsightEventState> = {};
       return highWaitTimeQuery.toState(result, results);
+    },
+  );
+}
+
+// Details.
+
+export type InsightEventDetailsState = Omit<InsightEventDetails, "insights"> & {
+  insightName: string;
+};
+export type InsightEventDetailsResponse = InsightEventDetailsState[];
+export type InsightEventDetailsRequest = { id: string };
+
+type TransactionContentionDetailsResponseColumns = {
+  blocking_txn_id: string;
+  blocking_queries: string[];
+  collection_ts: string;
+  contention_duration: string;
+  app_name: string;
+  blocking_txn_fingerprint_id: string;
+  waiting_txn_id: string;
+  waiting_txn_fingerprint_id: string;
+  waiting_queries: string[];
+  schema_name: string;
+  database_name: string;
+  table_name: string;
+  index_name: string;
+  key: string;
+};
+
+function transactionContentionDetailsResultsToEventState(
+  response: SqlExecutionResponse<TransactionContentionDetailsResponseColumns>,
+  results: Record<string, InsightEventDetailsState>,
+): InsightEventDetailsState[] {
+  response.execution.txn_results[0].rows.forEach(row => {
+    const key = row.blocking_txn_id;
+    if (!results[key]) {
+      results[key] = {
+        executionID: row.blocking_txn_id,
+        queries: row.blocking_queries,
+        startTime: moment(row.collection_ts),
+        elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
+        application: row.app_name,
+        fingerprintID: row.blocking_txn_fingerprint_id,
+        waitingExecutionID: row.waiting_txn_id,
+        waitingFingerprintID: row.waiting_txn_fingerprint_id,
+        waitingQueries: row.waiting_queries,
+        schemaName: row.schema_name,
+        databaseName: row.database_name,
+        tableName: row.table_name,
+        indexName: row.index_name,
+        contendedKey: row.key,
+        insightName: highWaitTimeQuery.name,
+        execType: InsightExecEnum.TRANSACTION,
+      };
+    }
+  });
+
+  return Object.values(results);
+}
+
+const highWaitTimeDetailsQuery = (
+  id: string,
+): InsightQuery<
+  TransactionContentionDetailsResponseColumns,
+  InsightEventDetailsState
+> => {
+  return {
+    name: InsightNameEnum.highWaitTime,
+    query: `SELECT
+  collection_ts, 
+  blocking_txn_id, 
+  blocking_txn_fingerprint_id, 
+  waiting_txn_id, 
+  waiting_txn_fingerprint_id, 
+  contention_duration, 
+  crdb_internal.pretty_key(contending_key, 0) as key, 
+  database_name, 
+  schema_name, 
+  table_name, 
+  index_name,
+  app_name, 
+  blocking_queries, 
+  waiting_queries 
+FROM 
+  crdb_internal.transaction_contention_events AS tce 
+  LEFT OUTER JOIN crdb_internal.ranges AS ranges ON tce.contending_key BETWEEN ranges.start_key 
+  AND ranges.end_key 
+  JOIN (
+    SELECT 
+      transaction_fingerprint_id,
+      array_agg(metadata ->> 'query') AS waiting_queries 
+    FROM 
+      crdb_internal.statement_statistics 
+    GROUP BY 
+      transaction_fingerprint_id
+  ) AS wqs ON wqs.transaction_fingerprint_id = tce.waiting_txn_fingerprint_id 
+  JOIN (
+    SELECT 
+      transaction_fingerprint_id,
+      app_name,
+      array_agg(metadata ->> 'query') AS blocking_queries 
+    FROM 
+      crdb_internal.statement_statistics 
+    GROUP BY 
+      transaction_fingerprint_id,
+      app_name
+  ) AS bqs ON bqs.transaction_fingerprint_id = tce.blocking_txn_fingerprint_id
+    WHERE blocking_txn_id = '${id}'`,
+    toState: transactionContentionDetailsResultsToEventState,
+  };
+};
+
+// getInsightEventState is currently hardcoded to use the High Wait Time insight type
+// for transaction contention events.
+export function getInsightEventDetailsState(
+  req: InsightEventDetailsRequest,
+): Promise<InsightEventDetailsResponse> {
+  const detailsQuery = highWaitTimeDetailsQuery(req.id);
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `${detailsQuery.query}`,
+      },
+    ],
+    execute: true,
+  };
+  return executeSql<TransactionContentionDetailsResponseColumns>(request).then(
+    result => {
+      if (!result.execution.txn_results[0].rows) {
+        // No data.
+        return [];
+      }
+      const results: Record<string, InsightEventDetailsState> = {};
+      return detailsQuery.toState(result, results);
     },
   );
 }

--- a/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
@@ -31,6 +31,7 @@ export const WaitTimeInsightsLabels = {
   BLOCKED_TABLE: "Blocked Table",
   BLOCKED_INDEX: "Blocked Index",
   BLOCKED_ROW: "Blocked Row",
+  CONTENDED_KEY: "Contended Key",
   WAIT_TIME: "Time Spent Waiting",
   BLOCKING_TXNS_TABLE_TITLE: (id: string, execType: ExecutionType): string =>
     `${capitalize(execType)} ID: ${id} waiting on`,
@@ -45,6 +46,7 @@ type WaitTimeInsightsPanelProps = {
   schemaName?: string;
   tableName?: string;
   indexName?: string;
+  contendedKey?: string;
   waitTime?: moment.Duration;
   waitingExecutions: ContendedExecution[];
   blockingExecutions: ContendedExecution[];
@@ -57,6 +59,7 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
   schemaName,
   tableName,
   indexName,
+  contendedKey,
   waitTime,
   waitingExecutions,
   blockingExecutions,
@@ -79,28 +82,42 @@ export const WaitTimeInsightsPanel: React.FC<WaitTimeInsightsPanelProps> = ({
                       waitTime ? Duration(waitTime.milliseconds() * 1e6) : "N/A"
                     }
                   />
-                  <SummaryCardItem
-                    label={WaitTimeInsightsLabels.BLOCKED_SCHEMA}
-                    value={schemaName}
-                  />
-                  <SummaryCardItem
-                    label={WaitTimeInsightsLabels.BLOCKED_DATABASE}
-                    value={databaseName}
-                  />
+                  {schemaName && (
+                    <SummaryCardItem
+                      label={WaitTimeInsightsLabels.BLOCKED_SCHEMA}
+                      value={schemaName}
+                    />
+                  )}
+                  {databaseName && (
+                    <SummaryCardItem
+                      label={WaitTimeInsightsLabels.BLOCKED_DATABASE}
+                      value={databaseName}
+                    />
+                  )}
                 </SummaryCard>
               </Col>
-              <Col className="gutter-row" span={12}>
-                <SummaryCard className={cx("summary-card")}>
-                  <SummaryCardItem
-                    label={WaitTimeInsightsLabels.BLOCKED_TABLE}
-                    value={tableName}
-                  />
-                  <SummaryCardItem
-                    label={WaitTimeInsightsLabels.BLOCKED_INDEX}
-                    value={indexName}
-                  />
-                </SummaryCard>
-              </Col>
+              {tableName && (
+                <Col className="gutter-row" span={12}>
+                  <SummaryCard className={cx("summary-card")}>
+                    <SummaryCardItem
+                      label={WaitTimeInsightsLabels.BLOCKED_TABLE}
+                      value={tableName}
+                    />
+                    {indexName && (
+                      <SummaryCardItem
+                        label={WaitTimeInsightsLabels.BLOCKED_INDEX}
+                        value={indexName}
+                      />
+                    )}
+                    {contendedKey && (
+                      <SummaryCardItem
+                        label={WaitTimeInsightsLabels.CONTENDED_KEY}
+                        value={contendedKey}
+                      />
+                    )}
+                  </SummaryCard>
+                </Col>
+              )}
             </Row>
           )}
           {blockingExecutions.length > 0 && (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -13,7 +13,7 @@ import { HIGH_WAIT_CONTENTION_THRESHOLD } from "../api";
 import { Filters } from "../queryFilter";
 
 export enum InsightNameEnum {
-  highWaitTime = "highWaitTime",
+  highWaitTime = "HIGH_WAIT_TIME",
 }
 
 export enum InsightExecEnum {
@@ -31,22 +31,52 @@ export type InsightEvent = {
   execType: InsightExecEnum;
 };
 
+export type InsightEventDetails = {
+  executionID: string;
+  queries: string[];
+  insights: Insight[];
+  startTime: Moment;
+  elapsedTime: number;
+  application: string;
+  fingerprintID: string;
+  waitingExecutionID: string;
+  waitingFingerprintID: string;
+  waitingQueries: string[];
+  contendedKey: string;
+  schemaName: string;
+  databaseName: string;
+  tableName: string;
+  indexName: string;
+  execType: InsightExecEnum;
+};
+
 export type Insight = {
   name: InsightNameEnum;
   label: string;
   description: string;
+  tooltipDescription: string;
+};
+
+export type EventExecution = {
+  executionID: string;
+  fingerprintID: string;
+  queries: string[];
+  startTime: Moment;
+  elapsedTime: number;
+  execType: InsightExecEnum;
 };
 
 const highWaitTimeInsight = (
   execType: InsightExecEnum = InsightExecEnum.TRANSACTION,
 ): Insight => {
   const threshold = HIGH_WAIT_CONTENTION_THRESHOLD.asMilliseconds();
+  const description = `This ${execType} has been waiting for more than ${threshold}ms on other ${execType}s to execute.`;
   return {
     name: InsightNameEnum.highWaitTime,
     label: "High Wait Time",
-    description:
-      `This ${execType} has been waiting for more than ${threshold}ms on other ${execType}s to execute. ` +
-      `Click the ${execType} execution ID to see more details.`,
+    description: description,
+    tooltipDescription:
+      description + ` Click the ${execType} execution ID to see more details.`,
   };
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -9,16 +9,24 @@
 // licenses/APL.txt.
 
 import { unset } from "src/util";
-import { InsightEventsResponse, InsightEventState } from "src/api/insightsApi";
+import {
+  InsightEventsResponse,
+  InsightEventState,
+  InsightEventDetailsResponse,
+  InsightEventDetailsState,
+} from "src/api/insightsApi";
 import {
   Insight,
   InsightExecEnum,
   InsightTypes,
   InsightEvent,
   InsightEventFilters,
+  InsightEventDetails,
 } from "./types";
 
-export const getInsights = (eventState: InsightEventState): Insight[] => {
+export const getInsights = (
+  eventState: InsightEventState | InsightEventDetailsState,
+): Insight[] => {
   const insights: Insight[] = [];
   InsightTypes.forEach(insight => {
     if (insight(eventState.execType).name == eventState.insightName) {
@@ -54,6 +62,21 @@ export function getInsightsFromState(
   });
 
   return insightEvents;
+}
+
+export function getInsightEventDetailsFromState(
+  insightEventDetailsResponse: InsightEventDetailsResponse,
+): InsightEventDetails {
+  let insightEventDetails: InsightEventDetails = null;
+  const insightsForEventDetails = getInsights(insightEventDetailsResponse[0]);
+  if (insightsForEventDetails.length > 0) {
+    delete insightEventDetailsResponse[0].insightName;
+    insightEventDetails = {
+      ...insightEventDetailsResponse[0],
+      insights: insightsForEventDetails,
+    };
+  }
+  return insightEventDetails;
 }
 
 export const filterTransactionInsights = (

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/index.ts
@@ -8,7 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./workloadInsights";
-export * from "./workloadInsightDetails";
-export * from "./utils";
-export * from "./types";
+export * from "./transactionInsightDetails";

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -1,0 +1,68 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { SortedTable, ColumnDescriptor } from "src/sortedtable";
+import { DATE_FORMAT, Duration } from "src/util";
+import { EventExecution, InsightExecEnum } from "../types";
+import { insightsTableTitles, QueriesCell } from "../workloadInsights/util";
+
+interface InsightDetailsTableProps {
+  data: EventExecution[];
+  execType: InsightExecEnum;
+}
+
+export function makeInsightDetailsColumns(
+  execType: InsightExecEnum,
+): ColumnDescriptor<EventExecution>[] {
+  const columns: ColumnDescriptor<EventExecution>[] = [
+    {
+      name: "executionID",
+      title: insightsTableTitles.executionID(execType),
+      cell: (item: EventExecution) => String(item.executionID),
+      sort: (item: EventExecution) => item.executionID,
+    },
+    {
+      name: "fingerprintID",
+      title: insightsTableTitles.fingerprintID(execType),
+      cell: (item: EventExecution) => String(item.fingerprintID),
+      sort: (item: EventExecution) => item.fingerprintID,
+    },
+    {
+      name: "query",
+      title: insightsTableTitles.query(execType),
+      cell: (item: EventExecution) =>
+        QueriesCell({ transactionQueries: item.queries, textLimit: 50 }),
+      sort: (item: EventExecution) => item.queries.length,
+    },
+    {
+      name: "startTime",
+      title: insightsTableTitles.startTime(execType),
+      cell: (item: EventExecution) => item.startTime.format(DATE_FORMAT),
+      sort: (item: EventExecution) => item.startTime.unix(),
+    },
+    {
+      name: "elapsedTime",
+      title: insightsTableTitles.elapsedTime(execType),
+      cell: (item: EventExecution) => Duration(item.elapsedTime * 1e6),
+      sort: (item: EventExecution) => item.elapsedTime,
+    },
+  ];
+  return columns;
+}
+
+export const WaitTimeDetailsTable: React.FC<
+  InsightDetailsTableProps
+> = props => {
+  const columns = makeInsightDetailsColumns(props.execType);
+  return (
+    <SortedTable className="statements-table" columns={columns} {...props} />
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -1,0 +1,235 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import React from "react";
+import Helmet from "react-helmet";
+import { RouteComponentProps } from "react-router-dom";
+import { ArrowLeft } from "@cockroachlabs/icons";
+import { Heading } from "@cockroachlabs/ui-components";
+import { Col, Row } from "antd";
+import "antd/lib/col/style";
+import "antd/lib/row/style";
+import moment from "moment";
+import { Button } from "src/button";
+import { Loading } from "src/loading";
+import { SqlBox } from "src/sql";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import { Duration } from "src/util";
+import { DATE_FORMAT_24_UTC } from "src/util/format";
+import { getMatchParamByName } from "src/util/query";
+import {
+  WaitTimeInsightsLabels,
+  WaitTimeInsightsPanel,
+} from "src/detailsPanels/waitTimeInsightsPanel";
+import {
+  InsightEventDetailsRequest,
+  InsightEventDetailsResponse,
+} from "src/api";
+import {
+  InsightRecommendation,
+  InsightsSortedTable,
+  makeInsightsColumns,
+} from "src/insightsTable/insightsTable";
+import { WaitTimeDetailsTable } from "./insightDetailsTables";
+import { getInsightEventDetailsFromState } from "../utils";
+import { EventExecution } from "../types";
+import { WorkloadInsightsError } from "../workloadInsights/util";
+
+import classNames from "classnames/bind";
+import { commonStyles } from "src/common";
+import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
+
+const tableCx = classNames.bind(insightTableStyles);
+
+export interface InsightDetailsStateProps {
+  insightEventDetails: InsightEventDetailsResponse;
+  insightError: Error | null;
+}
+
+export interface InsightDetailsDispatchProps {
+  refreshInsightDetails: (req: InsightEventDetailsRequest) => void;
+}
+
+export type InsightDetailsProps = InsightDetailsStateProps &
+  InsightDetailsDispatchProps &
+  RouteComponentProps<unknown>;
+
+export class InsightDetails extends React.Component<InsightDetailsProps> {
+  constructor(props: InsightDetailsProps) {
+    super(props);
+  }
+  private refresh(): void {
+    this.props.refreshInsightDetails({
+      id: getMatchParamByName(this.props.match, "id"),
+    });
+  }
+
+  componentDidMount(): void {
+    this.refresh();
+  }
+
+  componentDidUpdate(): void {
+    this.refresh();
+  }
+
+  prevPage = (): void => this.props.history.goBack();
+
+  renderContent = (): React.ReactElement => {
+    const insightDetails = getInsightEventDetailsFromState(
+      this.props.insightEventDetails,
+    );
+    if (!insightDetails) {
+      return null;
+    }
+    const insightQueries = insightDetails.queries
+      .map((query, idx) => {
+        if (idx != 0) {
+          return "\n" + query;
+        } else {
+          return query;
+        }
+      })
+      .toString();
+    const insightsColumns = makeInsightsColumns();
+    function insightsTableData(): InsightRecommendation[] {
+      const recs = [];
+      let rec: InsightRecommendation;
+      insightDetails.insights.forEach(insight => {
+        switch (insight.name.toString()) {
+          case "HIGH_WAIT_TIME":
+            rec = {
+              type: "HIGH_WAIT_TIME",
+              details: {
+                duration: insightDetails.elapsedTime,
+                description: insight.description,
+              },
+            };
+            break;
+        }
+      });
+      recs.push(rec);
+      return recs;
+    }
+    const tableData = insightsTableData();
+    const waitingExecutions: EventExecution[] = [
+      {
+        executionID: insightDetails.waitingExecutionID,
+        fingerprintID: insightDetails.waitingFingerprintID,
+        queries: insightDetails.waitingQueries,
+        startTime: insightDetails.startTime,
+        elapsedTime: insightDetails.elapsedTime,
+        execType: insightDetails.execType,
+      },
+    ];
+    return (
+      <>
+        <section>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={24}>
+              <SqlBox value={insightQueries} />
+            </Col>
+          </Row>
+          <Row gutter={24}>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard>
+                <SummaryCardItem
+                  label="Start Time"
+                  value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
+                />
+                <SummaryCardItem
+                  label="Elapsed Time"
+                  value={Duration(insightDetails.elapsedTime * 1e6)}
+                />
+              </SummaryCard>
+            </Col>
+            <Col className="gutter-row" span={12}>
+              <SummaryCard>
+                <SummaryCardItem
+                  label="Transaction Fingerprint ID"
+                  value={String(insightDetails.fingerprintID)}
+                />
+              </SummaryCard>
+            </Col>
+          </Row>
+          <Row gutter={24} className={tableCx("margin-bottom")}>
+            <InsightsSortedTable columns={insightsColumns} data={tableData} />
+          </Row>
+        </section>
+        <section>
+          <WaitTimeInsightsPanel
+            execType={insightDetails.execType}
+            executionID={insightDetails.executionID}
+            schemaName={insightDetails.schemaName}
+            tableName={insightDetails.tableName}
+            indexName={insightDetails.indexName}
+            databaseName={insightDetails.databaseName}
+            contendedKey={String(insightDetails.contendedKey)}
+            waitTime={moment.duration(insightDetails.elapsedTime)}
+            waitingExecutions={[]}
+            blockingExecutions={[]}
+          />
+          <Row gutter={24}>
+            <Col>
+              <Row>
+                <Heading type="h5">
+                  {WaitTimeInsightsLabels.WAITING_TXNS_TABLE_TITLE(
+                    insightDetails.executionID,
+                    insightDetails.execType,
+                  )}
+                </Heading>
+                <div>
+                  <WaitTimeDetailsTable
+                    data={waitingExecutions}
+                    execType={insightDetails.execType}
+                  />
+                </div>
+              </Row>
+            </Col>
+          </Row>
+        </section>
+      </>
+    );
+  };
+
+  render(): React.ReactElement {
+    return (
+      <div>
+        <Helmet title={"Details | Insight"} />
+        <div>
+          <Button
+            onClick={this.prevPage}
+            type="unstyled-link"
+            size="small"
+            icon={<ArrowLeft fontSize={"10px"} />}
+            iconPosition="left"
+            className={commonStyles("small-margin")}
+          >
+            Insights
+          </Button>
+          <h3>{`Transaction Execution ID: ${String(
+            getMatchParamByName(this.props.match, "id"),
+          )}`}</h3>
+        </div>
+        <section>
+          <Loading
+            loading={this.props.insightEventDetails == null}
+            page={"Transaction Insight details"}
+            error={this.props.insightError}
+            render={this.renderContent}
+            renderError={() =>
+              WorkloadInsightsError({
+                execType: "transaction insights",
+              })
+            }
+          />
+        </section>
+      </div>
+    );
+  }
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -19,7 +19,7 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       queries: [
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       ],
-      insightName: "highWaitTime",
+      insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
@@ -31,7 +31,7 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
         "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
         "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
       ],
-      insightName: "highWaitTime",
+      insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
@@ -42,7 +42,7 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       queries: [
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       ],
-      insightName: "highWaitTime",
+      insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -18,6 +18,7 @@ import {
 import { DATE_FORMAT, Duration } from "src/util";
 import { InsightExecEnum, InsightEvent } from "src/insights";
 import { QueriesCell, InsightCell, insightsTableTitles } from "../util";
+import { Link } from "react-router-dom";
 
 interface TransactionInsightsTable {
   data: InsightEvent[];
@@ -33,8 +34,12 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<InsightEvent>
     {
       name: "executionID",
       title: insightsTableTitles.executionID(execType),
-      cell: (item: InsightEvent) => String(item.executionID),
-      sort: (item: InsightEvent) => String(item.executionID),
+      cell: (item: InsightEvent) => (
+        <Link to={`/insights/${item.executionID}`}>
+          {String(item.executionID)}
+        </Link>
+      ),
+      sort: (item: InsightEvent) => item.executionID,
     },
     {
       name: "query",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightCell.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import classNames from "classnames/bind";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { Insight } from "src/insights";
-import styles from "./insightTable.module.scss";
+import styles from "./workloadInsights.module.scss";
 
 const cx = classNames.bind(styles);
 
@@ -28,7 +28,11 @@ function mapInsightTypesToStatus(insight: Insight): string {
 export function InsightCell(insight: Insight) {
   const status = mapInsightTypesToStatus(insight);
   return (
-    <Tooltip content={insight.description} style="tableTitle">
+    <Tooltip
+      key={Math.random()}
+      content={insight.tooltipDescription}
+      style="tableTitle"
+    >
       <span className={cx("insight-type", `insight-type--${status}`)}>
         {insight.label}
       </span>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -19,6 +19,7 @@ export const insightsColumnLabels = {
   startTime: "Start Time (UTC)",
   elapsedTime: "Elapsed Time",
   applicationName: "Application",
+  fingerprintID: "Fingerprint ID",
 };
 
 export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
@@ -111,6 +112,17 @@ export const insightsTableTitles: InsightsTableTitleType = {
         content={<p>The name of the application that ran the {execType}.</p>}
       >
         {getLabel("applicationName")}
+      </Tooltip>
+    );
+  },
+  fingerprintID: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={<p>The {execType} fingerprint ID.</p>}
+      >
+        {getLabel("fingerprintID", execType)}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/queriesCell.tsx
@@ -12,7 +12,7 @@ import React from "react";
 import { Tooltip } from "@cockroachlabs/ui-components";
 import { limitText } from "src/util";
 import classNames from "classnames/bind";
-import styles from "./insightTable.module.scss";
+import styles from "./workloadInsights.module.scss";
 
 const cx = classNames.bind(styles);
 
@@ -37,9 +37,11 @@ export const QueriesCell = ({
         placement="bottom"
         content={
           <div>
-            {transactionQueries.map(query => (
-              <div key={query.slice(0, 3) + transactionQueries.indexOf(query)}>
+            {transactionQueries.map((query, idx, arr) => (
+              <div key={Math.random()}>
+                {idx != 0 && <br />}
                 {query}
+                {idx != arr.length - 1 && <br />}
               </div>
             ))}
           </div>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsights.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsights.module.scss
@@ -22,10 +22,6 @@
   }
 }
 
-.insight-table {
-  display:flex;
-}
-
 .action {
   color: $colors--link;
   display: flex;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsightsError.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/workloadInsightsError.tsx
@@ -10,7 +10,7 @@
 
 import React from "react";
 import classNames from "classnames/bind";
-import styles from "./insightTable.module.scss";
+import styles from "./workloadInsights.module.scss";
 
 const cx = classNames.bind(styles);
 

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -15,3 +15,7 @@
 .description-item {
   margin-bottom: 5px;
 }
+
+.margin-bottom {
+  margin-bottom: 20px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -14,18 +14,24 @@ import { ColumnDescriptor, SortedTable } from "../sortedtable";
 import classNames from "classnames/bind";
 import styles from "./insightsTable.module.scss";
 import { StatementLink } from "../statementsTable";
+import { Duration } from "../util";
 
 const cx = classNames.bind(styles);
 
-export type InsightType = "DROP_INDEX" | "CREATE_INDEX" | "REPLACE_INDEX";
+export type InsightType =
+  | "DROP_INDEX"
+  | "CREATE_INDEX"
+  | "REPLACE_INDEX"
+  | "HIGH_WAIT_TIME";
 
 export interface InsightRecommendation {
   type: InsightType;
-  database: string;
-  table: string;
-  index_id: number;
-  query: string;
-  execution: executionDetails;
+  database?: string;
+  table?: string;
+  index_id?: number;
+  query?: string;
+  execution?: executionDetails;
+  details?: insightDetails;
 }
 
 export interface executionDetails {
@@ -33,6 +39,11 @@ export interface executionDetails {
   summary: string;
   fingerprintID: string;
   implicit: boolean;
+}
+
+export interface insightDetails {
+  duration: number;
+  description: string;
 }
 
 export class InsightsSortedTable extends SortedTable<InsightRecommendation> {}
@@ -80,6 +91,8 @@ function insightType(type: InsightType): string {
       return "Drop Unused Index";
     case "REPLACE_INDEX":
       return "Replace Index";
+    case "HIGH_WAIT_TIME":
+      return "High Wait Time";
     default:
       return "Insight";
   }
@@ -115,6 +128,19 @@ function descriptionCell(
       );
     case "DROP_INDEX":
       return <>{`Index ${insightRec.index_id}`}</>;
+    case "HIGH_WAIT_TIME":
+      return (
+        <>
+          <div className={cx("description-item")}>
+            <span className={cx("label-bold")}>Time Spent Waiting: </span>{" "}
+            {Duration(insightRec.details.duration * 1e6)}
+          </div>
+          <div className={cx("description-item")}>
+            <span className={cx("label-bold")}>Description: </span>{" "}
+            {insightRec.details.description}
+          </div>
+        </>
+      );
     default:
       return <>{insightRec.query}</>;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/index.ts
@@ -8,7 +8,6 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./workloadInsights";
-export * from "./workloadInsightDetails";
-export * from "./utils";
-export * from "./types";
+export * from "./insightDetails.reducer";
+export * from "./insightDetails.sagas";
+export * from "./insightDetails.selectors";

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.reducer.ts
@@ -1,0 +1,52 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { DOMAIN_NAME } from "../utils";
+import moment, { Moment } from "moment";
+import {
+  InsightEventDetailsRequest,
+  InsightEventDetailsResponse,
+} from "src/api/insightsApi";
+
+export type InsightDetailsState = {
+  data: InsightEventDetailsResponse | null;
+  lastUpdated: Moment | null;
+  lastError: Error;
+  valid: boolean;
+};
+
+const initialState: InsightDetailsState = {
+  data: null,
+  lastUpdated: null,
+  lastError: null,
+  valid: true,
+};
+
+const insightDetailsSlice = createSlice({
+  name: `${DOMAIN_NAME}/insightDetailsSlice`,
+  initialState,
+  reducers: {
+    received: (state, action: PayloadAction<InsightEventDetailsResponse>) => {
+      state.data = action.payload;
+      state.valid = true;
+      state.lastError = null;
+      state.lastUpdated = moment.utc();
+    },
+    failed: (state, action: PayloadAction<Error>) => {
+      state.valid = false;
+      state.lastError = action.payload;
+    },
+    refresh: (_, action: PayloadAction<InsightEventDetailsRequest>) => {},
+    request: (_, action: PayloadAction<InsightEventDetailsRequest>) => {},
+  },
+});
+
+export const { reducer, actions } = insightDetailsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.sagas.ts
@@ -1,0 +1,41 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { all, call, delay, put, takeLatest } from "redux-saga/effects";
+
+import { actions } from "./insightDetails.reducer";
+import {
+  getInsightEventDetailsState,
+  InsightEventDetailsRequest,
+} from "src/api/insightsApi";
+import { throttleWithReset } from "../utils";
+import { rootActions } from "../reducers";
+import { PayloadAction } from "@reduxjs/toolkit";
+
+export function* refreshInsightDetailsSaga(
+  action: PayloadAction<InsightEventDetailsRequest>,
+) {
+  yield put(actions.request(action.payload));
+}
+
+export function* requestInsightDetailsSaga(
+  action: PayloadAction<InsightEventDetailsRequest>,
+): any {
+  try {
+    const result = yield call(getInsightEventDetailsState, action.payload);
+    yield put(actions.received(result));
+  } catch (e) {
+    yield put(actions.failed(e));
+  }
+}
+
+export function* insightDetailsSaga() {
+  yield all([takeLatest(actions.request, requestInsightDetailsSaga)]);
+}

--- a/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/insightDetails/insightDetails.selectors.ts
@@ -8,7 +8,13 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-export * from "./workloadInsights";
-export * from "./workloadInsightDetails";
-export * from "./utils";
-export * from "./types";
+import { createSelector } from "reselect";
+import { adminUISelector } from "../utils/selectors";
+
+export const selectInsightDetails = createSelector(
+  adminUISelector,
+  adminUiState => {
+    if (!adminUiState.insights) return [];
+    return adminUiState.insightDetails.data;
+  },
+);

--- a/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/reducers.ts
@@ -40,6 +40,10 @@ import {
   reducer as clusterLocks,
 } from "./clusterLocks/clusterLocks.reducer";
 import { InsightsState, reducer as insights } from "./insights";
+import {
+  InsightDetailsState,
+  reducer as insightDetails,
+} from "./insightDetails";
 
 export type AdminUiState = {
   statementDiagnostics: StatementDiagnosticsState;
@@ -56,6 +60,7 @@ export type AdminUiState = {
   job: JobState;
   clusterLocks: ClusterLocksReqState;
   insights: InsightsState;
+  insightDetails: InsightDetailsState;
 };
 
 export type AppState = {
@@ -69,6 +74,7 @@ export const reducers = combineReducers<AdminUiState>({
   liveness,
   sessions,
   insights,
+  insightDetails,
   terminateQuery,
   uiConfig,
   sqlStats,

--- a/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sagas.ts
@@ -25,6 +25,7 @@ import { sqlDetailsStatsSaga } from "./statementDetails";
 import { indexStatsSaga } from "./indexStats/indexStats.sagas";
 import { clusterLocksSaga } from "./clusterLocks/clusterLocks.saga";
 import { insightsSaga } from "./insights/insights.sagas";
+import { insightDetailsSaga } from "./insightDetails";
 
 export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
   yield all([
@@ -33,6 +34,7 @@ export function* sagas(cacheInvalidationPeriod?: number): SagaIterator {
     fork(nodesSaga, cacheInvalidationPeriod),
     fork(livenessSaga, cacheInvalidationPeriod),
     fork(insightsSaga),
+    fork(insightDetailsSaga),
     fork(jobsSaga),
     fork(jobSaga),
     fork(sessionsSaga),

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -35,6 +35,10 @@ stubComponentInModule(
   "src/views/insights/workloadInsightsPageConnected",
   "default",
 );
+stubComponentInModule(
+  "src/views/insights/workloadInsightDetailsPageConnected",
+  "default",
+);
 
 import React from "react";
 import { Action, Store } from "redux";
@@ -424,6 +428,12 @@ describe("Routing to", () => {
     test("routes to <InsightsOverviewPage> component", () => {
       navigateToPath("/insights");
       screen.getByTestId("workloadInsightsPageConnected");
+    });
+  });
+  describe("'/insights/insightID' path", () => {
+    test("routes to <WorkloadInsightDetailsPageConnected> component", () => {
+      navigateToPath("/insights/insightID");
+      screen.getByTestId("workloadInsightDetailsPageConnected");
     });
   });
   {

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -79,6 +79,7 @@ import ActiveTransactionDetails from "./views/transactions/activeTransactionDeta
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
 import InsightsOverviewPage from "src/views/insights/insightsOverview";
+import WorkloadInsightDetailsPageConnected from "src/views/insights/workloadInsightDetailsPageConnected";
 import { CockroachCloudContext } from "@cockroachlabs/cluster-ui";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
@@ -296,11 +297,16 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                     from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
                     to={`/transaction/:${txnFingerprintIdAttr}`}
                   />
+
                   {/* Insights */}
                   <Route
                     exact
                     path="/insights"
                     component={InsightsOverviewPage}
+                  />
+                  <Route
+                    path={"/insights/:id"}
+                    component={WorkloadInsightDetailsPageConnected}
                   />
 
                   {/* debug pages */}

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -403,6 +403,17 @@ const insightsReducerObj = new CachedDataReducer(
 );
 export const refreshInsights = insightsReducerObj.refresh;
 
+export const insightRequestKey = (
+  req: clusterUiApi.InsightEventDetailsRequest,
+): string => `${req.id}`;
+
+const insightDetailsReducerObj = new KeyedCachedDataReducer(
+  clusterUiApi.getInsightEventDetailsState,
+  "insightDetails",
+  insightRequestKey,
+);
+export const refreshInsightDetails = insightDetailsReducerObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<api.EventsResponseMessage>;
@@ -439,6 +450,7 @@ export interface APIReducersState {
   hotRanges: PaginatedCachedDataReducerState<api.HotRangesV2ResponseMessage>;
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
   insights: CachedDataReducerState<clusterUiApi.InsightEventsResponse>;
+  insightDetails: KeyedCachedDataReducerState<clusterUiApi.InsightEventDetailsResponse>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -481,6 +493,7 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [hotRangesReducerObj.actionNamespace]: hotRangesReducerObj.reducer,
   [clusterLocksReducerObj.actionNamespace]: clusterLocksReducerObj.reducer,
   [insightsReducerObj.actionNamespace]: insightsReducerObj.reducer,
+  [insightDetailsReducerObj.actionNamespace]: insightDetailsReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
+++ b/pkg/ui/workspaces/db-console/src/views/insights/insightsSelectors.ts
@@ -15,7 +15,11 @@ import {
   defaultFilters,
   SortSetting,
   InsightEventFilters,
+  api,
 } from "@cockroachlabs/cluster-ui";
+import { RouteComponentProps } from "react-router-dom";
+import { CachedDataReducerState } from "src/redux/cachedDataReducer";
+import { getMatchParamByName } from "src/util/query";
 
 export const filtersLocalSetting = new LocalSetting<
   AdminUIState,
@@ -37,5 +41,19 @@ export const selectInsights = createSelector(
   adminUiState => {
     if (!adminUiState.insights) return [];
     return adminUiState.insights.data;
+  },
+);
+
+export const selectInsightDetails = createSelector(
+  [
+    (state: AdminUIState) => state.cachedData.insightDetails,
+    (_state: AdminUIState, props: RouteComponentProps) => props,
+  ],
+  (insight, props): CachedDataReducerState<api.InsightEventDetailsResponse> => {
+    const insightId = getMatchParamByName(props.match, "id");
+    if (!insight) {
+      return null;
+    }
+    return insight[insightId];
   },
 );

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightDetailsPageConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightDetailsPageConnected.tsx
@@ -1,0 +1,50 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import {
+  InsightDetails,
+  InsightDetailsStateProps,
+  InsightDetailsDispatchProps,
+  api,
+} from "@cockroachlabs/cluster-ui";
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { refreshInsightDetails } from "src/redux/apiReducers";
+import { AdminUIState } from "src/redux/state";
+import { selectInsightDetails } from "src/views/insights/insightsSelectors";
+
+const mapStateToProps = (
+  state: AdminUIState,
+  props: RouteComponentProps,
+): InsightDetailsStateProps => {
+  const insightDetailsState = selectInsightDetails(state, props);
+  const insight: api.InsightEventDetailsResponse = insightDetailsState?.data;
+  const insightError = insightDetailsState?.lastError;
+  return {
+    insightEventDetails: insight,
+    insightError: insightError,
+  };
+};
+
+const mapDispatchToProps = {
+  refreshInsightDetails: refreshInsightDetails,
+};
+
+const WorkloadInsightDetailsPageConnected = withRouter(
+  connect<
+    InsightDetailsStateProps,
+    InsightDetailsDispatchProps,
+    RouteComponentProps
+  >(
+    mapStateToProps,
+    mapDispatchToProps,
+  )(InsightDetails),
+);
+
+export default WorkloadInsightDetailsPageConnected;


### PR DESCRIPTION
This commit adds the v1 Workload Insight Details page to the DB Console, via the `cluster-ui` package. The v1 Workload Insight Details page only includes details about a specific High Wait Time transaction insight event, populated with information served a new "endpoint" built on top of the SQL-over-HTTP API.

Note that this v1 page only includes information available on contention for individual transaction executions recorded in the `crdb_internal.transaction_contention_events` table. As most transaction statistics are aggregated across multiple transaction executions, there are some data missing in this v1, most notably: end time, rows processed, priority, full scan, retry count, last retry reason, session id.

Fixes #83775.

https://www.loom.com/share/3f7dbd1326954c4ca7949ed8539ae4e9

Release note (ui change): Added new Workload Insight Details page to DB Console

Release justification: low-risk updates to new functionality