### PR TITLE
ui: add actionable btn for idx recommendation

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -15,3 +15,4 @@ export * from "./basePath";
 export * from "./nodesApi";
 export * from "./clusterLocksApi";
 export * from "./insightsApi";
+export * from "./indexActionsApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+// getInsightEventState is currently hardcoded to use the High Wait Time insight type
+// for transaction contention events
+import { executeSql, SqlExecutionRequest } from "./sqlApi";
+
+type IndexAction = {
+  status: "SUCCESS" | "FAILED";
+  error?: string;
+};
+
+export type IndexActionResponse = IndexAction[];
+
+export function executeIndexRecAction(
+  stmts: string,
+  databaseName: string,
+): Promise<IndexActionResponse> {
+  const statements = stmts
+    .split(";")
+    .filter(stmt => stmt.length != 0)
+    .map(stmt => {
+      return { sql: stmt };
+    });
+
+  const request: SqlExecutionRequest = {
+    statements: statements,
+    database: databaseName,
+    execute: true,
+  };
+  return executeSql<IndexActionResponse>(request)
+    .then(result => {
+      const res: IndexActionResponse = [];
+      if (result.error) {
+        res.push({ error: result.error.message, status: "FAILED" });
+        return res;
+      }
+      for (let i = 0; i < result.num_statements; i++) {
+        res.push({
+          status: "SUCCESS",
+        });
+      }
+      return res;
+    })
+    .catch(result => {
+      const res: IndexActionResponse = [
+        { error: result.toString(), status: "FAILED" },
+      ];
+      return res;
+    });
+}

--- a/pkg/ui/workspaces/cluster-ui/src/icon/spin.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/icon/spin.tsx
@@ -11,7 +11,14 @@
 import * as React from "react";
 
 const SpinIcon = (props: React.SVGProps<SVGSVGElement>): React.ReactElement => (
-  <svg width={18} height={18} viewBox="0 0 18 18" fill="none" {...props}>
+  <svg
+    width={18}
+    height={18}
+    viewBox="0 0 18 18"
+    fill="none"
+    style={{ animation: "loadingCircle 1s infinite linear" }}
+    {...props}
+  >
     <path
       fillRule="evenodd"
       clipRule="evenodd"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
@@ -1,0 +1,6 @@
+@import "src/core/index.module";
+
+.alert-area {
+  margin-top: 10px;
+  margin-left: -5px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.spec.ts
@@ -1,0 +1,80 @@
+// Copyright 2021 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createIdxName } from "./indexActionBtn";
+import { getHighlightedText } from "../highlightedText";
+
+describe("Create index name", () => {
+  const testCases = [
+    {
+      name: "one parameter",
+      query: "CREATE INDEX ON t (i)",
+      expected: "CREATE INDEX IF NOT EXISTS t_i_rec_idx ON t (i)",
+    },
+    {
+      name: "one parameter no space",
+      query: "CREATE INDEX ON t(i) STORING (k)",
+      expected: "CREATE INDEX IF NOT EXISTS t_i_rec_idx ON t(i) STORING (k)",
+    },
+    {
+      name: "two parameters",
+      query: "CREATE INDEX ON t (i, j) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_i_j_rec_idx ON t (i, j) STORING (k)",
+    },
+    {
+      name: "one parameter, one expression",
+      query: "CREATE INDEX ON t (i, (j + k)) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_i_expr_rec_idx ON t (i, (j + k)) STORING (k)",
+    },
+    {
+      name: "one parameter, one expression no parenthesis",
+      query: "CREATE INDEX ON t (i, j + k)",
+      expected: "CREATE INDEX IF NOT EXISTS t_i_expr_rec_idx ON t (i, j + k)",
+    },
+    {
+      name: "two expressions",
+      query: "CREATE INDEX ON t ((i+l), (j + k)) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_rec_idx ON t ((i+l), (j + k)) STORING (k)",
+    },
+    {
+      name: "one expression, one parameter",
+      query: "CREATE INDEX ON t ((i+l), j)",
+      expected: "CREATE INDEX IF NOT EXISTS t_expr_j_rec_idx ON t ((i+l), j)",
+    },
+    {
+      name: "two expressions, one parameter",
+      query: "CREATE INDEX ON t ((i + l), (j + k), a) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_a_rec_idx ON t ((i + l), (j + k), a) STORING (k)",
+    },
+    {
+      name: "invalid expression, missing )",
+      query: "CREATE INDEX ON t ((i + l, (j + k), a) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_expr_expr1_expr2_rec_idx ON t ((i + l, (j + k), a) STORING (k)",
+    },
+    {
+      name: "invalid expression, extra )",
+      query: "CREATE INDEX ON t ((i + l)), (j + k), a) STORING (k)",
+      expected:
+        "CREATE INDEX IF NOT EXISTS t_expr_rec_idx ON t ((i + l)), (j + k), a) STORING (k)",
+    },
+  ];
+
+  for (let i = 0; i < testCases.length; i++) {
+    const test = testCases[i];
+    it(test.name, () => {
+      expect(createIdxName(test.query)).toEqual(test.expected);
+    });
+  }
+});

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
-import React from "react";
+import React, { useContext } from "react";
 import Helmet from "react-helmet";
 import { RouteComponentProps } from "react-router-dom";
 import { ArrowLeft } from "@cockroachlabs/icons";
@@ -44,6 +44,7 @@ import { WorkloadInsightsError } from "../workloadInsights/util";
 import classNames from "classnames/bind";
 import { commonStyles } from "src/common";
 import insightTableStyles from "src/insightsTable/insightsTable.module.scss";
+import { CockroachCloudContext } from "../../contexts";
 
 const tableCx = classNames.bind(insightTableStyles);
 
@@ -96,7 +97,8 @@ export class InsightDetails extends React.Component<InsightDetailsProps> {
         }
       })
       .toString();
-    const insightsColumns = makeInsightsColumns();
+    const isCockroachCloud = useContext(CockroachCloudContext);
+    const insightsColumns = makeInsightsColumns(isCockroachCloud);
     function insightsTableData(): InsightRecommendation[] {
       const recs = [];
       let rec: InsightRecommendation;

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -15,7 +15,7 @@ import classNames from "classnames/bind";
 import styles from "./insightsTable.module.scss";
 import { StatementLink } from "../statementsTable";
 import { Duration } from "../util";
-
+import IdxRecAction from "../insights/indexActionBtn";
 const cx = classNames.bind(styles);
 
 export type InsightType =
@@ -51,6 +51,7 @@ export class InsightsSortedTable extends SortedTable<InsightRecommendation> {}
 const insightColumnLabels = {
   insights: "Insights",
   details: "Details",
+  actions: "",
 };
 export type InsightsTableColumnKeys = keyof typeof insightColumnLabels;
 
@@ -80,6 +81,9 @@ export const insightsTableTitles: InsightsTableTitleType = {
         {insightColumnLabels.details}
       </Tooltip>
     );
+  },
+  actions: () => {
+    return <></>;
   },
 };
 
@@ -146,7 +150,31 @@ function descriptionCell(
   }
 }
 
-export function makeInsightsColumns(): ColumnDescriptor<InsightRecommendation>[] {
+function actionCell(
+  insightRec: InsightRecommendation,
+  isCockroachCloud: boolean,
+): React.ReactElement {
+  if (isCockroachCloud) {
+    return <></>;
+  }
+  switch (insightRec.type) {
+    case "CREATE_INDEX":
+    case "REPLACE_INDEX":
+    case "DROP_INDEX":
+      return (
+        <IdxRecAction
+          actionQuery={insightRec.query}
+          actionType={insightRec.type}
+          database={insightRec.database}
+        />
+      );
+  }
+  return <></>;
+}
+
+export function makeInsightsColumns(
+  isCockroachCloud: boolean,
+): ColumnDescriptor<InsightRecommendation>[] {
   return [
     {
       name: "insights",
@@ -159,6 +187,11 @@ export function makeInsightsColumns(): ColumnDescriptor<InsightRecommendation>[]
       title: insightsTableTitles.details(),
       cell: (item: InsightRecommendation) => descriptionCell(item),
       sort: (item: InsightRecommendation) => item.type,
+    },
+    {
+      name: "action",
+      title: insightsTableTitles.actions(),
+      cell: (item: InsightRecommendation) => actionCell(item, isCockroachCloud),
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/modal/modal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/modal/modal.tsx
@@ -15,6 +15,7 @@ import "antd/lib/modal/style";
 import { Button } from "../button";
 import { Text, TextTypes } from "../text";
 import styles from "./modal.module.scss";
+import SpinIcon from "../icon/spin";
 
 export interface ModalProps {
   title?: string;
@@ -24,6 +25,7 @@ export interface ModalProps {
   cancelText?: string;
   visible: boolean;
   className?: string;
+  okLoading?: boolean;
 }
 
 const cx = classNames.bind(styles);
@@ -37,6 +39,7 @@ export const Modal: React.FC<ModalProps> = ({
   visible,
   title,
   className,
+  okLoading,
 }) => {
   return (
     <AntModal
@@ -52,7 +55,13 @@ export const Modal: React.FC<ModalProps> = ({
         <Button onClick={onCancel} type="secondary" key="cancelButton">
           {cancelText}
         </Button>,
-        <Button onClick={onOk} type="primary" key="okButton">
+        <Button
+          onClick={onOk}
+          type="primary"
+          key="okButton"
+          icon={okLoading ? <SpinIcon width={15} height={15} /> : undefined}
+          disabled={okLoading}
+        >
           {okText}
         </Button>,
       ]}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
 import { Helmet } from "react-helmet";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import {
@@ -29,6 +29,7 @@ import {
 } from "../../insightsTable/insightsTable";
 import classNames from "classnames/bind";
 import styles from "../statementDetails.module.scss";
+import { CockroachCloudContext } from "../../contexts";
 
 const cx = classNames.bind(styles);
 
@@ -200,8 +201,6 @@ interface InsightsProps {
   onChangeSortSetting: (ss: SortSetting) => void;
 }
 
-const insightsColumns = makeInsightsColumns();
-
 function Insights({
   idxRecommendations,
   plan,
@@ -209,6 +208,8 @@ function Insights({
   sortSetting,
   onChangeSortSetting,
 }: InsightsProps): React.ReactElement {
+  const isCockroachCloud = useContext(CockroachCloudContext);
+  const insightsColumns = makeInsightsColumns(isCockroachCloud);
   const data = formatIdxRecommendations(
     idxRecommendations,
     plan,

--- a/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
@@ -41,3 +41,11 @@
   white-space: nowrap;
   overflow: hidden;
 }
+
+.code-area {
+  background-color: $colors--neutral-1;
+  display: block;
+  margin-top: 20px;
+  margin-left: -5px;
+  padding: 5px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -107,6 +107,9 @@ export const fullScan = docsURL(
   "sql-tuning-with-explain.html#issue-full-table-scans",
 );
 export const secondaryIndex = docsURL("schema-design-indexes.html");
+export const onlineSchemaChanges = docsURL("online-schema-changes.html");
+export const createIndex = docsURL("create-index.html");
+export const dropIndex = docsURL("drop-index.html");
 export const lockingStrength = docsURL(
   "explain.html#find-out-if-a-statement-is-using-select-for-update-locking",
 );


### PR DESCRIPTION
Now we added a new button on each index
recommendation where the user can create/drop
indexes from DB Console.
This is not available yet on CC Console.

Fixes #85611

<img width="937" alt="Screen Shot 2022-08-19 at 2 03 51 PM" src="https://user-images.githubusercontent.com/1017486/185680315-5336f2e1-d91d-4248-974e-431c95a465db.png">
<img width="581" alt="Screen Shot 2022-08-19 at 2 04 00 PM" src="https://user-images.githubusercontent.com/1017486/185680327-883b6653-bd7a-43b1-8233-18806aa28a0b.png">
<img width="934" alt="Screen Shot 2022-08-19 at 2 04 16 PM" src="https://user-images.githubusercontent.com/1017486/185680336-af8dec07-91b1-4d82-b72c-317ebc2e385b.png">
<img width="580" alt="Screen Shot 2022-08-19 at 2 04 23 PM" src="https://user-images.githubusercontent.com/1017486/185680350-99ad8b1d-cd09-4dcd-8d5f-31bb95aa908b.png">

Example of error message:
<img width="584" alt="Screen Shot 2022-08-19 at 2 01 29 PM" src="https://user-images.githubusercontent.com/1017486/185680366-22da6848-25c0-4e61-a58f-5dbc3d100b9a.png">



Release note (ui change): Adding a button to perform
the index recommendation directly from DB Console. Being
added to the Statement Details page, under the Explain
Plan tab.

Loom: https://www.loom.com/share/f206d1428ed7458dade251089b7e01f0

Release justification: category 2, update to new functionality