### PR TITLE
release-22.1: storage: fix BenchmarkExportToSst

### DIFF
--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -107,6 +107,7 @@ func BenchmarkMVCCGarbageCollect(b *testing.B) {
 }
 
 func BenchmarkExportToSst(b *testing.B) {
+	skip.UnderShort(b)
 	defer log.Scope(b).Close(b)
 
 	numKeys := []int{64, 512, 1024, 8192, 65536}

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -11,6 +11,7 @@
 package storage
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -1512,10 +1513,11 @@ func runExportToSst(
 	engine := emk(b, dir)
 	defer engine.Close()
 
-	batch := engine.NewUnindexedBatch(true /* writeOnly */)
+	batch := engine.NewBatch()
 	for i := 0; i < numKeys; i++ {
-		key := make([]byte, 16)
-		key = append(key, 'a', 'a', 'a')
+		var key []byte
+		key = append(key, keys.LocalMax...)
+		key = append(key, bytes.Repeat([]byte{'a'}, 19)...)
 		key = encoding.EncodeUint32Ascending(key, uint32(i))
 
 		for j := 0; j < numRevisions; j++ {


### PR DESCRIPTION
Backport 4/6 commits from #86141.

@tbg Backporting the non-rangekey bits, to allow comparisons between 22.1 and `master`. Had to tweak them a bit due to code changes, but nothing substantial.

/cc @cockroachdb/release

---

Release justification: Non-production code changes
Release note: None