### PR TITLE
cli: support `COCKROACH_REDACTION_POLICY_MANAGED` env var

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -537,7 +537,7 @@ func (cfg *Config) Report(ctx context.Context) {
 	} else {
 		log.Infof(ctx, "system total memory: %s", humanizeutil.IBytes(memSize))
 	}
-	log.Infof(ctx, "server configuration:\n%s", cfg)
+	log.Infof(ctx, "server configuration:\n%s", log.SafeManaged(cfg))
 }
 
 // Engines is a container of engines, allowing convenient closing.
@@ -731,7 +731,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 	}
 
 	log.Infof(ctx, "%d storage engine%s initialized",
-		len(engines), util.Pluralize(int64(len(engines))))
+		len(engines), redact.Safe(util.Pluralize(int64(len(engines)))))
 	for _, s := range details {
 		log.Infof(ctx, "%v", s)
 	}

--- a/pkg/server/goroutinedumper/goroutinedumper.go
+++ b/pkg/server/goroutinedumper/goroutinedumper.go
@@ -119,7 +119,7 @@ func NewGoroutineDumper(
 		return nil, errors.New("directory to store dumps could not be determined")
 	}
 
-	log.Infof(ctx, "writing goroutine dumps to %s", dir)
+	log.Infof(ctx, "writing goroutine dumps to %s", log.SafeManaged(dir))
 
 	gd := &GoroutineDumper{
 		heuristics: []heuristic{

--- a/pkg/server/heapprofiler/activequeryprofiler.go
+++ b/pkg/server/heapprofiler/activequeryprofiler.go
@@ -76,13 +76,13 @@ func NewActiveQueryProfiler(
 
 	maxMem, warn, err := memLimitFn()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to detect cgroup memory limit")
 	}
 	if warn != "" {
-		log.Warningf(ctx, "warning when reading cgroup memory limit: %s", warn)
+		log.Warningf(ctx, "warning when reading cgroup memory limit: %s", log.SafeManaged(warn))
 	}
 
-	log.Infof(ctx, "writing go query profiles to %s", dir)
+	log.Infof(ctx, "writing go query profiles to %s", log.SafeManaged(dir))
 	qp := &ActiveQueryProfiler{
 		profiler: profiler{
 			store: newProfileStore(dumpStore, QueryFileNamePrefix, QueryFileNameSuffix, st),

--- a/pkg/server/heapprofiler/activequeryprofiler_test.go
+++ b/pkg/server/heapprofiler/activequeryprofiler_test.go
@@ -36,7 +36,7 @@ func TestNewActiveQueryProfiler(t *testing.T) {
 		{
 			name:     "returns error when no access to cgroups",
 			wantErr:  true,
-			errMsg:   "cgroups not available",
+			errMsg:   "failed to detect cgroup memory limit: cgroups not available",
 			storeDir: heapProfilerDirName,
 			limitFn:  cgroupFnWithReturn(0, "", errors.New("cgroups not available")),
 		},

--- a/pkg/server/heapprofiler/heapprofiler.go
+++ b/pkg/server/heapprofiler/heapprofiler.go
@@ -46,7 +46,10 @@ func NewHeapProfiler(ctx context.Context, dir string, st *cluster.Settings) (*He
 		return nil, errors.AssertionFailedf("need to specify dir for NewHeapProfiler")
 	}
 
-	log.Infof(ctx, "writing go heap profiles to %s at least every %s", dir, resetHighWaterMarkInterval)
+	log.Infof(ctx,
+		"writing go heap profiles to %s at least every %s",
+		log.SafeManaged(dir),
+		resetHighWaterMarkInterval)
 
 	dumpStore := dumpstore.NewStore(dir, maxCombinedFileSize, st)
 

--- a/pkg/server/heapprofiler/statsprofiler.go
+++ b/pkg/server/heapprofiler/statsprofiler.go
@@ -51,7 +51,7 @@ func NewStatsProfiler(
 		return nil, errors.AssertionFailedf("need to specify dir for NewStatsProfiler")
 	}
 
-	log.Infof(ctx, "writing memory stats to %s at last every %s", dir, resetHighWaterMarkInterval)
+	log.Infof(ctx, "writing memory stats to %s at last every %s", log.SafeManaged(dir), resetHighWaterMarkInterval)
 
 	dumpStore := dumpstore.NewStore(dir, maxCombinedFileSize, st)
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1518,14 +1518,15 @@ func (s *Server) PreStart(ctx context.Context) error {
 	logPendingLossOfQuorumRecoveryEvents(ctx, s.node.stores)
 
 	log.Ops.Infof(ctx, "starting %s server at %s (use: %s)",
-		redact.Safe(s.cfg.HTTPRequestScheme()), s.cfg.HTTPAddr, s.cfg.HTTPAdvertiseAddr)
+		redact.Safe(s.cfg.HTTPRequestScheme()), log.SafeManaged(s.cfg.HTTPAddr), log.SafeManaged(s.cfg.HTTPAdvertiseAddr))
 	rpcConnType := redact.SafeString("grpc/postgres")
 	if s.cfg.SplitListenSQL {
 		rpcConnType = "grpc"
-		log.Ops.Infof(ctx, "starting postgres server at %s (use: %s)", s.cfg.SQLAddr, s.cfg.SQLAdvertiseAddr)
+		log.Ops.Infof(ctx, "starting postgres server at %s (use: %s)",
+			log.SafeManaged(s.cfg.SQLAddr), log.SafeManaged(s.cfg.SQLAdvertiseAddr))
 	}
-	log.Ops.Infof(ctx, "starting %s server at %s", rpcConnType, s.cfg.Addr)
-	log.Ops.Infof(ctx, "advertising CockroachDB node at %s", s.cfg.AdvertiseAddr)
+	log.Ops.Infof(ctx, "starting %s server at %s", log.SafeManaged(rpcConnType), log.SafeManaged(s.cfg.Addr))
+	log.Ops.Infof(ctx, "advertising CockroachDB node at %s", log.SafeManaged(s.cfg.AdvertiseAddr))
 
 	log.Event(ctx, "accepting connections")
 

--- a/pkg/server/tracedumper/tracedumper.go
+++ b/pkg/server/tracedumper/tracedumper.go
@@ -117,7 +117,7 @@ func NewTraceDumper(ctx context.Context, dir string, st *cluster.Settings) *Trac
 		return nil
 	}
 
-	log.Infof(ctx, "writing job trace dumps to %s", dir)
+	log.Infof(ctx, "writing job trace dumps to %s", log.SafeManaged(dir))
 
 	td := &TraceDumper{
 		currentTime: timeutil.Now,

--- a/pkg/util/cgroups/BUILD.bazel
+++ b/pkg/util/cgroups/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/system",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/cgroups/cgroups.go
+++ b/pkg/util/cgroups/cgroups.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -427,7 +428,10 @@ func readInt64Value(
 func detectCntrlPath(cgroupFilePath string, controller string) (string, error) {
 	cgroup, err := os.Open(cgroupFilePath)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read %s cgroup from cgroups file: %s", controller, cgroupFilePath)
+		return "", errors.Wrapf(err,
+			"failed to read %s cgroup from cgroups file: %s",
+			redact.Safe(controller),
+			log.SafeManaged(cgroupFilePath))
 	}
 	defer func() { _ = cgroup.Close() }()
 
@@ -459,7 +463,7 @@ func detectCntrlPath(cgroupFilePath string, controller string) (string, error) {
 func getCgroupDetails(mountinfoPath string, cRoot string, controller string) (string, int, error) {
 	info, err := os.Open(mountinfoPath)
 	if err != nil {
-		return "", 0, errors.Wrapf(err, "failed to read mounts info from file: %s", mountinfoPath)
+		return "", 0, errors.Wrapf(err, "failed to read mounts info from file: %s", log.SafeManaged(mountinfoPath))
 	}
 	defer func() {
 		_ = info.Close()

--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -190,6 +190,9 @@ var safeVarRegistry = map[redact.SafeString]struct{}{
 	"GODEBUG":     {},
 	"GOMAXPROCS":  {},
 	"GOTRACEBACK": {},
+	// gRPC.
+	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
+	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},
 }
 
 // valueReportableUnsafeVarRegistry is the list of variables where we can
@@ -198,21 +201,19 @@ var safeVarRegistry = map[redact.SafeString]struct{}{
 // that users would be unhappy to see them enclosed within redaction
 // markers in log files.
 var valueReportableUnsafeVarRegistry = map[redact.SafeString]struct{}{
-	"DEBUG_HTTP2_GOROUTINES":      {},
-	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
-	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},
-	"HOST_IP":                     {},
-	"LANG":                        {},
-	"LC_ALL":                      {},
-	"LC_COLLATE":                  {},
-	"LC_CTYPE":                    {},
-	"LC_TIME":                     {},
-	"LC_NUMERIC":                  {},
-	"LC_MESSAGES":                 {},
-	"LS_METRICS_ENABLED":          {},
-	"TERM":                        {},
-	"TZ":                          {},
-	"ZONEINFO":                    {},
+	"DEBUG_HTTP2_GOROUTINES": {},
+	"HOST_IP":                {},
+	"LANG":                   {},
+	"LC_ALL":                 {},
+	"LC_COLLATE":             {},
+	"LC_CTYPE":               {},
+	"LC_TIME":                {},
+	"LC_NUMERIC":             {},
+	"LC_MESSAGES":            {},
+	"LS_METRICS_ENABLED":     {},
+	"TERM":                   {},
+	"TZ":                     {},
+	"ZONEINFO":               {},
 	// From the Go runtime.
 	"LOCALDOMAIN":    {},
 	"RES_OPTIONS":    {},
@@ -258,9 +259,6 @@ var nameReportableUnsafeVarRegistry = map[redact.SafeString]struct{}{
 	"GAE_MODULE_NAME":     {},
 	"GAE_PARTITION":       {},
 	"GAE_SERVICE":         {},
-	// gRPC.
-	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
-	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},
 	// Kerberos.
 	"KRB5CCNAME": {},
 	// Pprof.

--- a/pkg/util/log/BUILD.bazel
+++ b/pkg/util/log/BUILD.bazel
@@ -167,6 +167,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/util/caller",
         "//pkg/util/ctxgroup",
+        "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log/channel",
         "//pkg/util/log/logconfig",

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -276,9 +276,9 @@ func (l *sinkInfo) getStartLines(now time.Time) []*buffer {
 	messages := make([]*buffer, 0, 6)
 	messages = append(messages,
 		makeStartLine(f, "file created at: %s", redact.Safe(now.Format("2006/01/02 15:04:05"))),
-		makeStartLine(f, "running on machine: %s", fullHostName),
+		makeStartLine(f, "running on machine: %s", SafeManaged(fullHostName)),
 		makeStartLine(f, "binary: %s", redact.Safe(build.GetInfo().Short())),
-		makeStartLine(f, "arguments: %s", os.Args),
+		makeStartLine(f, "arguments: %s", SafeManaged(os.Args)),
 	)
 
 	// Including a non-ascii character in the first 1024 bytes of the log helps


### PR DESCRIPTION
Currently, log redaction policies have no way to discern their own
runtime environment. Logged objects that may be considered sensitive
and unsafe in on-prem deployments of CockroachDB might be otherwise
safe when we're running within a managed service such as Cockroach
Cloud. For example, CLI argument lists included as part of the
`cockroach start` command are already known to those operating the
managed service, so there's no reason we should be redacting this
information from logs in this case.

This patch adds the `--managed` flag to the start commands. This
flag is plumbed through to the global logging config object where
the log package has access to it.

We also introduce `log.SafeManaged(s interface{})`, which conditionally
marks an object with `redact.Safe()` depending on whether or not we
are running as a managed service. This is inspired by the original
`log.SafeOperational(s interface{})` function.

I believe that this new `--managed` flag should not be advertised in
our public documentation, as its intended use is for those running
Cockroach Cloud.

Release justification: low-risk, high benefit changes to existing
functionality. The new CLI flag has a minimal impact on DB
operations and provides high value reduction of log redaction,
which will be necessary for support staff with our latest compliance
requirements.

Release note (cli change): `cockroach start` commands now have an
additional `--managed` flag that can be used to indicate whether
or not the node is running as part of a managed service (e.g.
Cockroach Cloud). Perhaps this shouldn't be advertised in our
public facing docs, as its only intended for use by those running
Cockroach Cloud and not for on-prem deployments.

Addresses https://github.com/cockroachdb/cockroach/issues/86316