### PR TITLE
opt: reduce allocations in hypothetical indexes

### DIFF
--- a/pkg/sql/opt/indexrec/index_recommendation_set.go
+++ b/pkg/sql/opt/indexrec/index_recommendation_set.go
@@ -212,7 +212,12 @@ func (ir *indexRecommendation) init(
 	ir.existingIndex = hypTable.existingRedundantIndex(index)
 
 	// Only store columns useful to the statement plan, found in scannedColOrds.
-	ir.newStoredColOrds = index.storedColsOrdSet.Intersection(scannedColOrds)
+	for i := range index.storedCols {
+		colOrd := index.storedCols[i].Column.Ordinal()
+		if scannedColOrds.Contains(colOrd) {
+			ir.newStoredColOrds.Add(colOrd)
+		}
+	}
 
 	// If there is no existing index, return.
 	if ir.existingIndex == nil {
@@ -243,8 +248,12 @@ func (ir *indexRecommendation) redundantRecommendation() bool {
 // addStoredColOrds updates an index recommendation's newStoredColOrds field to
 // also contain the scannedColOrds columns.
 func (ir *indexRecommendation) addStoredColOrds(scannedColOrds util.FastIntSet) {
-	scannedStoredColOrds := ir.index.storedColsOrdSet.Intersection(scannedColOrds)
-	ir.newStoredColOrds.UnionWith(scannedStoredColOrds)
+	for i := range ir.index.storedCols {
+		colOrd := ir.index.storedCols[i].Column.Ordinal()
+		if scannedColOrds.Contains(colOrd) {
+			ir.newStoredColOrds.Add(colOrd)
+		}
+	}
 }
 
 // indexCols returns the explicit key columns of the index, used in


### PR DESCRIPTION
When looking at a recent profile of a slow running query, I noticed a
whopping 10% of the allocated memory was being allocated in
`hypotheticalIndex.Column()`. The transformation from the stored column
set into an ordered list was the source of all of the allocations.

This commit updates `hypotheticalIndex` so that stored columns are
stored in a slice instead of a set, making it faster to randomly access
a column.

Release justification: This is a minor change that improve performance
of index recommendations.

Release note: None