### PR TITLE
sql: remove unused map

### DIFF
--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -59,11 +59,6 @@ func RevertTables(
 	ignoreGCThreshold bool,
 	batchSize int64,
 ) error {
-	reverting := make(map[descpb.ID]bool, len(tables))
-	for i := range tables {
-		reverting[tables[i].GetID()] = true
-	}
-
 	spans := make([]roachpb.Span, 0, len(tables))
 
 	// Check that all the tables are revertable -- i.e. offline.


### PR DESCRIPTION
This commit removes a map that is unused as of
e800d749e5384d52b008029fdc26ce89bff97db9.

Release justification: low-risk cleanup.

Release note: None