### PR TITLE
changefeedccl: Assignable Kafka Partition Key

### DIFF
--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -94,6 +94,23 @@ var cdcFunctions = map[string]*tree.FunctionDefinition{
 			Info:       "Returns previous value of a row as JSONB",
 			Volatility: volatility.Stable,
 		}),
+	"cdc_partition_key": makeCDCBuiltIn(
+		"cdc_partition_key",
+		tree.Overload{
+			Types:      tree.VariadicType{VarType: types.Any},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				var datums []tree.Datum
+				rowEvalContext := rowEvalContextFromEvalContext(evalCtx)
+				for _, arg := range args {
+					datums = append(datums, arg)
+				}
+				rowEvalContext.updatedRow.GetEventDescriptor().AssignPartitionDatums(datums)
+				return tree.DBoolTrue, nil
+			},
+			Info:       "Returns true and allows for partitioning off of inputted columns",
+			Volatility: volatility.Stable,
+		}),
 }
 
 // TODO(yevgeniy): Implement additional functions (some ideas, not all should be implemented):

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -11,6 +11,7 @@ package cdcevent
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -75,6 +76,10 @@ type Iterator interface {
 	Datum(fn DatumFn) error
 	// Col invokes fn for each column.
 	Col(fn ColumnFn) error
+	// PartitionDatum invokes fn for each partition datum.
+	PartitionDatum(fn DatumFn) error
+	// PartitionCol invokes fn for each partition column.
+	PartitionCol(fn ColumnFn) error
 }
 
 // ForEachKeyColumn returns Iterator for each key column
@@ -90,6 +95,25 @@ func (r Row) ForEachColumn() Iterator {
 // ForEachUDTColumn returns Datum iterator for each column containing user defined types.
 func (r Row) ForEachUDTColumn() Iterator {
 	return iter{r: r, cols: r.udtCols}
+}
+
+//ForEachPartitionDatum returns Datum iterator for each partition datum.
+func (r Row) ForEachPartitionDatum() Iterator {
+	return iter{r: r, datums: r.partitionDatums}
+}
+
+//ForEachPartitionColumn returns Iterator for each partition column.
+func (r Row) ForEachPartitionColumn() Iterator {
+	var cols []int
+	for i := 0; i < len(r.partitionCols); i++ {
+		cols = append(cols, i)
+	}
+	return iter{r: r, cols: cols}
+}
+
+// GetEventDescriptor returns the EventDescriptor for the row.
+func (r Row) GetEventDescriptor() *EventDescriptor {
+	return r.EventDescriptor
 }
 
 // DatumAt returns Datum at specified position.
@@ -152,6 +176,26 @@ func (r Row) forEachColumn(fn ColumnFn, colIndexes []int) error {
 	return nil
 }
 
+// forEachPartitionDatum is a helper which invokes fn for each partition datum.
+func (r Row) forEachPartitionDatum(fn DatumFn, partitionDatums []tree.Datum) error {
+	for i, datum := range partitionDatums {
+		if err := fn(datum, r.partitionCols[i]); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
+}
+
+// forEachPartitionCol is a helper which invokes fn for each column in the partitionCols list.
+func (r Row) forEachPartitionColumn(fn ColumnFn, colIndexes []int) error {
+	for _, colIdx := range colIndexes {
+		if err := fn(r.partitionCols[colIdx]); err != nil {
+			return iterutil.Map(err)
+		}
+	}
+	return nil
+}
+
 // ResultColumn associates ResultColumn with an ordinal position where
 // such column expected to be found.
 type ResultColumn struct {
@@ -159,6 +203,9 @@ type ResultColumn struct {
 	ord       int
 	sqlString string
 }
+
+// ResultColumns is used to describe a list of ResultColumn structs.
+type ResultColumns []ResultColumn
 
 // SQLStringNotHumanReadable returns the SQL statement describing the column.
 func (c ResultColumn) SQLStringNotHumanReadable() string {
@@ -185,6 +232,9 @@ type EventDescriptor struct {
 	keyCols   []int // Primary key columns.
 	valueCols []int // All column family columns.
 	udtCols   []int // Columns containing UDTs.
+
+	partitionDatums []tree.Datum   // Datums to partition by
+	partitionCols   []ResultColumn // Columns to partition by
 }
 
 // NewEventDescriptor returns EventDescriptor for specified table and family descriptors.
@@ -310,6 +360,31 @@ func (d *EventDescriptor) HasUserDefinedTypes() bool {
 // higher level methods/structs (e.g. Metadata) instead.
 func (d *EventDescriptor) TableDescriptor() catalog.TableDescriptor {
 	return d.td
+}
+
+// PartitionDatums returns the underlying partitioning datums.
+func (d *EventDescriptor) PartitionDatums() []tree.Datum {
+	return d.partitionDatums
+}
+
+// AssignPartitionDatums assigns the inputted datums to the partitioning datums
+// field of the EventDescriptor
+func (d *EventDescriptor) AssignPartitionDatums(datums []tree.Datum) {
+	d.partitionDatums = datums
+	cols := make(ResultColumns, len(datums))
+	for i := range cols {
+		name := "partitionCol" + strconv.Itoa(i)
+		typ := datums[i].ResolvedType()
+		cols[i] = ResultColumn{
+			ResultColumn: colinfo.ResultColumn{
+				Name:   name,
+				Typ:    typ,
+				Hidden: true,
+			},
+			ord: i,
+		}
+	}
+	d.partitionCols = cols
 }
 
 type eventDescriptorFactory func(
@@ -483,8 +558,9 @@ func (m Metadata) String() string {
 }
 
 type iter struct {
-	r    Row
-	cols []int
+	r      Row
+	cols   []int
+	datums []tree.Datum
 }
 
 var _ Iterator = iter{}
@@ -497,6 +573,16 @@ func (it iter) Datum(fn DatumFn) error {
 // Col implements Iterator interface.
 func (it iter) Col(fn ColumnFn) error {
 	return it.r.forEachColumn(fn, it.cols)
+}
+
+// PartitionDatum implements Iterator interface
+func (it iter) PartitionDatum(fn DatumFn) error {
+	return it.r.forEachPartitionDatum(fn, it.datums)
+}
+
+// PartitionCol implements Iterator interface.
+func (it iter) PartitionCol(fn ColumnFn) error {
+	return it.r.forEachPartitionColumn(fn, it.cols)
 }
 
 // TestingMakeEventRow initializes Row with provided arguments.

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -20,11 +20,12 @@ import (
 // Encoder turns a row into a serialized changefeed key, value, or resolved
 // timestamp. It represents one of the `format=` changefeed options.
 type Encoder interface {
-	// EncodeKey encodes the primary key of the given row. The columns of the
+	// EncodeKey encodes the primary key of the given row or the partitionCols of
+	// the inputted row based upon the inputted bool. The columns of the
 	// datums are expected to match 1:1 with the `Columns` field of the
 	// `TableDescriptor`, but only the primary key fields will be used. The
 	// returned bytes are only valid until the next call to Encode*.
-	EncodeKey(context.Context, cdcevent.Row) ([]byte, error)
+	EncodeKey(context.Context, cdcevent.Row, bool) ([]byte, error)
 	// EncodeValue encodes the primary key of the given row. The columns of the
 	// datums are expected to match 1:1 with the `Columns` field of the
 	// `TableDescriptor`. The returned bytes are only valid until the next call

--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -39,7 +39,7 @@ func newCSVEncoder(opts changefeedbase.EncodingOptions) *csvEncoder {
 }
 
 // EncodeKey implements the Encoder interface.
-func (e *csvEncoder) EncodeKey(_ context.Context, row cdcevent.Row) ([]byte, error) {
+func (e *csvEncoder) EncodeKey(_ context.Context, row cdcevent.Row, _ bool) ([]byte, error) {
 	return nil, nil
 }
 

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -62,8 +62,20 @@ func makeJSONEncoder(
 }
 
 // EncodeKey implements the Encoder interface.
-func (e *jsonEncoder) EncodeKey(_ context.Context, row cdcevent.Row) ([]byte, error) {
-	jsonEntries, err := e.encodeKeyRaw(row)
+func (e *jsonEncoder) EncodeKey(
+	_ context.Context, row cdcevent.Row, partitioning bool,
+) ([]byte, error) {
+	var jsonEntries []interface{}
+	var err error
+	var encodeIter cdcevent.Iterator
+
+	if partitioning {
+		encodeIter = row.ForEachPartitionDatum()
+	} else {
+		encodeIter = row.ForEachKeyColumn()
+	}
+
+	jsonEntries, err = e.encodeKeyIter(encodeIter, partitioning)
 	if err != nil {
 		return nil, err
 	}
@@ -74,6 +86,32 @@ func (e *jsonEncoder) EncodeKey(_ context.Context, row cdcevent.Row) ([]byte, er
 	e.buf.Reset()
 	j.Format(&e.buf)
 	return e.buf.Bytes(), nil
+}
+
+// Encodes the datums of either the key columns or partition columns.
+func (e *jsonEncoder) encodeKeyIter(
+	it cdcevent.Iterator, partitioning bool,
+) ([]interface{}, error) {
+	var jsonEntries []interface{}
+	encode := func(d tree.Datum, col cdcevent.ResultColumn) error {
+		j, err := tree.AsJSON(d, sessiondatapb.DataConversionConfig{}, time.UTC)
+		if err != nil {
+			return err
+		}
+		jsonEntries = append(jsonEntries, j)
+		return nil
+	}
+
+	var err error
+	if partitioning {
+		err = it.PartitionDatum(encode)
+	} else {
+		err = it.Datum(encode)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return jsonEntries, nil
 }
 
 func (e *jsonEncoder) encodeKeyRaw(row cdcevent.Row) ([]interface{}, error) {

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -237,7 +237,7 @@ func TestEncoders(t *testing.T) {
 			prevRow := cdcevent.TestingMakeEventRow(tableDesc, 0, nil, false)
 			evCtx := eventContext{updated: ts}
 
-			keyInsert, err := e.EncodeKey(context.Background(), rowInsert)
+			keyInsert, err := e.EncodeKey(context.Background(), rowInsert, false)
 			require.NoError(t, err)
 			keyInsert = append([]byte(nil), keyInsert...)
 			valueInsert, err := e.EncodeValue(context.Background(), evCtx, rowInsert, prevRow)
@@ -247,7 +247,7 @@ func TestEncoders(t *testing.T) {
 			rowDelete := cdcevent.TestingMakeEventRow(tableDesc, 0, row, true)
 			prevRow = cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
 
-			keyDelete, err := e.EncodeKey(context.Background(), rowDelete)
+			keyDelete, err := e.EncodeKey(context.Background(), rowDelete, false)
 			require.NoError(t, err)
 			keyDelete = append([]byte(nil), keyDelete...)
 			valueDelete, err := e.EncodeValue(context.Background(), evCtx, rowDelete, prevRow)
@@ -376,7 +376,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		rowInsert := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
 		var prevRow cdcevent.Row
 		evCtx := eventContext{updated: ts}
-		keyInsert, err := e.EncodeKey(context.Background(), rowInsert)
+		keyInsert, err := e.EncodeKey(context.Background(), rowInsert, false)
 		require.NoError(t, err)
 		keyInsert = append([]byte(nil), keyInsert...)
 		valueInsert, err := e.EncodeValue(context.Background(), evCtx, rowInsert, prevRow)
@@ -386,7 +386,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 		rowDelete := cdcevent.TestingMakeEventRow(tableDesc, 0, row, true)
 		prevRow = cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
 
-		keyDelete, err := e.EncodeKey(context.Background(), rowDelete)
+		keyDelete, err := e.EncodeKey(context.Background(), rowDelete, false)
 		require.NoError(t, err)
 		keyDelete = append([]byte(nil), keyDelete...)
 		valueDelete, err := e.EncodeValue(context.Background(), evCtx, rowDelete, prevRow)
@@ -404,7 +404,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 
 		enc, err := getEncoder(opts, targets)
 		require.NoError(t, err)
-		_, err = enc.EncodeKey(context.Background(), rowInsert)
+		_, err = enc.EncodeKey(context.Background(), rowInsert, false)
 		require.EqualError(t, err, fmt.Sprintf("retryable changefeed error: "+
 			`contacting confluent schema registry: Post "%s/subjects/foo-key/versions": x509: certificate signed by unknown authority`,
 			opts.SchemaRegistryURI))
@@ -419,7 +419,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 
 		enc, err = getEncoder(opts, targets)
 		require.NoError(t, err)
-		_, err = enc.EncodeKey(context.Background(), rowInsert)
+		_, err = enc.EncodeKey(context.Background(), rowInsert, false)
 		require.EqualError(t, err, fmt.Sprintf("retryable changefeed error: "+
 			`contacting confluent schema registry: Post "%s/subjects/foo-key/versions": x509: certificate signed by unknown authority`,
 			opts.SchemaRegistryURI))

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -212,8 +212,12 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		evCtx.topic = topic
 	}
 
+	partitioning := false
+	if len(updatedRow.GetEventDescriptor().PartitionDatums()) > 0 {
+		partitioning = true
+	}
 	var keyCopy, valueCopy []byte
-	encodedKey, err := c.encoder.EncodeKey(ctx, updatedRow)
+	encodedKey, err := c.encoder.EncodeKey(ctx, updatedRow, partitioning)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/sink_test.go
+++ b/pkg/ccl/changefeedccl/sink_test.go
@@ -370,7 +370,7 @@ func BenchmarkEmitRow(b *testing.B) {
 
 type testEncoder struct{}
 
-func (testEncoder) EncodeKey(context.Context, cdcevent.Row) ([]byte, error) {
+func (testEncoder) EncodeKey(context.Context, cdcevent.Row, bool) ([]byte, error) {
 	panic(`unimplemented`)
 }
 func (testEncoder) EncodeValue(


### PR DESCRIPTION
ccl: implementing functionality to allow for users to pick which 
columns they would want Kafka messages to be partitioned by

Resolves: #54461

Release note (enterprise change): implementing functionality to
allow for users to pick which columns they would want Kafka
messages to be partitioned by

Progress: So far I created a custom CDC function that can take
inputted column names and stores those datums within a row's
EventDescriptor. Then I changed the EncodeKey functions to be
able to handle whether or not they are encoding a row's key
columns or the partition columns that we had taken in from the 
custom function. A bit of hacking was involved in the
cdcevent/event.go file to be able to get a similar flow to how
key columns were being encoded to work with partition columns 
instead (creating partition column iterator, hacked resultColumns
array to represent the partition columns, etc.).

Where to go from here: Lots of testing needs to be done with the 
current implementation to ensure things are working properly
including ensuring previous tests work properly and creating new
tests for this issue. It seems likely to me that because of the
hacking involved to get an encoding partition columns flow working
smoothly, there might be some issues involved with decoding
particularly with the Avro encodings.

Feel free to email me at suraj_rao@berkeley.edu if there are any 
questions and I can also spend some time with finishing off this 
feature if needed as well. 
