### PR TITLE
storage: use `RangeKeyChanged` in `ReadAsOfIterator`

### DIFF
--- a/pkg/storage/sst_iterator_test.go
+++ b/pkg/storage/sst_iterator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/stretchr/testify/require"
 )
 
 func runTestSSTIterator(t *testing.T, iter SimpleMVCCIterator, allKVs []MVCCKeyValue) {
@@ -85,12 +86,17 @@ func TestSSTIterator(t *testing.T) {
 	var allKVs []MVCCKeyValue
 	maxWallTime := 10
 	for i := 0; i < maxWallTime; i++ {
+		var v MVCCValue
+		v.Value.SetBytes([]byte{'a', byte(i)})
+		vRaw, err := EncodeMVCCValue(v)
+		require.NoError(t, err)
+
 		kv := MVCCKeyValue{
 			Key: MVCCKey{
 				Key:       []byte{'A' + byte(i)},
 				Timestamp: hlc.Timestamp{WallTime: int64(i)},
 			},
-			Value: []byte{'a' + byte(i)},
+			Value: vRaw,
 		}
 		if err := sst.Put(kv.Key, kv.Value); err != nil {
 			t.Fatalf("%+v", err)


### PR DESCRIPTION
This patch uses `RangeKeyChanged()` to detect range keys in
`ReadAsOfIterator`, and caches them to improve performance.
It also fixes a bug where the iterator would fail to detect tombstones
with a non-empty `MVCCValueHeader`.

Resolves #84714.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None