### PR TITLE
storage: disable `pebbleIterator` range key block filtering

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -401,6 +401,10 @@ type IterOptions struct {
 	// separate [3-5] SST where foo@5 was removed or updated. See also:
 	// https://github.com/cockroachdb/pebble/issues/1786
 	//
+	// NB: Range keys are not currently subject to timestamp filtering due to
+	// complications with MVCCIncrementalIterator. See:
+	// https://github.com/cockroachdb/cockroach/issues/86260
+	//
 	// Currently, the only way to correctly use such an iterator is to use it in
 	// concert with an iterator without timestamp hints, as done by
 	// MVCCIncrementalIterator.

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -284,6 +284,13 @@ func (i *MVCCIncrementalIterator) NextKey() {
 // It is expected (but not required) that TBI is at a key <= main iterator key
 // when calling maybeSkipKeys().
 //
+// NB: This logic will not handle TBI range key filtering properly -- the TBI
+// may see different range key fragmentation than the regular iterator, causing
+// it to skip past range key fragments. Range key filtering has therefore been
+// disabled in pebbleMVCCIterator, since the performance gains are expected to
+// be marginal, and the necessary seeks/processing here would likely negate it.
+// See: https://github.com/cockroachdb/cockroach/issues/86260
+//
 // TODO(erikgrinaker): Make sure this works properly when TBIs handle range
 // keys. In particular, we need to make sure a SeekGE doesn't get stuck
 // prematurely on a bare range key that we've already emitted, but moves onto

--- a/pkg/storage/mvcc_incremental_iterator.go
+++ b/pkg/storage/mvcc_incremental_iterator.go
@@ -290,11 +290,6 @@ func (i *MVCCIncrementalIterator) NextKey() {
 // disabled in pebbleMVCCIterator, since the performance gains are expected to
 // be marginal, and the necessary seeks/processing here would likely negate it.
 // See: https://github.com/cockroachdb/cockroach/issues/86260
-//
-// TODO(erikgrinaker): Make sure this works properly when TBIs handle range
-// keys. In particular, we need to make sure a SeekGE doesn't get stuck
-// prematurely on a bare range key that we've already emitted, but moves onto
-// the next TBI point key (which can be much further ahead).
 func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 	if i.timeBoundIter == nil {
 		// If there is no time bound iterator, we cannot skip any keys.
@@ -316,8 +311,7 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 		// using the incremental iterator, by avoiding a SeekGE.
 		i.timeBoundIter.NextKey()
 		if ok, err := i.timeBoundIter.Valid(); !ok {
-			i.err = err
-			i.valid = false
+			i.valid, i.err = false, err
 			return
 		}
 		tbiKey = i.timeBoundIter.UnsafeKey().Key
@@ -332,11 +326,23 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 			seekKey := MakeMVCCMetadataKey(iterKey)
 			i.timeBoundIter.SeekGE(seekKey)
 			if ok, err := i.timeBoundIter.Valid(); !ok {
-				i.err = err
-				i.valid = false
+				i.valid, i.err = false, err
 				return
 			}
 			tbiKey = i.timeBoundIter.UnsafeKey().Key
+
+			// If there is an MVCC range key across iterKey, then the TBI seek may get
+			// stuck in the middle of the bare range key so we step forward.
+			if hasPoint, hasRange := i.timeBoundIter.HasPointAndRange(); hasRange && !hasPoint {
+				if !i.timeBoundIter.RangeBounds().Key.Equal(tbiKey) {
+					i.timeBoundIter.Next()
+					if ok, err := i.timeBoundIter.Valid(); !ok {
+						i.valid, i.err = false, err
+						return
+					}
+					tbiKey = i.timeBoundIter.UnsafeKey().Key
+				}
+			}
 			cmp = iterKey.Compare(tbiKey)
 		}
 
@@ -352,6 +358,17 @@ func (i *MVCCIncrementalIterator) maybeSkipKeys() {
 			i.iter.SeekGE(seekKey)
 			if !i.updateValid() {
 				return
+			}
+
+			// The seek may have landed in the middle of a bare range key, in which
+			// case we should move on to the next key.
+			if hasPoint, hasRange := i.iter.HasPointAndRange(); hasRange && !hasPoint {
+				if !i.iter.RangeBounds().Key.Equal(i.iter.UnsafeKey().Key) {
+					i.iter.Next()
+					if !i.updateValid() {
+						return
+					}
+				}
 			}
 		}
 	}

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -259,11 +259,16 @@ func (p *pebbleIterator) setOptions(opts IterOptions, durability DurabilityRequi
 				uint64(opts.MinTimestampHint.WallTime),
 				uint64(opts.MaxTimestampHint.WallTime)+1),
 		}
-		p.options.RangeKeyFilters = []pebble.BlockPropertyFilter{
-			sstable.NewBlockIntervalFilter(mvccWallTimeIntervalCollector,
-				uint64(opts.MinTimestampHint.WallTime),
-				uint64(opts.MaxTimestampHint.WallTime)+1),
-		}
+		// NB: We disable range key block filtering because of complications in
+		// MVCCIncrementalIterator.maybeSkipKeys: the TBI may see different range
+		// key fragmentation than the main iterator due to the filtering. This would
+		// necessitate additional seeks/processing that likely negate the marginal
+		// benefit of the range key filters. See:
+		// https://github.com/cockroachdb/cockroach/issues/86260.
+		//
+		// However, we do collect block properties for range keys, in case we enable
+		// this later.
+		p.options.RangeKeyFilters = nil
 	}
 
 	// Set the new iterator options. We unconditionally do so, since Pebble will


### PR DESCRIPTION
**storage: disable `pebbleIterator` range key block filtering**

This patch disables TBI filtering of MVCC range keys blocks via
`MinTimestampHint` and `MaxTimestampHint`, due to complications with
`MVCCIncrementalIterator`. Specifically, the TBI and regular iterators
would have a different view of the range key fragmentation, which could
cause it to skip past range key fragments. The necessary seeks and other
processing to handle this would likely negate the benefit of the
filtering.

This causes a minor regression when range keys are present, because the
TBI optimization can currently get "stuck" when seeking into range keys.
Previously, these range keys would be filtered out by the TBI. A
separate commit will address this.

```
name                                                                  old time/op  new time/op  delta
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=0-24      804ms ± 1%   798ms ± 1%    ~     (p=0.151 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=1-24      990ms ± 1%   972ms ± 1%  -1.84%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=100-24    991ms ± 0%   984ms ± 1%  -0.73%  (p=0.032 n=4+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=0-24     676ms ± 0%   689ms ± 1%  +2.03%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=1-24     859ms ± 0%   867ms ± 1%  +0.95%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=100-24   868ms ± 0%   877ms ± 0%  +1.06%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=0-24     181ms ± 0%   183ms ± 1%  +0.90%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=1-24     204ms ± 1%   206ms ± 1%  +1.20%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=100-24   294ms ± 1%   323ms ± 4%  +9.87%  (p=0.008 n=5+5)
```

Resolves #86260.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None
  
**storage: prevent `MVCCIncrementalIterator` TBI stuck on range key**

This patch prevents the internal TBI used in `MVCCIncrementalIterator`
from getting prematurely stuck on an MVCC range key covering a seek key.

Consider the following visible keys for the TBI (time range 3-5) and
regular iterator:

Iterator: `[a-f)@5`, `a@4`, `c@1`, and `e@4`
TBI: `[a-f)@5`, `a@4`, `e@4`.

If the iterator is positioned on `c@1` (outside the time bounds), and
the TBI is seeked to `c` to find newer keys, the the TBI will get stuck
on the range key `[a-f)@5` even though it has already been emitted,
preventing the TBI from being used at all. This patch moves the TBI
forward to `e@4` in this case, and similarly when seeking iter ahead.

The effect on performance appears rather marginal though.

```
name                                                                  old time/op  new time/op  delta
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=0-24      798ms ± 1%   805ms ± 1%  +0.93%  (p=0.032 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=1-24      972ms ± 1%   983ms ± 0%  +1.15%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=100-24    984ms ± 1%   995ms ± 0%  +1.09%  (p=0.016 n=5+4)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=0-24     689ms ± 1%   681ms ± 0%  -1.28%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=1-24     867ms ± 1%   854ms ± 0%  -1.57%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=100-24   877ms ± 0%   869ms ± 1%    ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=0-24     183ms ± 1%   179ms ± 0%  -1.90%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=1-24     206ms ± 1%   204ms ± 1%  -1.10%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=100-24   323ms ± 4%   315ms ± 1%  -2.37%  (p=0.016 n=5+5)
```

Release justification: bug fixes and low-risk updates to new functionality

Release note: None