### PR TITLE
storage: use concrete `pebbleIterator` in `intentInterleavingIter`

### DIFF
--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -1245,7 +1245,7 @@ func (i *intentInterleavingIter) SupportsPrev() bool {
 	return true
 }
 
-// unsageMVCCIterator is used in RaceEnabled test builds to randomly inject
+// unsafeMVCCIterator is used in RaceEnabled test builds to randomly inject
 // changes to unsafe keys retrieved from MVCCIterators.
 type unsafeMVCCIterator struct {
 	MVCCIterator
@@ -1254,8 +1254,12 @@ type unsafeMVCCIterator struct {
 	rawMVCCKeyBuf []byte
 }
 
-func wrapInUnsafeIter(iter MVCCIterator) MVCCIterator {
-	return &unsafeMVCCIterator{MVCCIterator: iter}
+// gcassert:inline
+func maybeWrapInUnsafeIter(iter MVCCIterator) MVCCIterator {
+	if util.RaceEnabled {
+		return &unsafeMVCCIterator{MVCCIterator: iter}
+	}
+	return iter
 }
 
 var _ MVCCIterator = &unsafeMVCCIterator{}

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -345,6 +345,8 @@ func (i *intentInterleavingIter) makeLowerLimitKey() roachpb.Key {
 // NB: This is called before computePos(), and can't rely on intentCmp.
 //
 // REQUIRES: i.dir > 0
+//
+// gcassert:inline
 func (i *intentInterleavingIter) maybeSkipIntentRangeKey() error {
 	if util.RaceEnabled && i.dir < 0 {
 		i.err = errors.AssertionFailedf("maybeSkipIntentRangeKey called in reverse")
@@ -352,38 +354,45 @@ func (i *intentInterleavingIter) maybeSkipIntentRangeKey() error {
 		return i.err
 	}
 	if i.iterValid && i.intentKey != nil {
-		if hasPoint, hasRange := i.iter.HasPointAndRange(); hasRange && !hasPoint {
-			// iter may be on a bare range key that will cover the provisional value,
-			// in which case we can step onto it. We guard against emitting the wrong
-			// range key for the intent if the provisional value turns out to be
-			// missing by:
-			//
-			// 1. Before we step, make sure iter isn't ahead of intentIter. We have
-			//    to do a key comparison anyway in case intentIter is ahead of iter.
-			// 2. After we step, make sure we're on a point key covered by a range key.
-			//    We don't need a key comparison (but do so under race), because if
-			//    the provisional value is missing then we'll either land on a
-			//    different point key below the range key (which will emit the
-			//    correct range key), or we'll land on a different bare range key.
-			//
-			// TODO(erikgrinaker): in cases where we don't step iter, we can save
-			// the result of the comparison in i.intentCmp to avoid another one.
-			if intentCmp := i.intentKey.Compare(i.iterKey.Key); intentCmp < 0 {
-				i.err = errors.Errorf("iter ahead of provisional value for intent %s (at %s)",
-					i.intentKey, i.iterKey)
+		return i.doMaybeSkipIntentRangeKey()
+	}
+	return nil
+}
+
+// doMaybeSkipIntentRangeKey is a helper for maybeSkipIntentRangeKey(), which
+// allows mid-stack inlining of the former.
+func (i *intentInterleavingIter) doMaybeSkipIntentRangeKey() error {
+	if hasPoint, hasRange := i.iter.HasPointAndRange(); hasRange && !hasPoint {
+		// iter may be on a bare range key that will cover the provisional value,
+		// in which case we can step onto it. We guard against emitting the wrong
+		// range key for the intent if the provisional value turns out to be
+		// missing by:
+		//
+		// 1. Before we step, make sure iter isn't ahead of intentIter. We have
+		//    to do a key comparison anyway in case intentIter is ahead of iter.
+		// 2. After we step, make sure we're on a point key covered by a range key.
+		//    We don't need a key comparison (but do so under race), because if
+		//    the provisional value is missing then we'll either land on a
+		//    different point key below the range key (which will emit the
+		//    correct range key), or we'll land on a different bare range key.
+		//
+		// TODO(erikgrinaker): in cases where we don't step iter, we can save
+		// the result of the comparison in i.intentCmp to avoid another one.
+		if intentCmp := i.intentKey.Compare(i.iterKey.Key); intentCmp < 0 {
+			i.err = errors.Errorf("iter ahead of provisional value for intent %s (at %s)",
+				i.intentKey, i.iterKey)
+			i.valid = false
+			return i.err
+		} else if intentCmp == 0 {
+			i.iter.Next()
+			if err := i.tryDecodeKey(); err != nil {
+				return err
+			}
+			hasPoint, hasRange = i.iter.HasPointAndRange()
+			if !hasPoint || !hasRange || (util.RaceEnabled && !i.iterKey.Key.Equal(i.intentKey)) {
+				i.err = errors.Errorf("iter not on provisional value for intent %s", i.intentKey)
 				i.valid = false
 				return i.err
-			} else if intentCmp == 0 {
-				i.iter.Next()
-				if err := i.tryDecodeKey(); err != nil {
-					return err
-				}
-				hasPoint, hasRange = i.iter.HasPointAndRange()
-				if !hasPoint || !hasRange || (util.RaceEnabled && !i.iterKey.Key.Equal(i.intentKey)) {
-					i.err = errors.Errorf("iter not on provisional value for intent %s", i.intentKey)
-					i.valid = false
-					return i.err
-				}
 			}
 		}
 	}
@@ -394,14 +403,22 @@ func (i *intentInterleavingIter) maybeSkipIntentRangeKey() error {
 // direction if the underlying iterator has moved past an intent onto a
 // different range key that should not be surfaced yet. Must be called after
 // computePos().
+//
+// gcassert:inline
 func (i *intentInterleavingIter) maybeSuppressRangeKeyChanged() {
 	if util.RaceEnabled && i.dir > 0 {
 		panic(errors.AssertionFailedf("maybeSuppressRangeKeyChanged called in forward direction"))
 	}
-	if i.rangeKeyChanged && i.isCurAtIntentIterReverse() && i.intentCmp > 0 &&
-		i.iter.RangeBounds().EndKey.Compare(i.intentKey) <= 0 {
-		i.rangeKeyChanged = false
+	// NB: i.intentCmp implies isCurAtIntentIterReverse(), but cheaper.
+	if i.rangeKeyChanged && i.intentCmp > 0 {
+		i.doMaybeSuppressRangeKeyChanged()
 	}
+}
+
+// doMaybeSuppressRangeKeyChanges is a helper for maybeSuppressRangeKeyChanged
+// which allows mid-stack inlining of the former.
+func (i *intentInterleavingIter) doMaybeSuppressRangeKeyChanged() {
+	i.rangeKeyChanged = i.iter.RangeBounds().EndKey.Compare(i.intentKey) > 0
 }
 
 func (i *intentInterleavingIter) SeekGE(key MVCCKey) {

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -332,7 +332,7 @@ func TestIntentInterleavingIter(t *testing.T) {
 				if d.HasArg("prefix") {
 					d.ScanArgs(t, "prefix", &opts.Prefix)
 				}
-				iter := wrapInUnsafeIter(newIntentInterleavingIterator(eng, opts))
+				iter := maybeWrapInUnsafeIter(newIntentInterleavingIterator(eng, opts))
 				var b strings.Builder
 				defer iter.Close()
 				// pos is the original <file>:<lineno> prefix computed by


### PR DESCRIPTION
**storage: tweak `unsafeMVCCIterator` construction**

Release justification: non-production code changes

Release note: None

**storage: inline some `intentInterleavingIter` methods**

This patch splits up `maybeSkipIntentRangeKeys()` and
`maybeSuppressRangeKeyChanged()` to allow for mid-stack inlining.

I doubt that the gains are as large as these microbenchmarks claim, and
there's a fair bit of variance between runs, but it can't hurt.

```
name                                                                         old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24               5.37µs ± 2%    5.43µs ± 2%  +1.13%  (p=0.041 n=10+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24             38.2µs ± 2%    38.2µs ± 2%    ~     (p=0.971 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24           2.79ms ± 2%    2.71ms ± 2%  -2.59%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24        5.99µs ± 1%    5.99µs ± 2%    ~     (p=0.541 n=10+10)
MVCCReverseScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24      51.7µs ± 3%    52.1µs ± 1%    ~     (p=0.631 n=10+10)
MVCCReverseScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24    3.88ms ± 2%    3.87ms ± 1%    ~     (p=0.897 n=10+8)
MVCCComputeStats_Pebble/valueSize=32/numRangeKeys=0-24                          158ms ± 1%     155ms ± 1%  -2.34%  (p=0.000 n=10+9)
```

Touches #82559.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None
  
**storage: use concrete `pebbleIterator` in `intentInterleavingIter`**

Since `intentInterleavingIter` always constructs the underlying
iterators from the given reader, and these readers always construct
`*pebbleIterator`, it can use the concrete type rather than interfaces
for both iterators. This avoids dynamic dispatch, yielding a decent
performance improvement.

Unfortunately, this requires disabling `unsafeMVCCIterator` inside
`intentInterleavingIter`. This wasn't always enabled anyway, since it
was omitted both for the engine iterator and when using an engine
directly (which doesn't have consistent iterators).

```
name                                                                         old time/op    new time/op    delta
MVCCScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24               5.43µs ± 2%    5.45µs ± 2%    ~     (p=0.566 n=10+10)
MVCCScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24             38.2µs ± 2%    37.0µs ± 1%  -3.02%  (p=0.000 n=10+10)
MVCCScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24           2.71ms ± 2%    2.66ms ± 1%  -1.83%  (p=0.000 n=10+9)
MVCCReverseScan_Pebble/rows=1/versions=1/valueSize=64/numRangeKeys=0-24        5.99µs ± 2%    5.86µs ± 2%  -2.15%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=100/versions=1/valueSize=64/numRangeKeys=0-24      52.1µs ± 1%    50.2µs ± 2%  -3.77%  (p=0.000 n=10+10)
MVCCReverseScan_Pebble/rows=10000/versions=1/valueSize=64/numRangeKeys=0-24    3.87ms ± 1%    3.83ms ± 1%  -1.26%  (p=0.000 n=8+10)
MVCCComputeStats_Pebble/valueSize=32/numRangeKeys=0-24                          155ms ± 1%     155ms ± 1%    ~     (p=0.842 n=9+10)
```

Touches #82559.

Release justification: low risk, high benefit changes to existing functionality

Release note: None