### PR TITLE
kvserver: decrease trace verbosity for change replicas db operations

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -68,7 +68,7 @@ const (
 	// the key space being written is starting out empty.
 	optimizePutThreshold = 10
 
-	// Transaction names used for range changes.
+	// Transaction names and operations used for range changes.
 	// Note that those names are used by tests to perform request filtering
 	// in absence of better criteria. If names are changed, tests should be
 	// updated accordingly to avoid flakiness.
@@ -76,6 +76,9 @@ const (
 	replicaChangeTxnName = "change-replica"
 	splitTxnName         = "split"
 	mergeTxnName         = "merge"
+
+	replicaChangeTxnGetDescOpName    = "change-replica-get-desc"
+	replicaChangeTxnUpdateDescOpName = "change-replica-update-desc"
 
 	defaultReplicaRaftMuWarnThreshold = 500 * time.Millisecond
 )

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -688,9 +688,7 @@ func TestReplicateQueueTracingOnError(t *testing.T) {
 	log.Flush()
 	entries, err := log.FetchEntriesFromFiles(testStartTs.UnixNano(),
 		math.MaxInt64, 100, regexp.MustCompile(`replicate_queue\.go`), log.WithMarkedSensitiveData)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	opName := "process replica"
 	errRegexp, err := regexp.Compile(`error processing replica:.*boom`)
@@ -715,6 +713,15 @@ func TestReplicateQueueTracingOnError(t *testing.T) {
 	// Validate that the trace is included in the log message.
 	require.Regexp(t, traceRegexp, entry.Message)
 	require.Regexp(t, opRegexp, entry.Message)
+
+	// Validate that the logged trace filtered out the verbose execChangeReplicasTxn
+	// child span, as well as the verbose child spans tracing txn operations.
+	require.NotRegexp(t, `operation:change-replica-update-desc`, entry.Message)
+	require.NotRegexp(t, `operation:txn coordinator send`, entry.Message)
+	require.NotRegexp(t, `operation:log-range-event`, entry.Message)
+
+	// Validate that the logged trace includes the changes to the descriptor.
+	require.Regexp(t, `change replicas \(add.*remove.*\): existing descriptor`, entry.Message)
 
 	// Validate that the trace was logged with the correct tags for the replica.
 	require.Regexp(t, fmt.Sprintf("n%d", repl.NodeID()), entry.Tags)


### PR DESCRIPTION
While we introduced logging of traces from replicate queue processing
in #86007, it was noted that when collecting traces with verbose recording
enabled, a significant fraction of these traces were from low-level
database operations, particularly during the transaction run in
`execChangeReplicasTxn(..)`. This function performs necessary
bookkeeping of range descriptors when replica movement occurs, however
the high verbosity on the low-level database operations within the
transaction is not necessary when examining traces from higher-level
operations like replicate queue processing. Hence, this change
creates child tracing spans within `execChangeReplicasTxn` which
can be filtered out prior to logging the traces in the replicate queue
processing loop. This decreases the size of the logged trace by a factor
of 10, allowing the resulting log message to be much more succinct and
focused.

Release justification: Low-risk, high benefit observability change.
Release note: None