### PR TITLE
storage: omit key comparison in `pebbleMVCCScanner.nextKey()`

### DIFF
--- a/pkg/storage/pebble_mvcc_scanner.go
+++ b/pkg/storage/pebble_mvcc_scanner.go
@@ -861,10 +861,12 @@ func (p *pebbleMVCCScanner) nextKey() bool {
 	p.keyBuf = append(p.keyBuf[:0], p.curUnsafeKey.Key...)
 
 	for i := 0; i < p.itersBeforeSeek; i++ {
+		prevTS := p.curUnsafeKey.Timestamp
 		if !p.iterNext() {
 			return false
 		}
-		if !bytes.Equal(p.curUnsafeKey.Key, p.keyBuf) {
+		if (!prevTS.IsEmpty() && prevTS.LessEq(p.curUnsafeKey.Timestamp)) ||
+			!bytes.Equal(p.curUnsafeKey.Key, p.keyBuf) {
 			p.incrementItersBeforeSeek()
 			return true
 		}

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -40,6 +40,7 @@ with t=A
   get  k=k
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
@@ -88,6 +89,7 @@ with t=A
   get  k=k
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
@@ -104,6 +106,7 @@ with t=A
   get         k=k
 ----
 scan: "k" -> /BYTES/a @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "k/10" -> /BYTES/10 @11.000000000,0
 get: "k" -> /BYTES/a @11.000000000,0
 >> at end:
@@ -120,6 +123,7 @@ with t=A
   get         k=k
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
@@ -136,6 +140,7 @@ with t=A
   get         k=k
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0

--- a/pkg/storage/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/testdata/mvcc_histories/max_keys
@@ -126,9 +126,9 @@ with t=A ts=11,0 max=3
   scan      k=k end=o reverse=true
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
+scan: "k" -> /BYTES/c @11.000000000,0
 scan: "l" -> /BYTES/b @11.000000000,0
-scan: "m" -> /BYTES/b @11.000000000,0
-scan: resume span ["n","o") RESUME_KEY_LIMIT nextBytes=0
+scan: resume span ["l","o") RESUME_KEY_LIMIT nextBytes=0
 scan: "n" -> /BYTES/b @11.000000000,0
 scan: "m" -> /BYTES/b @11.000000000,0
 scan: "l" -> /BYTES/b @11.000000000,0
@@ -202,9 +202,9 @@ with t=B ts=12,0 max=3
   scan      k=k end=o
 ----
 scan: "k" -> /BYTES/b @12.000000000,0
+scan: "k" -> /BYTES/c @12.000000000,0
 scan: "l" -> /BYTES/b @12.000000000,0
-scan: "m" -> /BYTES/b @12.000000000,0
-scan: resume span ["n","o") RESUME_KEY_LIMIT nextBytes=0
+scan: resume span ["l","o") RESUME_KEY_LIMIT nextBytes=0
 >> at end:
 txn: "B" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
 data: "a"/1.000000000,0 -> /BYTES/val-a

--- a/pkg/storage/testdata/mvcc_histories/target_bytes
+++ b/pkg/storage/testdata/mvcc_histories/target_bytes
@@ -576,7 +576,7 @@ with t=A ts=11,0 targetbytes=32
   scan      k=k end=o reverse=true
 ----
 scan: "k" -> /BYTES/b @11.000000000,0
-scan: resume span ["l","o") RESUME_BYTE_LIMIT nextBytes=25
+scan: resume span ["k","o") RESUME_BYTE_LIMIT nextBytes=25
 scan: 25 bytes (target 32)
 scan: "n" -> /BYTES/b @11.000000000,0
 scan: resume span ["k","m\x00") RESUME_BYTE_LIMIT nextBytes=25


### PR DESCRIPTION
Demonstrates how `intentInterleavingIter` can surface multiple keys at
the same timestamp.

Release justification: None

Release note: None