### PR TITLE
externalconn,amazon: support s3 KMS in External Connecetions

### DIFF
--- a/pkg/ccl/cloudccl/amazon/s3_connection_test.go
+++ b/pkg/ccl/cloudccl/amazon/s3_connection_test.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -180,5 +181,249 @@ func TestS3ExternalConnection(t *testing.T) {
 		// Specify aws:kms encryption mode but don't specify kms ID.
 		sqlDB.ExpectErr(t, "AWS_SERVER_KMS_ID param must be set when using aws:kms server side encryption mode.", fmt.Sprintf(`BACKUP DATABASE foo INTO '%s'`,
 			invalidS3URI))
+	})
+}
+
+func TestAWSKMSExternalConnection(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	params := base.TestClusterArgs{}
+	params.ServerArgs.ExternalIODir = dir
+
+	tc := testcluster.StartTestCluster(t, 1, params)
+	defer tc.Stopper().Stop(context.Background())
+
+	tc.WaitForNodeLiveness(t)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Setup some dummy data.
+	sqlDB.Exec(t, `CREATE DATABASE foo`)
+	sqlDB.Exec(t, `USE foo`)
+	sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+
+	createExternalConnection := func(externalConnectionName, uri string) {
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE EXTERNAL CONNECTION '%s' AS '%s'`, externalConnectionName, uri))
+	}
+	backupAndRestoreFromExternalConnection := func(backupExternalConnectionName, kmsExternalConnectionName string) {
+		backupURI := fmt.Sprintf("external://%s", backupExternalConnectionName)
+		kmsURI := fmt.Sprintf("external://%s", kmsExternalConnectionName)
+		sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE foo INTO '%s' WITH kms='%s'`, backupURI, kmsURI))
+		sqlDB.Exec(t, fmt.Sprintf(`RESTORE DATABASE foo FROM LATEST IN '%s' WITH new_db_name = bar, kms='%s'`, backupURI, kmsURI))
+		sqlDB.CheckQueryResults(t, `SELECT * FROM bar.foo`, [][]string{{"1"}, {"2"}, {"3"}})
+		sqlDB.CheckQueryResults(t, `SELECT * FROM crdb_internal.invalid_objects`, [][]string{})
+		sqlDB.Exec(t, `DROP DATABASE bar CASCADE`)
+	}
+
+	// If environment credentials are not present, we want to
+	// skip all AWS KMS tests, including auth-implicit, even though
+	// it is not used in auth-implicit.
+	_, err := credentials.NewEnvCredentials().Get()
+	if err != nil {
+		skip.IgnoreLint(t, "Test only works with AWS credentials")
+	}
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_ACCESS_KEY_ID":     amazon.AWSAccessKeyParam,
+		"AWS_SECRET_ACCESS_KEY": amazon.AWSSecretParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			skip.IgnoreLintf(t, "%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+	// Get AWS KMS region from env variable.
+	kmsRegion := os.Getenv("AWS_KMS_REGION")
+	if kmsRegion == "" {
+		skip.IgnoreLint(t, "AWS_KMS_REGION env var must be set")
+	}
+	q.Add(amazon.KMSRegionParam, kmsRegion)
+
+	// Get AWS Key identifier from env variable.
+	keyID := os.Getenv("AWS_KMS_KEY_ARN")
+	if keyID == "" {
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
+	}
+
+	bucket := os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+	}
+
+	// Create an external connection where we will write the backup.
+	backupURI := fmt.Sprintf("s3://%s/backup?%s=%s", bucket,
+		cloud.AuthParam, cloud.AuthParamImplicit)
+	backupExternalConnectionName := "backup"
+	createExternalConnection(backupExternalConnectionName, backupURI)
+
+	t.Run("auth-implicit", func(t *testing.T) {
+		// Set the AUTH to implicit.
+		params := make(url.Values)
+		params.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+		params.Add(amazon.KMSRegionParam, kmsRegion)
+
+		kmsURI := fmt.Sprintf("aws-kms:///%s?%s", keyID, params.Encode())
+		createExternalConnection("auth-implicit-kms", kmsURI)
+		backupAndRestoreFromExternalConnection(backupExternalConnectionName,
+			"auth-implicit-kms")
+	})
+
+	t.Run("auth-specified", func(t *testing.T) {
+		kmsURI := fmt.Sprintf("aws-kms:///%s?%s", keyID, q.Encode())
+		createExternalConnection("auth-specified-kms", kmsURI)
+		backupAndRestoreFromExternalConnection(backupExternalConnectionName,
+			"auth-specified-kms")
+	})
+
+	t.Run("kms-uses-incorrect-external-connection-type", func(t *testing.T) {
+		// Point the KMS to the External Connection object that represents an
+		// ExternalStorage. This should be disallowed.
+		backupExternalConnectionURI := fmt.Sprintf("external://%s", backupExternalConnectionName)
+		sqlDB.ExpectErr(t,
+			"KMS cannot use object of type STORAGE",
+			fmt.Sprintf(`BACKUP DATABASE foo INTO '%s' WITH kms='%s'`,
+				backupExternalConnectionURI, backupExternalConnectionURI))
+	})
+}
+
+func TestAWSKMSExternalConnectionAssumeRole(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	dir, dirCleanupFn := testutils.TempDir(t)
+	defer dirCleanupFn()
+
+	params := base.TestClusterArgs{}
+	params.ServerArgs.ExternalIODir = dir
+
+	tc := testcluster.StartTestCluster(t, 1, params)
+	defer tc.Stopper().Stop(context.Background())
+
+	tc.WaitForNodeLiveness(t)
+	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+
+	// Setup some dummy data.
+	sqlDB.Exec(t, `CREATE DATABASE foo`)
+	sqlDB.Exec(t, `USE foo`)
+	sqlDB.Exec(t, `CREATE TABLE foo (id INT PRIMARY KEY)`)
+	sqlDB.Exec(t, `INSERT INTO foo VALUES (1), (2), (3)`)
+
+	createExternalConnection := func(externalConnectionName, uri string) {
+		sqlDB.Exec(t, fmt.Sprintf(`CREATE EXTERNAL CONNECTION '%s' AS '%s'`, externalConnectionName, uri))
+	}
+	disallowedCreateExternalConnection := func(externalConnectionName, uri string) {
+		sqlDB.ExpectErr(t, "(PermissionDenied|AccessDenied|PERMISSION_DENIED)",
+			fmt.Sprintf(`CREATE EXTERNAL CONNECTION '%s' AS '%s'`, externalConnectionName, uri))
+	}
+	backupAndRestoreFromExternalConnection := func(backupExternalConnectionName, kmsExternalConnectionName string) {
+		backupURI := fmt.Sprintf("external://%s", backupExternalConnectionName)
+		kmsURI := fmt.Sprintf("external://%s", kmsExternalConnectionName)
+		sqlDB.Exec(t, fmt.Sprintf(`BACKUP DATABASE foo INTO '%s' WITH kms='%s'`, backupURI, kmsURI))
+		sqlDB.Exec(t, fmt.Sprintf(`RESTORE DATABASE foo FROM LATEST IN '%s' WITH new_db_name = bar, kms='%s'`, backupURI, kmsURI))
+		sqlDB.CheckQueryResults(t, `SELECT * FROM bar.foo`, [][]string{{"1"}, {"2"}, {"3"}})
+		sqlDB.CheckQueryResults(t, `SELECT * FROM crdb_internal.invalid_objects`, [][]string{})
+		sqlDB.Exec(t, `DROP DATABASE bar CASCADE`)
+	}
+
+	// If environment credentials are not present, we want to
+	// skip all AWS KMS tests, including auth-implicit, even though
+	// it is not used in auth-implicit.
+	_, err := credentials.NewEnvCredentials().Get()
+	if err != nil {
+		skip.IgnoreLint(t, "Test only works with AWS credentials")
+	}
+
+	q := make(url.Values)
+	expect := map[string]string{
+		"AWS_ACCESS_KEY_ID":     amazon.AWSAccessKeyParam,
+		"AWS_SECRET_ACCESS_KEY": amazon.AWSSecretParam,
+		"AWS_ASSUME_ROLE":       amazon.AssumeRoleParam,
+	}
+	for env, param := range expect {
+		v := os.Getenv(env)
+		if v == "" {
+			skip.IgnoreLintf(t, "%s env var must be set", env)
+		}
+		q.Add(param, v)
+	}
+	// Get AWS KMS region from env variable.
+	kmsRegion := os.Getenv("AWS_KMS_REGION")
+	if kmsRegion == "" {
+		skip.IgnoreLint(t, "AWS_KMS_REGION env var must be set")
+	}
+	q.Add(amazon.KMSRegionParam, kmsRegion)
+	q.Set(cloud.AuthParam, cloud.AuthParamSpecified)
+
+	// Get AWS Key identifier from env variable.
+	keyID := os.Getenv("AWS_KMS_KEY_ARN")
+	if keyID == "" {
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
+	}
+
+	bucket := os.Getenv("AWS_S3_BUCKET")
+	if bucket == "" {
+		skip.IgnoreLint(t, "AWS_S3_BUCKET env var must be set")
+	}
+
+	// Create an external connection where we will write the backup.
+	backupURI := fmt.Sprintf("s3://%s/backup?%s=%s", bucket,
+		cloud.AuthParam, cloud.AuthParamImplicit)
+	backupExternalConnectionName := "backup"
+	createExternalConnection(backupExternalConnectionName, backupURI)
+
+	t.Run("auth-assume-role-implicit", func(t *testing.T) {
+		// You can create an IAM that can access AWS KMS
+		// in the AWS console, then set it up locally.
+		// https://docs.aws.com/cli/latest/userguide/cli-configure-role.html
+		// We only run this test if default role exists.
+		credentialsProvider := credentials.SharedCredentialsProvider{}
+		_, err := credentialsProvider.Retrieve()
+		if err != nil {
+			skip.IgnoreLint(t, err)
+		}
+
+		// Create params for implicit user.
+		params := make(url.Values)
+		params.Add(cloud.AuthParam, cloud.AuthParamImplicit)
+		params.Add(amazon.AssumeRoleParam, q.Get(amazon.AssumeRoleParam))
+		params.Add(amazon.KMSRegionParam, kmsRegion)
+
+		uri := fmt.Sprintf("aws-kms:///%s?%s", keyID, params.Encode())
+		createExternalConnection("auth-assume-role-implicit", uri)
+		backupAndRestoreFromExternalConnection(backupExternalConnectionName, "auth-assume-role-implicit")
+	})
+
+	t.Run("auth-assume-role-specified", func(t *testing.T) {
+		uri := fmt.Sprintf("aws-kms:///%s?%s", keyID, q.Encode())
+		createExternalConnection("auth-assume-role-specified", uri)
+		backupAndRestoreFromExternalConnection(backupExternalConnectionName, "auth-assume-role-specified")
+	})
+
+	t.Run("auth-assume-role-chaining", func(t *testing.T) {
+		roleChainStr := os.Getenv("AWS_ROLE_ARN_CHAIN")
+		roleChain := strings.Split(roleChainStr, ",")
+
+		// First verify that none of the individual roles in the chain can be used
+		// to access the KMS.
+		for i, role := range roleChain {
+			i := i
+			q.Set(amazon.AssumeRoleParam, role)
+			disallowedKMSURI := fmt.Sprintf("aws-kms:///%s?%s", keyID, q.Encode())
+			disallowedECName := fmt.Sprintf("auth-assume-role-chaining-disallowed-%d", i)
+			disallowedCreateExternalConnection(disallowedECName, disallowedKMSURI)
+		}
+
+		// Finally, check that the chain of roles can be used to access the KMS.
+		q.Set(amazon.AssumeRoleParam, roleChainStr)
+		uri := fmt.Sprintf("aws-kms:///%s?%s", keyID, q.Encode())
+		createExternalConnection("auth-assume-role-chaining", uri)
+		backupAndRestoreFromExternalConnection(backupExternalConnectionName, "auth-assume-role-chaining")
 	})
 }

--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "amazon",
     srcs = [
         "aws_kms.go",
+        "aws_kms_connection.go",
         "s3_connection.go",
         "s3_storage.go",
     ],

--- a/pkg/cloud/amazon/aws_kms_connection.go
+++ b/pkg/cloud/amazon/aws_kms_connection.go
@@ -1,0 +1,48 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package amazon
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/connectionpb"
+	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn/utils"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/errors"
+)
+
+func parseAndValidateAWSKMSConnectionURI(
+	ctx context.Context, execCfg interface{}, user username.SQLUsername, uri *url.URL,
+) (externalconn.ExternalConnection, error) {
+	if err := utils.CheckKMSConnection(ctx, execCfg, user, uri.String()); err != nil {
+		return nil, errors.Wrap(err, "failed to create AWS KMS external connection")
+	}
+
+	connDetails := connectionpb.ConnectionDetails{
+		Provider: connectionpb.ConnectionProvider_aws_kms,
+		Details: &connectionpb.ConnectionDetails_SimpleURI{
+			SimpleURI: &connectionpb.SimpleURI{
+				URI: uri.String(),
+			},
+		},
+	}
+
+	return externalconn.NewExternalConnection(connDetails), nil
+}
+
+func init() {
+	externalconn.RegisterConnectionDetailsFromURIFactory(
+		awsKMSScheme,
+		parseAndValidateAWSKMSConnectionURI,
+	)
+}

--- a/pkg/cloud/amazon/aws_kms_test.go
+++ b/pkg/cloud/amazon/aws_kms_test.go
@@ -227,9 +227,9 @@ func TestPutAWSKMSEndpoint(t *testing.T) {
 		q.Add(param, v)
 	}
 
-	keyARN := os.Getenv("AWS_KMS_KEY_ARN_A")
+	keyARN := os.Getenv("AWS_KMS_KEY_ARN")
 	if keyARN == "" {
-		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN_A env var must be set")
+		skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
 	}
 
 	t.Run("allow-endpoints", func(t *testing.T) {

--- a/pkg/cloud/externalconn/connectionpb/connection.go
+++ b/pkg/cloud/externalconn/connectionpb/connection.go
@@ -18,7 +18,7 @@ func (d *ConnectionDetails) Type() ConnectionType {
 	case ConnectionProvider_nodelocal, ConnectionProvider_s3, ConnectionProvider_userfile,
 		ConnectionProvider_gs, ConnectionProvider_azure_storage:
 		return TypeStorage
-	case ConnectionProvider_gcp_kms:
+	case ConnectionProvider_gcp_kms, ConnectionProvider_aws_kms:
 		return TypeKMS
 	case ConnectionProvider_kafka:
 		return TypeStorage

--- a/pkg/cloud/externalconn/connectionpb/connection.proto
+++ b/pkg/cloud/externalconn/connectionpb/connection.proto
@@ -26,6 +26,7 @@ enum ConnectionProvider {
 
   // KMS providers.
   gcp_kms = 2;
+  aws_kms = 8;
 
   // Sink providers.
   kafka = 3;


### PR DESCRIPTION
Informs: #84228

Release note (sql change): Users can now
`CREATE EXTERNAL CONNECTION` to represent an `aws-kms`
scheme that represents an AWS KMS resource.

Release justification: low risk change to new functionality to register s3 KMS as a supported External Connection