### PR TITLE
sql: remove no longer used map

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2013,17 +2013,12 @@ func NewTableDesc(
 	// Now that all columns are in place, add any explicit families (this is done
 	// here, rather than in the constraint pass below since we want to pick up
 	// explicit allocations before AllocateIDs adds implicit ones).
-	columnsInExplicitFamilies := map[string]bool{}
 	for _, def := range n.Defs {
 		if d, ok := def.(*tree.FamilyTableDef); ok {
-			fam := descpb.ColumnFamilyDescriptor{
+			desc.AddFamily(descpb.ColumnFamilyDescriptor{
 				Name:        string(d.Name),
 				ColumnNames: d.Columns.ToStrings(),
-			}
-			for _, c := range fam.ColumnNames {
-				columnsInExplicitFamilies[c] = true
-			}
-			desc.AddFamily(fam)
+			})
 		}
 	}
 	version := st.Version.ActiveVersionOrEmpty(ctx)


### PR DESCRIPTION
This commit removes a map that is no longer used as of
91113b0fd56663508ad4cca0ca825ddd16b8906e.

Release justification: low-risk cleanup.

Release note: None