### PR TITLE
sql: remove leftover unused code for window functions

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4028,26 +4028,12 @@ func (dsp *DistSQLPlanner) createPlanForWindow(
 	}
 
 	// We definitely added new columns, so we need to update PlanToStreamColMap.
-	// We need to update the map before adding rendering or projection because
-	// it is used there.
 	plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(plan.GetResultTypes()))
 
 	// windowers do not guarantee maintaining the order at the moment, so we
 	// reset MergeOrdering. There shouldn't be an ordering here, but we reset it
 	// defensively (see #35179).
 	plan.SetMergeOrdering(execinfrapb.Ordering{})
-
-	// After the window functions are computed, we need to add rendering or
-	// projection.
-	if err := addRenderingOrProjection(n, planCtx, plan); err != nil {
-		return nil, err
-	}
-
-	if len(plan.GetResultTypes()) != len(plan.PlanToStreamColMap) {
-		// We added/removed columns while rendering or projecting, so we need to
-		// update PlanToStreamColMap.
-		plan.PlanToStreamColMap = identityMap(plan.PlanToStreamColMap, len(plan.GetResultTypes()))
-	}
 
 	return plan, nil
 }

--- a/pkg/sql/distsql_plan_window.go
+++ b/pkg/sql/distsql_plan_window.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execagg"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/errors"
 )
@@ -67,106 +66,4 @@ func createWindowFnSpec(
 	}
 
 	return funcInProgressSpec, outputType, nil
-}
-
-// windowers currently cannot maintain the ordering (see #36310).
-var windowerMergeOrdering = execinfrapb.Ordering{}
-
-// addRenderingOrProjection checks whether any of the window functions' outputs
-// are used in another expression and, if they are, adds rendering to the plan.
-// If no rendering is required, it adds a projection to remove all columns that
-// were arguments to window functions or were used within OVER clauses.
-func addRenderingOrProjection(n *windowNode, planCtx *PlanningCtx, plan *PhysicalPlan) error {
-	// numWindowFuncsAsIs is the number of window functions output of which is
-	// used directly (i.e. simply as an output column). Note: the same window
-	// function might appear multiple times in the query, but its every
-	// occurrence is replaced by a different windowFuncHolder. For example, on
-	// query like 'SELECT avg(a) OVER (), avg(a) OVER () + 1 FROM t', only the
-	// first window function is used "as is."
-	numWindowFuncsAsIs := 0
-	for _, render := range n.windowRender {
-		if _, ok := render.(*windowFuncHolder); ok {
-			numWindowFuncsAsIs++
-		}
-	}
-	if numWindowFuncsAsIs == len(n.funcs) {
-		// All window functions' outputs are used directly, so there is no
-		// rendering to do and simple projection is sufficient.
-		columns := make([]uint32, len(n.windowRender))
-		passedThruColIdx := uint32(0)
-		for i, render := range n.windowRender {
-			if render == nil {
-				columns[i] = passedThruColIdx
-				passedThruColIdx++
-			} else {
-				// We have done the type introspection above, so all non-nil renders
-				// are windowFuncHolders.
-				holder := render.(*windowFuncHolder)
-				columns[i] = uint32(holder.outputColIdx)
-			}
-		}
-		plan.AddProjection(columns, windowerMergeOrdering)
-		return nil
-	}
-
-	// windowNode contains render expressions that might contain:
-	// 1) IndexedVars that refer to columns by their indices in the full table,
-	// 2) IndexedVars that replaced regular aggregates that are above
-	//    "windowing level."
-	// The mapping of both types IndexedVars is stored in n.colAndAggContainer.
-	renderExprs := make([]tree.TypedExpr, len(n.windowRender))
-	visitor := replaceWindowFuncsVisitor{
-		columnsMap: n.colAndAggContainer.idxMap,
-	}
-
-	// All passed through columns are contiguous and at the beginning of the
-	// output schema.
-	passedThruColIdx := 0
-	renderTypes := make([]*types.T, 0, len(n.windowRender))
-	for i, render := range n.windowRender {
-		if render != nil {
-			// render contains at least one reference to windowFuncHolder, so we need
-			// to walk over the render and replace all windowFuncHolders and (if found)
-			// IndexedVars using columnsMap and outputColIdx of windowFuncHolders.
-			renderExprs[i] = visitor.replace(render)
-		} else {
-			// render is nil meaning that a column is being passed through.
-			renderExprs[i] = tree.NewTypedOrdinalReference(passedThruColIdx, plan.GetResultTypes()[passedThruColIdx])
-			passedThruColIdx++
-		}
-		outputType := renderExprs[i].ResolvedType()
-		renderTypes = append(renderTypes, outputType)
-	}
-	return plan.AddRendering(renderExprs, planCtx, plan.PlanToStreamColMap, renderTypes, windowerMergeOrdering)
-}
-
-// replaceWindowFuncsVisitor is used to populate render expressions containing
-// the results of window functions. It recurses into all expressions except for
-// windowFuncHolders (which are replaced by the indices to the corresponding
-// output columns) and IndexedVars (which are replaced using columnsMap).
-type replaceWindowFuncsVisitor struct {
-	columnsMap map[int]int
-}
-
-var _ tree.Visitor = &replaceWindowFuncsVisitor{}
-
-// VisitPre satisfies the Visitor interface.
-func (v *replaceWindowFuncsVisitor) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
-	switch t := expr.(type) {
-	case *windowFuncHolder:
-		return false, tree.NewTypedOrdinalReference(t.outputColIdx, t.ResolvedType())
-	case *tree.IndexedVar:
-		return false, tree.NewTypedOrdinalReference(v.columnsMap[t.Idx], t.ResolvedType())
-	}
-	return true, expr
-}
-
-// VisitPost satisfies the Visitor interface.
-func (v *replaceWindowFuncsVisitor) VisitPost(expr tree.Expr) tree.Expr {
-	return expr
-}
-
-func (v *replaceWindowFuncsVisitor) replace(typedExpr tree.TypedExpr) tree.TypedExpr {
-	expr, _ := tree.WalkExpr(v, typedExpr)
-	return expr.(tree.TypedExpr)
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1086,9 +1086,8 @@ func (ef *execFactory) ConstructProjectSet(
 // ConstructWindow is part of the exec.Factory interface.
 func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec.Node, error) {
 	p := &windowNode{
-		plan:         root.(planNode),
-		columns:      wi.Cols,
-		windowRender: make([]tree.TypedExpr, len(wi.Cols)),
+		plan:    root.(planNode),
+		columns: wi.Cols,
 	}
 
 	partitionIdxs := make([]int, len(wi.Partition))
@@ -1121,8 +1120,6 @@ func (ef *execFactory) ConstructWindow(root exec.Node, wi exec.WindowInfo) (exec
 				return nil, errors.AssertionFailedf("a RANGE mode frame with an offset bound must have an ORDER BY column")
 			}
 		}
-
-		p.windowRender[wi.OutputIdxs[i]] = p.funcs[i]
 	}
 
 	return p, nil


### PR DESCRIPTION
This commit removes some of the dead code around the planning of window
functions. The code hasn't been used since the optimizer added the
support of the window functions (which was like a couple of years ago).

Release justification: low-risk cleanup.

Release note: None