### PR TITLE
sql: don't no-op SET SESSION AUTHORIZATION DEFAULT

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -709,7 +709,17 @@ func (s *Server) SetupConn(
 	sdMutIterator := s.makeSessionDataMutatorIterator(sds, args.SessionDefaults)
 	sdMutIterator.onDefaultIntSizeChange = onDefaultIntSizeChange
 	if err := sdMutIterator.applyOnEachMutatorError(func(m sessionDataMutator) error {
-		return resetSessionVars(ctx, m)
+		for varName, v := range varGen {
+			if v.Set != nil {
+				hasDefault, defVal := getSessionVarDefaultString(varName, v, m.sessionDataMutatorBase)
+				if hasDefault {
+					if err := v.Set(ctx, m, defVal); err != nil {
+						return err
+					}
+				}
+			}
+		}
+		return nil
 	}); err != nil {
 		log.Errorf(ctx, "error setting up client session: %s", err)
 		return ConnectionHandler{}, err

--- a/pkg/sql/copyshim.go
+++ b/pkg/sql/copyshim.go
@@ -110,9 +110,7 @@ func RunCopyFrom(
 	)
 	// TODO(cucaroach): I believe newInternalPlanner should do this but doing it
 	// there causes lots of session diffs and test failures and is risky.
-	if err := p.sessionDataMutatorIterator.applyOnEachMutatorError(func(m sessionDataMutator) error {
-		return resetSessionVars(ctx, m)
-	}); err != nil {
+	if err := p.resetAllSessionVars(ctx); err != nil {
 		return -1, err
 	}
 	defer cleanup()

--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -374,5 +374,11 @@ WHERE active_queries LIKE 'SELECT user_name%'
 ----
 root
 
+# Verify that SET SESSION AUTHORIZATION *does* reset the role.
 statement ok
-RESET ROLE
+SET SESSION AUTHORIZATION DEFAULT
+
+query TTTT
+SELECT current_user(), current_user, session_user(), session_user
+----
+root  root  root  root

--- a/pkg/sql/pgwire/testdata/pgtest/pgjdbc
+++ b/pkg/sql/pgwire/testdata/pgtest/pgjdbc
@@ -42,13 +42,7 @@ send
 Query {"String": "DISCARD ALL"}
 ----
 
-until crdb_only ignore=ParameterStatus
-ReadyForQuery
-----
-{"Type":"CommandComplete","CommandTag":"DISCARD"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-until noncrdb_only ignore=ParameterStatus
+until ignore=ParameterStatus ignore=NoticeResponse
 ReadyForQuery
 ----
 {"Type":"CommandComplete","CommandTag":"DISCARD ALL"}

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -853,7 +853,13 @@ func (*Discard) StatementReturnType() StatementReturnType { return Ack }
 func (*Discard) StatementType() StatementType { return TypeTCL }
 
 // StatementTag returns a short string identifying the type of statement.
-func (*Discard) StatementTag() string { return "DISCARD" }
+func (d *Discard) StatementTag() string {
+	switch d.Mode {
+	case DiscardModeAll:
+		return "DISCARD ALL"
+	}
+	return "DISCARD"
+}
 
 // StatementReturnType implements the Statement interface.
 func (n *DeclareCursor) StatementReturnType() StatementReturnType { return Ack }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -169,6 +169,8 @@ message LocalOnlySessionData {
   // established the connection before SET ROLE was first performed.
   // This is only populated when SET ROLE is used, otherwise the session_user
   // is the same as the UserProto in SessionData.
+  // Postgres allows the SessionUser to be changed with SET SESSION AUTHORIZATION
+  // but CockroachDB doesn't allow that at the time of this writing.
   string session_user_proto = 46 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
   // TxnRowsWrittenLog is the threshold for the number of rows written by a SQL
   // transaction which - once exceeded - will trigger a logging event to SQL_PERF

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -449,6 +449,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&sequenceSelectNode{}):                      "sequence select",
 	reflect.TypeOf(&serializeNode{}):                           "run",
 	reflect.TypeOf(&setClusterSettingNode{}):                   "set cluster setting",
+	reflect.TypeOf(&setSessionAuthorizationDefaultNode{}):      "set session authorization",
 	reflect.TypeOf(&setVarNode{}):                              "set",
 	reflect.TypeOf(&setZoneConfigNode{}):                       "configure zone",
 	reflect.TypeOf(&showFingerprintsNode{}):                    "show fingerprints",

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -393,6 +393,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&delayedNode{}):                             "virtual table",
 	reflect.TypeOf(&deleteNode{}):                              "delete",
 	reflect.TypeOf(&deleteRangeNode{}):                         "delete range",
+	reflect.TypeOf(&discardNode{}):                             "discard",
 	reflect.TypeOf(&distinctNode{}):                            "distinct",
 	reflect.TypeOf(&dropDatabaseNode{}):                        "drop database",
 	reflect.TypeOf(&dropExternalConnectionNode{}):              "drop external connection",


### PR DESCRIPTION
Release note (bug fix): Previously, SET SESSION AUTHORIZATION DEFAULT
would have no effect. Now, it causes the current role to be reset to the
original user who logged into the session.

Release justification: low risk bug fix to existing functionality

Also includes:
- sql: refactor DISCARD so it runs during execution
- sql: consolidate logic for RESET ALL