### PR TITLE
*: add restriction to running DDL with internal executors

### DIFF
--- a/pkg/ccl/backupccl/backup_metadata_test.go
+++ b/pkg/ccl/backupccl/backup_metadata_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -86,7 +87,11 @@ func checkMetadata(
 		tc.Servers[0].ClusterSettings(),
 		blobs.TestEmptyBlobClientFactory,
 		username.RootUserName(),
-		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
+		tc.Servers[0].InternalExecutor().(*sql.InternalExecutor),
+		tc.Servers[0].CollectionFactory().(*descs.CollectionFactory),
+		tc.Servers[0].DB(),
+		nil, /* limiters */
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -572,7 +572,11 @@ func TestBackupRestoreAppend(t *testing.T) {
 				tc.Servers[0].ClusterSettings(),
 				blobs.TestEmptyBlobClientFactory,
 				username.RootUserName(),
-				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
+				tc.Servers[0].InternalExecutor().(*sql.InternalExecutor),
+				tc.Servers[0].CollectionFactory().(*descs.CollectionFactory),
+				tc.Servers[0].DB(),
+				nil, /* limiters */
+			)
 			require.NoError(t, err)
 			defer store.Close()
 			var files []string
@@ -8021,7 +8025,12 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 		base.ExternalIODirConfig{},
 		st,
 		blobs.TestBlobServiceClient(dir),
-		username.RootUserName(), nil, nil, nil)
+		username.RootUserName(),
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
 
 	m := mon.NewMonitor("test-monitor", mon.MemoryResource, nil, nil, 0, 0, st)

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -253,7 +253,12 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			DB: kvDB,
 			ExternalStorage: func(ctx context.Context, dest cloudpb.ExternalStorage, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
 				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir), nil, nil, nil, opts...)
+					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir),
+					nil, /* ie */
+					nil, /* cf */
+					nil, /* kvDB */
+					nil, /* limiters */
+					opts...)
 			},
 			Settings:          s.ClusterSettings(),
 			Codec:             keys.SystemSQLCodec,

--- a/pkg/ccl/backupccl/testdata/backup-restore/file_table_read_write
+++ b/pkg/ccl/backupccl/testdata/backup-restore/file_table_read_write
@@ -1,0 +1,43 @@
+subtest backup_file_table
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE to_backup;
+----
+
+exec-sql
+CREATE DATABASE backups;
+----
+
+exec-sql
+BACKUP DATABASE to_backup INTO 'userfile://backups.public.userfiles_$user/data';
+----
+
+query-sql
+SELECT * FROM backups.crdb_internal.invalid_objects;
+----
+
+exec-sql
+USE backups;
+----
+
+query-sql
+SELECT * FROM pg_catalog.pg_tables where schemaname='public';
+----
+public userfiles_$user_upload_files root <nil> true false false false
+public userfiles_$user_upload_payload root <nil> true false false false
+
+query-sql
+SELECT conname FROM pg_catalog.pg_constraint con
+INNER JOIN pg_catalog.pg_class rel   ON rel.oid = con.conrelid
+INNER JOIN pg_catalog.pg_namespace nsp
+ON nsp.oid = connamespace
+WHERE rel.relname='userfiles_$user_upload_payload'
+ORDER BY conname;
+----
+file_id_fk
+userfiles_$user_upload_payload_pkey
+
+subtest end

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -169,7 +169,13 @@ func TestCloudStorageSink(t *testing.T) {
 	externalStorageFromURI := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage,
 		error) {
 		return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{}, settings,
-			clientFactory, user, nil, nil, nil, opts...)
+			clientFactory,
+			user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+			opts...)
 	}
 
 	user := username.RootUserName()

--- a/pkg/ccl/cliccl/debug_backup.go
+++ b/pkg/ccl/cliccl/debug_backup.go
@@ -291,7 +291,12 @@ func externalStorageFromURIFactory(
 	defaultSettings := &cluster.Settings{}
 	defaultSettings.SV.Init(ctx, nil /* opaque */)
 	return cloud.ExternalStorageFromURI(ctx, uri, base.ExternalIODirConfig{},
-		defaultSettings, newBlobFactory, user, nil /*Internal Executor*/, nil /*kvDB*/, nil, opts...)
+		defaultSettings, newBlobFactory, user,
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+		opts...)
 }
 
 func getManifestFromURI(ctx context.Context, path string) (backuppb.BackupManifest, error) {
@@ -588,7 +593,13 @@ func makeIters(
 		var err error
 		clusterSettings := cluster.MakeClusterSettings()
 		dirStorage[i], err = cloud.MakeExternalStorage(ctx, file.Dir, base.ExternalIODirConfig{},
-			clusterSettings, newBlobFactory, nil /*internal executor*/, nil /*kvDB*/, nil)
+			clusterSettings,
+			newBlobFactory,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+		)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "making external storage")
 		}

--- a/pkg/ccl/storageccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/catalog/descs",
         "//pkg/storage",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/ccl/storageccl/external_sst_reader_test.go
+++ b/pkg/ccl/storageccl/external_sst_reader_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
@@ -122,7 +123,11 @@ func TestNewExternalSSTReader(t *testing.T) {
 			clusterSettings,
 			blobs.TestBlobServiceClient(tempDir),
 			username.RootUserName(),
-			tc.Servers[0].InternalExecutor().(*sql.InternalExecutor), tc.Servers[0].DB(), nil)
+			tc.Servers[0].InternalExecutor().(*sql.InternalExecutor),
+			tc.Servers[0].CollectionFactory().(*descs.CollectionFactory),
+			tc.Servers[0].DB(),
+			nil, /* limiters */
+		)
 		require.NoError(t, err)
 		fileStores[i].Store = store
 

--- a/pkg/ccl/workloadccl/storage.go
+++ b/pkg/ccl/workloadccl/storage.go
@@ -35,9 +35,18 @@ func GetStorage(ctx context.Context, cfg FixtureConfig) (cloud.ExternalStorage, 
 		return nil, errors.AssertionFailedf("unsupported external storage provider; valid providers are gs, s3, and azure")
 	}
 
-	s, err := cloud.ExternalStorageFromURI(ctx, cfg.ObjectPathToURI(),
-		base.ExternalIODirConfig{}, clustersettings.MakeClusterSettings(),
-		nil, username.SQLUsername{}, nil, nil, nil)
+	s, err := cloud.ExternalStorageFromURI(
+		ctx,
+		cfg.ObjectPathToURI(),
+		base.ExternalIODirConfig{},
+		clustersettings.MakeClusterSettings(),
+		nil, /* blobClientFactory */
+		username.SQLUsername{},
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, storageError)
 	}

--- a/pkg/cloud/BUILD.bazel
+++ b/pkg/cloud/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/security/username",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/sqlutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -67,9 +67,17 @@ func TestAzure(t *testing.T) {
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
 	cloudtestutils.CheckExportStore(t, cfg.filePath("backup-test"),
-		false, username.RootUserName(), nil, nil, testSettings)
-	cloudtestutils.CheckListFiles(
-		t, cfg.filePath("listing-test"), username.RootUserName(), nil, nil, testSettings,
+		false, username.RootUserName(),
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		testSettings,
+	)
+	cloudtestutils.CheckListFiles(t, cfg.filePath("listing-test"), username.RootUserName(),
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		testSettings,
 	)
 }
 

--- a/pkg/cloud/cloudtestutils/BUILD.bazel
+++ b/pkg/cloud/cloudtestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kv",
         "//pkg/security/username",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/sqlutil",
         "//pkg/util/ioctx",
         "//pkg/util/randutil",

--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -108,6 +109,7 @@ func storeFromURI(
 	clientFactory blobs.BlobClientFactory,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	testSettings *cluster.Settings,
 ) cloud.ExternalStorage {
@@ -117,7 +119,7 @@ func storeFromURI(
 	}
 	// Setup a sink for the given args.
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory, ie, kvDB, nil)
+		clientFactory, ie, cf, kvDB, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,6 +133,7 @@ func CheckExportStore(
 	skipSingleFile bool,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	testSettings *cluster.Settings,
 ) {
@@ -144,7 +147,8 @@ func CheckExportStore(
 
 	// Setup a sink for the given args.
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
-	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory,
+		ie, cf, kvDB, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -252,7 +256,7 @@ func CheckExportStore(
 			t.Fatal(err)
 		}
 		singleFile := storeFromURI(ctx, t, appendPath(t, storeURI, testingFilename), clientFactory,
-			user, ie, kvDB, testSettings)
+			user, ie, cf, kvDB, testSettings)
 		defer singleFile.Close()
 
 		res, err := singleFile.ReadFile(ctx, "")
@@ -273,7 +277,7 @@ func CheckExportStore(
 	t.Run("write-single-file-by-uri", func(t *testing.T) {
 		const testingFilename = "B"
 		singleFile := storeFromURI(ctx, t, appendPath(t, storeURI, testingFilename), clientFactory,
-			user, ie, kvDB, testSettings)
+			user, ie, cf, kvDB, testSettings)
 		defer singleFile.Close()
 
 		if err := cloud.WriteFile(ctx, singleFile, "", bytes.NewReader([]byte("bbb"))); err != nil {
@@ -304,7 +308,7 @@ func CheckExportStore(
 		if err := cloud.WriteFile(ctx, s, testingFilename, bytes.NewReader([]byte("aaa"))); err != nil {
 			t.Fatal(err)
 		}
-		singleFile := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
+		singleFile := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, cf, kvDB, testSettings)
 		defer singleFile.Close()
 
 		// Read a valid file.
@@ -346,10 +350,11 @@ func CheckListFiles(
 	storeURI string,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	testSettings *cluster.Settings,
 ) {
-	CheckListFilesCanonical(t, storeURI, "", user, ie, kvDB, testSettings)
+	CheckListFilesCanonical(t, storeURI, "", user, ie, cf, kvDB, testSettings)
 }
 
 // CheckListFilesCanonical is like CheckListFiles but takes a canonical prefix
@@ -361,6 +366,7 @@ func CheckListFilesCanonical(
 	canonical string,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	testSettings *cluster.Settings,
 ) {
@@ -374,7 +380,7 @@ func CheckListFilesCanonical(
 
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	for _, fileName := range fileNames {
-		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
+		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, cf, kvDB, testSettings)
 		if err := cloud.WriteFile(ctx, file, fileName, bytes.NewReader([]byte("bbb"))); err != nil {
 			t.Fatal(err)
 		}
@@ -462,7 +468,7 @@ func CheckListFilesCanonical(
 			},
 		} {
 			t.Run(tc.name, func(t *testing.T) {
-				s := storeFromURI(ctx, t, tc.uri, clientFactory, user, ie, kvDB, testSettings)
+				s := storeFromURI(ctx, t, tc.uri, clientFactory, user, ie, cf, kvDB, testSettings)
 				var actual []string
 				require.NoError(t, s.List(ctx, tc.prefix, tc.delimiter, func(f string) error {
 					actual = append(actual, f)
@@ -475,7 +481,7 @@ func CheckListFilesCanonical(
 	})
 
 	for _, fileName := range fileNames {
-		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, kvDB, testSettings)
+		file := storeFromURI(ctx, t, storeURI, clientFactory, user, ie, cf, kvDB, testSettings)
 		if err := file.Delete(ctx, fileName); err != nil {
 			t.Fatal(err)
 		}
@@ -493,9 +499,13 @@ func uploadData(
 	data := randutil.RandBytes(rnd, 16<<20)
 	ctx := context.Background()
 
-	s, err := cloud.MakeExternalStorage(
-		ctx, dest, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{}, testSettings,
+		nil, /* blobClientFactory */
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
 	require.NoError(t, cloud.WriteFile(ctx, s, basename, bytes.NewReader(data)))
 	return data, func() {
@@ -534,9 +544,13 @@ func CheckAntagonisticRead(
 	}()
 
 	ctx := context.Background()
-	s, err := cloud.MakeExternalStorage(
-		ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
+		nil, /* blobClientFactory */
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
 	defer s.Close()
 
@@ -555,6 +569,7 @@ func CheckNoPermission(
 	storeURI string,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	testSettings *cluster.Settings,
 ) {
@@ -567,7 +582,7 @@ func CheckNoPermission(
 	}
 
 	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
-	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, kvDB, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory, ie, cf, kvDB, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/errors"
@@ -153,6 +154,7 @@ type ExternalStorageContext struct {
 	Settings          *cluster.Settings
 	BlobClientFactory blobs.BlobClientFactory
 	InternalExecutor  sqlutil.InternalExecutor
+	CollectionFactory *descs.CollectionFactory
 	DB                *kv.DB
 	Options           []ExternalStorageOption
 	Limiters          Limiters

--- a/pkg/cloud/externalconn/connection_storage.go
+++ b/pkg/cloud/externalconn/connection_storage.go
@@ -92,7 +92,7 @@ func makeExternalConnectionStorage(
 		uri.Path = path.Join(uri.Path, cfg.Path)
 		return cloud.ExternalStorageFromURI(ctx, uri.String(), args.IOConf, args.Settings,
 			args.BlobClientFactory, username.MakeSQLUsernameFromPreNormalizedString(cfg.User),
-			args.InternalExecutor, args.DB, args.Limiters, args.Options...)
+			args.InternalExecutor, args.CollectionFactory, args.DB, args.Limiters, args.Options...)
 	default:
 		return nil, errors.Newf("cannot connect to %T; unsupported resource for an ExternalStorage connection", d)
 	}

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -60,18 +60,20 @@ func TestPutGoogleCloud(t *testing.T) {
 		if specified {
 			uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
 		}
-		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, testSettings)
-		cloudtestutils.CheckListFiles(t,
-			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
-				bucket,
-				"backup-test-specified",
-				"listing-test",
-				cloud.AuthParam,
-				cloud.AuthParamSpecified,
-				CredentialsParam,
-				url.QueryEscape(encoded),
-			),
-			username.RootUserName(), nil, nil, testSettings,
+		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+			bucket,
+			"backup-test-specified",
+			"listing-test",
+			cloud.AuthParam,
+			cloud.AuthParamSpecified,
+			CredentialsParam,
+			url.QueryEscape(encoded),
+		), username.RootUserName(),
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
 		)
 	})
 	t.Run("auth-implicit", func(t *testing.T) {
@@ -80,16 +82,18 @@ func TestPutGoogleCloud(t *testing.T) {
 		}
 
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s", bucket, "backup-test-implicit",
-			cloud.AuthParam, cloud.AuthParamImplicit), false, user, nil, nil, testSettings)
-		cloudtestutils.CheckListFiles(t,
-			fmt.Sprintf("gs://%s/%s/%s?%s=%s",
-				bucket,
-				"backup-test-implicit",
-				"listing-test",
-				cloud.AuthParam,
-				cloud.AuthParamImplicit,
-			),
-			username.RootUserName(), nil, nil, testSettings,
+			cloud.AuthParam, cloud.AuthParamImplicit), false, user, nil, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s",
+			bucket,
+			"backup-test-implicit",
+			"listing-test",
+			cloud.AuthParam,
+			cloud.AuthParamImplicit,
+		), username.RootUserName(),
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
 		)
 	})
 
@@ -114,18 +118,20 @@ func TestPutGoogleCloud(t *testing.T) {
 			token.AccessToken,
 		)
 		uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
-		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, testSettings)
-		cloudtestutils.CheckListFiles(t,
-			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
-				bucket,
-				"backup-test-specified",
-				"listing-test",
-				cloud.AuthParam,
-				cloud.AuthParamSpecified,
-				BearerTokenParam,
-				token.AccessToken,
-			),
-			username.RootUserName(), nil, nil, testSettings,
+		cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+			bucket,
+			"backup-test-specified",
+			"listing-test",
+			cloud.AuthParam,
+			cloud.AuthParamSpecified,
+			BearerTokenParam,
+			token.AccessToken,
+		), username.RootUserName(),
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
 		)
 	})
 }
@@ -153,7 +159,12 @@ func TestGCSAssumeRole(t *testing.T) {
 		// Verify that specified permissions with the credentials do not give us
 		// access to the bucket.
 		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s?%s=%s", limitedBucket, "backup-test-assume-role",
-			CredentialsParam, url.QueryEscape(encoded)), user, nil, nil, testSettings)
+			CredentialsParam, url.QueryEscape(encoded)), user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
+		)
 
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s&%s=%s&%s=%s",
 			limitedBucket,
@@ -163,21 +174,22 @@ func TestGCSAssumeRole(t *testing.T) {
 			AssumeRoleParam,
 			assumedAccount, CredentialsParam,
 			url.QueryEscape(encoded),
-		),
-			false, user, nil, nil, testSettings)
-		cloudtestutils.CheckListFiles(t,
-			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s&%s=%s",
-				limitedBucket,
-				"backup-test-assume-role",
-				"listing-test",
-				cloud.AuthParam,
-				cloud.AuthParamSpecified,
-				AssumeRoleParam,
-				assumedAccount,
-				CredentialsParam,
-				url.QueryEscape(encoded),
-			),
-			username.RootUserName(), nil, nil, testSettings,
+		), false, user, nil, nil, nil, testSettings)
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s&%s=%s",
+			limitedBucket,
+			"backup-test-assume-role",
+			"listing-test",
+			cloud.AuthParam,
+			cloud.AuthParamSpecified,
+			AssumeRoleParam,
+			assumedAccount,
+			CredentialsParam,
+			url.QueryEscape(encoded),
+		), username.RootUserName(),
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
 		)
 	})
 
@@ -189,21 +201,33 @@ func TestGCSAssumeRole(t *testing.T) {
 		// Verify that implicit permissions with the credentials do not give us
 		// access to the bucket.
 		cloudtestutils.CheckNoPermission(t, fmt.Sprintf("gs://%s/%s?%s=%s", limitedBucket, "backup-test-assume-role",
-			cloud.AuthParam, cloud.AuthParamImplicit), user, nil, nil, testSettings)
+			cloud.AuthParam, cloud.AuthParamImplicit), user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
+		)
 
 		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s?%s=%s&%s=%s", limitedBucket, "backup-test-assume-role",
-			cloud.AuthParam, cloud.AuthParamImplicit, AssumeRoleParam, assumedAccount), false, user, nil, nil, testSettings)
-		cloudtestutils.CheckListFiles(t,
-			fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
-				limitedBucket,
-				"backup-test-assume-role",
-				"listing-test",
-				cloud.AuthParam,
-				cloud.AuthParamImplicit,
-				AssumeRoleParam,
-				assumedAccount,
-			),
-			username.RootUserName(), nil, nil, testSettings,
+			cloud.AuthParam, cloud.AuthParamImplicit, AssumeRoleParam, assumedAccount), false, user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
+		)
+		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s/%s?%s=%s&%s=%s",
+			limitedBucket,
+			"backup-test-assume-role",
+			"listing-test",
+			cloud.AuthParam,
+			cloud.AuthParamImplicit,
+			AssumeRoleParam,
+			assumedAccount,
+		), username.RootUserName(),
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
 		)
 	})
 
@@ -243,7 +267,12 @@ func TestGCSAssumeRole(t *testing.T) {
 						"listing-test",
 						q.Encode(),
 					)
-					cloudtestutils.CheckNoPermission(t, roleURI, user, nil, nil, testSettings)
+					cloudtestutils.CheckNoPermission(t, roleURI, user,
+						nil, /* ie */
+						nil, /* cf */
+						nil, /* kvDB */
+						testSettings,
+					)
 				}
 
 				// Finally, check that the chain of roles can be used to access the storage.
@@ -254,8 +283,18 @@ func TestGCSAssumeRole(t *testing.T) {
 					"listing-test",
 					q.Encode(),
 				)
-				cloudtestutils.CheckExportStore(t, uri, false, user, nil, nil, testSettings)
-				cloudtestutils.CheckListFiles(t, uri, user, nil, nil, testSettings)
+				cloudtestutils.CheckExportStore(t, uri, false, user,
+					nil, /* ie */
+					nil, /* cf */
+					nil, /* kvDB */
+					testSettings,
+				)
+				cloudtestutils.CheckListFiles(t, uri, user,
+					nil, /* ie */
+					nil, /* cf */
+					nil, /* kvDB */
+					testSettings,
+				)
 			})
 		}
 	})
@@ -297,9 +336,13 @@ func TestFileDoesNotExist(t *testing.T) {
 		conf, err := cloud.ExternalStorageConfFromURI(gsFile, user)
 		require.NoError(t, err)
 
-		s, err := cloud.MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings,
-			nil, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{}, testSettings,
+			nil, /* blobClientFactory */
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+		)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -312,9 +355,13 @@ func TestFileDoesNotExist(t *testing.T) {
 		conf, err := cloud.ExternalStorageConfFromURI(gsFile, user)
 		require.NoError(t, err)
 
-		s, err := cloud.MakeExternalStorage(
-			context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-			nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{}, testSettings,
+			nil, /* blobClientFactory */
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+		)
 		require.NoError(t, err)
 		_, err = s.ReadFile(context.Background(), "")
 		require.Error(t, err, "")
@@ -345,9 +392,21 @@ func TestCompressedGCS(t *testing.T) {
 	conf2, err := cloud.ExternalStorageConfFromURI(gsFile2, user)
 	require.NoError(t, err)
 
-	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
+	s1, err := cloud.MakeExternalStorage(ctx, conf1, base.ExternalIODirConfig{}, testSettings,
+		nil, /* blobClientFactory */
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
-	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings, nil, nil, nil, nil)
+	s2, err := cloud.MakeExternalStorage(ctx, conf2, base.ExternalIODirConfig{}, testSettings,
+		nil, /* blobClientFactory */
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
 
 	reader1, err := s1.ReadFile(context.Background(), "")

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -121,7 +121,12 @@ func TestPutHttp(t *testing.T) {
 	t.Run("singleHost", func(t *testing.T) {
 		srv, files, cleanup := makeServer()
 		defer cleanup()
-		cloudtestutils.CheckExportStore(t, srv.String(), false, user, nil, nil, testSettings)
+		cloudtestutils.CheckExportStore(t, srv.String(), false, user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
+		)
 		if expected, actual := 14, files(); expected != actual {
 			t.Fatalf("expected %d files to be written to single http store, got %d", expected, actual)
 		}
@@ -138,7 +143,12 @@ func TestPutHttp(t *testing.T) {
 		combined := *srv1
 		combined.Host = strings.Join([]string{srv1.Host, srv2.Host, srv3.Host}, ",")
 
-		cloudtestutils.CheckExportStore(t, combined.String(), true, user, nil, nil, testSettings)
+		cloudtestutils.CheckExportStore(t, combined.String(), true, user,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			testSettings,
+		)
 		if expected, actual := 3, files1(); expected != actual {
 			t.Fatalf("expected %d files written to http host 1, got %d", expected, actual)
 		}
@@ -161,8 +171,12 @@ func TestPutHttp(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
-			testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings, blobs.TestEmptyBlobClientFactory,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+		)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -315,10 +329,12 @@ func TestCanDisableHttp(t *testing.T) {
 	}
 	testSettings := cluster.MakeTestingClusterSettings()
 
-	s, err := cloud.MakeExternalStorage(
-		context.Background(),
-		cloudpb.ExternalStorage{Provider: cloudpb.ExternalStorageProvider_http},
-		conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(context.Background(), cloudpb.ExternalStorage{Provider: cloudpb.ExternalStorageProvider_http}, conf, testSettings, blobs.TestEmptyBlobClientFactory,
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.Nil(t, s)
 	require.Error(t, err)
 }
@@ -336,10 +352,12 @@ func TestCanDisableOutbound(t *testing.T) {
 		cloudpb.ExternalStorageProvider_gs,
 		cloudpb.ExternalStorageProvider_nodelocal,
 	} {
-		s, err := cloud.MakeExternalStorage(
-			context.Background(),
-			cloudpb.ExternalStorage{Provider: provider},
-			conf, testSettings, blobs.TestEmptyBlobClientFactory, nil, nil, nil)
+		s, err := cloud.MakeExternalStorage(context.Background(), cloudpb.ExternalStorage{Provider: provider}, conf, testSettings, blobs.TestEmptyBlobClientFactory,
+			nil, /* ie */
+			nil, /* cf */
+			nil, /* kvDB */
+			nil, /* limiters */
+		)
 		require.Nil(t, s)
 		require.Error(t, err)
 	}
@@ -368,9 +386,12 @@ func TestExternalStorageCanUseHTTPProxy(t *testing.T) {
 
 	conf, err := cloud.ExternalStorageConfFromURI("http://my-server", username.RootUserName())
 	require.NoError(t, err)
-	s, err := cloud.MakeExternalStorage(
-		context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
-		nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(context.Background(), conf, base.ExternalIODirConfig{}, testSettings, nil,
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	require.NoError(t, err)
 	stream, err := s.ReadFile(context.Background(), "file")
 	require.NoError(t, err)

--- a/pkg/cloud/impl_registry.go
+++ b/pkg/cloud/impl_registry.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -151,6 +152,7 @@ func ExternalStorageFromURI(
 	blobClientFactory blobs.BlobClientFactory,
 	user username.SQLUsername,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	limiters Limiters,
 	opts ...ExternalStorageOption,
@@ -159,7 +161,8 @@ func ExternalStorageFromURI(
 	if err != nil {
 		return nil, err
 	}
-	return MakeExternalStorage(ctx, conf, externalConfig, settings, blobClientFactory, ie, kvDB, limiters, opts...)
+	return MakeExternalStorage(ctx, conf, externalConfig, settings, blobClientFactory,
+		ie, cf, kvDB, limiters, opts...)
 }
 
 // SanitizeExternalStorageURI returns the external storage URI with with some
@@ -204,6 +207,7 @@ func MakeExternalStorage(
 	settings *cluster.Settings,
 	blobClientFactory blobs.BlobClientFactory,
 	ie sqlutil.InternalExecutor,
+	cf *descs.CollectionFactory,
 	kvDB *kv.DB,
 	limiters Limiters,
 	opts ...ExternalStorageOption,
@@ -213,6 +217,7 @@ func MakeExternalStorage(
 		Settings:          settings,
 		BlobClientFactory: blobClientFactory,
 		InternalExecutor:  ie,
+		CollectionFactory: cf,
 		DB:                kvDB,
 		Options:           opts,
 		Limiters:          limiters,

--- a/pkg/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage_test.go
@@ -30,7 +30,11 @@ func TestPutLocal(t *testing.T) {
 	testSettings.ExternalIODir = p
 	dest := MakeLocalStorageURI(p)
 
-	cloudtestutils.CheckExportStore(t, dest, false, username.RootUserName(), nil, nil, testSettings)
-	cloudtestutils.CheckListFiles(t, "nodelocal://0/listing-test/basepath",
-		username.RootUserName(), nil, nil, testSettings)
+	cloudtestutils.CheckExportStore(t, dest, false, username.RootUserName(), nil, nil, nil, testSettings)
+	cloudtestutils.CheckListFiles(t, "nodelocal://0/listing-test/basepath", username.RootUserName(),
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		testSettings,
+	)
 }

--- a/pkg/cloud/nullsink/nullsink_storage_test.go
+++ b/pkg/cloud/nullsink/nullsink_storage_test.go
@@ -36,7 +36,14 @@ func TestNullSinkReadAndWrite(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, nil, nil, nil, nil, nil)
+	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{},
+		nil, /* Cluster Settings */
+		nil, /* blobClientFactory */
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cloud/userfile/BUILD.bazel
+++ b/pkg/cloud/userfile/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sqlutil",
         "//pkg/sql/tests",

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -122,7 +122,7 @@ func makeFileTableStorage(
 
 	// cfg.User is already a normalized SQL username.
 	user := username.MakeSQLUsernameFromPreNormalizedString(cfg.User)
-	executor := filetable.MakeInternalFileToTableExecutor(args.InternalExecutor, args.DB)
+	executor := filetable.MakeInternalFileToTableExecutor(args.InternalExecutor, args.CollectionFactory, args.DB)
 
 	fileToTableSystem, err := filetable.NewFileToTableSystem(ctx,
 		cfg.QualifiedTableName, executor, user)

--- a/pkg/cloud/userfile/filetable/BUILD.bazel
+++ b/pkg/cloud/userfile/filetable/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/cloud",
         "//pkg/kv",
         "//pkg/security/username",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/cloud/userfile/filetable/file_table_read_writer.go
+++ b/pkg/cloud/userfile/filetable/file_table_read_writer.go
@@ -245,25 +245,27 @@ func NewFileToTableSystem(
 	if err != nil {
 		return nil, err
 	}
-	if err := e.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+	if err := e.cf.TxnWithExecutor(ctx, e.db, nil /* SessionData */, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor,
+	) error {
 		// TODO(adityamaru): Handle scenario where the user has already created
 		// tables with the same names not via the FileToTableSystem
 		// object. Not sure if we want to error out or work around it.
-		tablesExist, err := f.checkIfFileAndPayloadTableExist(ctx, txn, e.ie)
+		tablesExist, err := f.checkIfFileAndPayloadTableExist(ctx, txn, ie)
 		if err != nil {
 			return err
 		}
 
 		if !tablesExist {
-			if err := f.createFileAndPayloadTables(ctx, txn, e.ie); err != nil {
+			if err := f.createFileAndPayloadTables(ctx, txn, ie); err != nil {
 				return err
 			}
 
-			if err := f.grantCurrentUserTablePrivileges(ctx, txn, e.ie); err != nil {
+			if err := f.grantCurrentUserTablePrivileges(ctx, txn, ie); err != nil {
 				return err
 			}
 
-			if err := f.revokeOtherUserTablePrivileges(ctx, txn, e.ie); err != nil {
+			if err := f.revokeOtherUserTablePrivileges(ctx, txn, ie); err != nil {
 				return err
 			}
 		}
@@ -364,26 +366,27 @@ func DestroyUserFileSystem(ctx context.Context, f *FileToTableSystem) error {
 		return err
 	}
 
-	if err := e.db.Txn(ctx,
-		func(ctx context.Context, txn *kv.Txn) error {
-			dropPayloadTableQuery := fmt.Sprintf(`DROP TABLE %s`, f.GetFQPayloadTableName())
-			_, err := e.ie.ExecEx(ctx, "drop-payload-table", txn,
-				sessiondata.InternalExecutorOverride{User: f.username},
-				dropPayloadTableQuery)
-			if err != nil {
-				return errors.Wrap(err, "failed to drop payload table")
-			}
+	if err := e.cf.TxnWithExecutor(ctx, e.db, nil, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor,
+	) error {
+		dropPayloadTableQuery := fmt.Sprintf(`DROP TABLE %s`, f.GetFQPayloadTableName())
+		_, err := ie.ExecEx(ctx, "drop-payload-table", txn,
+			sessiondata.InternalExecutorOverride{User: f.username},
+			dropPayloadTableQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to drop payload table")
+		}
 
-			dropFileTableQuery := fmt.Sprintf(`DROP TABLE %s CASCADE`, f.GetFQFileTableName())
-			_, err = e.ie.ExecEx(ctx, "drop-file-table", txn,
-				sessiondata.InternalExecutorOverride{User: f.username},
-				dropFileTableQuery)
-			if err != nil {
-				return errors.Wrap(err, "failed to drop file table")
-			}
+		dropFileTableQuery := fmt.Sprintf(`DROP TABLE %s CASCADE`, f.GetFQFileTableName())
+		_, err = ie.ExecEx(ctx, "drop-file-table", txn,
+			sessiondata.InternalExecutorOverride{User: f.username},
+			dropFileTableQuery)
+		if err != nil {
+			return errors.Wrap(err, "failed to drop file table")
+		}
 
-			return nil
-		}); err != nil {
+		return nil
+	}); err != nil {
 		return err
 	}
 

--- a/pkg/cloud/userfile/filetable/file_table_read_writer.go
+++ b/pkg/cloud/userfile/filetable/file_table_read_writer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
@@ -60,6 +61,7 @@ type FileToTableSystemExecutor interface {
 // SQL connection to interact with the database.
 type InternalFileToTableExecutor struct {
 	ie sqlutil.InternalExecutor
+	cf *descs.CollectionFactory
 	db *kv.DB
 }
 
@@ -68,9 +70,9 @@ var _ FileToTableSystemExecutor = &InternalFileToTableExecutor{}
 // MakeInternalFileToTableExecutor returns an instance of a
 // InternalFileToTableExecutor.
 func MakeInternalFileToTableExecutor(
-	ie sqlutil.InternalExecutor, db *kv.DB,
+	ie sqlutil.InternalExecutor, cf *descs.CollectionFactory, db *kv.DB,
 ) *InternalFileToTableExecutor {
-	return &InternalFileToTableExecutor{ie, db}
+	return &InternalFileToTableExecutor{ie, cf, db}
 }
 
 // Query implements the FileToTableSystemExecutor interface.

--- a/pkg/cloud/userfile/filetable/filetabletest/BUILD.bazel
+++ b/pkg/cloud/userfile/filetable/filetabletest/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/catalog/descs",
         "//pkg/sql/tests",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",

--- a/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
+++ b/pkg/cloud/userfile/filetable/filetabletest/file_table_read_writer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -107,7 +108,7 @@ func TestListAndDeleteFiles(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, username.RootUserName())
 	require.NoError(t, err)
@@ -158,7 +159,7 @@ func TestReadWriteFile(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, username.RootUserName())
 	require.NoError(t, err)
@@ -341,7 +342,7 @@ func TestUserGrants(t *testing.T) {
 
 	// Operate under non-admin user.
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	johnUser := username.MakeSQLUsernameFromPreNormalizedString("john")
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, johnUser)
@@ -425,7 +426,7 @@ func TestDifferentUserDisallowed(t *testing.T) {
 
 	// Operate under non-admin user john.
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	johnUser := username.MakeSQLUsernameFromPreNormalizedString("john")
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, johnUser)
@@ -483,7 +484,7 @@ func TestDifferentRoleDisallowed(t *testing.T) {
 
 	// Operate under non-admin user john.
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	johnUser := username.MakeSQLUsernameFromPreNormalizedString("john")
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, johnUser)
@@ -518,7 +519,7 @@ func TestDatabaseScope(t *testing.T) {
 	defer s.Stopper().Stop(ctx)
 
 	executor := filetable.MakeInternalFileToTableExecutor(s.InternalExecutor().(*sql.
-		InternalExecutor), kvDB)
+		InternalExecutor), s.CollectionFactory().(*descs.CollectionFactory), kvDB)
 	fileTableReadWriter, err := filetable.NewFileToTableSystem(ctx, qualifiedTableName,
 		executor, username.RootUserName())
 	require.NoError(t, err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigkvsubscriber"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig/spanconfigptsreader"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	_ "github.com/cockroachdb/cockroach/pkg/sql/catalog/schematelemetry" // register schedules declared outside of pkg/sql
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -487,6 +488,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 	// InternalExecutor uses this one instance.
 	internalExecutor := &sql.InternalExecutor{}
 	jobRegistry := &jobs.Registry{} // ditto
+	collectionFactory := &descs.CollectionFactory{}
 
 	// Create an ExternalStorageBuilder. This is only usable after Start() where
 	// we initialize all the configuration params.
@@ -836,6 +838,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (*Server, error) {
 		closedSessionCache:       closedSessionCache,
 		flowScheduler:            flowScheduler,
 		circularInternalExecutor: internalExecutor,
+		collectionFactory:        collectionFactory,
 		internalExecutorFactory:  nil, // will be initialized in server.newSQLServer.
 		circularJobRegistry:      jobRegistry,
 		jobAdoptionStopFile:      jobAdoptionStopFile,
@@ -1083,6 +1086,7 @@ func (s *Server) PreStart(ctx context.Context) error {
 		s.nodeDialer,
 		s.cfg.TestingKnobs,
 		&fileTableInternalExecutor,
+		s.sqlServer.execCfg.CollectionFactory,
 		s.db,
 		nil, /* TenantExternalIORecorder */
 	)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -306,6 +306,8 @@ type sqlServerArgs struct {
 	// TODO(tbg): make this less hacky.
 	circularInternalExecutor *sql.InternalExecutor // empty initially
 
+	collectionFactory *descs.CollectionFactory
+
 	// internalExecutorFactory is to initialize an internal executor.
 	internalExecutorFactory sqlutil.InternalExecutorFactory
 
@@ -988,6 +990,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		cfg.registry.AddMetricStruct(m)
 	}
 	*cfg.circularInternalExecutor = sql.MakeInternalExecutor(pgServer.SQLServer, internalMemMetrics, ieFactoryMonitor)
+	*cfg.collectionFactory = *collectionFactory
 	cfg.internalExecutorFactory = ieFactory
 	execCfg.InternalExecutor = cfg.circularInternalExecutor
 	stmtDiagnosticsRegistry := stmtdiagnostics.NewRegistry(

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/optionalnodeliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -500,6 +501,7 @@ func makeTenantSQLServerArgs(
 
 	circularInternalExecutor := &sql.InternalExecutor{}
 	circularJobRegistry := &jobs.Registry{}
+	collectionFactory := &descs.CollectionFactory{}
 
 	// Initialize the protectedts subsystem in multi-tenant clusters.
 	var protectedTSProvider protectedts.Provider
@@ -539,6 +541,7 @@ func makeTenantSQLServerArgs(
 		nodeDialer,
 		baseCfg.TestingKnobs,
 		circularInternalExecutor,
+		collectionFactory,
 		db,
 		costController,
 	)
@@ -607,6 +610,7 @@ func makeTenantSQLServerArgs(
 		sessionRegistry:          sessionRegistry,
 		flowScheduler:            flowScheduler,
 		circularInternalExecutor: circularInternalExecutor,
+		collectionFactory:        collectionFactory,
 		circularJobRegistry:      circularJobRegistry,
 		protectedtsProvider:      protectedTSProvider,
 		rangeFeedFactory:         rangeFeedFactory,

--- a/pkg/sql/authorization_test.go
+++ b/pkg/sql/authorization_test.go
@@ -15,8 +15,10 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -30,7 +32,7 @@ func TestCheckAnyPrivilegeForNodeUser(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	s, _, kv := serverutils.StartServer(t, base.TestServerArgs{})
+	s, _, _ := serverutils.StartServer(t, base.TestServerArgs{})
 
 	defer s.Stopper().Stop(ctx)
 
@@ -38,45 +40,52 @@ func TestCheckAnyPrivilegeForNodeUser(t *testing.T) {
 
 	require.NotNil(t, ts.InternalExecutor())
 
-	ie := ts.InternalExecutor().(sqlutil.InternalExecutor)
+	cf := ts.CollectionFactory().(*descs.CollectionFactory)
 
-	txn := kv.NewTxn(ctx, "get-all-databases")
-	row, err := ie.QueryRowEx(
-		ctx, "get-all-databases", txn, sessiondata.NodeUserSessionDataOverride,
-		"SELECT count(1) FROM crdb_internal.databases",
-	)
-	require.NoError(t, err)
-	// 3 databases (system, defaultdb, postgres).
-	require.Equal(t, row.String(), "(3)")
+	if err := cf.TxnWithExecutor(ctx, s.DB(), nil, func(
+		ctx context.Context, txn *kv.Txn, descriptors *descs.Collection, ie sqlutil.InternalExecutor,
+	) error {
+		row, err := ie.QueryRowEx(
+			ctx, "get-all-databases", txn, sessiondata.NodeUserSessionDataOverride,
+			"SELECT count(1) FROM crdb_internal.databases",
+		)
+		require.NoError(t, err)
+		// 3 databases (system, defaultdb, postgres).
+		require.Equal(t, row.String(), "(3)")
 
-	_, err = ie.ExecEx(ctx, "create-database1", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"CREATE DATABASE test1")
-	require.NoError(t, err)
+		_, err = ie.ExecEx(ctx, "create-database1", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"CREATE DATABASE test1")
+		require.NoError(t, err)
 
-	_, err = ie.ExecEx(ctx, "create-database2", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"CREATE DATABASE test2")
-	require.NoError(t, err)
+		_, err = ie.ExecEx(ctx, "create-database2", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"CREATE DATABASE test2")
+		require.NoError(t, err)
 
-	// Revoke CONNECT on all non-system databases and ensure that when querying
-	// with node, we can still see all the databases.
-	_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"REVOKE CONNECT ON DATABASE test1 FROM public")
-	require.NoError(t, err)
-	_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"REVOKE CONNECT ON DATABASE test2 FROM public")
-	require.NoError(t, err)
-	_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"REVOKE CONNECT ON DATABASE defaultdb FROM public")
-	require.NoError(t, err)
-	_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
-		"REVOKE CONNECT ON DATABASE postgres FROM public")
-	require.NoError(t, err)
+		// Revoke CONNECT on all non-system databases and ensure that when querying
+		// with node, we can still see all the databases.
+		_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"REVOKE CONNECT ON DATABASE test1 FROM public")
+		require.NoError(t, err)
+		_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"REVOKE CONNECT ON DATABASE test2 FROM public")
+		require.NoError(t, err)
+		_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"REVOKE CONNECT ON DATABASE defaultdb FROM public")
+		require.NoError(t, err)
+		_, err = ie.ExecEx(ctx, "revoke-privileges", txn, sessiondata.InternalExecutorOverride{User: username.RootUserName()},
+			"REVOKE CONNECT ON DATABASE postgres FROM public")
+		require.NoError(t, err)
 
-	row, err = ie.QueryRowEx(
-		ctx, "get-all-databases", txn, sessiondata.NodeUserSessionDataOverride,
-		"SELECT count(1) FROM crdb_internal.databases",
-	)
-	require.NoError(t, err)
-	// 3 databases (system, defaultdb, postgres, test1, test2).
-	require.Equal(t, row.String(), "(5)")
+		row, err = ie.QueryRowEx(
+			ctx, "get-all-databases", txn, sessiondata.NodeUserSessionDataOverride,
+			"SELECT count(1) FROM crdb_internal.databases",
+		)
+		require.NoError(t, err)
+		// 3 databases (system, defaultdb, postgres, test1, test2).
+		require.Equal(t, row.String(), "(5)")
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 }

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -16,12 +16,14 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/errors"
 )
@@ -112,22 +114,24 @@ func (p *planner) createExternalConnection(
 	ex.SetConnectionType(exConn.ConnectionType())
 	ex.SetOwner(p.User())
 
-	// Create the External Connection and persist it in the
-	// `system.external_connections` table.
-	if err := ex.Create(params.ctx, params.ExecCfg().InternalExecutor, params.p.User(), p.Txn()); err != nil {
-		return errors.Wrap(err, "failed to create external connection")
-	}
+	return p.WithInternalExecutor(params.ctx, func(ctx context.Context, txn *kv.Txn, ie sqlutil.InternalExecutor) error {
+		// Create the External Connection and persist it in the
+		// `system.external_connections` table.
+		if err := ex.Create(params.ctx, ie, p.User(), txn); err != nil {
+			return errors.Wrap(err, "failed to create external connection")
+		}
 
-	// Grant user `ALL` on the newly created External Connection.
-	grantStatement := fmt.Sprintf(`GRANT ALL ON EXTERNAL CONNECTION "%s" TO %s`,
-		name, p.User().SQLIdentifier())
-	_, err = params.ExecCfg().InternalExecutor.ExecEx(params.ctx,
-		"grant-on-create-external-connection", p.Txn(),
-		sessiondata.InternalExecutorOverride{User: username.NodeUserName()}, grantStatement)
-	if err != nil {
-		return errors.Wrap(err, "failed to grant on newly created External Connection")
-	}
-	return nil
+		// Grant user `ALL` on the newly created External Connection.
+		grantStatement := fmt.Sprintf(`GRANT ALL ON EXTERNAL CONNECTION "%s" TO %s`,
+			name, p.User().SQLIdentifier())
+		_, err = ie.ExecEx(params.ctx,
+			"grant-on-create-external-connection", txn,
+			sessiondata.InternalExecutorOverride{User: username.NodeUserName()}, grantStatement)
+		if err != nil {
+			return errors.Wrap(err, "failed to grant on newly created External Connection")
+		}
+		return nil
+	})
 }
 
 func (c *createExternalConectionNode) Next(_ runParams) (bool, error) { return false, nil }

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -876,7 +876,12 @@ func externalStorageFactory(
 		return nil, err
 	}
 	return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-		nil, blobs.TestBlobServiceClient(workdir), nil, nil, nil)
+		nil, blobs.TestBlobServiceClient(workdir),
+		nil, /* ie */
+		nil, /* cf */
+		nil, /* kvDB */
+		nil, /* limiters */
+	)
 }
 
 // Helper to create and initialize testSpec.

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -2700,8 +2700,9 @@ func TestImportObjectLevelRBAC(t *testing.T) {
 	writeToUserfile := func(filename, data string) {
 		// Write to userfile storage now that testuser has CREATE privileges.
 		ie := tc.Server(0).InternalExecutor().(*sql.InternalExecutor)
+		cf := tc.Server(0).CollectionFactory().(*descs.CollectionFactory)
 		fileTableSystem1, err := cloud.ExternalStorageFromURI(ctx, dest, base.ExternalIODirConfig{},
-			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.TestUserName(), ie, tc.Server(0).DB(), nil)
+			cluster.NoSettings, blobs.TestEmptyBlobClientFactory, username.TestUserName(), ie, cf, tc.Server(0).DB(), nil)
 		require.NoError(t, err)
 		require.NoError(t, cloud.WriteFile(ctx, fileTableSystem1, filename, bytes.NewReader([]byte(data))))
 	}
@@ -5848,7 +5849,11 @@ func TestImportPgDumpIgnoredStmts(t *testing.T) {
 			tc.Server(0).ClusterSettings(),
 			blobs.TestEmptyBlobClientFactory,
 			username.RootUserName(),
-			tc.Server(0).InternalExecutor().(*sql.InternalExecutor), tc.Server(0).DB(), nil)
+			tc.Server(0).InternalExecutor().(*sql.InternalExecutor),
+			tc.Server(0).CollectionFactory().(*descs.CollectionFactory),
+			tc.Server(0).DB(),
+			nil,
+		)
 		require.NoError(t, err)
 		defer store.Close()
 

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -616,7 +616,7 @@ func (ie *InternalExecutor) queryInternalBuffered(
 	txn *kv.Txn,
 	sessionDataOverride sessiondata.InternalExecutorOverride,
 	stmt string,
-// Non-zero limit specifies the limit on the number of rows returned.
+	// Non-zero limit specifies the limit on the number of rows returned.
 	limit int,
 	qargs ...interface{},
 ) ([]tree.Datums, colinfo.ResultColumns, error) {

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -616,7 +616,7 @@ func (ie *InternalExecutor) queryInternalBuffered(
 	txn *kv.Txn,
 	sessionDataOverride sessiondata.InternalExecutorOverride,
 	stmt string,
-	// Non-zero limit specifies the limit on the number of rows returned.
+// Non-zero limit specifies the limit on the number of rows returned.
 	limit int,
 	qargs ...interface{},
 ) ([]tree.Datums, colinfo.ResultColumns, error) {
@@ -831,6 +831,10 @@ func (ie *InternalExecutor) execInternal(
 	stmt string,
 	qargs ...interface{},
 ) (r *rowsIterator, retErr error) {
+	if err := ie.checkIfTxnIsConsistent(txn); err != nil {
+		return nil, err
+	}
+
 	ctx = logtags.AddTag(ctx, "intExec", opName)
 
 	var sd *sessiondata.SessionData
@@ -896,6 +900,9 @@ func (ie *InternalExecutor) execInternal(
 	timeReceived := timeutil.Now()
 	parseStart := timeReceived
 	parsed, err := parser.ParseOne(stmt)
+	if err := ie.checkIfStmtIsAllowed(parsed.AST, txn); err != nil {
+		return nil, err
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1073,6 +1080,29 @@ func (ie *InternalExecutor) commitTxn(ctx context.Context) error {
 	}
 	defer ex.close(ctx, externalTxnClose)
 	return ex.commitSQLTransactionInternal(ctx)
+}
+
+// checkIfStmtIsAllowed returns an error if the internal executor is not bound
+// with the outer-txn-related info but is used to run DDL statements within an
+// outer txn.
+// TODO (janexing): this will be deprecate soon since it's not a good idea
+// to have `extraTxnState` to store the info from a outer txn.
+func (ie *InternalExecutor) checkIfStmtIsAllowed(stmt tree.Statement, txn *kv.Txn) error {
+	if tree.CanModifySchema(stmt) && txn != nil && ie.extraTxnState == nil {
+		return errors.New("DDL statement is disallowed if internal " +
+			"executor is not bound with txn metadata")
+	}
+	return nil
+}
+
+// checkIfTxnIsConsistent returns true if the given txn is not nil and is not
+// the same txn that is used to construct the internal executor.
+func (ie *InternalExecutor) checkIfTxnIsConsistent(txn *kv.Txn) error {
+	if txn != nil && ie.extraTxnState != nil && ie.extraTxnState.txn != txn {
+		return errors.New("txn is inconsistent with the one when " +
+			"constructing the internal executor")
+	}
+	return nil
 }
 
 // internalClientComm is an implementation of ClientComm used by the

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -193,7 +193,6 @@ func cleanupSessionTempObjects(
 		for _, dbDesc := range allDbDescs {
 			if err := cleanupSchemaObjects(
 				ctx,
-				settings,
 				txn,
 				descsCol,
 				codec,
@@ -225,7 +224,6 @@ func cleanupSessionTempObjects(
 // API or avoid it entirely.
 func cleanupSchemaObjects(
 	ctx context.Context,
-	settings *cluster.Settings,
 	txn *kv.Txn,
 	descsCol *descs.Collection,
 	codec keys.SQLCodec,

--- a/pkg/sql/temporary_schema_test.go
+++ b/pkg/sql/temporary_schema_test.go
@@ -111,7 +111,6 @@ INSERT INTO perm_table VALUES (DEFAULT, 1);
 		}
 		return cleanupSchemaObjects(
 			ctx,
-			execCfg.Settings,
 			txn,
 			descsCol,
 			execCfg.Codec,


### PR DESCRIPTION
The current internal executor has its lifecycle, which makes it erroneous
when being used to execute DDL statements if under an outer txn. 

In this commit, we 
1. Migrated the existing DDLs with internal executor with not-nil txn to either 
`descs.CollectionFactory.TxnWithExecutor()` or `planner.WithInternalExecutor()`.
Only internal executors inited via these 2 interfaces are bounded with txn-related
metadata, and hence are allowed to run DDLs in a transactional manner.
2. Added a restriction for running DDLs with internal executor only if it's bound with
txn-related metadata.

fixes #87281

Release justification: bug fix for the internal executor
Release note: none