### PR TITLE
externalconn: grant `ALL` on `CREATE EXTERNAL CONNECTION`

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-privileges
@@ -12,7 +12,7 @@ CREATE EXTERNAL CONNECTION root AS 'nodelocal://1/root'
 ----
 
 exec-sql user=testuser
-CREATE EXTERNAL CONNECTION fails AS 'userfile:///noprivs'
+CREATE EXTERNAL CONNECTION "testuser-ec" AS 'userfile:///noprivs'
 ----
 pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
 
@@ -21,7 +21,7 @@ GRANT SYSTEM EXTERNALCONNECTION TO testuser;
 ----
 
 exec-sql user=testuser
-CREATE EXTERNAL CONNECTION fails AS 'nodelocal://1/privs'
+CREATE EXTERNAL CONNECTION "testuser-ec" AS 'nodelocal://1/privs'
 ----
 
 exec-sql
@@ -32,17 +32,17 @@ exec-sql
 GRANT SELECT ON TABLE foo TO testuser
 ----
 
+# Since testuser created the External Connection they have `ALL` privileges on the object.
 exec-sql user=testuser
-BACKUP TABLE foo INTO 'external://fails'
+BACKUP TABLE foo INTO 'external://testuser-ec'
 ----
-pq: user testuser does not have USAGE privilege on external_connection fails
 
 exec-sql
-GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+GRANT USAGE ON EXTERNAL CONNECTION "testuser-ec" TO testuser;
 ----
 
 exec-sql user=testuser
-BACKUP TABLE foo INTO 'external://fails'
+BACKUP TABLE foo INTO LATEST IN 'external://testuser-ec'
 ----
 
 # Sanity check that the user can't write to any other external connection.
@@ -51,18 +51,34 @@ BACKUP TABLE foo INTO 'external://root'
 ----
 pq: user testuser does not have USAGE privilege on external_connection root
 
-# Revoke the USAGE privilege to test that restore also requires it.
-exec-sql
-REVOKE USAGE ON EXTERNAL CONNECTION fails FROM testuser;
+query-sql
+SELECT * FROM system.privileges
 ----
+root /externalconn/root {ALL} {}
+testuser /externalconn/testuser-ec {ALL} {}
+testuser /global/ {EXTERNALCONNECTION} {}
+
+# Revoke the USAGE privilege. Note testuser had ALL privileges since they
+# created the External Connection, but revoking USAGE means that they will now
+# only have DROP privileges. Thus, they shouldn't be able to restore.
+exec-sql
+REVOKE USAGE ON EXTERNAL CONNECTION "testuser-ec" FROM testuser;
+----
+
+query-sql
+SELECT * FROM system.privileges
+----
+root /externalconn/root {ALL} {}
+testuser /externalconn/testuser-ec {DROP} {}
+testuser /global/ {EXTERNALCONNECTION} {}
 
 exec-sql user=testuser
-RESTORE TABLE foo FROM LATEST IN 'external://fails'
+RESTORE TABLE foo FROM LATEST IN 'external://testuser-ec'
 ----
-pq: user testuser does not have USAGE privilege on external_connection fails
+pq: user testuser does not have USAGE privilege on external_connection testuser-ec
 
 exec-sql
-GRANT USAGE ON EXTERNAL CONNECTION fails TO testuser;
+GRANT USAGE ON EXTERNAL CONNECTION "testuser-ec" TO testuser;
 ----
 
 exec-sql
@@ -71,7 +87,7 @@ GRANT CREATE ON DATABASE failsdb TO testuser;
 ----
 
 exec-sql user=testuser
-RESTORE TABLE foo FROM LATEST IN 'external://fails' WITH into_db=failsdb;
+RESTORE TABLE foo FROM LATEST IN 'external://testuser-ec' WITH into_db=failsdb;
 ----
 
 subtest end

--- a/pkg/ccl/cloudccl/externalconn/BUILD.bazel
+++ b/pkg/ccl/cloudccl/externalconn/BUILD.bazel
@@ -10,6 +10,7 @@ go_test(
     data = glob(["testdata/**"]),
     deps = [
         "//pkg/base",
+        "//pkg/ccl/backupccl",
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/kvccl/kvtenantccl",
         "//pkg/cloud/externalconn",

--- a/pkg/ccl/cloudccl/externalconn/datadriven_test.go
+++ b/pkg/ccl/cloudccl/externalconn/datadriven_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/externalconn/providers" // register all the concrete External Connection implementations

--- a/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/create_drop_external_connection
@@ -23,7 +23,7 @@ pq: failed to construct External Connection details: failed to create nodelocal 
 exec-sql
 CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
 ----
-pq: external connection with connection name 'foo' already exists
+pq: failed to create external connection: external connection with connection name 'foo' already exists
 
 # Create another External Connection with a unique name.
 exec-sql
@@ -53,89 +53,6 @@ DROP EXTERNAL CONNECTION foo;
 ----
 
 inspect-system-table
-----
-
-subtest end
-
-subtest create-external-connection-global-privilege
-
-exec-sql
-CREATE USER testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
-
-exec-sql
-GRANT SYSTEM EXTERNALCONNECTION TO testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-
-inspect-system-table
-----
-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-DROP EXTERNAL CONNECTION privileged;
-----
-
-exec-sql
-REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
-
-subtest end
-
-subtest drop-external-storage-privilege
-
-exec-sql
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-
-# Create another External Connection.
-exec-sql
-CREATE EXTERNAL CONNECTION 'privileged-dup' AS 'nodelocal://1/foo'
-----
-
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION privileged
-----
-pq: user testuser does not have DROP privilege on external_connection privileged
-
-inspect-system-table
-----
-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-GRANT DROP ON EXTERNAL CONNECTION privileged TO testuser;
-----
-
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION privileged
-----
-
-# Try to drop the second external connection, testuser should be disallowed.
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION 'privileged-dup'
-----
-pq: user testuser does not have DROP privilege on external_connection privileged-dup
-
-inspect-system-table
-----
-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-DROP EXTERNAL CONNECTION 'privileged-dup'
 ----
 
 subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/create_drop_external_connection
@@ -26,7 +26,7 @@ pq: failed to construct External Connection details: failed to create nodelocal 
 exec-sql
 CREATE EXTERNAL CONNECTION foo AS 'nodelocal://1/foo';
 ----
-pq: external connection with connection name 'foo' already exists
+pq: failed to create external connection: external connection with connection name 'foo' already exists
 
 # Create another External Connection with a unique name.
 exec-sql
@@ -56,89 +56,6 @@ DROP EXTERNAL CONNECTION foo;
 ----
 
 inspect-system-table
-----
-
-subtest end
-
-subtest create-external-connection-global-privilege
-
-exec-sql
-CREATE USER testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
-
-exec-sql
-GRANT SYSTEM EXTERNALCONNECTION TO testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-
-inspect-system-table
-----
-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-DROP EXTERNAL CONNECTION privileged;
-----
-
-exec-sql
-REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;
-----
-
-exec-sql user=testuser
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
-
-subtest end
-
-subtest drop-external-storage-privilege
-
-exec-sql
-CREATE EXTERNAL CONNECTION privileged AS 'nodelocal://1/foo'
-----
-
-# Create another External Connection.
-exec-sql
-CREATE EXTERNAL CONNECTION 'privileged-dup' AS 'nodelocal://1/foo'
-----
-
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION privileged
-----
-pq: user testuser does not have DROP privilege on external_connection privileged
-
-inspect-system-table
-----
-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-GRANT DROP ON EXTERNAL CONNECTION privileged TO testuser;
-----
-
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION privileged
-----
-
-# Try to drop the second external connection, testuser should be disallowed.
-exec-sql user=testuser
-DROP EXTERNAL CONNECTION 'privileged-dup'
-----
-pq: user testuser does not have DROP privilege on external_connection privileged-dup
-
-inspect-system-table
-----
-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
-
-exec-sql
-DROP EXTERNAL CONNECTION 'privileged-dup'
 ----
 
 subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/privileges_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/multi-tenant/privileges_external_connection
@@ -1,0 +1,126 @@
+subtest create-external-connection-global-privilege
+
+initialize tenant=10
+----
+
+exec-sql
+CREATE USER testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+
+inspect-system-table
+----
+global-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION "global-privileged";
+----
+
+exec-sql
+REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+subtest end
+
+subtest drop-external-storage-privilege
+
+exec-sql
+CREATE EXTERNAL CONNECTION "drop-privileged" AS 'nodelocal://1/foo'
+----
+
+# Create another External Connection.
+exec-sql
+CREATE EXTERNAL CONNECTION 'drop-privileged-dup' AS 'nodelocal://1/foo'
+----
+
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION "drop-privileged"
+----
+pq: user testuser does not have DROP privilege on external_connection drop-privileged
+
+inspect-system-table
+----
+drop-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+drop-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+GRANT DROP ON EXTERNAL CONNECTION "drop-privileged" TO testuser;
+----
+
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION "drop-privileged"
+----
+
+# Try to drop the second external connection, testuser should be disallowed.
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION 'drop-privileged-dup'
+----
+pq: user testuser does not have DROP privilege on external_connection drop-privileged-dup
+
+inspect-system-table
+----
+drop-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION 'drop-privileged-dup'
+----
+
+subtest end
+
+subtest create-grants-all
+
+# Reset the user.
+exec-sql
+DROP USER testuser
+----
+
+exec-sql
+CREATE USER testuser
+----
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser
+----
+
+# Create an EC as root, testuser cannot use this.
+exec-sql
+CREATE EXTERNAL CONNECTION root AS 'userfile:///foo'
+----
+
+exec-sql user=testuser
+CREATE TABLE foo (id INT)
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://foo'
+----
+pq: user testuser does not have USAGE privilege on external_connection foo
+
+# Now create an EC as testuser, they should be able to use this EC since on
+# creation they are given `ALL` privileges.
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION 'not-root' AS 'userfile:///bar'
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://not-root'
+----
+
+subtest end

--- a/pkg/ccl/cloudccl/externalconn/testdata/privileges_external_connection
+++ b/pkg/ccl/cloudccl/externalconn/testdata/privileges_external_connection
@@ -1,0 +1,123 @@
+subtest create-external-connection-global-privilege
+
+exec-sql
+CREATE USER testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+
+inspect-system-table
+----
+global-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION "global-privileged";
+----
+
+exec-sql
+REVOKE SYSTEM EXTERNALCONNECTION FROM testuser;
+----
+
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION "global-privileged" AS 'nodelocal://1/foo'
+----
+pq: only users with the EXTERNALCONNECTION system privilege are allowed to CREATE EXTERNAL CONNECTION
+
+subtest end
+
+subtest drop-external-storage-privilege
+
+exec-sql
+CREATE EXTERNAL CONNECTION "drop-privileged" AS 'nodelocal://1/foo'
+----
+
+# Create another External Connection.
+exec-sql
+CREATE EXTERNAL CONNECTION 'drop-privileged-dup' AS 'nodelocal://1/foo'
+----
+
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION "drop-privileged"
+----
+pq: user testuser does not have DROP privilege on external_connection drop-privileged
+
+inspect-system-table
+----
+drop-privileged STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+drop-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+GRANT DROP ON EXTERNAL CONNECTION "drop-privileged" TO testuser;
+----
+
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION "drop-privileged"
+----
+
+# Try to drop the second external connection, testuser should be disallowed.
+exec-sql user=testuser
+DROP EXTERNAL CONNECTION 'drop-privileged-dup'
+----
+pq: user testuser does not have DROP privilege on external_connection drop-privileged-dup
+
+inspect-system-table
+----
+drop-privileged-dup STORAGE {"provider": "nodelocal", "simpleUri": {"uri": "nodelocal://1/foo"}}
+
+exec-sql
+DROP EXTERNAL CONNECTION 'drop-privileged-dup'
+----
+
+subtest end
+
+subtest create-grants-all
+
+# Reset the user.
+exec-sql
+DROP USER testuser
+----
+
+exec-sql
+CREATE USER testuser
+----
+
+exec-sql
+GRANT SYSTEM EXTERNALCONNECTION TO testuser
+----
+
+# Create an EC as root, testuser cannot use this.
+exec-sql
+CREATE EXTERNAL CONNECTION root AS 'userfile:///foo'
+----
+
+exec-sql user=testuser
+CREATE TABLE foo (id INT)
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://foo'
+----
+pq: user testuser does not have USAGE privilege on external_connection foo
+
+# Now create an EC as testuser, they should be able to use this EC since on
+# creation they are given `ALL` privileges.
+exec-sql user=testuser
+CREATE EXTERNAL CONNECTION 'not-root' AS 'userfile:///bar'
+----
+
+exec-sql user=testuser
+BACKUP TABLE foo INTO 'external://not-root'
+----
+
+subtest end

--- a/pkg/sql/create_external_connection.go
+++ b/pkg/sql/create_external_connection.go
@@ -12,13 +12,16 @@ package sql
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/errors"
 )
@@ -110,7 +113,20 @@ func (p *planner) createExternalConnection(
 
 	// Create the External Connection and persist it in the
 	// `system.external_connections` table.
-	return ex.Create(params.ctx, params.ExecCfg().InternalExecutor, params.p.User(), p.Txn())
+	if err := ex.Create(params.ctx, params.ExecCfg().InternalExecutor, params.p.User(), p.Txn()); err != nil {
+		return errors.Wrap(err, "failed to create external connection")
+	}
+
+	// Grant user `ALL` on the newly created External Connection.
+	grantStatement := fmt.Sprintf(`GRANT ALL ON EXTERNAL CONNECTION "%s" TO %s`,
+		name, p.User().SQLIdentifier())
+	_, err = params.ExecCfg().InternalExecutor.ExecEx(params.ctx,
+		"grant-on-create-external-connection", p.Txn(),
+		sessiondata.InternalExecutorOverride{User: username.NodeUserName()}, grantStatement)
+	if err != nil {
+		return errors.Wrap(err, "failed to grant on newly created External Connection")
+	}
+	return nil
 }
 
 func (c *createExternalConectionNode) Next(_ runParams) (bool, error) { return false, nil }

--- a/pkg/sql/grant_revoke_system.go
+++ b/pkg/sql/grant_revoke_system.go
@@ -224,13 +224,13 @@ func (n *changeNonDescriptorBackedPrivilegesNode) makeSystemPrivilegeObject(
 		var ret []syntheticprivilege.Object
 		for _, externalConnectionName := range n.targets.ExternalConnections {
 			// Ensure that an External Connection of this name actually exists.
-			if _, err := externalconn.LoadExternalConnection(ctx, externalConnectionName.String(),
+			if _, err := externalconn.LoadExternalConnection(ctx, string(externalConnectionName),
 				p.ExecCfg().InternalExecutor, p.Txn()); err != nil {
 				return nil, errors.Wrap(err, "failed to resolve External Connection")
 			}
 
 			ret = append(ret, &syntheticprivilege.ExternalConnectionPrivilege{
-				ConnectionName: externalConnectionName.String(),
+				ConnectionName: string(externalConnectionName),
 			})
 		}
 		return ret, nil

--- a/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/external_connection_privileges
@@ -24,6 +24,7 @@ GRANT USAGE,DROP ON EXTERNAL CONNECTION foo TO testuser
 query TTTT
 SELECT * FROM system.privileges
 ----
+root      /externalconn/foo  {ALL}         {}
 testuser  /externalconn/foo  {DROP,USAGE}  {}
 
 statement ok
@@ -32,6 +33,7 @@ REVOKE USAGE,DROP ON EXTERNAL CONNECTION foo FROM testuser
 query TTTT
 SELECT * FROM system.privileges
 ----
+root  /externalconn/foo  {ALL}  {}
 
 statement ok
 GRANT USAGE,DROP ON EXTERNAL CONNECTION foo TO testuser
@@ -62,6 +64,7 @@ query TTTT
 SELECT * FROM system.privileges ORDER BY username
 ----
 bar       /externalconn/foo  {DROP,USAGE}  {}
+root      /externalconn/foo  {ALL}         {}
 testuser  /externalconn/foo  {DROP,USAGE}  {DROP,USAGE}
 
 # Invalid grants on external connections.

--- a/pkg/sql/logictest/testdata/logic_test/system_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/system_privileges
@@ -39,7 +39,8 @@ user root
 query TTTT
 SELECT * FROM system.privileges ORDER BY 1, 2
 ----
-testuser  /global/  {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
+testuser  /externalconn/foo  {ALL}                                      {}
+testuser  /global/           {EXTERNALCONNECTION,MODIFYCLUSTERSETTING}  {}
 
 query TT
 SELECT connection_name, connection_type FROM system.external_connections
@@ -51,6 +52,11 @@ REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
 
 statement ok
 REVOKE SYSTEM EXTERNALCONNECTION FROM testuser
+
+# testuser is granted ALL privileges on the External Connection they create,
+# revoke that.
+statement ok
+REVOKE ALL ON EXTERNAL CONNECTION foo FROM testuser
 
 user testuser
 
@@ -119,7 +125,7 @@ REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
 query TTTT
 SELECT * FROM system.privileges ORDER BY 1, 2
 ----
-root      /global/  {MODIFYCLUSTERSETTING}  {}
+root  /global/  {MODIFYCLUSTERSETTING}  {}
 
 # test VIEWCLUSTERSETTING
 user testuser
@@ -158,7 +164,7 @@ user root
 query TTTT
 SELECT * FROM system.privileges
 ----
-root      /global/  {MODIFYCLUSTERSETTING}  {}
+root  /global/  {MODIFYCLUSTERSETTING}  {}
 
 # test VIEWACTIVITY
 user testuser
@@ -197,7 +203,7 @@ user root
 query TTTT
 SELECT * FROM system.privileges
 ----
-root      /global/  {MODIFYCLUSTERSETTING}  {}
+root  /global/  {MODIFYCLUSTERSETTING}  {}
 
 # test VIEWACTIVITYREDACTED
 user testuser
@@ -220,8 +226,8 @@ user root
 query TTTT
 SELECT * FROM system.privileges ORDER BY 1, 2
 ----
-root     /global/  {MODIFYCLUSTERSETTING}  {}
-testuser /global/  {VIEWACTIVITYREDACTED}   {}
+root      /global/  {MODIFYCLUSTERSETTING}  {}
+testuser  /global/  {VIEWACTIVITYREDACTED}  {}
 
 statement ok
 REVOKE SYSTEM VIEWACTIVITYREDACTED FROM testuser
@@ -236,4 +242,4 @@ user root
 query TTTT
 SELECT * FROM system.privileges
 ----
-root      /global/  {MODIFYCLUSTERSETTING}  {}
+root  /global/  {MODIFYCLUSTERSETTING}  {}


### PR DESCRIPTION
Previously, the user that created the external connection
was not granted any privileges as the creator/owner of the
object. This diff changes this by granting the user `ALL`
privileges.

When synthetic privileges have a concept of owners, we should
also set the owner of the External Connection object to the
creator. This can happen once https://github.com/cockroachdb/cockroach/issues/86181
is addressed.

There was also a small bug in the grant/revoke code where
external connection names that required to be wrapped in
`""` egs: `"foo-kms"` were being incorrectly stringified when
creating the synthetic privilege path. This resulted in:

```
CREATE EXTERNAL CONNECTION "foo-kms" AS ...
GRANT USAGE ON EXTERNAL CONNECTION "foo-kms" TO baz
```

To fail with a "foo-kms" cannot be found, even though it was
infact created before attempting the grant. Tests have been added to
test this case.

Fixes: #86261

Release note (bug fix): Users that create an external connection
are now granted `ALL` privileges on the object.

Release justification: bug fix for new functionality