### PR TITLE
roachtest: enable better vmodules for drain/quit roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/quit.go
+++ b/pkg/cmd/roachtest/tests/quit.go
@@ -55,7 +55,7 @@ func runQuitTransfersLeases(
 }
 
 func (q *quitTest) init(ctx context.Context) {
-	q.args = []string{"--vmodule=store=1,replica=1,replica_proposal=1"}
+	q.args = []string{"--vmodule=replica_proposal=1,allocator=3,allocator_scorer=3"}
 	q.env = []string{"COCKROACH_SCAN_MAX_IDLE_TIME=5ms"}
 	q.c.Put(ctx, q.t.Cockroach(), "./cockroach")
 	settings := install.MakeClusterSettings(install.EnvOption(q.env))


### PR DESCRIPTION
This should help in debugging failures like #85203 when they happen again.

Release note: None

Release justification: testing only