### PR TITLE
kvserver/rangefeed: use `RangeKeyChanged()` in catchup scans

### DIFF
--- a/pkg/kv/kvserver/rangefeed/catchup_scan.go
+++ b/pkg/kv/kvserver/rangefeed/catchup_scan.go
@@ -34,6 +34,7 @@ import (
 type simpleCatchupIter interface {
 	storage.SimpleMVCCIterator
 	NextIgnoringTime()
+	RangeKeyChangedIgnoringTime() bool
 	RangeKeysIgnoringTime() storage.MVCCRangeKeyStack
 }
 
@@ -43,6 +44,10 @@ type simpleCatchupIterAdapter struct {
 
 func (i simpleCatchupIterAdapter) NextIgnoringTime() {
 	i.SimpleMVCCIterator.Next()
+}
+
+func (i simpleCatchupIterAdapter) RangeKeyChangedIgnoringTime() bool {
+	return i.SimpleMVCCIterator.RangeKeyChanged()
 }
 
 func (i simpleCatchupIterAdapter) RangeKeysIgnoringTime() storage.MVCCRangeKeyStack {
@@ -137,7 +142,6 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 	// can't use NextKey.
 	var lastKey roachpb.Key
 	var meta enginepb.MVCCMetadata
-	var rangeKeysStart roachpb.Key
 	i.SeekGE(storage.MVCCKey{Key: i.span.Key})
 	for {
 		if ok, err := i.Valid(); err != nil {
@@ -146,31 +150,26 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 			break
 		}
 
-		hasPoint, hasRange := i.HasPointAndRange()
-
 		// Emit any new MVCC range tombstones when their start key is encountered.
 		// Range keys can currently only be MVCC range tombstones.
 		//
-		// TODO(erikgrinaker): Find a faster/better way to detect range key changes
-		// that doesn't involve constant comparisons. Pebble probably already knows,
-		// we just need a way to ask it.
-		// Note that byte slice comparison in Go is smart enough to immediately bail
-		// if lengths are different. However, it isn't smart enough to compare from
-		// the end, which would really help since our keys share prefixes.
-		if hasRange {
-			if rangeBounds := i.RangeBounds(); !rangeBounds.Key.Equal(rangeKeysStart) {
-				rangeKeysStart = append(rangeKeysStart[:0], rangeBounds.Key...)
-
+		// NB: RangeKeyChangedIgnoringTime() may trigger because a previous
+		// NextIgnoringTime() call moved onto an MVCC range tombstone outside of the
+		// time bounds. In this case, HasPointAndRange() will return false,false and
+		// we step forward.
+		if i.RangeKeyChangedIgnoringTime() {
+			hasPoint, hasRange := i.HasPointAndRange()
+			if hasRange {
 				// Emit events for these MVCC range tombstones, in chronological order.
-				versions := i.RangeKeys().Versions
-				for j := len(versions) - 1; j >= 0; j-- {
+				rangeKeys := i.RangeKeys()
+				for j := rangeKeys.Len() - 1; j >= 0; j-- {
 					var span roachpb.Span
-					a, span.Key = a.Copy(rangeBounds.Key, 0)
-					a, span.EndKey = a.Copy(rangeBounds.EndKey, 0)
+					a, span.Key = a.Copy(rangeKeys.Bounds.Key, 0)
+					a, span.EndKey = a.Copy(rangeKeys.Bounds.EndKey, 0)
 					err := outputFn(&roachpb.RangeFeedEvent{
 						DeleteRange: &roachpb.RangeFeedDeleteRange{
 							Span:      span,
-							Timestamp: versions[j].Timestamp,
+							Timestamp: rangeKeys.Versions[j].Timestamp,
 						},
 					})
 					if err != nil {
@@ -178,14 +177,13 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 					}
 				}
 			}
-		}
-
-		// If there's no point key here (i.e. we found a bare range key above), then
-		// step onto the next key. This may be a point key version at the same key
-		// as the range key's start bound, or a later point/range key.
-		if !hasPoint {
-			i.Next()
-			continue
+			// If there's no point key here (e.g. we found a bare range key above), then
+			// step onto the next key. This may be a point key version at the same key
+			// as the range key's start bound, or a later point/range key.
+			if !hasPoint {
+				i.Next()
+				continue
+			}
 		}
 
 		unsafeKey := i.UnsafeKey()
@@ -281,10 +279,11 @@ func (i *CatchUpIterator) CatchUpScan(outputFn outputEventFn, withDiff bool) err
 						return errors.AssertionFailedf("unexpected previous value %s for key %s",
 							reorderBuf[l].Val.PrevValue, key)
 					}
-					// If an MVCC range tombstone exists between this value and the next
-					// one, we don't emit the value after all -- it should be a tombstone.
-					// The RangeKeysIgnoringTime() call is cheap, no need for caching.
-					if !i.RangeKeysIgnoringTime().HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
+					// However, don't emit a value if an MVCC range tombstone existed
+					// between this value and the next one. The RangeKeysIgnoringTime()
+					// call is cheap, no need for caching.
+					rangeKeys := i.RangeKeysIgnoringTime()
+					if rangeKeys.IsEmpty() || !rangeKeys.HasBetween(ts, reorderBuf[l].Val.Value.Timestamp) {
 						// TODO(sumeer): find out if it is deliberate that we are not populating
 						// PrevValue.Timestamp.
 						reorderBuf[l].Val.PrevValue.RawBytes = val


### PR DESCRIPTION
This avoids a key comparison in the hot path. However, we do not have
any benchmarks that emit range keys (they are always filtered out by the
`MVCCIncrementalIterator`), so it doesn't show up here:

```
name                                                                  old time/op  new time/op  delta
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=0-24       525ms ± 1%   520ms ± 1%    ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=1-24       570ms ± 0%   559ms ± 0%  -1.98%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=0.00/numRangeKeys=100-24     624ms ± 1%   618ms ± 0%  -0.96%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=50.00/numRangeKeys=0-24      1.03s ± 0%   1.02s ± 0%  -0.56%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=50.00/numRangeKeys=1-24      1.21s ± 0%   1.21s ± 0%    ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=50.00/numRangeKeys=100-24    1.71s ± 0%   1.70s ± 1%    ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=75.00/numRangeKeys=0-24      898ms ± 0%   906ms ± 0%  +0.86%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=75.00/numRangeKeys=1-24      1.08s ± 1%   1.07s ± 1%    ~     (p=0.421 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=75.00/numRangeKeys=100-24    1.44s ± 0%   1.44s ± 0%    ~     (p=0.841 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=95.00/numRangeKeys=0-24      190ms ± 1%   189ms ± 1%    ~     (p=0.056 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=95.00/numRangeKeys=1-24      215ms ± 0%   215ms ± 1%    ~     (p=0.421 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=95.00/numRangeKeys=100-24    325ms ± 1%   324ms ± 1%    ~     (p=0.548 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=99.00/numRangeKeys=0-24      158ms ± 1%   158ms ± 1%    ~     (p=0.690 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=99.00/numRangeKeys=1-24      181ms ± 0%   182ms ± 0%  +0.73%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=true/perc=99.00/numRangeKeys=100-24    294ms ± 0%   293ms ± 1%    ~     (p=0.421 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=0-24      782ms ± 0%   788ms ± 1%  +0.81%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=1-24      901ms ± 0%   906ms ± 0%  +0.55%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=0.00/numRangeKeys=100-24    918ms ± 1%   920ms ± 0%    ~     (p=0.310 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=0-24     663ms ± 1%   671ms ± 0%  +1.21%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=1-24     793ms ± 0%   799ms ± 0%  +0.68%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=50.00/numRangeKeys=100-24   803ms ± 0%   813ms ± 1%  +1.25%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=75.00/numRangeKeys=0-24     594ms ± 0%   601ms ± 0%  +1.28%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=75.00/numRangeKeys=1-24     722ms ± 0%   730ms ± 1%  +1.17%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=75.00/numRangeKeys=100-24   733ms ± 0%   742ms ± 1%  +1.20%  (p=0.008 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=0-24     172ms ± 0%   170ms ± 1%  -0.70%  (p=0.032 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=1-24     194ms ± 0%   194ms ± 1%    ~     (p=0.421 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=95.00/numRangeKeys=100-24   303ms ± 0%   303ms ± 1%    ~     (p=0.841 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=99.00/numRangeKeys=0-24     153ms ± 0%   154ms ± 0%  +0.59%  (p=0.016 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=99.00/numRangeKeys=1-24     177ms ± 1%   177ms ± 1%    ~     (p=0.690 n=5+5)
CatchUpScan/mixed-case/withDiff=false/perc=99.00/numRangeKeys=100-24   288ms ± 1%   288ms ± 0%    ~     (p=0.841 n=5+5)
```

Release justification: bug fixes and low-risk updates to new functionality

Release note: None