### PR TITLE
ui: remove next run from jobs that don't have next run

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -76,6 +76,8 @@ export class JobDetails extends React.Component<JobDetailsProps> {
 
   renderContent = (): React.ReactElement => {
     const job = this.props.job;
+    const nextRun = TimestampToMoment(job.next_run);
+    const hasNextRun = nextRun.isAfter();
     return (
       <>
         <Row gutter={24}>
@@ -88,10 +90,14 @@ export class JobDetails extends React.Component<JobDetailsProps> {
             <SummaryCard>
               <h3 className={jobCx("summary--card--title")}>Status</h3>
               <JobStatusCell job={job} lineWidth={1.5} hideDuration={true} />
-              <h3 className={jobCx("summary--card--title", "secondary")}>
-                Next Planned Execution Time:
-              </h3>
-              {TimestampToMoment(job.next_run).format(DATE_FORMAT_24_UTC)}
+              {hasNextRun && (
+                <>
+                  <h3 className={jobCx("summary--card--title", "secondary")}>
+                    Next Planned Execution Time:
+                  </h3>
+                  {nextRun.format(DATE_FORMAT_24_UTC)}
+                </>
+              )}
             </SummaryCard>
           </Col>
           <Col className="gutter-row" span={12}>


### PR DESCRIPTION
Several jobs don't have a future run, so the value
being displayed on the Jobs Details page would should
the last time it was scheduled.
This commit hides the next run field from the page
if is not in the future.

Fixes #86359

Release justification: low risk, high benefit change
Release note (ui change): Remove the Next Planned Execution
Time label, when the job doesn't have a next planned execution
scheduled.