### PR TITLE
opt: reduce allocations in OrderingSet.LongestCommonPrefix

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -656,16 +656,15 @@ func (o *Optimizer) enforceProps(
 		memberProps := BuildChildPhysicalProps(o.mem, enforcer, 0, required)
 		fullyOptimized = o.optimizeEnforcer(state, enforcer, required, member, memberProps)
 
-		// Try Sort enforcer that requires a partial ordering from its input. Choose
-		// the interesting ordering that forms the longest common prefix with the
-		// required ordering. We do not need to add the enforcer if the required
-		// ordering is implied by the input ordering (in which case the returned
-		// prefix is nil).
+		// Try Sort enforcer that requires a partial ordering from its input.
+		// Choose the interesting ordering that forms the longest common prefix
+		// with the required ordering. We do not need to add the enforcer if
+		// there is no common prefix or if the required ordering is implied by
+		// the input ordering.
 		interestingOrderings := ordering.DeriveInterestingOrderings(member)
-		longestCommonPrefix := interestingOrderings.LongestCommonPrefix(&required.Ordering)
-		if longestCommonPrefix != nil {
+		if lcp, ok := interestingOrderings.LongestCommonPrefix(&required.Ordering); ok {
 			enforcer := &memo.SortExpr{Input: state.best}
-			enforcer.InputOrdering = *longestCommonPrefix
+			enforcer.InputOrdering = lcp
 			memberProps := BuildChildPhysicalProps(o.mem, enforcer, 0, required)
 			if o.optimizeEnforcer(state, enforcer, required, member, memberProps) {
 				fullyOptimized = true


### PR DESCRIPTION
Previously, the `*OrderingChoice` returned by `LongestCommonPrefix` was
allocated on the heap (except in the case where the ordering set
contained a ordering choice that implies the given ordering). Now,
`LongestCommonPrefix` returns a non-pointer type and avoids these
allocations.

Release justification: This is a minor change that improves performance.

Release note: None