### PR TITLE
storage: use concrete `pebbleIterator` in `verifyingIterator`

### DIFF
--- a/pkg/storage/bench_pebble_test.go
+++ b/pkg/storage/bench_pebble_test.go
@@ -494,9 +494,13 @@ func BenchmarkCheckSSTConflicts(b *testing.B) {
 func BenchmarkSSTIterator(b *testing.B) {
 	for _, numKeys := range []int{1, 100, 10000} {
 		b.Run(fmt.Sprintf("keys=%d", numKeys), func(b *testing.B) {
-			for _, verify := range []bool{false, true} {
-				b.Run(fmt.Sprintf("verify=%t", verify), func(b *testing.B) {
-					runSSTIterator(b, numKeys, verify)
+			for _, variant := range []string{"legacy", "pebble"} {
+				b.Run(fmt.Sprintf("variant=%s", variant), func(b *testing.B) {
+					for _, verify := range []bool{false, true} {
+						b.Run(fmt.Sprintf("verify=%t", verify), func(b *testing.B) {
+							runSSTIterator(b, variant, numKeys, verify)
+						})
+					}
 				})
 			}
 		})

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1728,7 +1728,7 @@ func runCheckSSTConflicts(
 	}
 }
 
-func runSSTIterator(b *testing.B, numKeys int, verify bool) {
+func runSSTIterator(b *testing.B, variant string, numKeys int, verify bool) {
 	keyBuf := append(make([]byte, 0, 64), []byte("key-")...)
 	value := MVCCValue{Value: roachpb.MakeValueFromBytes(bytes.Repeat([]byte("a"), 128))}
 
@@ -1744,9 +1744,27 @@ func runSSTIterator(b *testing.B, numKeys int, verify bool) {
 	}
 	sstWriter.Close()
 
+	var makeSSTIterator func(data []byte, verify bool) (SimpleMVCCIterator, error)
+	switch variant {
+	case "legacy":
+		makeSSTIterator = func(data []byte, verify bool) (SimpleMVCCIterator, error) {
+			return NewMemSSTIterator(data, verify)
+		}
+	case "pebble":
+		makeSSTIterator = func(data []byte, verify bool) (SimpleMVCCIterator, error) {
+			return NewPebbleMemSSTIterator(data, verify, IterOptions{
+				KeyTypes:   IterKeyTypePointsAndRanges,
+				LowerBound: keys.MinKey,
+				UpperBound: keys.MaxKey,
+			})
+		}
+	default:
+		b.Fatalf("unknown variant %q", variant)
+	}
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		iter, err := NewMemSSTIterator(sstFile.Bytes(), verify)
+		iter, err := makeSSTIterator(sstFile.Bytes(), verify)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/pkg/storage/sst_iterator.go
+++ b/pkg/storage/sst_iterator.go
@@ -52,7 +52,7 @@ func NewPebbleMultiMemSSTIterator(
 		return nil, err
 	}
 	if verify {
-		iter = NewVerifyingMVCCIterator(iter)
+		iter = newVerifyingMVCCIterator(iter.(*pebbleIterator))
 	}
 	return iter, nil
 }


### PR DESCRIPTION
**storage: add Pebble SST iterator benchmarks**

Release justification: non-production code changes

Release note: None
  
**storage: use concrete `pebbleIterator` in `verifyingIterator`**

Gives a slight performance boost, since it avoid dynamic dispatch:

```
name                                                  old time/op  new time/op  delta
SSTIterator/keys=1/variant=pebble/verify=true-24      42.8µs ± 1%  42.4µs ± 1%  -0.79%  (p=0.043 n=10+10)
SSTIterator/keys=100/variant=pebble/verify=true-24    61.8µs ± 1%  60.7µs ± 1%  -1.64%  (p=0.000 n=10+10)
SSTIterator/keys=10000/variant=pebble/verify=true-24  1.91ms ± 0%  1.88ms ± 0%  -1.79%  (p=0.000 n=10+10)
```

An attempt was also made at using `RangeKeyChanged()` instead of
`HasPointAndRange()`, but this had no effect.

Touches #83051.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None