### PR TITLE
opt: clarify the return type of Index.Ordinal()

### DIFF
--- a/pkg/sql/opt/cat/index.go
+++ b/pkg/sql/opt/cat/index.go
@@ -48,7 +48,7 @@ type Index interface {
 
 	// Ordinal returns the ordinal of this index within the context of its Table.
 	// Specifically idx = Table().Index(idx.Ordinal).
-	Ordinal() int
+	Ordinal() IndexOrdinal
 
 	// IsUnique returns true if this index is declared as UNIQUE in the schema.
 	IsUnique() bool

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -591,7 +591,7 @@ func (u *unknownIndex) Table() cat.Table {
 	panic(errors.AssertionFailedf("not implemented"))
 }
 
-func (u *unknownIndex) Ordinal() int {
+func (u *unknownIndex) Ordinal() cat.IndexOrdinal {
 	return 0
 }
 

--- a/pkg/sql/opt/indexrec/hypothetical_index.go
+++ b/pkg/sql/opt/indexrec/hypothetical_index.go
@@ -198,7 +198,7 @@ func (hi *hypotheticalIndex) Table() cat.Table {
 }
 
 // Ordinal is part of the cat.Index interface.
-func (hi *hypotheticalIndex) Ordinal() int {
+func (hi *hypotheticalIndex) Ordinal() cat.IndexOrdinal {
 	return hi.indexOrdinal
 }
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -986,7 +986,7 @@ func (ti *Index) Table() cat.Table {
 }
 
 // Ordinal is part of the cat.Index interface.
-func (ti *Index) Ordinal() int {
+func (ti *Index) Ordinal() cat.IndexOrdinal {
 	return ti.ordinal
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1541,7 +1541,7 @@ func (oi *optIndex) Table() cat.Table {
 }
 
 // Ordinal is part of the cat.Index interface.
-func (oi *optIndex) Ordinal() int {
+func (oi *optIndex) Ordinal() cat.IndexOrdinal {
 	return oi.indexOrdinal
 }
 
@@ -2352,7 +2352,7 @@ func (oi *optVirtualIndex) Table() cat.Table {
 }
 
 // Ordinal is part of the cat.Index interface.
-func (oi *optVirtualIndex) Ordinal() int {
+func (oi *optVirtualIndex) Ordinal() cat.IndexOrdinal {
 	return oi.indexOrdinal
 }
 


### PR DESCRIPTION
The return type of `Index.Ordinal()` is now the type alias
`cat.IndexOrdinal` to be consistent with other functions that use an
index ordinal, like `Table.Index(i cat.IndexOrdinal)`. It is now more
clear that `idx == Table().Index(idx.Ordinal())`

Release justification: This is a very small, low-risk change.

Release note: None