### PR TITLE
util: fix loop var capture in TestFastIntMap

### DIFF
--- a/pkg/util/fast_int_map_test.go
+++ b/pkg/util/fast_int_map_test.go
@@ -29,6 +29,7 @@ func TestFastIntMap(t *testing.T) {
 		{keyRange: 100, valRange: 100},
 	}
 	for _, tc := range cases {
+		tc := tc // necessary since the tests below run in parallel
 		t.Run(fmt.Sprintf("%d-%d", tc.keyRange, tc.valRange), func(t *testing.T) {
 			t.Parallel() // SAFE FOR TESTING (this comment is for the linter)
 			rng, _ := randutil.NewTestRand()


### PR DESCRIPTION
The `TestFastIntMap` test used `t.Parallel()` with a comment
indicating that it is safe for concurrent execution. However, the `tc`
variable was captured by the closure passed to `t.Run()`; this means
that, in practice, we will not actually run all test cases since the
loop variable will change before it is read by the Go routine (with
very high probability, only the last test case is executed).

This commit fixes the issue by creating a local copy of the loop
variable before the `t.Run()` call.

This bug was found by an updated version of the `loopvarcapture`
linter that has not been merged yet.

Release justification: test-only change.
Release note: None.