### PR TITLE
ui,cluster-ui: fix active execs table time waiting column sorting

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/execTableCommon.tsx
@@ -200,7 +200,8 @@ function makeActiveExecutionColumns(
       title: executionsTableTitles.timeSpentWaiting(execType),
       cell: (item: ActiveExecution) =>
         Duration(item.timeSpentWaiting?.asMilliseconds() ?? 0 * 1e6),
-      sort: (item: ActiveExecution) => item.timeSpentWaiting?.asMilliseconds(),
+      sort: (item: ActiveExecution) =>
+        item.timeSpentWaiting?.asMilliseconds() || 0,
     },
     applicationName: {
       name: "applicationName",


### PR DESCRIPTION
This commit fixes the 'Time Spent Waiting' column sorting for
executions where `timeSpentWaiting` is null. Previously, the
cell would return null if this field did not exist. We now
return 0 to properly sort cells with this value.

Release justification: bug fix
Release note: None