### PR TITLE
ui: create new cell types for different insights

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -174,8 +174,6 @@ function formatIdxRecommendations(
     const idxRec: InsightRecommendation = {
       type: idxType,
       database: plan.metadata.databases[0],
-      table: "",
-      index_id: 0,
       query: rec.split(" : ")[1],
       execution: {
         statement: plan.metadata.query,


### PR DESCRIPTION
Adding the new types for high retry, suboptimal plan
and failed to the insights table component.
That can be used on Workload Statement Details page.

Release justification: low risk, high benefit change
Release note: None