### PR TITLE
build: don't include @cockroachlabs/ JS packages in vendor bundle

### DIFF
--- a/pkg/ui/workspaces/db-console/webpack.vendor.js
+++ b/pkg/ui/workspaces/db-console/webpack.vendor.js
@@ -15,7 +15,7 @@ const webpack = require("webpack");
 
 const pkg = require("./package.json");
 
-const prodDependencies = Object.keys(pkg.dependencies);
+const prodDependencies = Object.keys(pkg.dependencies).filter(name => !name.startsWith("@cockroachlabs"));
 
 // tslint:disable:object-literal-sort-keys
 module.exports = (env, argv) => {


### PR DESCRIPTION
OSS builds previously included @cockroachlabs/crdb-protobuf-client-ccl
in the intermediate vendor.oss.dll.js file, but the Makefile didn't
force that module to be built before the vendor bundle was built because
it isn't used for OSS builds. Luckily, the vendor bundle is a
UI development affordance meant to improve build times, and the presence
of any particular package in that bundle isn't necessary for a build to
succeed. Don't include any @cockroachlabs/* packages in the intermediate
vendor bundle, since they're likely to change much more often than
third-party packages anyway.

fixes #86403

Release note (build change): Fixed OSS builds that didn't have
CCL-licensed UI intermediates lingering on-disk.

Release justification: Non-production code changes