### PR TITLE
kvevent: implement chunked blocking buffer

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "alloc.go",
         "blocking_buffer.go",
         "chan_buffer.go",
+        "chunked_event_queue.go",
         "err_buffer.go",
         "event.go",
         "metrics.go",
@@ -38,6 +39,7 @@ go_test(
         "alloc_test.go",
         "bench_test.go",
         "blocking_buffer_test.go",
+        "chunked_event_queue_test.go",
     ],
     embed = [":kvevent"],
     deps = [
@@ -58,6 +60,7 @@ go_test(
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvevent/alloc.go
+++ b/pkg/ccl/changefeedccl/kvevent/alloc.go
@@ -46,6 +46,16 @@ func (a *Alloc) Release(ctx context.Context) {
 	a.clear()
 }
 
+// Bytes returns the size of this alloc in bytes.
+func (a *Alloc) Bytes() int64 {
+	return a.bytes
+}
+
+// Events returns the number of items associated with this alloc.
+func (a *Alloc) Events() int64 {
+	return a.entries
+}
+
 // Merge merges other resources into this allocation.
 func (a *Alloc) Merge(other *Alloc) {
 	defer other.clear()
@@ -84,6 +94,14 @@ func (a *Alloc) Merge(other *Alloc) {
 
 func (a *Alloc) clear()       { *a = Alloc{} }
 func (a *Alloc) isZero() bool { return a.ap == nil }
+func (a *Alloc) init(bytes int64, p pool) {
+	if !a.isZero() {
+		panic("cannot initialize already initialized alloc")
+	}
+	a.bytes = bytes
+	a.entries = 1
+	a.ap = p
+}
 
 // TestingMakeAlloc creates allocation for the specified number of bytes
 // in a single message using allocation pool 'p'.

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -10,9 +10,6 @@ package kvevent_test
 
 import (
 	"context"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"math/rand"
 	"testing"
 	"time"
@@ -24,8 +21,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 

--- a/pkg/ccl/changefeedccl/kvevent/bench_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/bench_test.go
@@ -10,6 +10,9 @@ package kvevent_test
 
 import (
 	"context"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"math/rand"
 	"testing"
 	"time"
@@ -21,75 +24,99 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkMemBuffer(b *testing.B) {
-	rand, _ := randutil.NewTestRand()
+	log.Infof(context.Background(), "b.N=%d", b.N)
 
-	run := func() {
-		ba, release := getBoundAccountWithBudget(4096)
-		defer release()
-
-		metrics := kvevent.MakeMetrics(time.Minute)
-
-		// Arrange for mem buffer to notify us when it waits for resources.
-		waitCh := make(chan struct{}, 1)
-		notifyWait := func(ctx context.Context, poolName string, r quotapool.Request) {
-			select {
-			case waitCh <- struct{}{}:
-			default:
+	eventPool := func() []kvevent.Event {
+		const valSize = 16 << 10
+		rng, _ := randutil.NewTestRand()
+		p := make([]kvevent.Event, 32<<10)
+		for i := range p {
+			if rng.Int31()%20 == 0 {
+				p[i] = kvevent.MakeResolvedEvent(generateSpan(rng), hlc.Timestamp{}, jobspb.ResolvedSpan_NONE)
+			} else {
+				p[i] = kvevent.MakeKVEvent(
+					makeKV(rng, valSize),
+					roachpb.Value{RawBytes: randutil.RandBytes(rng, rng.Intn(valSize))},
+					hlc.Timestamp{})
 			}
 		}
+		return p
+	}()
 
-		st := cluster.MakeTestingClusterSettings()
-		buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics, quotapool.OnWaitStart(notifyWait))
-		defer func() {
-			require.NoError(b, buf.CloseWithReason(context.Background(), nil))
-		}()
+	ba, release := getBoundAccountWithBudget(1 << 30)
+	defer release()
 
-		producerCtx, stopProducers := context.WithCancel(context.Background())
-		wg := ctxgroup.WithContext(producerCtx)
-		defer func() {
-			_ = wg.Wait() // Ignore error -- this group returns context cancellation.
-		}()
+	b.ResetTimer()
+	b.ReportAllocs()
 
-		numRows := 0
-		wg.GoCtx(func(ctx context.Context) error {
-			for {
-				err := buf.Add(ctx, kvevent.MakeResolvedEvent(generateSpan(b, rand), hlc.Timestamp{}, jobspb.ResolvedSpan_NONE))
-				if err != nil {
-					return err
-				}
-				numRows++
-			}
-		})
+	metrics := kvevent.MakeMetrics(time.Minute)
+	st := cluster.MakeTestingClusterSettings()
 
-		<-waitCh
-		writtenRows := numRows
+	buf := kvevent.NewMemBuffer(ba, &st.SV, &metrics)
+	defer func() {
+		require.NoError(b, buf.CloseWithReason(context.Background(), nil))
+	}()
 
-		for i := 0; i < writtenRows; i++ {
-			e, err := buf.Get(context.Background())
+	addToBuff := func(ctx context.Context) error {
+		rng, _ := randutil.NewTestRand()
+		for {
+			err := buf.Add(ctx, eventPool[rng.Intn(len(eventPool))])
 			if err != nil {
-				b.Fatal("could not read from buffer")
+				return err
+			}
+		}
+	}
+
+	consumedN := make(chan struct{})
+	consumeBuf := func(ctx context.Context) error {
+		const flushBytes = 32 << 20
+		var alloc kvevent.Alloc
+		defer alloc.Release(ctx)
+
+		for consumed := 0; ; {
+			e, err := buf.Get(ctx)
+			if err != nil {
+				return err
 			}
 			a := e.DetachAlloc()
-			a.Release(context.Background())
+			alloc.Merge(&a)
+
+			if alloc.Bytes() > flushBytes || e.Type() == kvevent.TypeFlush || consumed+int(alloc.Events()) >= b.N {
+				consumed += int(alloc.Events())
+				alloc.Release(ctx)
+			}
+
+			if consumed >= b.N {
+				close(consumedN)
+				return nil
+			}
 		}
-		stopProducers()
 	}
 
-	for i := 0; i < b.N; i++ {
-		run()
+	producerCtx, stopProducers := context.WithCancel(context.Background())
+	wg := ctxgroup.WithContext(producerCtx)
+
+	// During backfill, we start 3*number of nodes producers; Simulate ~10 node cluster.
+	for i := 0; i < 32; i++ {
+		wg.GoCtx(addToBuff)
 	}
+	// We only have 1 consumer.
+	wg.GoCtx(consumeBuf)
+
+	<-consumedN
+	b.StopTimer() // Done with this benchmark after we consumed N events.
+
+	stopProducers()
+	_ = wg.Wait() // Ignore error -- this group returns context cancellation.
 }
 
-func generateSpan(b *testing.B, rng *rand.Rand) roachpb.Span {
+func generateSpan(rng *rand.Rand) roachpb.Span {
 	start := rng.Intn(2 << 20)
 	end := start + rng.Intn(2<<20)
 	startDatum := tree.NewDInt(tree.DInt(start))
@@ -102,7 +129,7 @@ func generateSpan(b *testing.B, rng *rand.Rand) roachpb.Span {
 		encoding.Ascending,
 	)
 	if err != nil {
-		b.Fatal("could not generate key")
+		panic(err)
 	}
 
 	endKey, err := keyside.Encode(
@@ -111,7 +138,7 @@ func generateSpan(b *testing.B, rng *rand.Rand) roachpb.Span {
 		encoding.Ascending,
 	)
 	if err != nil {
-		b.Fatal("could not generate key")
+		panic(err)
 	}
 
 	return roachpb.Span{

--- a/pkg/ccl/changefeedccl/kvevent/chunked_event_queue.go
+++ b/pkg/ccl/changefeedccl/kvevent/chunked_event_queue.go
@@ -1,0 +1,125 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import "sync"
+
+const bufferEventChunkArrSize = 128
+
+// bufferEventChunkQueue is a queue implemented as a linked-list of bufferEntry.
+type bufferEventChunkQueue struct {
+	head, tail *bufferEventChunk
+}
+
+func (l *bufferEventChunkQueue) enqueue(e Event) {
+	if l.tail == nil {
+		chunk := newBufferEntryChunk()
+		l.head, l.tail = chunk, chunk
+		l.head.push(e) // guaranteed to insert into new chunk
+		return
+	}
+
+	if !l.tail.push(e) {
+		chunk := newBufferEntryChunk()
+		l.tail.next = chunk
+		l.tail = chunk
+		l.tail.push(e) // guaranteed to insert into new chunk
+	}
+}
+
+func (l *bufferEventChunkQueue) empty() bool {
+	return l.head == nil || l.head.empty()
+}
+
+func (l *bufferEventChunkQueue) dequeue() (e Event, ok bool) {
+	if l.head == nil {
+		return Event{}, false
+	}
+
+	e, ok, consumedAllFromChunk := l.head.pop()
+
+	if consumedAllFromChunk {
+		toFree := l.head
+		if l.tail == l.head {
+			l.tail = l.head.next
+		}
+		l.head = l.head.next
+		freeBufferEventChunk(toFree)
+		return l.dequeue()
+	}
+
+	if !ok {
+		return Event{}, false
+	}
+
+	return e, true
+
+}
+
+func (l *bufferEventChunkQueue) purge() {
+	for l.head != nil {
+		chunkToFree := l.head
+		l.head = l.head.next
+		freeBufferEventChunk(chunkToFree)
+	}
+	l.tail = l.head
+}
+
+type bufferEventChunk struct {
+	events [bufferEventChunkArrSize]Event
+	// Since bufferEventChunkArrSize may be increased beyond 128 in the future, we
+	// can leave this as an int32 for now. Also, bufferEventChunk allocations are
+	// pooled, so there should not be a significant increase in memory because of
+	// this.
+	head, tail int32
+	next       *bufferEventChunk // linked-list element
+}
+
+var bufferEntryChunkPool = sync.Pool{
+	New: func() interface{} {
+		return new(bufferEventChunk)
+	},
+}
+
+func newBufferEntryChunk() *bufferEventChunk {
+	return bufferEntryChunkPool.Get().(*bufferEventChunk)
+}
+
+func freeBufferEventChunk(c *bufferEventChunk) {
+	*c = bufferEventChunk{}
+	bufferEntryChunkPool.Put(c)
+}
+
+func (bec *bufferEventChunk) push(e Event) (inserted bool) {
+	if bec.tail == bufferEventChunkArrSize {
+		return false
+	}
+
+	bec.events[bec.tail] = e
+	bec.tail++
+	return true
+}
+
+func (bec *bufferEventChunk) pop() (e Event, ok bool, consumedAll bool) {
+	if bec.head == bufferEventChunkArrSize {
+		return Event{}, false, true
+	}
+
+	if bec.head == bec.tail {
+		return Event{}, false, false
+	}
+
+	e = bec.events[bec.head]
+	bec.head++
+	return e, true, false
+}
+
+func (bec *bufferEventChunk) empty() bool {
+	return bec.tail == bec.head
+}

--- a/pkg/ccl/changefeedccl/kvevent/chunked_event_queue_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/chunked_event_queue_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package kvevent
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferEntryQueue(t *testing.T) {
+	rand, _ := randutil.NewTestRand()
+
+	q := bufferEventChunkQueue{}
+
+	// Add one event and remove it
+	assert.True(t, q.empty())
+	q.enqueue(Event{})
+	assert.False(t, q.empty())
+	_, ok := q.dequeue()
+	assert.True(t, ok)
+	assert.True(t, q.empty())
+
+	// Add events to fill 5 chunks and assert they are consumed in fifo order.
+	eventCount := bufferEventChunkArrSize * 5
+	lastPop := -1
+	lastPush := -1
+
+	for eventCount > 0 {
+		op := rand.Intn(2)
+		if op == 0 {
+			q.enqueue(Event{approxSize: lastPush + 1})
+			lastPush++
+		} else {
+			e, ok := q.dequeue()
+			if !ok {
+				assert.Equal(t, lastPop, lastPush)
+				assert.True(t, q.empty())
+			} else {
+				assert.Equal(t, e.approxSize, lastPop+1)
+				lastPop++
+				eventCount--
+			}
+		}
+	}
+
+	// Verify that purging works.
+	eventCount = bufferEventChunkArrSize * 2.5
+	for eventCount > 0 {
+		q.enqueue(Event{approxSize: lastPush + 1})
+		eventCount--
+	}
+	q.purge()
+	assert.True(t, q.empty())
+}


### PR DESCRIPTION
### **kvevent: refactor blocking buffer benchmark**
This change updates the blocking buffer micro benchmark
in several ways:
- it uses different types of events
- it uses more producers than consumers to keep the
  buffer full
- it makes b.N correspond to the total number of events,
  so the benchmark can analyze allocs per event

Release note: None

Release justification: This change updates a benchmark only.

### **kvevent: implement chunked buffer event queue**
This change implements a simple chunked event queue.
The purpose of this queue is to be used by
kvevent.blockingBuffer in subsequent commits.

Release note: None

Release justification: This change does not affect
any production code. It adds files which are not
called by any packages.

### **kvevent: refactor memory buffer to chunked linked list**
This change refactors kvevent/blocking_buffer.go to use
a chunked linked list instead of a regular linked list to
reduce pointer usage. Note that the underlying sync.Pool,
which is also a linked list, will use less pointers due to
us pooling chunks instead of events.

Release note: None

Release justification: This change significantly
improves performance by significantly reducing
pressure on GC. Consequently, this significantly
improves foreground SQL p99 latency. GC has
been causing severe issues in production changefeeds.
Merging this change in this release is worth it
for its potential to reduce incidents.

### **Results (micro)**
These are the results of running the microbenchmark.
`./dev bench pkg/ccl/changefeedccl/kvevent --filter=BenchmarkMemBuffer --count=10 --bench-mem  --stream-output  --test-args="--test.benchtime=45s" -- --nocache_test_results --test_verbose_timeout_warnings |& tee bench.txt`
```
name          old time/op    new time/op    delta
MemBuffer-10    1.22µs ± 2%    0.85µs ± 3%  -30.04%  (p=0.000 n=8+10)

name          old alloc/op   new alloc/op   delta
MemBuffer-10     0.00B          0.00B          ~     (all equal)

name          old allocs/op  new allocs/op  delta
MemBuffer-10      0.00           0.00          ~     (all equal)
```
- Memory usage is 0 due to pooling in both implementations. 
- We can achieve a higher throughput with the chunked implementation - about 50-60M events in 45 seconds as opposed to ~40M with the old implementation. 


### **Results (Macro)**
Full results are published [here](https://docs.google.com/document/d/10-Pc_cnkCUhkRFpLyBAId39q1aqsjuqTb2k4ehTmQCY/edit?usp=sharing). In summary:

I analyzed performing by running TPC-C for 30 mins on a 15 node cluster with 10k warehouses. Before starting the workload, I started a changefeed on the `order_line` table (~200GB). I also set the following cluster settings to stress the buffer and pressure GC:
`changefeed.backfill.concurrent_scan_requests = 100;`
`changefeed.memory.per_changefeed_limit = '1073741824';` (~1GB)

Then, I analyzed SQL latency from admin UI and GC performance using the output of `GODEBUG=gctrace=1.` These are the outcomes:
- The p99 SQL latency during the workload was reduced from approx. 1.75s -> 0.150s (91%)
- CPU time spent doing GC was reduced from 37.86 mins -> 20.75 mins (45%)
- The p99 spike at the beginning of the workload was reduced from approx. 15s -> 12s (20%)

### Relevant Issues
Addresses: https://github.com/cockroachdb/cockroach/issues/84582
(for now...)