### PR TITLE
storage: add default-off setting for MVCC range tombstones

### DIFF
--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -657,8 +657,8 @@ func (b *Batch) DelRange(s, e interface{}, returnKeys bool) {
 }
 
 // DelRangeUsingTombstone deletes the rows between begin (inclusive) and end
-// (exclusive) using an MVCC range tombstone. Callers must check the
-// MVCCRangeTombstones version gate before using this.
+// (exclusive) using an MVCC range tombstone. Callers must check
+// storage.CanUseMVCCRangeTombstones before using this.
 func (b *Batch) DelRangeUsingTombstone(s, e interface{}) {
 	start, err := marshalKey(s)
 	if err != nil {

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -375,8 +375,9 @@ message DeleteRangeRequest {
   // for conflicts and adjust MVCC stats). This option cannot be used in a
   // transaction, and it cannot be combined with Inline or ReturnKeys.
   //
-  // The caller must check the MVCCRangeTombstones version gate before using
-  // this parameter, as it is new in 22.2.
+  // The caller must check storage.CanUseMVCCRangeTombstones before using this
+  // parameter: it is new in 22.2, and controlled by the default-off cluster
+  // setting storage.mvcc.range_tombstones.enabled.
   bool use_range_tombstone = 5;
   // If enabled together with UseRangeTombstone, the MVCC range tombstone will
   // only be written if there exists point key/tombstones in the span that

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
@@ -68,6 +69,30 @@ var minWALSyncInterval = settings.RegisterDurationSetting(
 	"minimum duration between syncs of the RocksDB WAL",
 	0*time.Millisecond,
 )
+
+// MVCCRangeTombstonesEnabled enables writing of MVCC range tombstones.
+// Currently, this is used for schema GC and import cancellation rollbacks.
+//
+// Note that any executing jobs may not pick up this change, so these need to be
+// waited out before being certain that the setting has taken effect.
+//
+// If disabled after being enabled, this will prevent new range tombstones from
+// being written, but already written tombstones will remain until GCed. The
+// above note on jobs also applies in this case.
+var MVCCRangeTombstonesEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"storage.mvcc.range_tombstones.enabled",
+	"if true, enable the use of MVCC range tombstones",
+	false)
+
+// CanUseMVCCRangeTombstones returns true if the caller can begin writing
+// MVCC range tombstones, by setting DeleteRangeRequest.UseRangeTombstone.
+// It requires the MVCCRangeTombstones version gate to be active, and the
+// setting storage.mvcc.range_tombstones.enabled to be enabled.
+func CanUseMVCCRangeTombstones(ctx context.Context, st *cluster.Settings) bool {
+	return st.Version.IsActive(ctx, clusterversion.MVCCRangeTombstones) &&
+		MVCCRangeTombstonesEnabled.Get(&st.SV)
+}
 
 // MaxIntentsPerWriteIntentError sets maximum number of intents returned in
 // WriteIntentError in operations that return multiple intents per error.


### PR DESCRIPTION
This patch adds the default-off cluster setting
`storage.mvcc.range_tombstones.enabled` to control whether or not to
write MVCC range tombstones. The setting is internal and system-only.
The read path is always active, this only determines whether KV clients
should write them.

A helper function `CanUseMVCCRangeTombstones()` has also been added.
Callers have not yet been updated to respect this.

Note that any in-flight jobs may not pick up this change, so these need
to be waited out before being certain that the setting has taken effect.

If disabled after being enabled, this will prevent new range tombstones
from being written, but already written tombstones will remain until
GCed. The above note on jobs above also applies in this case.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None