### PR TITLE
insights: tidying

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -424,7 +424,7 @@ func (b *baseStatusServer) localExecutionInsights(
 ) (*serverpb.ListExecutionInsightsResponse, error) {
 	var response serverpb.ListExecutionInsightsResponse
 
-	reader := b.sqlServer.pgServer.SQLServer.GetSQLStatsProvider()
+	reader := b.sqlServer.pgServer.SQLServer.GetInsightsReader()
 	reader.IterateInsights(ctx, func(ctx context.Context, insight *insights.Insight) {
 		response.Insights = append(response.Insights, *insight)
 	})

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessionphase",
-        "//pkg/sql/sqlstats/insights",
         "//pkg/util/stop",
         "//pkg/util/uuid",
     ],

--- a/pkg/sql/sqlstats/insights/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/clusterunique",
         "//pkg/util/stop",
-        "//pkg/util/syncutil",
         "//pkg/util/uint128",
         "//pkg/util/uuid",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/sqlstats/insights/detector.go
+++ b/pkg/sql/sqlstats/insights/detector.go
@@ -31,8 +31,8 @@ type compositeDetector struct {
 	detectors []detector
 }
 
-func (a compositeDetector) enabled() bool {
-	for _, d := range a.detectors {
+func (d *compositeDetector) enabled() bool {
+	for _, d := range d.detectors {
 		if d.enabled() {
 			return true
 		}
@@ -40,11 +40,11 @@ func (a compositeDetector) enabled() bool {
 	return false
 }
 
-func (a compositeDetector) isSlow(statement *Statement) bool {
+func (d *compositeDetector) isSlow(statement *Statement) bool {
 	// Because some detectors may need to observe all statements to build up
 	// their baseline sense of what "normal" is, we avoid short-circuiting.
 	result := false
-	for _, d := range a.detectors {
+	for _, d := range d.detectors {
 		result = d.isSlow(statement) || result
 	}
 	return result
@@ -64,7 +64,7 @@ type latencySummaryEntry struct {
 	value *quantile.Stream
 }
 
-func (d anomalyDetector) enabled() bool {
+func (d *anomalyDetector) enabled() bool {
 	return AnomalyDetectionEnabled.Get(&d.settings.SV)
 }
 
@@ -121,7 +121,7 @@ func (d *anomalyDetector) withFingerprintLatencySummary(
 	}
 }
 
-func newAnomalyDetector(settings *cluster.Settings, metrics Metrics) detector {
+func newAnomalyDetector(settings *cluster.Settings, metrics Metrics) *anomalyDetector {
 	return &anomalyDetector{
 		settings: settings,
 		metrics:  metrics,
@@ -134,10 +134,10 @@ type latencyThresholdDetector struct {
 	st *cluster.Settings
 }
 
-func (l latencyThresholdDetector) enabled() bool {
-	return LatencyThreshold.Get(&l.st.SV) > 0
+func (d *latencyThresholdDetector) enabled() bool {
+	return LatencyThreshold.Get(&d.st.SV) > 0
 }
 
-func (l latencyThresholdDetector) isSlow(s *Statement) bool {
-	return l.enabled() && s.LatencyInSeconds >= LatencyThreshold.Get(&l.st.SV).Seconds()
+func (d *latencyThresholdDetector) isSlow(s *Statement) bool {
+	return d.enabled() && s.LatencyInSeconds >= LatencyThreshold.Get(&d.st.SV).Seconds()
 }

--- a/pkg/sql/sqlstats/insights/detector_test.go
+++ b/pkg/sql/sqlstats/insights/detector_test.go
@@ -180,7 +180,7 @@ func TestLatencyQuantileDetector(t *testing.T) {
 	})
 }
 
-// dev bench pkg/sql/sqlstats/outliers  --bench-mem --verbose
+// dev bench pkg/sql/sqlstats/insights  --bench-mem --verbose
 // BenchmarkLatencyQuantileDetector-16    	 1589583	       701.1 ns/op	      24 B/op	       1 allocs/op
 func BenchmarkLatencyQuantileDetector(b *testing.B) {
 	random := rand.New(rand.NewSource(42))

--- a/pkg/sql/sqlstats/insights/ingester.go
+++ b/pkg/sql/sqlstats/insights/ingester.go
@@ -20,7 +20,7 @@ import (
 )
 
 // concurrentBufferIngester amortizes the locking cost of writing to an
-// insights Registry concurrently from multiple goroutines. To that end, it
+// insights registry concurrently from multiple goroutines. To that end, it
 // contains nothing specific to the insights domain; it is merely a bit of
 // asynchronous plumbing, built around a contentionutils.ConcurrentBufferGuard.
 type concurrentBufferIngester struct {
@@ -30,15 +30,13 @@ type concurrentBufferIngester struct {
 	}
 
 	eventBufferCh chan *eventBuffer
-	delegate      Registry
+	delegate      registry
 }
 
-// Meanwhile, it looks like a Registry to the outside world, so that others
-// needn't know it exist.
-var _ Registry = &concurrentBufferIngester{}
+var _ Provider = &concurrentBufferIngester{}
 
 // concurrentBufferIngester buffers the "events" it sees (via ObserveStatement
-// and ObserveTransaction) and passes them along to the underlying Registry
+// and ObserveTransaction) and passes them along to the underlying registry
 // once its buffer is full. (Or once a timeout has passed, for low-traffic
 // clusters and tests.)
 //
@@ -57,7 +55,7 @@ type event struct {
 
 func (i *concurrentBufferIngester) Start(ctx context.Context, stopper *stop.Stopper) {
 	// This task pulls buffers from the channel and forwards them along to the
-	// underlying Registry.
+	// underlying registry.
 	_ = stopper.RunAsyncTask(ctx, "insights-ingester", func(ctx context.Context) {
 		for {
 			select {
@@ -101,10 +99,18 @@ func (i *concurrentBufferIngester) ingest(events *eventBuffer) {
 	}
 }
 
+func (i *concurrentBufferIngester) Reader() Reader {
+	return i.delegate
+}
+
+func (i *concurrentBufferIngester) Writer() Writer {
+	return i
+}
+
 func (i *concurrentBufferIngester) ObserveStatement(
 	sessionID clusterunique.ID, statement *Statement,
 ) {
-	if !i.enabled() {
+	if !i.delegate.enabled() {
 		return
 	}
 	i.guard.AtomicWrite(func(writerIdx int64) {
@@ -118,7 +124,7 @@ func (i *concurrentBufferIngester) ObserveStatement(
 func (i *concurrentBufferIngester) ObserveTransaction(
 	sessionID clusterunique.ID, transaction *Transaction,
 ) {
-	if !i.enabled() {
+	if !i.delegate.enabled() {
 		return
 	}
 	i.guard.AtomicWrite(func(writerIdx int64) {
@@ -129,21 +135,11 @@ func (i *concurrentBufferIngester) ObserveTransaction(
 	})
 }
 
-func (i *concurrentBufferIngester) IterateInsights(
-	ctx context.Context, visitor func(context.Context, *Insight),
-) {
-	i.delegate.IterateInsights(ctx, visitor)
-}
-
-func (i *concurrentBufferIngester) enabled() bool {
-	return i.delegate.enabled()
-}
-
-func newConcurrentBufferIngester(delegate Registry) Registry {
+func newConcurrentBufferIngester(delegate registry) *concurrentBufferIngester {
 	i := &concurrentBufferIngester{
 		// A channel size of 1 is sufficient to avoid unnecessarily
 		// synchronizing producer (our clients) and consumer (the underlying
-		// Registry): moving from 0 to 1 here resulted in a 25% improvement
+		// registry): moving from 0 to 1 here resulted in a 25% improvement
 		// in the micro-benchmarks, but further increases had no effect.
 		// Otherwise, we rely solely on the size of the eventBuffer for
 		// adjusting our carrying capacity.

--- a/pkg/sql/sqlstats/insights/ingester_test.go
+++ b/pkg/sql/sqlstats/insights/ingester_test.go
@@ -102,7 +102,7 @@ func TestIngester_Disabled(t *testing.T) {
 	ingester := newConcurrentBufferIngester(&fakeRegistry{enable: false})
 	ingester.ObserveStatement(clusterunique.ID{}, &Statement{})
 	ingester.ObserveTransaction(clusterunique.ID{}, &Transaction{})
-	require.Nil(t, ingester.(*concurrentBufferIngester).guard.eventBuffer[0])
+	require.Nil(t, ingester.guard.eventBuffer[0])
 }
 
 type fakeRegistry struct {
@@ -112,10 +112,6 @@ type fakeRegistry struct {
 		syncutil.RWMutex
 		events []testEvent
 	}
-}
-
-func (r *fakeRegistry) Start(context.Context, *stop.Stopper) {
-	// No-op.
 }
 
 func (r *fakeRegistry) ObserveStatement(sessionID clusterunique.ID, statement *Statement) {

--- a/pkg/sql/sqlstats/insights/ingester_test.go
+++ b/pkg/sql/sqlstats/insights/ingester_test.go
@@ -12,13 +12,12 @@ package insights
 
 import (
 	"context"
-	"sort"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
@@ -26,25 +25,35 @@ import (
 
 func TestIngester(t *testing.T) {
 	testCases := []struct {
-		name   string
-		events []testEvent
+		name         string
+		observations []testEvent
+		insights     []testEvent
 	}{
 		{
 			name: "One Session",
-			events: []testEvent{
+			observations: []testEvent{
 				{sessionID: 1, statementID: 10},
 				{sessionID: 1, transactionID: 100},
+			},
+			insights: []testEvent{
+				{sessionID: 1, transactionID: 100, statementID: 10},
 			},
 		},
 		{
 			name: "Interleaved Sessions",
-			events: []testEvent{
+			observations: []testEvent{
 				{sessionID: 1, statementID: 10},
 				{sessionID: 2, statementID: 20},
 				{sessionID: 1, statementID: 11},
 				{sessionID: 2, statementID: 21},
 				{sessionID: 1, transactionID: 100},
 				{sessionID: 2, transactionID: 200},
+			},
+			insights: []testEvent{
+				{sessionID: 1, transactionID: 100, statementID: 10},
+				{sessionID: 1, transactionID: 100, statementID: 11},
+				{sessionID: 2, transactionID: 200, statementID: 20},
+				{sessionID: 2, transactionID: 200, statementID: 21},
 			},
 		},
 	}
@@ -55,41 +64,52 @@ func TestIngester(t *testing.T) {
 			stopper := stop.NewStopper()
 			defer stopper.Stop(ctx)
 
-			r := &fakeRegistry{enable: true}
-			ingester := newConcurrentBufferIngester(r)
-			ingester.Start(ctx, stopper)
+			// We use a fakeDetector claiming *every* statement is slow, so
+			// that we can assert on the generated insights to make sure all
+			// the events came through properly.
+			provider := newConcurrentBufferIngester(
+				newRegistry(
+					cluster.MakeTestingClusterSettings(), &fakeDetector{
+						stubEnabled: true,
+						stubIsSlow:  true,
+					}),
+			)
 
-			for _, e := range tc.events {
+			provider.Start(ctx, stopper)
+			writer := provider.Writer()
+			reader := provider.Reader()
+
+			for _, e := range tc.observations {
 				if e.statementID != 0 {
-					ingester.ObserveStatement(e.SessionID(), &Statement{ID: e.StatementID()})
+					writer.ObserveStatement(e.SessionID(), &Statement{ID: e.StatementID()})
 				} else {
-					ingester.ObserveTransaction(e.SessionID(), &Transaction{ID: e.TransactionID()})
+					writer.ObserveTransaction(e.SessionID(), &Transaction{ID: e.TransactionID()})
 				}
 			}
 
-			// Wait for the events to come through.
+			// Wait for the insights to come through.
 			require.Eventually(t, func() bool {
-				r.mu.RLock()
-				defer r.mu.RUnlock()
-				return len(r.mu.events) == len(tc.events)
+				var numInsights int
+				reader.IterateInsights(ctx, func(context.Context, *Insight) {
+					numInsights++
+				})
+				return numInsights == len(tc.insights)
 			}, 1*time.Second, 50*time.Millisecond)
 
-			// See that the events we were expecting are the ones that arrived.
-			// We allow the ingester to do whatever it needs to, so long as the ordering of statements
-			// and transactions for a given session is preserved.
-			sort.SliceStable(tc.events, func(i, j int) bool {
-				return tc.events[i].sessionID < tc.events[j].sessionID
+			// See that the insights we were expecting are the ones that
+			// arrived. We allow the provider to do whatever it needs to, so
+			// long as it can properly match statements with their
+			// transactions.
+			var actual []testEvent
+			reader.IterateInsights(ctx, func(ctx context.Context, insight *Insight) {
+				actual = append(actual, testEvent{
+					sessionID:     insight.Session.ID.Lo,
+					transactionID: insight.Transaction.ID.ToUint128().Lo,
+					statementID:   insight.Statement.ID.Lo,
+				})
 			})
 
-			sort.SliceStable(r.mu.events, func(i, j int) bool {
-				r.mu.Lock()
-				defer r.mu.Unlock()
-				return r.mu.events[i].sessionID < r.mu.events[j].sessionID
-			})
-
-			r.mu.RLock()
-			defer r.mu.RUnlock()
-			require.EqualValues(t, tc.events, r.mu.events)
+			require.ElementsMatch(t, tc.insights, actual)
 		})
 	}
 }
@@ -99,51 +119,14 @@ func TestIngester_Disabled(t *testing.T) {
 	// should something go wrong. Here we peek at the internals of the ingester
 	// to make sure it doesn't hold onto any statement or transaction info if
 	// the underlying registry is currently disabled.
-	ingester := newConcurrentBufferIngester(&fakeRegistry{enable: false})
+	ingester := newConcurrentBufferIngester(newRegistry(cluster.MakeTestingClusterSettings(), &fakeDetector{}))
 	ingester.ObserveStatement(clusterunique.ID{}, &Statement{})
 	ingester.ObserveTransaction(clusterunique.ID{}, &Transaction{})
 	require.Nil(t, ingester.guard.eventBuffer[0])
 }
 
-type fakeRegistry struct {
-	enable bool
-
-	mu struct {
-		syncutil.RWMutex
-		events []testEvent
-	}
-}
-
-func (r *fakeRegistry) ObserveStatement(sessionID clusterunique.ID, statement *Statement) {
-	// Rebuild the testEvent, so that we can assert on what we saw.
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mu.events = append(r.mu.events, testEvent{
-		sessionID:   sessionID.Lo,
-		statementID: statement.ID.Lo,
-	})
-}
-
-func (r *fakeRegistry) ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction) {
-	// Rebuild the testEvent, so that we can assert on what we saw.
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.mu.events = append(r.mu.events, testEvent{
-		sessionID:     sessionID.Lo,
-		transactionID: transaction.ID.ToUint128().Lo,
-	})
-}
-
-func (r *fakeRegistry) IterateInsights(context.Context, func(context.Context, *Insight)) {
-	// No-op.
-}
-
-func (r *fakeRegistry) enabled() bool {
-	return r.enable
-}
-
 type testEvent struct {
-	sessionID, statementID, transactionID uint64
+	sessionID, transactionID, statementID uint64
 }
 
 func (s testEvent) SessionID() clusterunique.ID {

--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -88,13 +88,13 @@ var HighRetryCountThreshold = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 ).WithPublic()
 
-// Metrics holds running measurements of various outliers-related runtime stats.
+// Metrics holds running measurements of various insights-related runtime stats.
 type Metrics struct {
 	// Fingerprints measures the number of statement fingerprints being monitored for
-	// outlier detection.
+	// anomaly detection.
 	Fingerprints *metric.Gauge
 
-	// Memory measures the memory used in support of outlier detection.
+	// Memory measures the memory used in support of anomaly detection.
 	Memory *metric.Gauge
 
 	// Evictions counts fingerprint latency summaries discarded due to memory
@@ -134,29 +134,34 @@ func NewMetrics() Metrics {
 	}
 }
 
-// Reader offers read-only access to the currently retained set of insights.
-type Reader interface {
-	// IterateInsights calls visitor with each of the currently retained set of insights.
-	IterateInsights(context.Context, func(context.Context, *Insight))
-}
-
-// Registry is the central object in the insights subsystem. It observes
-// statement execution, looking for suggestions we may expose to the user.
-type Registry interface {
-	Start(ctx context.Context, stopper *stop.Stopper)
-
+// Writer observes statement and transaction executions.
+type Writer interface {
 	// ObserveStatement notifies the registry of a statement execution.
 	ObserveStatement(sessionID clusterunique.ID, statement *Statement)
 
 	// ObserveTransaction notifies the registry of the end of a transaction.
 	ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction)
-
-	Reader
-
-	enabled() bool
 }
 
-// New builds a new Registry.
-func New(st *cluster.Settings, metrics Metrics) Registry {
+// Reader offers access to the currently retained set of insights.
+type Reader interface {
+	// IterateInsights calls visitor with each of the currently retained set of insights.
+	IterateInsights(context.Context, func(context.Context, *Insight))
+}
+
+// Provider offers access to the insights subsystem.
+type Provider interface {
+	// Start launches the background tasks necessary for processing insights.
+	Start(ctx context.Context, stopper *stop.Stopper)
+
+	// Writer returns an object that observes statement and transaction executions.
+	Writer() Writer
+
+	// Reader returns an object that offers read access to any detected insights.
+	Reader() Reader
+}
+
+// New builds a new Provider.
+func New(st *cluster.Settings, metrics Metrics) Provider {
 	return newConcurrentBufferIngester(newRegistry(st, metrics))
 }

--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -163,5 +163,10 @@ type Provider interface {
 
 // New builds a new Provider.
 func New(st *cluster.Settings, metrics Metrics) Provider {
-	return newConcurrentBufferIngester(newRegistry(st, metrics))
+	return newConcurrentBufferIngester(
+		newRegistry(st, &compositeDetector{detectors: []detector{
+			&latencyThresholdDetector{st: st},
+			newAnomalyDetector(st, metrics),
+		}}),
+	)
 }

--- a/pkg/sql/sqlstats/insights/registry.go
+++ b/pkg/sql/sqlstats/insights/registry.go
@@ -16,55 +16,41 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// registry is the central object in the outliers subsystem. It observes
+// registry is the central object in the insights subsystem. It observes
 // statement execution to determine which statements are outliers and
-// exposes the set of currently retained outliers.
-type registry struct {
+// exposes the set of currently retained insights.
+//
+// TODO(todd): Remove this interface once we pass detectors to newRegistry.
+//   At that point, we can use a fakeDetector instead of a fakeRegistry in
+//   ingester_test.go.
+type registry interface {
+	enabled() bool
+
+	Writer
+
+	Reader
+}
+
+type lockingRegistry struct {
 	detector detector
 	problems *problems
 
 	// Note that this single mutex places unnecessary constraints on outlier
 	// detection and reporting. We will develop a higher-throughput system
-	// before enabling the outliers subsystem by default.
+	// before enabling the insights subsystem by default.
 	mu struct {
 		syncutil.RWMutex
 		statements map[clusterunique.ID][]*Statement
-		outliers   *cache.UnorderedCache
+		insights   *cache.UnorderedCache
 	}
 }
 
-var _ Registry = &registry{}
+var _ registry = &lockingRegistry{}
 
-func newRegistry(st *cluster.Settings, metrics Metrics) Registry {
-	config := cache.Config{
-		Policy: cache.CacheFIFO,
-		ShouldEvict: func(size int, key, value interface{}) bool {
-			return int64(size) > ExecutionInsightsCapacity.Get(&st.SV)
-		},
-	}
-	r := &registry{
-		detector: compositeDetector{detectors: []detector{
-			latencyThresholdDetector{st: st},
-			newAnomalyDetector(st, metrics),
-		}},
-		problems: &problems{
-			st: st,
-		},
-	}
-	r.mu.statements = make(map[clusterunique.ID][]*Statement)
-	r.mu.outliers = cache.NewUnorderedCache(config)
-	return r
-}
-
-func (r *registry) Start(_ context.Context, _ *stop.Stopper) {
-	// No-op.
-}
-
-func (r *registry) ObserveStatement(sessionID clusterunique.ID, statement *Statement) {
+func (r *lockingRegistry) ObserveStatement(sessionID clusterunique.ID, statement *Statement) {
 	if !r.enabled() {
 		return
 	}
@@ -73,7 +59,7 @@ func (r *registry) ObserveStatement(sessionID clusterunique.ID, statement *State
 	r.mu.statements[sessionID] = append(r.mu.statements[sessionID], statement)
 }
 
-func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction) {
+func (r *lockingRegistry) ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction) {
 	if !r.enabled() {
 		return
 	}
@@ -95,7 +81,7 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *T
 			if _, ok := slowStatements[s.ID]; ok {
 				p = r.problems.examine(s)
 			}
-			r.mu.outliers.Add(s.ID, &Insight{
+			r.mu.insights.Add(s.ID, &Insight{
 				Session:     &Session{ID: sessionID},
 				Transaction: transaction,
 				Statement:   s,
@@ -105,10 +91,12 @@ func (r *registry) ObserveTransaction(sessionID clusterunique.ID, transaction *T
 	}
 }
 
-func (r *registry) IterateInsights(ctx context.Context, visitor func(context.Context, *Insight)) {
+func (r *lockingRegistry) IterateInsights(
+	ctx context.Context, visitor func(context.Context, *Insight),
+) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	r.mu.outliers.Do(func(e *cache.Entry) {
+	r.mu.insights.Do(func(e *cache.Entry) {
 		visitor(ctx, e.Value.(*Insight))
 	})
 }
@@ -118,6 +106,27 @@ func (r *registry) IterateInsights(ctx context.Context, visitor func(context.Con
 //   execution path in #81021, we can probably get rid of this external
 //   concept of "enabled" and let the detectors just decide for themselves
 //   internally.
-func (r *registry) enabled() bool {
+func (r *lockingRegistry) enabled() bool {
 	return r.detector.enabled()
+}
+
+func newRegistry(st *cluster.Settings, metrics Metrics) *lockingRegistry {
+	config := cache.Config{
+		Policy: cache.CacheFIFO,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return int64(size) > ExecutionInsightsCapacity.Get(&st.SV)
+		},
+	}
+	r := &lockingRegistry{
+		detector: &compositeDetector{detectors: []detector{
+			&latencyThresholdDetector{st: st},
+			newAnomalyDetector(st, metrics),
+		}},
+		problems: &problems{
+			st: st,
+		},
+	}
+	r.mu.statements = make(map[clusterunique.ID][]*Statement)
+	r.mu.insights = cache.NewUnorderedCache(config)
+	return r
 }

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -39,7 +39,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("detection", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
-		registry := newRegistry(st, NewMetrics())
+		registry := newRegistry(st, &latencyThresholdDetector{st: st})
 		registry.ObserveStatement(session.ID, statement)
 		registry.ObserveTransaction(session.ID, transaction)
 
@@ -64,7 +64,7 @@ func TestRegistry(t *testing.T) {
 	t.Run("disabled", func(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 0)
-		registry := newRegistry(st, NewMetrics())
+		registry := newRegistry(st, &latencyThresholdDetector{st: st})
 		registry.ObserveStatement(session.ID, statement)
 		registry.ObserveTransaction(session.ID, transaction)
 
@@ -86,7 +86,7 @@ func TestRegistry(t *testing.T) {
 			FingerprintID:    roachpb.StmtFingerprintID(100),
 			LatencyInSeconds: 0.5,
 		}
-		registry := newRegistry(st, NewMetrics())
+		registry := newRegistry(st, &latencyThresholdDetector{st: st})
 		registry.ObserveStatement(session.ID, statement2)
 		registry.ObserveTransaction(session.ID, transaction)
 
@@ -111,7 +111,7 @@ func TestRegistry(t *testing.T) {
 
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 1*time.Second)
-		registry := newRegistry(st, NewMetrics())
+		registry := newRegistry(st, &latencyThresholdDetector{st: st})
 		registry.ObserveStatement(session.ID, statement)
 		registry.ObserveStatement(otherSession.ID, otherStatement)
 		registry.ObserveTransaction(session.ID, transaction)
@@ -148,7 +148,7 @@ func TestRegistry(t *testing.T) {
 		st := cluster.MakeTestingClusterSettings()
 		LatencyThreshold.Override(ctx, &st.SV, 100*time.Millisecond)
 		slow := 2 * LatencyThreshold.Get(&st.SV).Seconds()
-		r := newRegistry(st, NewMetrics())
+		r := newRegistry(st, &latencyThresholdDetector{st: st})
 
 		// With the ExecutionInsightsCapacity set to 5, we retain the 5 most recently-seen insights.
 		ExecutionInsightsCapacity.Override(ctx, &st.SV, 5)
@@ -165,7 +165,7 @@ func TestRegistry(t *testing.T) {
 	})
 }
 
-func observeStatementExecution(registry registry, idBase uint64, latencyInSeconds float64) {
+func observeStatementExecution(registry *lockingRegistry, idBase uint64, latencyInSeconds float64) {
 	sessionID := clusterunique.ID{Uint128: uint128.FromInts(2, 0)}
 	txnID := uuid.FromUint128(uint128.FromInts(1, idBase))
 	stmtID := clusterunique.ID{Uint128: uint128.FromInts(0, idBase)}
@@ -173,7 +173,7 @@ func observeStatementExecution(registry registry, idBase uint64, latencyInSecond
 	registry.ObserveTransaction(sessionID, &Transaction{ID: txnID})
 }
 
-func assertInsightStatementIDs(t *testing.T, registry registry, expected []uint64) {
+func assertInsightStatementIDs(t *testing.T, registry *lockingRegistry, expected []uint64) {
 	var actual []uint64
 	registry.IterateInsights(context.Background(), func(ctx context.Context, insight *Insight) {
 		actual = append(actual, insight.Statement.ID.Lo)

--- a/pkg/sql/sqlstats/insights/registry_test.go
+++ b/pkg/sql/sqlstats/insights/registry_test.go
@@ -165,7 +165,7 @@ func TestRegistry(t *testing.T) {
 	})
 }
 
-func observeStatementExecution(registry Registry, idBase uint64, latencyInSeconds float64) {
+func observeStatementExecution(registry registry, idBase uint64, latencyInSeconds float64) {
 	sessionID := clusterunique.ID{Uint128: uint128.FromInts(2, 0)}
 	txnID := uuid.FromUint128(uint128.FromInts(1, idBase))
 	stmtID := clusterunique.ID{Uint128: uint128.FromInts(0, idBase)}
@@ -173,7 +173,7 @@ func observeStatementExecution(registry Registry, idBase uint64, latencyInSecond
 	registry.ObserveTransaction(sessionID, &Transaction{ID: txnID})
 }
 
-func assertInsightStatementIDs(t *testing.T, registry Registry, expected []uint64) {
+func assertInsightStatementIDs(t *testing.T, registry registry, expected []uint64) {
 	var actual []uint64
 	registry.IterateInsights(context.Background(), func(ctx context.Context, insight *Insight) {
 		actual = append(actual, insight.Statement.ID.Lo)

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -67,7 +67,7 @@ type SQLStats struct {
 
 	knobs *sqlstats.TestingKnobs
 
-	insights insights.Registry
+	insights insights.Writer
 }
 
 func newSQLStats(
@@ -76,7 +76,7 @@ func newSQLStats(
 	uniqueTxnFingerprintLimit *settings.IntSetting,
 	curMemBytesCount *metric.Gauge,
 	maxMemBytesHist *metric.Histogram,
-	outliersRegistry insights.Registry,
+	insightsWriter insights.Writer,
 	parentMon *mon.BytesMonitor,
 	flushTarget Sink,
 	knobs *sqlstats.TestingKnobs,
@@ -96,7 +96,7 @@ func newSQLStats(
 		uniqueTxnFingerprintLimit:  uniqueTxnFingerprintLimit,
 		flushTarget:                flushTarget,
 		knobs:                      knobs,
-		insights:                   outliersRegistry,
+		insights:                   insightsWriter,
 	}
 	s.mu.apps = make(map[string]*ssmemstorage.Container)
 	s.mu.mon = monitor
@@ -189,11 +189,4 @@ func (s *SQLStats) resetAndMaybeDumpStats(ctx context.Context, target Sink) (err
 	s.mu.lastReset = timeutil.Now()
 
 	return err
-}
-
-// IterateInsights calls visitor with each of the currently retained set of insights.
-func (s *SQLStats) IterateInsights(
-	ctx context.Context, visitor func(context.Context, *insights.Insight),
-) {
-	s.insights.IterateInsights(ctx, visitor)
 }

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -445,7 +445,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
 		nil, /* curMemoryBytesCount */
 		nil, /* maxMemoryBytesHist */
-		insights.New(st, insights.NewMetrics()),
+		insights.New(st, insights.NewMetrics()).Writer(),
 		monitor,
 		nil, /* reportingSink */
 		nil, /* knobs */
@@ -563,7 +563,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			sqlstats.MaxMemSQLStatsTxnFingerprints,
 			nil,
 			nil,
-			insights.New(st, insights.NewMetrics()),
+			insights.New(st, insights.NewMetrics()).Writer(),
 			monitor,
 			nil,
 			nil,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -38,13 +38,13 @@ func New(
 	maxTxnFingerprints *settings.IntSetting,
 	curMemoryBytesCount *metric.Gauge,
 	maxMemoryBytesHist *metric.Histogram,
-	outliersRegistry insights.Registry,
+	insightsWriter insights.Writer,
 	pool *mon.BytesMonitor,
 	reportingSink Sink,
 	knobs *sqlstats.TestingKnobs,
 ) *SQLStats {
 	return newSQLStats(settings, maxStmtFingerprints, maxTxnFingerprints,
-		curMemoryBytesCount, maxMemoryBytesHist, outliersRegistry, pool,
+		curMemoryBytesCount, maxMemoryBytesHist, insightsWriter, pool,
 		reportingSink, knobs)
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -119,8 +119,8 @@ type Container struct {
 	txnCounts transactionCounts
 	mon       *mon.BytesMonitor
 
-	knobs            *sqlstats.TestingKnobs
-	outliersRegistry insights.Registry
+	knobs    *sqlstats.TestingKnobs
+	insights insights.Writer
 }
 
 var _ sqlstats.ApplicationStats = &Container{}
@@ -135,7 +135,7 @@ func New(
 	mon *mon.BytesMonitor,
 	appName string,
 	knobs *sqlstats.TestingKnobs,
-	outliersRegistry insights.Registry,
+	insightsWriter insights.Writer,
 ) *Container {
 	s := &Container{
 		st:                         st,
@@ -144,7 +144,7 @@ func New(
 		uniqueTxnFingerprintLimit:  uniqueTxnFingerprintLimit,
 		mon:                        mon,
 		knobs:                      knobs,
-		outliersRegistry:           outliersRegistry,
+		insights:                   insightsWriter,
 	}
 
 	if mon != nil {
@@ -250,7 +250,7 @@ func NewTempContainerFromExistingStmtStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /* outliersRegistry */
+		nil, /* insights */
 	)
 
 	for i := range statistics {
@@ -323,7 +323,7 @@ func NewTempContainerFromExistingTxnStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /* outliersRegistry */
+		nil, /* insights */
 	)
 
 	for i := range statistics {
@@ -364,7 +364,7 @@ func (s *Container) NewApplicationStatsWithInheritedOptions() sqlstats.Applicati
 		s.mon,
 		s.appName,
 		s.knobs,
-		s.outliersRegistry,
+		s.insights,
 	)
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -181,7 +181,7 @@ func (s *Container) RecordStatement(
 		contention = &value.ExecStats.ContentionTime
 	}
 
-	s.outliersRegistry.ObserveStatement(value.SessionID, &insights.Statement{
+	s.insights.ObserveStatement(value.SessionID, &insights.Statement{
 		ID:                   value.StatementID,
 		FingerprintID:        stmtFingerprintID,
 		LatencyInSeconds:     value.ServiceLatency,
@@ -311,7 +311,7 @@ func (s *Container) RecordTransaction(
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 	}
 
-	s.outliersRegistry.ObserveTransaction(value.SessionID, &insights.Transaction{
+	s.insights.ObserveTransaction(value.SessionID, &insights.Transaction{
 		ID:            value.TransactionID,
 		FingerprintID: key})
 

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
@@ -169,8 +168,6 @@ type StatsCollector interface {
 // to sql statistics.
 type Storage interface {
 	Reader
-
-	insights.Reader
 
 	// GetLastReset returns the last time when the sqlstats is being reset.
 	GetLastReset() time.Time


### PR DESCRIPTION
A couple of Friday commits here, all mechanical refactorings so that we end up
with the following high-level shape for the insights package:

```go
func New(st *cluster.Settings, metrics Metrics) Provider {
    return newConcurrentBufferIngester(
        newRegistry(st, &compositeDetector{detectors: []detector{
            &latencyThresholdDetector{st: st},
            newAnomalyDetector(st, metrics),
        }}),
    )
}

type Provider interface {
    Start(context.Context, *stop.Stopper)
    Writer() Writer
    Reader() Reader
}

type Writer interface {
    ObserveStatement(sessionID clusterunique.ID, statement *Statement)
    ObserveTransaction(sessionID clusterunique.ID, transaction *Transaction)
}

type Reader interface {
    IterateInsights(context.Context, func(context.Context, *Insight))
}
```

This chunking into provider, writer, and reader matches client needs better;
and it stops having to pretend that an ingester and a registry are the same
kind of thing. It also begins to allow us to simplify many of the unit tests,
now that we've opened up the ability to inject a fake detector into the
registry.

Release justification: Category 2: Bug fixes and low-risk updates to new functionality.

Release note: None