### PR TITLE
cluster-ui: added internal prefix to transaction workload insights view

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -57,7 +57,6 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
   filters: {
     app: "",
   },
-  internalAppNamePrefix: "$ internal",
   refreshTransactionInsights: () => {},
   onSortChange: () => {},
   onFiltersChange: () => {},

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -56,7 +56,6 @@ export type TransactionInsightsViewStateProps = {
   transactionsError: Error | null;
   filters: InsightEventFilters;
   sortSetting: SortSetting;
-  internalAppNamePrefix: string;
 };
 
 export type TransactionInsightsViewDispatchProps = {
@@ -69,6 +68,7 @@ export type TransactionInsightsViewProps = TransactionInsightsViewStateProps &
   TransactionInsightsViewDispatchProps;
 
 const INSIGHT_TXN_SEARCH_PARAM = "q";
+const INTERNAL_APP_NAME_PREFIX = "$ internal";
 
 export const TransactionInsightsView: React.FC<
   TransactionInsightsViewProps
@@ -77,7 +77,6 @@ export const TransactionInsightsView: React.FC<
   transactions,
   transactionsError,
   filters,
-  internalAppNamePrefix,
   refreshTransactionInsights,
   onFiltersChange,
   onSortChange,
@@ -178,13 +177,13 @@ export const TransactionInsightsView: React.FC<
 
   const apps = getAppsFromTransactionInsights(
     transactionInsights,
-    internalAppNamePrefix,
+    INTERNAL_APP_NAME_PREFIX,
   );
   const countActiveFilters = calculateActiveFilters(filters);
   const filteredTransactions = filterTransactionInsights(
     transactionInsights,
     filters,
-    internalAppNamePrefix,
+    INTERNAL_APP_NAME_PREFIX,
     search,
   );
 

--- a/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPageConnected.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/insights/workloadInsightsPageConnected.tsx
@@ -19,7 +19,6 @@ import {
   TransactionInsightsViewDispatchProps,
   TransactionInsightsView,
 } from "@cockroachlabs/cluster-ui";
-import { selectAppName } from "src/selectors/activeExecutionsSelectors";
 import {
   filtersLocalSetting,
   sortSettingLocalSetting,
@@ -34,7 +33,6 @@ const mapStateToProps = (
   transactionsError: state.cachedData?.insights.lastError,
   filters: filtersLocalSetting.selector(state),
   sortSetting: sortSettingLocalSetting.selector(state),
-  internalAppNamePrefix: selectAppName(state),
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
Previously, the connected component for transaction workload insights was
using the selector for the sessions data slice to load the internal app
name prefix. This isn't necessary; we can just use a constant, as is done
on other pages.

Fixes #86250.

https://www.loom.com/share/18bf4edf46fb4b1dad2fe32f9d285dcd

Release justification: bug fixes and low-risk updates to new functionality

Release note: None