### PR TITLE
ui/cluster-ui: show status as waiting when txn is waiting for lock

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/selectors/activeExecutionsCommon.selectors.ts
@@ -24,7 +24,7 @@ import {
 export const selectExecutionID = (
   _state: unknown,
   props: RouteComponentProps,
-) => getMatchParamByName(props.match, executionIdAttr);
+): string | null => getMatchParamByName(props.match, executionIdAttr);
 
 export const selectActiveExecutionsCombiner = (
   sessions: SessionsResponse | null,
@@ -39,10 +39,12 @@ export const selectActiveExecutionsCombiner = (
   return {
     statements: execs.statements.map(s => ({
       ...s,
+      status: waitTimeByTxnID[s.transactionID] != null ? "Waiting" : s.status,
       timeSpentWaiting: waitTimeByTxnID[s.transactionID],
     })),
     transactions: execs.transactions.map(t => ({
       ...t,
+      status: waitTimeByTxnID[t.transactionID] != null ? "Waiting" : t.status,
       timeSpentWaiting: waitTimeByTxnID[t.transactionID],
     })),
   };


### PR DESCRIPTION
Now that we have surfaced contention information in the UI, we can
update the stmt / txn status field for active executions to be
'Waiting' when the stmt or txn is waiting to acquire a lock.

Release justification: low risk update to existing functionality
Release note (ui change): txns and stmts in active exec pages that
are waiting for a lock will now have the status 'Waiting'

<img width="654" alt="image" src="https://user-images.githubusercontent.com/20136951/185226858-8c194582-d405-4c8b-aec9-7a21a4bc1c22.png">
