### PR TITLE
execinfrapb: remove unnecessary non-nullable tag

### DIFF
--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -239,7 +239,7 @@ message ProducerMessage {
   // length rows will be sent.
   // TODO(yuzefovich): it should be possible to determine this information
   // statically instead of passing in the first message.
-  repeated sqlbase.DatumEncoding encoding = 4 [(gogoproto.nullable) = false];
+  repeated sqlbase.DatumEncoding encoding = 4;
 
   reserved 2;
 }


### PR DESCRIPTION
This fixes a warning from bazel.

Release justification: low-risk cleanup.

Release note: None