### PR TITLE
lint: enable MapToBool linter

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -68,7 +68,7 @@ var BackupCheckpointInterval = settings.RegisterDurationSetting(
 
 var forceReadBackupManifest = util.ConstantWithMetamorphicTestBool("backup-read-manifest", false)
 
-func countRows(raw roachpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount {
+func countRows(raw roachpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount { //nolint:maptobool
 	res := roachpb.RowCount{DataSize: raw.DataSize}
 	for id, count := range raw.EntryCounts {
 		if _, ok := pkIDs[id]; ok {
@@ -153,7 +153,7 @@ func backup(
 	spans := filterSpans(backupManifest.Spans, completedSpans)
 	introducedSpans := filterSpans(backupManifest.IntroducedSpans, completedIntroducedSpans)
 
-	pkIDs := make(map[uint64]bool)
+	pkIDs := make(map[uint64]bool) //nolint:maptobool
 	for i := range backupManifest.Descriptors {
 		if t, _, _, _, _ := descpb.FromDescriptor(&backupManifest.Descriptors[i]); t != nil {
 			pkIDs[roachpb.BulkOpSummaryID(uint64(t.ID), uint64(t.PrimaryIndex.ID))] = true

--- a/pkg/ccl/backupccl/backup_processor_planning.go
+++ b/pkg/ccl/backupccl/backup_processor_planning.go
@@ -36,7 +36,7 @@ func distBackupPlanSpecs(
 	jobID int64,
 	spans roachpb.Spans,
 	introducedSpans roachpb.Spans,
-	pkIDs map[uint64]bool,
+	pkIDs map[uint64]bool, //nolint:maptobool
 	defaultURI string,
 	urisByLocalityKV map[string]string,
 	encryption *jobspb.BackupEncryptionOptions,

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6247,7 +6247,7 @@ func TestPublicIndexTableSpans(t *testing.T) {
 	execCfg := &sql.ExecutorConfig{
 		Codec: codec,
 	}
-	unusedMap := make(map[tableAndIndex]bool)
+	unusedMap := make(map[tableAndIndex]struct{})
 	testCases := []struct {
 		name                string
 		tableID             descpb.ID

--- a/pkg/ccl/backupccl/backupresolver/targets.go
+++ b/pkg/ccl/backupccl/backupresolver/targets.go
@@ -70,17 +70,17 @@ func (e *MissingTableErr) GetTableName() string {
 // CheckExpansions determines if matched targets are covered by the specified
 // descriptors.
 func (d DescriptorsMatched) CheckExpansions(coveredDBs []descpb.ID) error {
-	covered := make(map[descpb.ID]bool)
+	covered := make(map[descpb.ID]struct{})
 	for _, i := range coveredDBs {
-		covered[i] = true
+		covered[i] = struct{}{}
 	}
 	for _, i := range d.RequestedDBs {
-		if !covered[i.GetID()] {
+		if _, ok := covered[i.GetID()]; !ok {
 			return errors.Errorf("cannot RESTORE DATABASE from a backup of individual tables (use SHOW BACKUP to determine available tables)")
 		}
 	}
 	for _, i := range d.ExpandedDB {
-		if !covered[i] {
+		if _, ok := covered[i]; !ok {
 			return errors.Errorf("cannot RESTORE <database>.* from a backup of individual tables (use SHOW BACKUP to determine available tables)")
 		}
 	}

--- a/pkg/ccl/backupccl/key_rewriter.go
+++ b/pkg/ccl/backupccl/key_rewriter.go
@@ -145,7 +145,7 @@ func makeKeyRewriter(
 	var tenantPrefixes prefixRewriter
 	tenantPrefixes.rewrites = make([]prefixRewrite, 0, len(tenants))
 
-	seenPrefixes := make(map[string]bool)
+	seenPrefixes := make(map[string]struct{})
 	for oldID, desc := range descs {
 		// The PrefixEnd() of index 1 is the same as the prefix of index 2, so use a
 		// map to avoid duplicating entries.
@@ -153,8 +153,8 @@ func makeKeyRewriter(
 		for _, index := range desc.NonDropIndexes() {
 			oldPrefix := roachpb.Key(MakeKeyRewriterPrefixIgnoringInterleaved(oldID, index.GetID()))
 			newPrefix := roachpb.Key(MakeKeyRewriterPrefixIgnoringInterleaved(desc.GetID(), index.GetID()))
-			if !seenPrefixes[string(oldPrefix)] {
-				seenPrefixes[string(oldPrefix)] = true
+			if _, ok := seenPrefixes[string(oldPrefix)]; !ok {
+				seenPrefixes[string(oldPrefix)] = struct{}{}
 				prefixes.rewrites = append(prefixes.rewrites, prefixRewrite{
 					OldPrefix: oldPrefix,
 					NewPrefix: newPrefix,
@@ -166,8 +166,8 @@ func makeKeyRewriter(
 			// (and we do), the prefix end needs to be in the map too.
 			oldPrefix = oldPrefix.PrefixEnd()
 			newPrefix = newPrefix.PrefixEnd()
-			if !seenPrefixes[string(oldPrefix)] {
-				seenPrefixes[string(oldPrefix)] = true
+			if _, ok := seenPrefixes[string(oldPrefix)]; !ok {
+				seenPrefixes[string(oldPrefix)] = struct{}{}
 				prefixes.rewrites = append(prefixes.rewrites, prefixRewrite{
 					OldPrefix: oldPrefix,
 					NewPrefix: newPrefix,

--- a/pkg/ccl/backupccl/restoration_data.go
+++ b/pkg/ccl/backupccl/restoration_data.go
@@ -35,7 +35,7 @@ type restorationData interface {
 	// included in this bundle.
 	getRekeys() []execinfrapb.TableRekey
 	getTenantRekeys() []execinfrapb.TenantRekey
-	getPKIDs() map[uint64]bool
+	getPKIDs() map[uint64]bool //nolint:maptobool
 
 	// isValidateOnly returns ture iff only validation should occur
 	isValidateOnly() bool
@@ -72,7 +72,7 @@ type restorationDataBase struct {
 	tenantRekeys []execinfrapb.TenantRekey
 	// pkIDs stores the ID of the primary keys for all of the tables that we're
 	// restoring for RowCount calculation.
-	pkIDs map[uint64]bool
+	pkIDs map[uint64]bool //nolint:maptobool
 
 	// systemTables store the system tables that need to be restored for cluster
 	// backups. Should be nil otherwise.
@@ -96,7 +96,7 @@ func (b *restorationDataBase) getTenantRekeys() []execinfrapb.TenantRekey {
 }
 
 // getPKIDs implements restorationData.
-func (b *restorationDataBase) getPKIDs() map[uint64]bool {
+func (b *restorationDataBase) getPKIDs() map[uint64]bool { //nolint:maptobool
 	return b.pkIDs
 }
 

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -503,7 +503,9 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 }
 
 func makeProgressUpdate(
-	summary roachpb.BulkOpSummary, entry execinfrapb.RestoreSpanEntry, pkIDs map[uint64]bool,
+	summary roachpb.BulkOpSummary,
+	entry execinfrapb.RestoreSpanEntry,
+	pkIDs map[uint64]bool, //nolint:maptobool
 ) (progDetails backuppb.RestoreProgress) {
 	progDetails.Summary = countRows(summary, pkIDs)
 	progDetails.ProgressIdx = entry.ProgressIdx

--- a/pkg/ccl/backupccl/restore_processor_planning.go
+++ b/pkg/ccl/backupccl/restore_processor_planning.go
@@ -61,7 +61,7 @@ func distRestore(
 	execCtx sql.JobExecContext,
 	jobID int64,
 	chunks [][]execinfrapb.RestoreSpanEntry,
-	pkIDs map[uint64]bool,
+	pkIDs map[uint64]bool, //nolint:maptobool
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 	tableRekeys []execinfrapb.TableRekey,

--- a/pkg/ccl/backupccl/restore_schema_change_creation.go
+++ b/pkg/ccl/backupccl/restore_schema_change_creation.go
@@ -167,15 +167,15 @@ func createSchemaChangeJobsFromMutations(
 	tableDesc *tabledesc.Mutable,
 ) error {
 	mutationJobs := make([]descpb.TableDescriptor_MutationJob, 0, len(tableDesc.Mutations))
-	seenMutations := make(map[descpb.MutationID]bool)
+	seenMutations := make(map[descpb.MutationID]struct{})
 	for idx, mutation := range tableDesc.Mutations {
-		if seenMutations[mutation.MutationID] {
+		if _, ok := seenMutations[mutation.MutationID]; ok {
 			// We've already seen a mutation with this ID, so a job that handles all
 			// mutations with this ID has already been created.
 			continue
 		}
 		mutationID := mutation.MutationID
-		seenMutations[mutationID] = true
+		seenMutations[mutationID] = struct{}{}
 		jobDesc, mutationCount, err := jobDescriptionFromMutationID(tableDesc.TableDesc(), mutationID)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
+++ b/pkg/ccl/changefeedccl/schemafeed/table_event_filter.go
@@ -122,7 +122,7 @@ func classifyTableEvent(e TableEvent) tableEventTypeSet {
 
 // typeFilters indicates whether a table event of a given type should be
 // permitted by the filter.
-type tableEventFilter map[tableEventType]bool
+type tableEventFilter map[tableEventType]bool //nolint:maptobool
 
 func (filter tableEventFilter) shouldFilter(
 	ctx context.Context, e TableEvent, targets changefeedbase.Targets,

--- a/pkg/cli/cpuprofile.go
+++ b/pkg/cli/cpuprofile.go
@@ -44,12 +44,12 @@ type cpuProfiler struct{}
 // PreFilter is part of the dumpstore.Dumper interface.
 func (s cpuProfiler) PreFilter(
 	ctx context.Context, files []os.FileInfo, cleanupFn func(fileName string) error,
-) (preserved map[int]bool, _ error) {
-	preserved = make(map[int]bool)
+) (preserved map[int]struct{}, _ error) {
+	preserved = make(map[int]struct{})
 	// Always keep at least the last profile.
 	for i := len(files) - 1; i >= 0; i-- {
 		if s.CheckOwnsFile(ctx, files[i]) {
-			preserved[i] = true
+			preserved[i] = struct{}{}
 			break
 		}
 	}

--- a/pkg/cmd/cmp-sql/main.go
+++ b/pkg/cmd/cmp-sql/main.go
@@ -74,14 +74,14 @@ func main() {
 	}
 
 	// Record unique errors and mismatches and only show them once.
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	sawErr := func(err error) string {
 		s := reduceErr(err)
 		// Ignore error strings after the first semicolon.
 		res := fmt.Sprintf("ERR: %s", s)
-		if !seen[res] {
+		if _, ok := seen[res]; !ok {
 			fmt.Print(err, "\n\n")
-			seen[res] = true
+			seen[res] = struct{}{}
 		}
 		return res
 	}
@@ -151,8 +151,8 @@ func main() {
 							confs[vi].Port,
 							v,
 						)
-						if !seen[mismatch] {
-							seen[mismatch] = true
+						if _, ok := seen[mismatch]; !ok {
+							seen[mismatch] = struct{}{}
 							fmt.Print("MISMATCH:\n", mismatch)
 							fmt.Println(repro)
 						}

--- a/pkg/cmd/docgen/extract/extract.go
+++ b/pkg/cmd/docgen/extract/extract.go
@@ -273,7 +273,7 @@ func (g Grammar) ExtractProduction(
 ) ([]byte, error) {
 	names := []token{token(name)}
 	b := new(bytes.Buffer)
-	done := map[token]bool{token(name): true}
+	done := map[token]struct{}{token(name): {}}
 	for i := 0; i < len(names); i++ {
 		if i > 0 {
 			b.WriteString("\n")
@@ -284,9 +284,9 @@ func (g Grammar) ExtractProduction(
 			return nil, fmt.Errorf("couldn't find %s", n)
 		}
 		walkToken(prods, func(t token) {
-			if !done[t] && descend {
+			if _, ok := done[t]; !ok && descend {
 				names = append(names, t)
-				done[t] = true
+				done[t] = struct{}{}
 			}
 		})
 		fmt.Fprintf(b, "%s ::=\n", n)

--- a/pkg/cmd/docgen/funcs.go
+++ b/pkg/cmd/docgen/funcs.go
@@ -148,17 +148,17 @@ func generateOperators() []byte {
 	}
 	sort.Strings(opstrs)
 	b := new(bytes.Buffer)
-	seen := map[string]bool{}
+	seen := map[string]struct{}{}
 	for _, op := range opstrs {
 		fmt.Fprintf(b, "<table><thead>\n")
 		fmt.Fprintf(b, "<tr><td><code>%s</code></td><td>Return</td></tr>\n", op)
 		fmt.Fprintf(b, "</thead><tbody>\n")
 		for _, v := range ops[op] {
 			s := fmt.Sprintf("<tr><td>%s</td><td>%s</td></tr>\n", v.String(), linkTypeName(v.ret))
-			if seen[s] {
+			if _, ok := seen[s]; ok {
 				continue
 			}
-			seen[s] = true
+			seen[s] = struct{}{}
 			b.WriteString(s)
 		}
 		fmt.Fprintf(b, "</tbody></table>")

--- a/pkg/cmd/docgen/http.go
+++ b/pkg/cmd/docgen/http.go
@@ -164,13 +164,13 @@ func runHTTP(protocPath, genDocPath, protocFlags, outPath string) error {
 	// also present in the messages map. Useful to recurse into types that have
 	// other types.
 	extraMessages := func(name string) []string {
-		seen := make(map[string]bool)
+		seen := make(map[string]struct{})
 		var extraFn func(name string) []string
 		extraFn = func(name string) []string {
-			if seen[name] {
+			if _, ok := seen[name]; ok {
 				return nil
 			}
-			seen[name] = true
+			seen[name] = struct{}{}
 			msg, ok := messages[name]
 			if !ok {
 				return nil

--- a/pkg/cmd/reduce/reduce/reducesql/reducesql.go
+++ b/pkg/cmd/reduce/reduce/reducesql/reducesql.go
@@ -114,7 +114,7 @@ var (
 	// LogUnknown determines whether unknown types encountered during
 	// statement walking.
 	LogUnknown   bool
-	unknownTypes = map[string]bool{}
+	unknownTypes = map[string]struct{}{}
 )
 
 func (w sqlWalker) Transform(s string, i int) (out string, ok bool, err error) {
@@ -360,8 +360,8 @@ func (w sqlWalker) Transform(s string, i int) (out string, ok bool, err error) {
 			default:
 				if LogUnknown {
 					n := fmt.Sprintf("%T", node)
-					if !unknownTypes[n] {
-						unknownTypes[n] = true
+					if _, ok := unknownTypes[n]; !ok {
+						unknownTypes[n] = struct{}{}
 						fmt.Println("UNKNOWN", n)
 					}
 				}

--- a/pkg/cmd/release/blockers.go
+++ b/pkg/cmd/release/blockers.go
@@ -306,7 +306,7 @@ func fetchOpenBlockers(client githubClient, releaseBranchLabel string) (*openBlo
 // through issue.Project.Name values found in the issues' timeline.
 // Returns nil if no project name found.
 func mostRecentProjectName(client githubClient, issueNum int) (string, error) {
-	removedProjects := make(map[string]bool)
+	removedProjects := make(map[string]struct{})
 	events, err := client.issueEvents(issueNum)
 	if err != nil {
 		return "", err
@@ -328,7 +328,7 @@ func mostRecentProjectName(client githubClient, issueNum int) (string, error) {
 			// Add ProjectName to a removedProjects "stack", so
 			// that we don't return this Project when we eventually
 			// get to the earlier "added" project event.
-			removedProjects[projectName] = true
+			removedProjects[projectName] = struct{}{}
 		} else if events[i].Event == eventAddedProject {
 
 			if _, exists := removedProjects[projectName]; exists {

--- a/pkg/cmd/roachtest/clusterstats/helpers.go
+++ b/pkg/cmd/roachtest/clusterstats/helpers.go
@@ -60,7 +60,7 @@ func TrimTaggedSeries(
 	highTS := int64(math.MinInt64)
 	longest := 0
 	result := make(map[string]map[string]StatSeries)
-	skip := make(map[string]bool)
+	skip := make(map[string]struct{})
 
 	// Find the highest start timestamp and the lowest end timestamp. These
 	// will be used as the bounds for all the series. If there exists a nil or
@@ -72,7 +72,7 @@ func TrimTaggedSeries(
 			// entries is nil or 0 length. Filter it out and continue to the
 			// next.
 			if len(series) < 1 {
-				skip[labelName] = true
+				skip[labelName] = struct{}{}
 				break
 			}
 			seriesLength := len(series)

--- a/pkg/cmd/roachtest/tests/tpcdsvec.go
+++ b/pkg/cmd/roachtest/tests/tpcdsvec.go
@@ -33,19 +33,19 @@ func registerTPCDSVec(r registry.Registry) {
 		withStatsSlowerWarningThreshold = 1.25
 	)
 
-	queriesToSkip := map[int]bool{
+	queriesToSkip := map[int]struct{}{
 		// These queries don't complete within 5 minutes.
-		1:  true,
-		64: true,
+		1:  {},
+		64: {},
 
 		// These queries contain unsupported function 'rollup' (#46280).
-		5:  true,
-		14: true,
-		18: true,
-		22: true,
-		67: true,
-		77: true,
-		80: true,
+		5:  {},
+		14: {},
+		18: {},
+		22: {},
+		67: {},
+		77: {},
+		80: {},
 	}
 
 	tpcdsTables := []string{

--- a/pkg/cmd/smithtest/main.go
+++ b/pkg/cmd/smithtest/main.go
@@ -97,7 +97,7 @@ func (s WorkerSetup) populateGitHubIssues(ctx context.Context) {
 		}
 		for _, issue := range results.Issues {
 			title := filterIssueTitle(issue.GetTitle())
-			seenIssues[title] = true
+			seenIssues[title] = struct{}{}
 			fmt.Println("pre populate", title)
 		}
 		if results.GetIncompleteResults() {
@@ -127,7 +127,7 @@ var (
 	// it takes for a single reduction run.
 	lock syncutil.RWMutex
 	// seenIssues tracks the seen github issues.
-	seenIssues = map[string]bool{}
+	seenIssues = map[string]struct{}{}
 
 	connRE         = regexp.MustCompile(`(?m)^sql:\s*(postgresql://.*)$`)
 	panicRE        = regexp.MustCompile(`(?m)^(panic: .*?)( \[recovered\])?$`)
@@ -308,11 +308,9 @@ func (s WorkerSetup) failure(ctx context.Context, initSQL []string, stmt string,
 	// at once.
 	defer lock.Unlock()
 	sqlFilteredMessage := fmt.Sprintf("sql: %s", filteredMessage)
-	alreadySeen := seenIssues[sqlFilteredMessage]
-	if !alreadySeen {
-		seenIssues[sqlFilteredMessage] = true
-	}
-	if alreadySeen {
+	if _, alreadySeen := seenIssues[sqlFilteredMessage]; !alreadySeen {
+		seenIssues[sqlFilteredMessage] = struct{}{}
+	} else {
 		fmt.Println("already found", message)
 		return nil
 	}

--- a/pkg/config/system.go
+++ b/pkg/config/system.go
@@ -89,7 +89,7 @@ type SystemConfig struct {
 	mu                struct {
 		syncutil.RWMutex
 		zoneCache        map[ObjectID]zoneEntry
-		shouldSplitCache map[ObjectID]bool
+		shouldSplitCache map[ObjectID]bool //nolint:maptobool
 	}
 }
 
@@ -98,7 +98,7 @@ func NewSystemConfig(defaultZoneConfig *zonepb.ZoneConfig) *SystemConfig {
 	sc := &SystemConfig{}
 	sc.DefaultZoneConfig = defaultZoneConfig
 	sc.mu.zoneCache = map[ObjectID]zoneEntry{}
-	sc.mu.shouldSplitCache = map[ObjectID]bool{}
+	sc.mu.shouldSplitCache = map[ObjectID]bool{} //nolint:maptobool
 	return sc
 }
 

--- a/pkg/internal/rsg/rsg.go
+++ b/pkg/internal/rsg/rsg.go
@@ -28,7 +28,7 @@ type RSG struct {
 	Rnd *rand.Rand
 
 	lock  syncutil.Mutex
-	seen  map[string]bool
+	seen  map[string]struct{}
 	prods map[string][]*yacc.ExpressionNode
 }
 
@@ -44,7 +44,7 @@ func NewRSG(seed int64, y string, allowDuplicates bool) (*RSG, error) {
 		prods: make(map[string][]*yacc.ExpressionNode),
 	}
 	if !allowDuplicates {
-		rsg.seen = make(map[string]bool)
+		rsg.seen = make(map[string]struct{})
 	}
 	for _, prod := range tree.Productions {
 		rsg.prods[prod.Name] = prod.Expressions
@@ -62,8 +62,8 @@ func (r *RSG) Generate(root string, depth int) string {
 		s := strings.Join(r.generate(root, depth), " ")
 		if r.seen != nil {
 			r.lock.Lock()
-			if !r.seen[s] {
-				r.seen[s] = true
+			if _, ok := r.seen[s]; !ok {
+				r.seen[s] = struct{}{}
 			} else {
 				s = ""
 			}

--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -319,15 +319,15 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 		return nil, false
 	}
 	var cols tree.IndexElemList
-	seen := map[tree.Name]bool{}
+	seen := map[tree.Name]struct{}{}
 	inverted := false
 	unique := s.coin()
 	for len(cols) < 1 || s.coin() {
 		col := tableRef.Columns[s.rnd.Intn(len(tableRef.Columns))]
-		if seen[col.Name] {
+		if _, ok := seen[col.Name]; ok {
 			continue
 		}
-		seen[col.Name] = true
+		seen[col.Name] = struct{}{}
 		// If this is the first column and it's invertible (i.e., JSONB), make an inverted index.
 		if len(cols) == 0 &&
 			colinfo.ColumnTypeIsOnlyInvertedIndexable(tree.MustBeStaticallyKnownType(col.Type)) {
@@ -348,10 +348,10 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 	var storing tree.NameList
 	for !inverted && s.coin() {
 		col := tableRef.Columns[s.rnd.Intn(len(tableRef.Columns))]
-		if seen[col.Name] {
+		if _, ok := seen[col.Name]; ok {
 			continue
 		}
-		seen[col.Name] = true
+		seen[col.Name] = struct{}{}
 		storing = append(storing, col.Name)
 	}
 

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -90,16 +90,16 @@ func makeAsOf(s *Smither) tree.AsOfClause {
 func makeBackup(s *Smither) (tree.Statement, bool) {
 	name := fmt.Sprintf("%s/%s", s.bulkSrv.URL, s.name("backup"))
 	var targets tree.BackupTargetList
-	seen := map[tree.TableName]bool{}
+	seen := map[tree.TableName]struct{}{}
 	for len(targets.Tables.TablePatterns) < 1 || s.coin() {
 		table, ok := s.getRandTable()
 		if !ok {
 			return nil, false
 		}
-		if seen[*table.TableName] {
+		if _, ok := seen[*table.TableName]; ok {
 			continue
 		}
-		seen[*table.TableName] = true
+		seen[*table.TableName] = struct{}{}
 		targets.Tables.TablePatterns = append(targets.Tables.TablePatterns, table.TableName)
 	}
 	s.lock.Lock()

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -317,11 +317,11 @@ func makeBinOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 	n := s.rnd.Intn(len(ops))
 	op := ops[n]
 	if s.postgres {
-		if ignorePostgresBinOps[binOpTriple{
+		if _, ok := ignorePostgresBinOps[binOpTriple{
 			op.LeftType.Family(),
 			op.Operator.Symbol,
 			op.RightType.Family(),
-		}] {
+		}]; ok {
 			return nil, false
 		}
 	}
@@ -357,22 +357,22 @@ type binOpOperands struct {
 	rightType *types.T
 }
 
-var ignorePostgresBinOps = map[binOpTriple]bool{
+var ignorePostgresBinOps = map[binOpTriple]struct{}{
 	// Integer division in cockroach returns a different type.
-	{types.IntFamily, treebin.Div, types.IntFamily}: true,
+	{types.IntFamily, treebin.Div, types.IntFamily}: {},
 	// Float * date isn't exact.
-	{types.FloatFamily, treebin.Mult, types.DateFamily}: true,
-	{types.DateFamily, treebin.Mult, types.FloatFamily}: true,
-	{types.DateFamily, treebin.Div, types.FloatFamily}:  true,
+	{types.FloatFamily, treebin.Mult, types.DateFamily}: {},
+	{types.DateFamily, treebin.Mult, types.FloatFamily}: {},
+	{types.DateFamily, treebin.Div, types.FloatFamily}:  {},
 
 	// Postgres does not have separate floor division operator.
-	{types.IntFamily, treebin.FloorDiv, types.IntFamily}:         true,
-	{types.FloatFamily, treebin.FloorDiv, types.FloatFamily}:     true,
-	{types.DecimalFamily, treebin.FloorDiv, types.DecimalFamily}: true,
-	{types.DecimalFamily, treebin.FloorDiv, types.IntFamily}:     true,
-	{types.IntFamily, treebin.FloorDiv, types.DecimalFamily}:     true,
+	{types.IntFamily, treebin.FloorDiv, types.IntFamily}:         {},
+	{types.FloatFamily, treebin.FloorDiv, types.FloatFamily}:     {},
+	{types.DecimalFamily, treebin.FloorDiv, types.DecimalFamily}: {},
+	{types.DecimalFamily, treebin.FloorDiv, types.IntFamily}:     {},
+	{types.IntFamily, treebin.FloorDiv, types.DecimalFamily}:     {},
 
-	{types.FloatFamily, treebin.Mod, types.FloatFamily}: true,
+	{types.FloatFamily, treebin.Mod, types.FloatFamily}: {},
 }
 
 // For certain operations, Postgres is picky about the operand types.

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -258,7 +258,7 @@ type validator struct {
 	// any "missing" or "extra" writes at the end.
 	// Each key has a map of all the tombstone timestamps, stored with a boolean
 	// flag indicating if it has been matched to a transactional delete or not.
-	tombstonesForKey       map[string]map[hlc.Timestamp]bool
+	tombstonesForKey       map[string]map[hlc.Timestamp]bool //nolint:maptobool
 	committedDeletesForKey map[string]int
 
 	failures []error
@@ -266,7 +266,7 @@ type validator struct {
 
 func makeValidator(kvs *Engine) (*validator, error) {
 	kvByValue := make(map[string]storage.MVCCKeyValue)
-	tombstonesForKey := make(map[string]map[hlc.Timestamp]bool)
+	tombstonesForKey := make(map[string]map[hlc.Timestamp]bool) //nolint:maptobool
 	var err error
 	kvs.Iterate(func(key storage.MVCCKey, value []byte, iterErr error) {
 		if iterErr != nil {
@@ -294,7 +294,7 @@ func makeValidator(kvs *Engine) (*validator, error) {
 		} else if !v.Value.IsPresent() {
 			rawKey := string(key.Key)
 			if _, ok := tombstonesForKey[rawKey]; !ok {
-				tombstonesForKey[rawKey] = make(map[hlc.Timestamp]bool)
+				tombstonesForKey[rawKey] = make(map[hlc.Timestamp]bool) //nolint:maptobool
 			}
 			tombstonesForKey[rawKey][key.Timestamp] = false
 		}

--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -121,14 +121,14 @@ func NewTestStateReplCounts(storeReplicas map[StoreID]int, replsPerRange int) St
 	nextKey := 0
 	freeKeys := []Key{}
 	splitKeys := []Key{}
-	rangeStoreMap := make(map[Key]map[StoreID]bool)
+	rangeStoreMap := make(map[Key]map[StoreID]struct{})
 	replicas := make(map[Key][]StoreID)
 
 	addKey := func() {
 		splitKeys = append(splitKeys, Key(nextKey))
 		freeKeys = append(freeKeys, Key(nextKey))
 		replicas[Key(nextKey)] = make([]StoreID, 0, 1)
-		rangeStoreMap[Key(nextKey)] = make(map[StoreID]bool)
+		rangeStoreMap[Key(nextKey)] = make(map[StoreID]struct{})
 		nextKey++
 	}
 
@@ -142,12 +142,12 @@ func NewTestStateReplCounts(storeReplicas map[StoreID]int, replsPerRange int) St
 				// current store. We then associate the store with this key as
 				// a replica to be created.
 				for i, key := range freeKeys {
-					if ok := rangeStoreMap[key][storeID]; !ok {
+					if _, ok := rangeStoreMap[key][storeID]; !ok {
 						// The key is not associated with this store, we may
 						// use it.
 						foundKey = true
 						replicas[key] = append(replicas[key], storeID)
-						rangeStoreMap[key][storeID] = true
+						rangeStoreMap[key][storeID] = struct{}{}
 						// Check if the number of stores associated with this
 						// key is equal to the replication factor; If so, it is
 						// now full in terms of stores. Remove it  from the

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -529,7 +529,7 @@ type intentBatcher struct {
 	options intentBatcherOptions
 
 	// Maps from txn ID to bool and intent slice to accumulate a batch.
-	pendingTxns          map[uuid.UUID]bool
+	pendingTxns          map[uuid.UUID]struct{}
 	pendingIntents       []roachpb.Intent
 	collectedIntentBytes int64
 
@@ -562,7 +562,7 @@ func newIntentBatcher(
 	return intentBatcher{
 		cleanupIntentsFn: cleanupIntentsFunc,
 		options:          options,
-		pendingTxns:      make(map[uuid.UUID]bool),
+		pendingTxns:      make(map[uuid.UUID]struct{}),
 		gcStats:          gcStats,
 	}
 }
@@ -594,7 +594,7 @@ func (b *intentBatcher) addAndMaybeFlushIntents(
 	b.alloc, key = b.alloc.Copy(key, 0)
 	b.pendingIntents = append(b.pendingIntents, roachpb.MakeIntent(meta.Txn, key))
 	b.collectedIntentBytes += int64(len(key))
-	b.pendingTxns[txnID] = true
+	b.pendingTxns[txnID] = struct{}{}
 
 	return err
 }

--- a/pkg/server/dumpstore/dumpstore.go
+++ b/pkg/server/dumpstore/dumpstore.go
@@ -64,7 +64,7 @@ type Dumper interface {
 	//
 	// There may be files not owned by this dumper in the files array;
 	// these should be ignored.
-	PreFilter(ctx context.Context, files []os.FileInfo, cleanupFn func(fileName string) error) (preserved map[int]bool, err error)
+	PreFilter(ctx context.Context, files []os.FileInfo, cleanupFn func(fileName string) error) (preserved map[int]struct{}, err error)
 
 	// CheckOwnsFile returns true iff the dumper owns the given file.
 	CheckOwnsFile(ctx context.Context, fi os.FileInfo) bool
@@ -128,7 +128,7 @@ func removeOldAndTooBigExcept(
 	files []os.FileInfo,
 	now time.Time,
 	maxS int64,
-	preserved map[int]bool,
+	preserved map[int]struct{},
 	fn func(string) error,
 ) {
 	actualSize := int64(0)
@@ -144,7 +144,7 @@ func removeOldAndTooBigExcept(
 		actualSize += fi.Size()
 
 		// Ignore all the preserved entries, even if they are "too old".
-		if preserved[i] {
+		if _, ok := preserved[i]; ok {
 			continue
 		}
 

--- a/pkg/server/dumpstore/dumpstore_test.go
+++ b/pkg/server/dumpstore/dumpstore_test.go
@@ -30,7 +30,7 @@ func TestRemoveOldAndTooBig(t *testing.T) {
 		startFiles []string
 		sizes      []int64
 		maxS       int64
-		preserved  map[int]bool
+		preserved  map[int]struct{}
 		cleaned    []string
 	}{
 		// Simple case: no files.
@@ -129,10 +129,10 @@ func TestRemoveOldAndTooBig(t *testing.T) {
 			25,
 			// The preserved files. This takes priority over size-based
 			// deletion.
-			map[int]bool{
-				0: true, // June 11
-				2: true, // June 13
-				3: true, // June 14
+			map[int]struct{}{
+				0: {}, // June 11
+				2: {}, // June 13
+				3: {}, // June 14
 			},
 			// Expected files to clean up. The other files
 			// are preserved.
@@ -162,7 +162,7 @@ type myDumper struct{}
 
 func (myDumper) PreFilter(
 	_ context.Context, files []os.FileInfo, cleanupFn func(fileName string) error,
-) (preserved map[int]bool, err error) {
+) (preserved map[int]struct{}, err error) {
 	panic("unimplemented")
 }
 

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -142,12 +142,12 @@ func (gd *GoroutineDumper) gcDumps(ctx context.Context, now time.Time) {
 // PreFilter is part of the dumpstore.Dumper interface.
 func (gd *GoroutineDumper) PreFilter(
 	ctx context.Context, files []os.FileInfo, cleanupFn func(fileName string) error,
-) (preserved map[int]bool, _ error) {
-	preserved = make(map[int]bool)
+) (preserved map[int]struct{}, _ error) {
+	preserved = make(map[int]struct{})
 	for i := len(files) - 1; i >= 0; i-- {
 		// Always preserve the last dump in chronological order.
 		if gd.CheckOwnsFile(ctx, files[i]) {
-			preserved[i] = true
+			preserved[i] = struct{}{}
 			break
 		}
 	}

--- a/pkg/server/heapprofiler/profilestore.go
+++ b/pkg/server/heapprofiler/profilestore.go
@@ -90,7 +90,7 @@ func (s *profileStore) makeNewFileName(timestamp time.Time, curHeap int64) strin
 // PreFilter is part of the dumpstore.Dumper interface.
 func (s *profileStore) PreFilter(
 	ctx context.Context, files []os.FileInfo, cleanupFn func(fileName string) error,
-) (preserved map[int]bool, _ error) {
+) (preserved map[int]struct{}, _ error) {
 	maxP := maxProfiles.Get(&s.st.SV)
 	preserved = s.cleanupLastRampup(ctx, files, maxP, cleanupFn)
 	return
@@ -114,8 +114,8 @@ func (s *profileStore) CheckOwnsFile(ctx context.Context, fi os.FileInfo) bool {
 // corresponding to the last ramp-up that were not passed to fn.
 func (s *profileStore) cleanupLastRampup(
 	ctx context.Context, files []os.FileInfo, maxP int64, fn func(string) error,
-) (preserved map[int]bool) {
-	preserved = make(map[int]bool)
+) (preserved map[int]struct{}) {
+	preserved = make(map[int]struct{})
 	curMaxHeap := uint64(math.MaxUint64)
 	numFiles := int64(0)
 	for i := len(files) - 1; i >= 0; i-- {
@@ -143,7 +143,7 @@ func (s *profileStore) cleanupLastRampup(
 			}
 		} else {
 			// No: we preserve this file.
-			preserved[i] = true
+			preserved[i] = struct{}{}
 		}
 	}
 

--- a/pkg/server/heapprofiler/profilestore_test.go
+++ b/pkg/server/heapprofiler/profilestore_test.go
@@ -81,11 +81,11 @@ func TestCleanupLastRampup(t *testing.T) {
 		startFiles []string
 		maxP       int64
 		cleaned    []string
-		preserved  map[int]bool
+		preserved  map[int]struct{}
 	}{
 		// When the directory is empty, nothing happens.
-		{[]string{}, 0, []string{}, map[int]bool{}},
-		{[]string{}, 5, []string{}, map[int]bool{}},
+		{[]string{}, 0, []string{}, map[int]struct{}{}},
+		{[]string{}, 5, []string{}, map[int]struct{}{}},
 		// General case, just one file.
 		{
 			// Starting files.
@@ -97,7 +97,7 @@ func TestCleanupLastRampup(t *testing.T) {
 			// Nothing gets cleaned.
 			[]string{},
 			// The one file gets preserved.
-			map[int]bool{0: true},
+			map[int]struct{}{0: {}},
 		},
 		// General case.
 		{
@@ -125,7 +125,7 @@ func TestCleanupLastRampup(t *testing.T) {
 				"memprof.2020-06-15T13_19_19.005.1",
 			},
 			// The last two files in the 2nd upramp are preserved.
-			map[int]bool{7: true, 8: true},
+			map[int]struct{}{7: {}, 8: {}},
 		},
 		// Odd case: num files to keep = 0 per upramp.  Everything gets
 		// deleted _inside the last upramp_ but previous upramps are
@@ -156,7 +156,7 @@ func TestCleanupLastRampup(t *testing.T) {
 				"memprof.2020-06-15T13_19_19.005.1",
 			},
 			// No file preserved.
-			map[int]bool{},
+			map[int]struct{}{},
 		},
 		// Odd case: bogus filenames "in the middle".
 		{
@@ -190,7 +190,7 @@ func TestCleanupLastRampup(t *testing.T) {
 				"memprof.2020-06-15T13_19_19.007.1",
 			},
 			// The last two _valid_ files in the 2nd upramp are preserved.
-			map[int]bool{8: true, 10: true},
+			map[int]struct{}{8: {}, 10: {}},
 		},
 	}
 

--- a/pkg/server/import_ts.go
+++ b/pkg/server/import_ts.go
@@ -149,8 +149,8 @@ func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
 
 	nodeIDs := map[string]struct{}{}
 	storeIDs := map[string]struct{}{}
-	nodeMetrics := map[string]bool{}
-	storeMetrics := map[string]bool{}
+	nodeMetrics := map[string]struct{}{}
+	storeMetrics := map[string]struct{}{}
 
 	nodeMetricIdentifier := "cr.node."
 	storeMetricIdentifier := "cr.store."
@@ -178,11 +178,11 @@ func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
 		if strings.HasPrefix(name, nodeMetricIdentifier) {
 			nodeIDs[source] = struct{}{}
 			metricName := strings.Replace(name, nodeMetricIdentifier, "", 1)
-			nodeMetrics[metricName] = true
+			nodeMetrics[metricName] = struct{}{}
 		} else if strings.HasPrefix(name, storeMetricIdentifier) {
 			storeIDs[source] = struct{}{}
 			metricName := strings.Replace(name, storeMetricIdentifier, "", 1)
-			storeMetrics[metricName] = true
+			storeMetrics[metricName] = struct{}{}
 		} else {
 			deferError(errors.Errorf("unknown metric %s", name))
 			continue
@@ -221,8 +221,8 @@ func maybeImportTS(ctx context.Context, s *Server) (returnErr error) {
 
 func makeFakeNodeStatuses(
 	storeToNode map[roachpb.StoreID]roachpb.NodeID,
-	nodeMetrics map[string]bool,
-	storeMetrics map[string]bool,
+	nodeMetrics map[string]struct{},
+	storeMetrics map[string]struct{},
 ) []statuspb.NodeStatus {
 
 	var sl []statuspb.NodeStatus

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -53,12 +53,12 @@ type TraceDumper struct {
 // PreFilter is part of the dumpstore.Dumper interface.
 func (t *TraceDumper) PreFilter(
 	ctx context.Context, files []os.FileInfo, _ func(fileName string) error,
-) (preserved map[int]bool, err error) {
-	preserved = make(map[int]bool)
+) (preserved map[int]struct{}, err error) {
+	preserved = make(map[int]struct{})
 	for i := len(files) - 1; i >= 0; i-- {
 		// Always preserve the last dump in chronological order.
 		if t.CheckOwnsFile(ctx, files[i]) {
-			preserved[i] = true
+			preserved[i] = struct{}{}
 			break
 		}
 	}

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -71,7 +71,7 @@ func NewMembershipCache(account mon.BoundAccount, stopper *stop.Stopper) *Member
 }
 
 // userRoleMembership is a mapping of "rolename" -> "with admin option".
-type userRoleMembership map[username.SQLUsername]bool
+type userRoleMembership map[username.SQLUsername]bool //nolint:maptobool
 
 // AuthorizationAccessor for checking authorization (e.g. desc privileges).
 type AuthorizationAccessor interface {
@@ -103,7 +103,7 @@ type AuthorizationAccessor interface {
 
 	// MemberOfWithAdminOption looks up all the roles (direct and indirect) that 'member' is a member
 	// of and returns a map of role -> isAdmin.
-	MemberOfWithAdminOption(ctx context.Context, member username.SQLUsername) (map[username.SQLUsername]bool, error)
+	MemberOfWithAdminOption(ctx context.Context, member username.SQLUsername) (map[username.SQLUsername]bool, error) //nolint:maptobool
 
 	// HasRoleOption converts the roleoption to its SQL column name and checks if
 	// the user belongs to a role where the option has value true. Requires a
@@ -429,7 +429,7 @@ func (p *planner) RequireAdminRole(ctx context.Context, action string) error {
 // method.
 func (p *planner) MemberOfWithAdminOption(
 	ctx context.Context, member username.SQLUsername,
-) (map[username.SQLUsername]bool, error) {
+) (map[username.SQLUsername]bool, error) { //nolint:maptobool
 	return MemberOfWithAdminOption(
 		ctx,
 		p.execCfg,
@@ -451,7 +451,7 @@ func MemberOfWithAdminOption(
 	descsCol *descs.Collection,
 	txn *kv.Txn,
 	member username.SQLUsername,
-) (map[username.SQLUsername]bool, error) {
+) (map[username.SQLUsername]bool, error) { //nolint:maptobool
 	if txn == nil || !txn.IsOpen() {
 		return nil, errors.AssertionFailedf("cannot use MemberOfWithAdminoption without a txn")
 	}
@@ -519,13 +519,13 @@ func MemberOfWithAdminOption(
 			)
 		},
 	)
-	var memberships map[username.SQLUsername]bool
+	var memberships map[username.SQLUsername]bool //nolint:maptobool
 	select {
 	case res := <-ch:
 		if res.Err != nil {
 			return nil, res.Err
 		}
-		memberships = res.Val.(map[username.SQLUsername]bool)
+		memberships = res.Val.(map[username.SQLUsername]bool) //nolint:maptobool
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -575,8 +575,8 @@ func resolveMemberOfWithAdminOption(
 	ie sqlutil.InternalExecutor,
 	txn *kv.Txn,
 	singleQuery bool,
-) (map[username.SQLUsername]bool, error) {
-	ret := map[username.SQLUsername]bool{}
+) (map[username.SQLUsername]bool, error) { //nolint:maptobool
+	ret := map[username.SQLUsername]bool{} //nolint:maptobool
 	if singleQuery {
 		type membership struct {
 			role    username.SQLUsername

--- a/pkg/sql/catalog/schemaexpr/sequence_options.go
+++ b/pkg/sql/catalog/schemaexpr/sequence_options.go
@@ -202,14 +202,14 @@ func AssignSequenceOptions(
 
 	// Fill in all other options.
 	var restartVal *int64
-	optionsSeen := map[string]bool{}
+	optionsSeen := map[string]struct{}{}
 	for _, option := range optsNode {
 		// Error on duplicate options.
 		_, seenBefore := optionsSeen[option.Name]
 		if seenBefore {
 			return errors.New("conflicting or redundant options")
 		}
-		optionsSeen[option.Name] = true
+		optionsSeen[option.Name] = struct{}{}
 
 		switch option.Name {
 		case tree.SeqOptCycle:

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -245,7 +245,7 @@ func hasPrimaryKeySerialType(params runParams, colDef *tree.ColumnTableDef) (boo
 func (n *createTableNode) startExec(params runParams) error {
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("table"))
 
-	colsWithPrimaryKeyConstraint := make(map[tree.Name]bool)
+	colsWithPrimaryKeyConstraint := make(map[tree.Name]struct{})
 
 	// Copy column definition slice, since we will modify it below. This
 	// ensures, that  nothing bad happens on a transaction retry errors, for
@@ -262,13 +262,13 @@ func (n *createTableNode) startExec(params runParams) error {
 		case *tree.UniqueConstraintTableDef:
 			if v.PrimaryKey {
 				for _, indexEle := range v.IndexTableDef.Columns {
-					colsWithPrimaryKeyConstraint[indexEle.Column] = true
+					colsWithPrimaryKeyConstraint[indexEle.Column] = struct{}{}
 				}
 			}
 
 		case *tree.ColumnTableDef:
 			if v.PrimaryKey.IsPrimaryKey {
-				colsWithPrimaryKeyConstraint[v.Name] = true
+				colsWithPrimaryKeyConstraint[v.Name] = struct{}{}
 			}
 		}
 	}

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -215,7 +215,7 @@ func (ep *DummyEvalPlanner) UserHasAdminRole(
 // MemberOfWithAdminOption is part of the Planner interface.
 func (ep *DummyEvalPlanner) MemberOfWithAdminOption(
 	ctx context.Context, member username.SQLUsername,
-) (map[username.SQLUsername]bool, error) {
+) (map[username.SQLUsername]bool, error) { //nolint:maptobool
 	return nil, errors.WithStack(errEvalPlanner)
 }
 

--- a/pkg/sql/grant_role.go
+++ b/pkg/sql/grant_role.go
@@ -126,7 +126,7 @@ func (p *planner) GrantRoleNode(ctx context.Context, n *tree.GrantRole) (*GrantR
 	// means checking whether we have an expanded relationship (grant.Role ∈ ... ∈ grant.Member)
 	// For each grant.Role, we lookup all the roles it is a member of.
 	// After adding a given edge (grant.Member ∈ grant.Role), we add the edge to the list as well.
-	allRoleMemberships := make(map[username.SQLUsername]map[username.SQLUsername]bool)
+	allRoleMemberships := make(map[username.SQLUsername]map[username.SQLUsername]bool) //nolint:maptobool
 	for _, r := range inputRoles {
 		allRoles, err := p.MemberOfWithAdminOption(ctx, r)
 		if err != nil {
@@ -152,7 +152,7 @@ func (p *planner) GrantRoleNode(ctx context.Context, n *tree.GrantRole) (*GrantR
 			}
 			// Add the new membership. We don't care about the actual bool value.
 			if _, ok := allRoleMemberships[m]; !ok {
-				allRoleMemberships[m] = make(map[username.SQLUsername]bool)
+				allRoleMemberships[m] = make(map[username.SQLUsername]bool) //nolint:maptobool
 			}
 			allRoleMemberships[m][r] = false
 		}

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -345,9 +345,9 @@ func ingestKvs(
 		}
 	}
 
-	isPK := make(map[tableAndIndex]bool, len(spec.Tables))
+	isPK := make(map[tableAndIndex]struct{}, len(spec.Tables))
 	for _, t := range spec.Tables {
-		isPK[tableAndIndex{tableID: t.Desc.ID, indexID: t.Desc.PrimaryIndex.ID}] = true
+		isPK[tableAndIndex{tableID: t.Desc.ID, indexID: t.Desc.PrimaryIndex.ID}] = struct{}{}
 	}
 
 	// We create two bulk adders so as to combat the excessive flushing of small
@@ -521,7 +521,7 @@ func ingestKvs(
 				// TODO(adityamaru): There is a potential optimization of plumbing the
 				// different putters, and differentiating based on their type. It might be
 				// more efficient than parsing every kv.
-				if isPK[tableAndIndex{tableID: catid.DescID(tableID), indexID: catid.IndexID(indexID)}] {
+				if _, ok := isPK[tableAndIndex{tableID: catid.DescID(tableID), indexID: catid.IndexID(indexID)}]; ok {
 					if err := pkIndexAdder.Add(ctx, kv.Key, kv.Value.RawBytes); err != nil {
 						if errors.HasType(err, (*kvserverbase.DuplicateKeyError)(nil)) {
 							return errors.Wrap(err, "duplicate key in primary index")

--- a/pkg/sql/lexbase/encode.go
+++ b/pkg/sql/lexbase/encode.go
@@ -107,11 +107,11 @@ func EncodeEscapedSQLIdent(buf *bytes.Buffer, s string) {
 	buf.WriteByte('"')
 }
 
-var mustQuoteMap = map[byte]bool{
-	' ': true,
-	',': true,
-	'{': true,
-	'}': true,
+var mustQuoteMap = map[byte]struct{}{
+	' ': {},
+	',': {},
+	'{': {},
+	'}': {},
 }
 
 // EncodeSQLString writes a string literal to buf. All unicode and
@@ -146,7 +146,7 @@ func EncodeSQLStringWithFlags(buf *bytes.Buffer, in string, flags EncodeFlags) {
 		}
 		ch := byte(r)
 		if r >= 0x20 && r < 0x7F {
-			if mustQuoteMap[ch] {
+			if _, ok := mustQuoteMap[ch]; ok {
 				// We have to quote this string - ignore bareStrings setting
 				bareStrings = false
 			}

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -151,7 +151,7 @@ type Builder struct {
 	// statement to true if all mutations of that table are simple inserts
 	// (without ON CONFLICT) or false otherwise. All mutated tables will have an
 	// entry in the map.
-	areAllTableMutationsSimpleInserts map[cat.StableID]bool
+	areAllTableMutationsSimpleInserts map[cat.StableID]bool //nolint:maptobool
 }
 
 // New creates a new Builder structure initialized with the given

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -512,7 +512,7 @@ func (b *Builder) resolveSchemaForCreate(
 
 func (b *Builder) checkMultipleMutations(tab cat.Table, simpleInsert bool) {
 	if b.areAllTableMutationsSimpleInserts == nil {
-		b.areAllTableMutationsSimpleInserts = make(map[cat.StableID]bool)
+		b.areAllTableMutationsSimpleInserts = make(map[cat.StableID]bool) //nolint:maptobool
 	}
 	allSimpleInserts, prevMutations := b.areAllTableMutationsSimpleInserts[tab.ID()]
 	if !prevMutations {

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_plan_gist_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_plan_gist_gen.go
@@ -48,12 +48,12 @@ func (g *execPlanGistGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 
 // boolAllowList includes all the "bool" operator properties that affect the
 // output of EXPLAIN (SHAPE) and therefore should be included in the gist.
-var boolAllowList = map[string]bool{
-	"autoCommit":        true,
-	"leftEqColsAreKey":  true,
-	"rightEqColsAreKey": true,
-	"eqColsAreKey":      true,
-	"all":               true,
+var boolAllowList = map[string]struct{}{
+	"autoCommit":        {},
+	"leftEqColsAreKey":  {},
+	"rightEqColsAreKey": {},
+	"eqColsAreKey":      {},
+	"all":               {},
 }
 
 func (g *execPlanGistGen) genPlanGistFactory() {
@@ -88,7 +88,7 @@ func (g *execPlanGistGen) genPlanGistFactory() {
 				expr = name
 				encoder = "encodeResultColumns"
 			case "bool":
-				if boolAllowList[name] {
+				if _, ok := boolAllowList[name]; ok {
 					expr = name
 					encoder = "encodeBool"
 				}
@@ -156,7 +156,7 @@ func (g *execPlanGistGen) genPlanGistDecoder() {
 			case "colinfo.ResultColumns":
 				decoder = "decodeResultColumns"
 			case "bool":
-				if boolAllowList[name] {
+				if _, ok := boolAllowList[name]; ok {
 					decoder = "decodeBool"
 				}
 			case "descpb.JoinType":

--- a/pkg/sql/opt/optgen/lang/compiler.go
+++ b/pkg/sql/opt/optgen/lang/compiler.go
@@ -148,7 +148,7 @@ func (c *Compiler) Errors() []error {
 func (c *Compiler) compileDefines(defines DefineSetExpr) bool {
 	c.compiled.Defines = defines
 
-	unique := make(map[TagExpr]bool)
+	unique := make(map[TagExpr]struct{})
 
 	for _, define := range defines {
 		// Record the define in the index for fast lookup.
@@ -162,9 +162,9 @@ func (c *Compiler) compileDefines(defines DefineSetExpr) bool {
 
 		// Determine unique set of tags.
 		for _, tag := range define.Tags {
-			if !unique[tag] {
+			if _, ok = unique[tag]; !ok {
 				c.compiled.DefineTags = append(c.compiled.DefineTags, string(tag))
-				unique[tag] = true
+				unique[tag] = struct{}{}
 			}
 		}
 	}
@@ -173,7 +173,7 @@ func (c *Compiler) compileDefines(defines DefineSetExpr) bool {
 }
 
 func (c *Compiler) compileRules(rules RuleSetExpr) bool {
-	unique := make(map[StringExpr]bool)
+	unique := make(map[StringExpr]struct{})
 
 	for _, rule := range rules {
 		// Ensure that rule names are unique.
@@ -181,7 +181,7 @@ func (c *Compiler) compileRules(rules RuleSetExpr) bool {
 		if ok {
 			c.addErr(rule.Source(), fmt.Errorf("duplicate rule name '%s'", rule.Name))
 		}
-		unique[rule.Name] = true
+		unique[rule.Name] = struct{}{}
 
 		var ruleCompiler ruleCompiler
 		ruleCompiler.compile(c, rule)

--- a/pkg/sql/opt/optgen/lang/data_type.go
+++ b/pkg/sql/opt/optgen/lang/data_type.go
@@ -112,12 +112,12 @@ func DoTypesContradict(dt1, dt2 DataType) bool {
 			if len(t2.Defines) > len(t1.Defines) {
 				t1, t2 = t2, t1
 			}
-			set := make(map[StringExpr]bool)
+			set := make(map[StringExpr]struct{})
 			for _, d := range t1.Defines {
-				set[d.Name] = true
+				set[d.Name] = struct{}{}
 			}
 			for _, d := range t2.Defines {
-				if !set[d.Name] {
+				if _, ok := set[d.Name]; !ok {
 					return true
 				}
 			}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -875,14 +875,16 @@ func populateTableConstraints(
 		switch con.Kind {
 		case descpb.ConstraintTypePK:
 			if !p.SessionData().ShowPrimaryKeyConstraintOnNotVisibleColumns {
-				colHiddenMap := make(map[descpb.ColumnID]bool, len(table.AllColumns()))
+				colHiddenMap := make(map[descpb.ColumnID]struct{}, len(table.AllColumns()))
 				for i := range table.AllColumns() {
 					col := table.AllColumns()[i]
-					colHiddenMap[col.GetID()] = col.IsHidden()
+					if col.IsHidden() {
+						colHiddenMap[col.GetID()] = struct{}{}
+					}
 				}
 				allHidden := true
 				for _, colIdx := range con.Index.KeyColumnIDs {
-					if !colHiddenMap[colIdx] {
+					if _, ok := colHiddenMap[colIdx]; !ok {
 						allHidden = false
 						break
 					}

--- a/pkg/sql/pgwire/identmap/ident_map.go
+++ b/pkg/sql/pgwire/identmap/ident_map.go
@@ -144,18 +144,20 @@ func (c *Conf) Map(mapName, systemIdentity string) ([]username.SQLUsername, erro
 		return nil, nil
 	}
 	var names []username.SQLUsername
-	seen := make(map[string]bool)
+	seen := make(map[string]struct{})
 	for _, elt := range elts {
-		if n := elt.substitute(systemIdentity); n != "" && !seen[n] {
-			// We're returning this as a for-validation username since a
-			// pattern-based mapping could still result in invalid characters
-			// being incorporated into the input.
-			u, err := username.MakeSQLUsernameFromUserInput(n, username.PurposeValidation)
-			if err != nil {
-				return nil, err
+		if n := elt.substitute(systemIdentity); n != "" {
+			if _, ok := seen[n]; !ok {
+				// We're returning this as a for-validation username since a
+				// pattern-based mapping could still result in invalid
+				// characters being incorporated into the input.
+				u, err := username.MakeSQLUsernameFromUserInput(n, username.PurposeValidation)
+				if err != nil {
+					return nil, err
+				}
+				names = append(names, u)
+				seen[n] = struct{}{}
 			}
-			names = append(names, u)
-			seen[n] = true
 		}
 	}
 	return names, nil

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -97,7 +97,7 @@ type PlanHookState interface {
 	AuthorizationAccessor
 	// The role create/drop call into OSS code to reuse plan nodes.
 	// TODO(mberhault): it would be easier to just pass a planner to plan hooks.
-	GetAllRoles(ctx context.Context) (map[username.SQLUsername]bool, error)
+	GetAllRoles(ctx context.Context) (map[username.SQLUsername]bool, error) //nolint:maptobool
 	BumpRoleMembershipTableVersion(ctx context.Context) error
 	EvalAsOfTimestamp(
 		ctx context.Context,

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -94,7 +94,7 @@ const (
 	ExternalConnection ObjectType = "external_connection"
 )
 
-var isDescriptorBacked = map[ObjectType]bool{
+var isDescriptorBacked = map[ObjectType]bool{ //nolint:maptobool
 	Database:           true,
 	Schema:             true,
 	Table:              true,

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -295,11 +295,11 @@ func PopulateTableWithRandData(
 	}
 
 	// Find columns subject to a foreign key constraint
-	var hasFK = map[string]bool{}
+	var hasFK = map[string]struct{}{}
 	for _, def := range createStmt.Defs {
 		if fk, ok := def.(*tree.ForeignKeyConstraintTableDef); ok {
 			for _, col := range fk.FromCols {
-				hasFK[col.String()] = true
+				hasFK[col.String()] = struct{}{}
 			}
 		}
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1677,7 +1677,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			update := make(map[descpb.ID]bool, newReferencedTypeIDs.Len()+referencedTypeIDs.Len())
+			update := make(map[descpb.ID]bool, newReferencedTypeIDs.Len()+referencedTypeIDs.Len()) //nolint:maptobool
 			newReferencedTypeIDs.ForEach(func(id descpb.ID) {
 				if !referencedTypeIDs.Contains(id) {
 					// Mark id as requiring update, `true` means addition.

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -175,7 +175,7 @@ type AuthorizationAccessor interface {
 
 	// MemberOfWithAdminOption looks up all the roles 'member' belongs to (direct
 	// and indirect) and returns a map of "role" -> "isAdmin".
-	MemberOfWithAdminOption(ctx context.Context, member username.SQLUsername) (map[username.SQLUsername]bool, error)
+	MemberOfWithAdminOption(ctx context.Context, member username.SQLUsername) (map[username.SQLUsername]bool, error) //nolint:maptobool
 }
 
 // AstFormatter provides interfaces for formatting AST nodes.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -128,7 +128,7 @@ func alterPrimaryKey(b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t alterPri
 
 		// Get all KEY columns from t.Columns
 		allColumnsNameToIDMapping := getAllColumnsNameToIDMapping(b, tbl.TableID)
-		allKeyColumnIDs := make(map[catid.ColumnID]bool)
+		allKeyColumnIDs := make(map[catid.ColumnID]struct{})
 		for _, col := range t.Columns {
 			colID, exist := allColumnsNameToIDMapping[string(col.Column)]
 			if !exist {
@@ -142,7 +142,7 @@ func alterPrimaryKey(b BuildCtx, tn *tree.TableName, tbl *scpb.Table, t alterPri
 				kind:      scpb.IndexColumn_KEY,
 				direction: indexColumnDirection(col.Direction),
 			})
-			allKeyColumnIDs[colID] = true
+			allKeyColumnIDs[colID] = struct{}{}
 		}
 
 		// What's left are STORED columns, excluding virtual columns and system columns

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -171,7 +171,7 @@ func (s *TestState) CheckPrivilegeForUser(
 // MemberOfWithAdminOption implements the scbuild.AuthorizationAccessor interface.
 func (s *TestState) MemberOfWithAdminOption(
 	ctx context.Context, member username.SQLUsername,
-) (map[username.SQLUsername]bool, error) {
+) (map[username.SQLUsername]bool, error) { //nolint:maptobool
 	return nil, nil
 }
 

--- a/pkg/sql/schemachanger/scplan/internal/opgen/register.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/register.go
@@ -198,29 +198,29 @@ func buildTargets(e scpb.Element, targetSpecs []targetSpec) ([]target, error) {
 }
 
 func validateTargets(targets []target) error {
-	allStatuses := map[scpb.Status]bool{}
-	absentStatuses := map[scpb.Status]bool{}
-	nonAbsentStatuses := map[scpb.Status]bool{}
+	allStatuses := map[scpb.Status]struct{}{}
+	absentStatuses := map[scpb.Status]struct{}{}
+	nonAbsentStatuses := map[scpb.Status]struct{}{}
 	for i, tgt := range targets {
-		var m map[scpb.Status]bool
+		var m map[scpb.Status]struct{}
 		if i == 0 {
 			m = absentStatuses
 		} else {
 			m = nonAbsentStatuses
 		}
 		for _, t := range tgt.transitions {
-			m[t.from] = true
-			allStatuses[t.from] = true
-			m[t.to] = true
-			allStatuses[t.to] = true
+			m[t.from] = struct{}{}
+			allStatuses[t.from] = struct{}{}
+			m[t.to] = struct{}{}
+			allStatuses[t.to] = struct{}{}
 		}
 	}
 
 	for s := range allStatuses {
-		if !absentStatuses[s] {
+		if _, ok := absentStatuses[s]; !ok {
 			return errors.Errorf("status %s is featured in non-ABSENT targets but not in the ABSENT target", s)
 		}
-		if !nonAbsentStatuses[s] {
+		if _, ok := nonAbsentStatuses[s]; !ok {
 			return errors.Errorf("status %s is featured in ABSENT target but not in any non-ABSENT targets", s)
 		}
 	}

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -330,11 +330,11 @@ func (g *Graph) Order() int {
 // Validate returns an error if there's a cycle in the graph.
 func (g *Graph) Validate() error {
 	order := g.Order()
-	done := make(map[*screl.Node]bool, order)
+	done := make(map[*screl.Node]struct{}, order)
 	pred := make(map[*screl.Node]Edge, order)
 	var visit func(n *screl.Node, in Edge) error
 	visit = func(n *screl.Node, in Edge) error {
-		if done[n] {
+		if _, ok := done[n]; ok {
 			return nil
 		}
 		if _, found := pred[n]; found {
@@ -354,7 +354,7 @@ func (g *Graph) Validate() error {
 		}); err != nil {
 			return err
 		}
-		done[n] = true
+		done[n] = struct{}{}
 		return nil
 	}
 	return g.ForEachNode(func(n *screl.Node) error {

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -257,7 +257,7 @@ type Planner interface {
 	MemberOfWithAdminOption(
 		ctx context.Context,
 		member username.SQLUsername,
-	) (map[username.SQLUsername]bool, error)
+	) (map[username.SQLUsername]bool, error) //nolint:maptobool
 
 	// ExternalReadFile reads the content from an external file URI.
 	ExternalReadFile(ctx context.Context, uri string) ([]byte, error)

--- a/pkg/sql/sequence.go
+++ b/pkg/sql/sequence.go
@@ -397,14 +397,14 @@ func assignSequenceOwner(
 	sequenceID descpb.ID,
 	sequenceParentID descpb.ID,
 ) error {
-	optionsSeen := map[string]bool{}
+	optionsSeen := map[string]struct{}{}
 	for _, option := range optsNode {
 		// Error on duplicate options.
 		_, seenBefore := optionsSeen[option.Name]
 		if seenBefore {
 			return pgerror.New(pgcode.Syntax, "conflicting or redundant options")
 		}
-		optionsSeen[option.Name] = true
+		optionsSeen[option.Name] = struct{}{}
 		switch option.Name {
 		case tree.SeqOptOwnedBy:
 			if p == nil {
@@ -453,14 +453,14 @@ func assignSequenceOwner(
 
 // checkDupSeqOption check if there is any duplicate sequence option.
 func checkDupSeqOption(optsNode tree.SequenceOptions) error {
-	optionsSeen := map[string]bool{}
+	optionsSeen := map[string]struct{}{}
 	for _, option := range optsNode {
 		// Error on duplicate options.
 		_, seenBefore := optionsSeen[option.Name]
 		if seenBefore {
 			return pgerror.New(pgcode.Syntax, "conflicting or redundant options")
 		}
-		optionsSeen[option.Name] = true
+		optionsSeen[option.Name] = struct{}{}
 	}
 	return nil
 }

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -448,7 +448,7 @@ var userLoginTimeout = settings.RegisterDurationSetting(
 ).WithPublic()
 
 // GetAllRoles returns a "set" (map) of Roles -> true.
-func (p *planner) GetAllRoles(ctx context.Context) (map[username.SQLUsername]bool, error) {
+func (p *planner) GetAllRoles(ctx context.Context) (map[username.SQLUsername]bool, error) { //nolint:maptobool
 	query := `SELECT username FROM system.users`
 	it, err := p.ExtendedEvalContext().ExecCfg.InternalExecutor.QueryIteratorEx(
 		ctx, "read-users", p.txn,
@@ -458,7 +458,7 @@ func (p *planner) GetAllRoles(ctx context.Context) (map[username.SQLUsername]boo
 		return nil, err
 	}
 
-	users := make(map[username.SQLUsername]bool)
+	users := make(map[username.SQLUsername]bool) //nolint:maptobool
 	var ok bool
 	for ok, err = it.Next(ctx); ok; ok, err = it.Next(ctx) {
 		user := tree.MustBeDString(it.Cur()[0])

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2095,6 +2095,7 @@ func TestLint(t *testing.T) {
 			"cmd",
 			"config",
 			"gossip",
+			"internal",
 			"server",
 			"sql/opt/norm*.go",
 			":!*_test.go",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2093,6 +2093,8 @@ func TestLint(t *testing.T) {
 			"ccl",
 			"cli",
 			"cmd",
+			"config",
+			"gossip",
 			"server",
 			"sql/opt/norm*.go",
 			":!*_test.go",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2092,9 +2092,11 @@ func TestLint(t *testing.T) {
 			"--",
 			"ccl",
 			"cli",
+			"cmd",
 			"server",
 			"sql/opt/norm*.go",
 			":!*_test.go",
+			":!*testdata*",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2096,6 +2096,7 @@ func TestLint(t *testing.T) {
 			"config",
 			"gossip",
 			"internal",
+			"kv",
 			"server",
 			"sql/opt/norm*.go",
 			":!*_test.go",

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2090,6 +2090,7 @@ func TestLint(t *testing.T) {
 			"-nE",
 			`map\[.*\]bool`,
 			"--",
+			"ccl",
 			"sql/opt/norm*.go",
 			":!*_test.go",
 		)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2080,7 +2080,6 @@ func TestLint(t *testing.T) {
 	// a map can be replaced with map[...]struct{} that is more efficient, and
 	// this linter nudges folks to do so. This linter can be disabled by
 	// '//nolint:maptobool' comment.
-	// TODO(yuzefovich): expand the scope where the linter is applied.
 	t.Run("TestMapToBool", func(t *testing.T) {
 		t.Parallel()
 		cmd, stderr, filter, err := dirCmd(
@@ -2090,17 +2089,10 @@ func TestLint(t *testing.T) {
 			"-nE",
 			`map\[[^]]*\]bool`,
 			"--",
-			"ccl",
-			"cli",
-			"cmd",
-			"config",
-			"gossip",
-			"internal",
-			"kv",
-			"server",
-			"sql",
 			":!*_test.go",
 			":!*testdata*",
+			":!roachprod*",
+			":!workload*",
 		)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2091,6 +2091,8 @@ func TestLint(t *testing.T) {
 			`map\[.*\]bool`,
 			"--",
 			"ccl",
+			"cli",
+			"server",
 			"sql/opt/norm*.go",
 			":!*_test.go",
 		)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2088,7 +2088,7 @@ func TestLint(t *testing.T) {
 			"git",
 			"grep",
 			"-nE",
-			`map\[.*\]bool`,
+			`map\[[^]]*\]bool`,
 			"--",
 			"ccl",
 			"cli",
@@ -2098,7 +2098,8 @@ func TestLint(t *testing.T) {
 			"internal",
 			"kv",
 			"server",
-			"sql/opt/norm*.go",
+			"sql",
+			":!sql/schemachanger*",
 			":!*_test.go",
 			":!*testdata*",
 		)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2099,7 +2099,6 @@ func TestLint(t *testing.T) {
 			"kv",
 			"server",
 			"sql",
-			":!sql/schemachanger*",
 			":!*_test.go",
 			":!*testdata*",
 		)

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -21,7 +21,7 @@ import (
 
 // requireConstMsg records functions for which the last string
 // argument must be a constant string.
-var requireConstMsg = map[string]bool{
+var requireConstMsg = map[string]bool{ //nolint:maptobool
 	"github.com/cockroachdb/cockroach/pkg/util/log.Shout":     true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Event":     true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.VEvent":    true,
@@ -34,7 +34,7 @@ var requireConstMsg = map[string]bool{
 
 // requireConstFmt records functions for which the string arg
 // before the final ellipsis must be a constant string.
-var requireConstFmt = map[string]bool{
+var requireConstFmt = map[string]bool{ //nolint:maptobool
 	// Logging things.
 	"log.Printf":           true,
 	"log.Fatalf":           true,

--- a/pkg/testutils/pgtest/datadriven.go
+++ b/pkg/testutils/pgtest/datadriven.go
@@ -186,7 +186,7 @@ func hasKeepErrMsg(d *datadriven.TestData) bool {
 // second argument can specify how to adjust the messages (e.g. to make them
 // more deterministic) if needed, see testdata for examples.
 func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestData) string {
-	ignore := map[string]bool{}
+	ignore := map[string]struct{}{}
 	errs := map[string]string{}
 	for _, arg := range args.CmdArgs {
 		switch arg.Key {
@@ -225,7 +225,7 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 			}
 		case "ignore":
 			for _, typ := range arg.Vals {
-				ignore[fmt.Sprintf("*pgproto3.%s", typ)] = true
+				ignore[fmt.Sprintf("*pgproto3.%s", typ)] = struct{}{}
 			}
 		case "mapError":
 			errs[arg.Vals[0]] = arg.Vals[1]
@@ -236,7 +236,7 @@ func MsgsToJSONWithIgnore(msgs []pgproto3.BackendMessage, args *datadriven.TestD
 	var sb strings.Builder
 	enc := json.NewEncoder(&sb)
 	for _, msg := range msgs {
-		if ignore[fmt.Sprintf("%T", msg)] {
+		if _, ok := ignore[fmt.Sprintf("%T", msg)]; ok {
 			continue
 		}
 		if errmsg, ok := msg.(*pgproto3.ErrorResponse); ok {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1417,15 +1417,16 @@ func (tc *TestCluster) WaitForNodeStatuses(t testing.TB) {
 		// Check that all the nodes in the testcluster have a status. We tolerate
 		// other nodes having statuses (in some tests the cluster is configured with
 		// a pre-existing store).
-		nodeIDs := make(map[roachpb.NodeID]bool)
+		nodeIDs := make(map[roachpb.NodeID]struct{})
 		for _, node := range response.Nodes {
 			if len(node.StoreStatuses) == 0 {
 				return fmt.Errorf("missing StoreStatuses in NodeStatus: %+v", node)
 			}
-			nodeIDs[node.Desc.NodeID] = true
+			nodeIDs[node.Desc.NodeID] = struct{}{}
 		}
 		for _, s := range tc.Servers {
-			if id := s.GetNode().Descriptor.NodeID; !nodeIDs[id] {
+			id := s.GetNode().Descriptor.NodeID
+			if _, ok := nodeIDs[id]; !ok {
 				return fmt.Errorf("missing n%d in NodeStatus: %+v", id, response)
 			}
 		}


### PR DESCRIPTION
This PR replaces `map[...]bool` with `map[...]struct{}` where
possible since the latter is more efficient. The corresponding linter is
now enabled on almost the whole codebase.

Release justification: low-risk improvement.

Release note: None