### PR TITLE
sql: step the sql transaction before commit

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -876,5 +876,13 @@ statement ok
 DROP SCHEMA sc
 
 statement ok
+BEGIN;
+CREATE SCHEMA sc;
+COMMIT
+
+statement ok
+DROP SCHEMA sc
+
+statement ok
 SET CLUSTER SETTING server.eventlog.enabled = false
 


### PR DESCRIPTION
In #86153 we added logic to step the transaction before auto-commit. This was
insufficient to resolve #86132 because we did not step the transaction before
committing an explicit transaction. This PR addresses that by moving the step
logic to a shared code path. It also adds a test which previously failed.

Fixes #86132

Release justification: bug fix

Release note: None