### PR TITLE
ci: add GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/bincheck.yml
+++ b/.github/workflows/bincheck.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags: [ v* ]
 
+permissions:
+  contents: read
+
 jobs:
 
   linux:


### PR DESCRIPTION
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using https://github.com/step-security/secure-workflows.

Other workflows already had permissions defined. 

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Before the change:
`GITHUB_TOKEN` has `write` permissions for multiple scopes, e.g. 
https://github.com/cockroachdb/cockroach/runs/7616637964?check_suite_focus=true#step:1:19

After the change:
`GITHUB_TOKEN` will have minimum permissions needed for the jobs. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>