### PR TITLE
roachtest: deflake kv0/enc=false/../no-admission

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -155,7 +155,7 @@ func registerKV(r registry.Registry) {
 				envFlags = " " + e
 			}
 
-			cmd := fmt.Sprintf("./workload run kv --init"+
+			cmd := fmt.Sprintf("./workload run kv --tolerate-errors --init"+
 				histograms+concurrency+splits+duration+readPercent+batchSize+blockSize+sequential+envFlags+
 				" {pgurl:1-%d}", nodes)
 			c.Run(ctx, c.Node(nodes+1), cmd)

--- a/pkg/cmd/roachtest/tests/util.go
+++ b/pkg/cmd/roachtest/tests/util.go
@@ -118,4 +118,10 @@ func SetAdmissionControl(ctx context.Context, t test.Test, c cluster.Cluster, en
 			t.Fatalf("failed to set admission control to %t: %v", enabled, err)
 		}
 	}
+	if !enabled {
+		if _, err := db.ExecContext(
+			ctx, "SET CLUSTER SETTING admission.kv.pause_replication_io_threshold = 0.0"); err != nil {
+			t.Fatalf("failed to set admission control to %t: %v", enabled, err)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #86299 (speculatively). It doesn't seem this perf test cared about
failing the entire test run in the face of errors (the errors tripping
the roachtest were as a result of circuit breakers tripping, possible
without admission control which this test disabled). While here, we also
switch off admission.kv.pause_replication_io_threshold for
configurations where admission is disabled -- it gives us a fuller
comparison point.

Release justification: stability work
Release note: None