### PR TITLE
storage: use prefix iteration for MVCC keyspace probes during ranged intent resolution

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4619,9 +4619,11 @@ func MVCCResolveWriteIntentRange(
 	engineIter := rw.NewEngineIterator(IterOptions{LowerBound: ltStart, UpperBound: ltEnd})
 	var mvccIter MVCCIterator
 	iterOpts := IterOptions{
-		KeyTypes:   IterKeyTypePointsAndRanges,
-		LowerBound: intent.Key,
-		UpperBound: intent.EndKey,
+		KeyTypes: IterKeyTypePointsAndRanges,
+		// The mvccIter will probe into MVCC keys when matching intents are found by
+		// the lock table scan using engineIter. Each individual probe will only
+		// look at the versions of a single key, so we can use prefix iteration.
+		Prefix: true,
 	}
 	if rw.ConsistentIterators() {
 		// Production code should always have consistent iterators.


### PR DESCRIPTION
This commit uses a prefix iterator for the `mvccIter` in `MVCCResolveWriteIntentRange`.
The `mvccIter` will probe into MVCC keys when matching intents are found by the
lock table scan using `engineIter`. Each individual probe will only look at the
versions of a single key, so we can use prefix iteration. This permits the use
of LSM bloom filters when resolving matching intents during ranged intent
resolution.

Related to https://github.com/cockroachlabs/support/issues/1761.

Release justification: Low risk change before branch cut.