### PR TITLE
kv: remove PrepareRetryableError from the (*kv.Txn) API

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -80,6 +80,7 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
+        "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -179,7 +179,8 @@ func (m *MockTransactionalSender) DisablePipelining() error { return nil }
 
 // PrepareRetryableError is part of the client.TxnSender interface.
 func (m *MockTransactionalSender) PrepareRetryableError(ctx context.Context, msg string) error {
-	return roachpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
+	retryErr := roachpb.NewTransactionRetryWithProtoRefreshError(msg, m.txn.ID, *m.txn.Clone())
+	return retryErr
 }
 
 // Step is part of the TxnSender interface.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -254,7 +254,9 @@ type TxnSender interface {
 
 	// PrepareRetryableError generates a
 	// TransactionRetryWithProtoRefreshError with a payload initialized
-	// from this txn.
+	// from this txn. The method also moves the transaction into the
+	// txnRestart state, forcing the client to handle the error before
+	// being able to use the transaction again.
 	PrepareRetryableError(ctx context.Context, msg string) error
 
 	// TestingCloneTxn returns a clone of the transaction's current

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -1449,8 +1449,9 @@ func (txn *Txn) SetFixedTimestamp(ctx context.Context, ts hlc.Timestamp) error {
 // cause the txn to be retried.
 //
 // The transaction's epoch is bumped, simulating to an extent what the
-// TxnCoordSender does on retriable errors. The transaction's timestamp is only
-// bumped to the extent that txn.ReadTimestamp is racheted up to txn.WriteTimestamp.
+// TxnCoordSender does on retriable errors. The transaction's timestamp is
+// bumped to the current clock timestamp.
+//
 // TODO(andrei): This method should take in an up-to-date timestamp, but
 // unfortunately its callers don't currently have that handy.
 func (txn *Txn) GenerateForcedRetryableError(ctx context.Context, msg string) error {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -714,9 +714,8 @@ func (ex *connExecutor) execStmtInOpenState(
 				IsCommit:     fsm.FromBool(isCommit(ast)),
 				CanAutoRetry: fsm.FromBool(canAutoRetry),
 			}
-			txn.ManualRestart(ctx, ex.server.cfg.Clock.Now())
 			payload := eventRetriableErrPayload{
-				err:    txn.PrepareRetryableError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
+				err:    txn.GenerateForcedRetryableError(ctx, "serializable transaction timestamp pushed (detected by connExecutor)"),
 				rewCap: rc,
 			}
 			return ev, payload, nil

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -412,7 +412,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -436,7 +436,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.False}, b
@@ -462,7 +462,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -487,7 +487,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: dummyRewCap,
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.True, IsCommit: fsm.True}, b
@@ -511,7 +511,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -536,7 +536,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b
@@ -565,7 +565,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.True}, b
@@ -605,7 +605,7 @@ func TestTransitions(t *testing.T) {
 			},
 			evFun: func(ts *txnState) (fsm.Event, fsm.EventPayload) {
 				b := eventRetriableErrPayload{
-					err:    ts.mu.txn.PrepareRetryableError(ctx, "test retriable err"),
+					err:    ts.mu.txn.GenerateForcedRetryableError(ctx, "test retriable err"),
 					rewCap: rewindCapability{},
 				}
 				return eventRetriableErr{CanAutoRetry: fsm.False, IsCommit: fsm.False}, b


### PR DESCRIPTION
This commit removes the `PrepareRetryableError` API from the `*kv.Txn` and the
`TxnSender`. This error was never what anybody wanted. It has the odd side-effect
of leaving the transaction usable -- and, worse, the `(*kv.Txn).exec` loop would
retry but would not restart or replace the transaction if such an error were
returned.

It then renames `GenerateForcedRetriableError` to `GenerateRetriableAbortedError`.
The advantage of aborting the transaction is that it means that we can use this after
rolling back the transaction to trigger a restart. The alternative API, `CleanupOnError`
also aborts the transaction, so that's no different. The difference is that the one cannot
create a retriable error from an already aborted transaction unless it itself came from
a `TransactionAbortedError`.

All of this change feels important, but a little off. The core motivation is that we'd
like to unify the logic related to descriptor management between the `sql` layer
and the `descs` layer. This is part of an initiative to make the `InternalExecutor`
more sane. We've realized that in many cases, we'd like to couple not just the
`*kv.Txn` to the `descs.Collection`, but also to an `InternalExecutor`. The change
in https://github.com/cockroachdb/cockroach/pull/82477 makes progress in that
direction. It, however, somewhat awkwardly leaves two nearly identical code paths
in [(*descs.CollectionFactory).Txn](https://github.com/cockroachdb/cockroach/blob/1be194d93921c8ef719995e0008e549bee3be97d/pkg/sql/catalog/descs/txn.go#L34-L116) and  [(*descs.CollectionFactory).TxnWithExecutor](https://github.com/cockroachdb/cockroach/blob/1be194d93921c8ef719995e0008e549bee3be97d/pkg/sql/catalog/descs/txn.go#L118-L208).
In #86301, we attempt to unify these and are *almost* successful (see [here](https://github.com/ajwerner/cockroach/blob/5685f05168bbb8c14fc83192b4baafe4af9a83b8/pkg/sql/catalog/descs/txn.go#L45-L55)).

The problem is that the new, and nicer method `TxnWithExecutor` is buggy in two ways (but
it's okay because literally nothing currently uses that better API). The first bug is that the 
`commitTxnFn` is going to, well, commit the `*Txn`, so it's weird for us to fully redo the
same work (and it is the same work) after the transaction is committed. The second bug is
that if that work fails, we're going to get one of those errors from `PrepareRetryableError`
and return it, but that won't lead to the transaction getting restarted because of this quirky
line in `(*kv.Txn).PrepareForRetry`:
https://github.com/cockroachdb/cockroach/blob/bd8bc0199eb19074029f29d1db17fc44fb9c5cc0/pkg/kv/txn.go#L1018-L1021

Even if we called `PrepareForRetry` because we thought we had a retryable error, we don't
have a claim that the transaction thinks it has a retryable error. This change happened in
#74563. It seems to me like something should either complain if the transaction does not think
it has a retryable error but we get one or it should use the one it gets. Maybe that's all I really
need to do here.

Release justification: important correctness change as part of making the
SQL-over-HTTP APIs work for index recommendations.

Release note: None