### PR TITLE
storage: do not panic on corruption in SST iterator

### DIFF
--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -13,14 +13,21 @@ package storage
 import (
 	"context"
 	"io/fs"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble"
+	"github.com/cockroachdb/pebble/sstable"
+	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
 )
 
@@ -74,4 +81,61 @@ func TestPebbleIterator_Corruption(t *testing.T) {
 
 	// Closing the iter results in a panic due to the corruption.
 	require.Panics(t, func() { iter.Close() })
+}
+
+func randStr(fill []byte, rng *rand.Rand) {
+	const letters = "abcdefghijklmnopqrstuvwxyz"
+	const lettersLen = len(letters)
+	for i := 0; i < len(fill); i++ {
+		fill[i] = letters[rng.Intn(lettersLen)]
+	}
+}
+
+func TestPebbleIterator_ExternalCorruption(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	version := clusterversion.ByKey(clusterversion.EnsurePebbleFormatVersionRangeKeys)
+	st := cluster.MakeTestingClusterSettingsWithVersions(version, version, true)
+	ctx := context.Background()
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+	f := &MemFile{}
+	w := MakeBackupSSTWriter(ctx, st, f)
+
+	// Create an example sstable.
+	var rawValue [64]byte
+	for i := 0; i < 26; i++ {
+		const numVersions = 10
+		for j := 0; j < numVersions; j++ {
+			randStr(rawValue[:], rng)
+			v, err := EncodeMVCCValue(MVCCValue{Value: roachpb.MakeValueFromBytes(rawValue[:])})
+			require.NoError(t, err)
+			require.NoError(t, w.Put(pointKey(string(rune('a'+i)), numVersions-j), v))
+		}
+	}
+	require.NoError(t, w.Finish())
+
+	// Trash a random byte.
+	b := f.Bytes()
+	b[rng.Intn(len(b))]++
+
+	it, err := NewPebbleSSTIterator([][]sstable.ReadableFile{{vfs.NewMemFile(b)}},
+		IterOptions{UpperBound: roachpb.KeyMax}, false)
+
+	// We may error early, while opening the iterator.
+	if err != nil {
+		require.True(t, errors.Is(err, pebble.ErrCorruption))
+		return
+	}
+
+	it.SeekGE(NilKey)
+	valid, err := it.Valid()
+	for valid {
+		it.Next()
+		valid, err = it.Valid()
+	}
+	// Or we may error during iteration.
+	if err != nil {
+		require.True(t, errors.Is(err, pebble.ErrCorruption))
+	}
+	it.Close()
 }


### PR DESCRIPTION
In iterators created through NewPebbleSSTIterator, do not panic on corruption
errors at Close. The panic is important for iterators created over committed
engine state, but it's a problem when iterating over sstables from external
sources like backups.

Release justification: minor, low-risk bug fix.
Release note: None