### PR TITLE
sql: allow controlling new tenants’ RANGE DEFAULT

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1075,11 +1075,17 @@ func createImportingDescriptors(
 				}
 			}
 
-			for _, tenant := range details.Tenants {
-				// Mark the tenant info as adding.
-				tenant.State = descpb.TenantInfo_ADD
-				if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), txn, &tenant); err != nil {
+			if len(details.Tenants) > 0 {
+				initialTenantZoneConfig, err := sql.GetHydratedZoneConfigForTenantsRange(ctx, txn)
+				if err != nil {
 					return err
+				}
+				for _, tenant := range details.Tenants {
+					// Mark the tenant info as adding.
+					tenant.State = descpb.TenantInfo_ADD
+					if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), txn, &tenant, initialTenantZoneConfig); err != nil {
+						return err
+					}
 				}
 			}
 

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/testdata/multitenant/range_tenants
@@ -1,0 +1,207 @@
+# Test what range default zone config each tenant's initialized with. It should
+# be whatever the system tenant's RANGE TENANTS is at the time.
+
+reconcile
+----
+
+mutations discard
+----
+
+# Initialize a tenant without mucking with the RANGE TENANTS zone config.
+initialize tenant=10
+----
+
+# Muck with the RANGE TENANTS zone config; lower the GC TTL to 4h.
+exec-sql
+ALTER RANGE TENANTS CONFIGURE ZONE USING gc.ttlseconds = 14400;
+----
+
+query-sql
+SHOW ZONE CONFIGURATION FOR RANGE TENANTS;
+----
+RANGE tenants ALTER RANGE tenants CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 14400,
+	num_replicas = 3,
+	constraints = '[]',
+	lease_preferences = '[]'
+
+# Initialize another tenant after having mucked with the RANGE TENANT zone
+# config.
+initialize tenant=11
+----
+
+# We should observe placeholder entries for both tenants (installed when
+# creating tenant records). tenant=11 should start off with whatever RANGE
+# TENANT was at the time.
+state offset=47
+----
+...
+/Table/4{8-9}                              database system (host)
+/Table/5{0-1}                              database system (host)
+/Table/5{1-2}                              database system (host)
+/Table/5{2-3}                              database system (host)
+/Tenant/10{-"\x00"}                        database system (tenant)
+/Tenant/11{-"\x00"}                        ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+
+# Start the reconciliation loop for the tenant=10. It should have the vanilla
+# RANGE DEFAULT. Check against the underlying KV state, the SQL view of the
+# tenant, and later through tenant created descriptors.
+reconcile tenant=10
+----
+
+mutations discard tenant=10
+----
+
+state offset=47
+----
+...
+/Table/4{8-9}                              database system (host)
+/Table/5{0-1}                              database system (host)
+/Table/5{1-2}                              database system (host)
+/Table/5{2-3}                              database system (host)
+/Tenant/10{-/Table/4}                      database system (tenant)
+/Tenant/10/Table/{4-5}                     database system (tenant)
+/Tenant/10/Table/{5-6}                     database system (tenant)
+/Tenant/10/Table/{6-7}                     database system (tenant)
+/Tenant/10/Table/{7-8}                     database system (tenant)
+/Tenant/10/Table/1{1-2}                    database system (tenant)
+/Tenant/10/Table/1{2-3}                    database system (tenant)
+/Tenant/10/Table/1{3-4}                    database system (tenant)
+/Tenant/10/Table/1{4-5}                    database system (tenant)
+/Tenant/10/Table/1{5-6}                    database system (tenant)
+/Tenant/10/Table/{19-20}                   database system (tenant)
+/Tenant/10/Table/2{0-1}                    database system (tenant)
+/Tenant/10/Table/2{1-2}                    database system (tenant)
+/Tenant/10/Table/2{3-4}                    database system (tenant)
+/Tenant/10/Table/2{4-5}                    database system (tenant)
+/Tenant/10/Table/2{5-6}                    database system (tenant)
+/Tenant/10/Table/2{6-7}                    database system (tenant)
+/Tenant/10/Table/2{7-8}                    database system (tenant)
+/Tenant/10/Table/2{8-9}                    database system (tenant)
+/Tenant/10/NamespaceTable/{30-Max}         database system (tenant)
+/Tenant/10/{NamespaceTable/Max-Table/32}   database system (tenant)
+/Tenant/10/Table/3{2-3}                    database system (tenant)
+/Tenant/10/Table/3{3-4}                    database system (tenant)
+/Tenant/10/Table/3{4-5}                    database system (tenant)
+/Tenant/10/Table/3{5-6}                    database system (tenant)
+/Tenant/10/Table/3{6-7}                    database system (tenant)
+/Tenant/10/Table/3{7-8}                    database system (tenant)
+/Tenant/10/Table/{39-40}                   database system (tenant)
+/Tenant/10/Table/4{0-1}                    database system (tenant)
+/Tenant/10/Table/4{1-2}                    database system (tenant)
+/Tenant/10/Table/4{2-3}                    database system (tenant)
+/Tenant/10/Table/4{3-4}                    database system (tenant)
+/Tenant/10/Table/4{4-5}                    database system (tenant)
+/Tenant/10/Table/4{6-7}                    database system (tenant)
+/Tenant/10/Table/4{8-9}                    database system (tenant)
+/Tenant/10/Table/5{0-1}                    database system (tenant)
+/Tenant/10/Table/5{1-2}                    database system (tenant)
+/Tenant/10/Table/5{2-3}                    database system (tenant)
+/Tenant/11{-"\x00"}                        ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+
+query-sql tenant=10
+SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
+----
+RANGE default ALTER RANGE default CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 90000,
+	num_replicas = 3,
+	constraints = '[]',
+	lease_preferences = '[]'
+
+exec-sql tenant=10
+CREATE DATABASE db;
+CREATE TABLE db.t1();
+CREATE TABLE db.t2();
+----
+
+mutations tenant=10
+----
+upsert /Tenant/10/Table/10{6-7}            range default
+upsert /Tenant/10/Table/10{7-8}            range default
+
+# Start the reconciliation loop for the tenant=11. It should have a modified
+# RANGE DEFAULT. Check against the underlying KV state, the SQL view of the
+# tenant, and later through tenant created descriptors.
+reconcile tenant=11
+----
+
+mutations discard tenant=11
+----
+
+state offset=81
+----
+...
+/Tenant/10/Table/4{2-3}                    database system (tenant)
+/Tenant/10/Table/4{3-4}                    database system (tenant)
+/Tenant/10/Table/4{4-5}                    database system (tenant)
+/Tenant/10/Table/4{6-7}                    database system (tenant)
+/Tenant/10/Table/4{8-9}                    database system (tenant)
+/Tenant/10/Table/5{0-1}                    database system (tenant)
+/Tenant/10/Table/5{1-2}                    database system (tenant)
+/Tenant/10/Table/5{2-3}                    database system (tenant)
+/Tenant/10/Table/10{6-7}                   range default
+/Tenant/10/Table/10{7-8}                   range default
+/Tenant/11{-/Table/4}                      ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{4-5}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{5-6}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{6-7}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{7-8}                     ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/1{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{19-20}                   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{7-8}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/2{8-9}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/NamespaceTable/{30-Max}         ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/{NamespaceTable/Max-Table/32}   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{5-6}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/3{7-8}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/{39-40}                   ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{3-4}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{4-5}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{6-7}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/4{8-9}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{0-1}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{1-2}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+/Tenant/11/Table/5{2-3}                    ttl_seconds=14400 ignore_strict_gc=true rangefeed_enabled=true
+
+query-sql tenant=11
+SHOW ZONE CONFIGURATION FOR RANGE DEFAULT
+----
+RANGE default ALTER RANGE default CONFIGURE ZONE USING
+	range_min_bytes = 134217728,
+	range_max_bytes = 536870912,
+	gc.ttlseconds = 14400,
+	num_replicas = 3,
+	constraints = '[]',
+	lease_preferences = '[]'
+
+exec-sql tenant=11
+CREATE DATABASE db;
+CREATE TABLE db.t1();
+CREATE TABLE db.t2();
+----
+
+mutations tenant=11
+----
+upsert /Tenant/11/Table/10{6-7}            ttl_seconds=14400
+upsert /Tenant/11/Table/10{7-8}            ttl_seconds=14400

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_planning.go
@@ -129,7 +129,12 @@ func ingestionPlanHook(
 				State: descpb.TenantInfo_ADD,
 			},
 		}
-		if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), p.Txn(), tenantInfo); err != nil {
+
+		initialTenantZoneConfig, err := sql.GetHydratedZoneConfigForTenantsRange(ctx, p.Txn())
+		if err != nil {
+			return err
+		}
+		if err := sql.CreateTenantRecord(ctx, p.ExecCfg(), p.Txn(), tenantInfo, initialTenantZoneConfig); err != nil {
 			return err
 		}
 

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -417,17 +417,13 @@ func TestGCTenant(t *testing.T) {
 		dropTenID        = 11
 		nonexistentTenID = 12
 	)
-	require.NoError(t, sql.CreateTenantRecord(
-		ctx, &execCfg, nil, /* txn */
-		&descpb.TenantInfoWithUsage{
-			TenantInfo: descpb.TenantInfo{ID: activeTenID},
-		}),
+	require.NoError(t, sql.CreateTenantRecord(ctx, &execCfg, nil, &descpb.TenantInfoWithUsage{
+		TenantInfo: descpb.TenantInfo{ID: activeTenID},
+	}, execCfg.DefaultZoneConfig),
 	)
-	require.NoError(t, sql.CreateTenantRecord(
-		ctx, &execCfg, nil, /* txn */
-		&descpb.TenantInfoWithUsage{
-			TenantInfo: descpb.TenantInfo{ID: dropTenID, State: descpb.TenantInfo_DROP},
-		}),
+	require.NoError(t, sql.CreateTenantRecord(ctx, &execCfg, nil, &descpb.TenantInfoWithUsage{
+		TenantInfo: descpb.TenantInfo{ID: dropTenID, State: descpb.TenantInfo_DROP},
+	}, execCfg.DefaultZoneConfig),
 	)
 
 	t.Run("unexpected progress state", func(t *testing.T) {

--- a/pkg/sql/zone_config.go
+++ b/pkg/sql/zone_config.go
@@ -258,6 +258,19 @@ func GetZoneConfigInTxn(
 	return zoneID, zone, subzone, nil
 }
 
+// GetHydratedZoneConfigForTenantsRange returns the zone config for RANGE
+// TENANTS.
+func GetHydratedZoneConfigForTenantsRange(
+	ctx context.Context, txn *kv.Txn,
+) (*zonepb.ZoneConfig, error) {
+	return GetHydratedZoneConfigForNamedZone(
+		ctx,
+		txn,
+		keys.SystemSQLCodec,
+		zonepb.TenantsZoneName,
+	)
+}
+
 // GetHydratedZoneConfigForNamedZone returns a zone config for the given named
 // zone. Any missing fields are filled through the RANGE DEFAULT zone config.
 func GetHydratedZoneConfigForNamedZone(


### PR DESCRIPTION
Newly created tenants will be initialized with whatever zone
configuration the system tenant's RANGE TENANTS has at that point in
time. This lets operators for multi-tenant clusters control what RANGE
DEFAULT newly created tenants start off with. Informs #85179.

```
ALTER RANGE TENANTS CONFIGURE ZONE USING gc.ttlseconds = 14400;
```

Release note: None
Release justification: Only affects serverless clusters.