### PR TITLE
ttl: fix SelectDuration, RowDeletions metrics

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -300,7 +300,7 @@ func (ttl *ttlProcessor) runTTLOnRange(
 		// SELECT query.
 		start := timeutil.Now()
 		expiredRowsPKs, err := selectBuilder.run(ctx, ie)
-		metrics.DeleteDuration.RecordValue(int64(timeutil.Since(start)))
+		metrics.SelectDuration.RecordValue(int64(timeutil.Since(start)))
 		if err != nil {
 			return rangeRowCount, errors.Wrapf(err, "error selecting rows to delete")
 		}
@@ -345,12 +345,12 @@ func (ttl *ttlProcessor) runTTLOnRange(
 				}
 
 				metrics.DeleteDuration.RecordValue(int64(timeutil.Since(start)))
-				rangeRowCount += int64(batchRowCount)
+				metrics.RowDeletions.Inc(batchRowCount)
+				rangeRowCount += batchRowCount
 				return nil
 			}); err != nil {
 				return rangeRowCount, errors.Wrapf(err, "error during row deletion")
 			}
-			metrics.RowDeletions.Inc(int64(len(deleteBatch)))
 		}
 
 		// Step 3. Early exit if necessary.

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -300,10 +300,10 @@ func (b *deleteQueryBuilder) buildQueryAndArgs(rows []tree.Datums) (string, []in
 
 func (b *deleteQueryBuilder) run(
 	ctx context.Context, ie sqlutil.InternalExecutor, txn *kv.Txn, rows []tree.Datums,
-) (int, error) {
+) (int64, error) {
 	q, deleteArgs := b.buildQueryAndArgs(rows)
 	qosLevel := sessiondatapb.TTLLow
-	return ie.ExecEx(
+	rowCount, err := ie.ExecEx(
 		ctx,
 		b.deleteOpName,
 		txn,
@@ -314,6 +314,7 @@ func (b *deleteQueryBuilder) run(
 		q,
 		deleteArgs...,
 	)
+	return int64(rowCount), err
 }
 
 // makeColumnNamesSQL converts columns into an escape string


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/86555

Fixes these issues:
1) DeleteDuration is being incorrectly used instead of SelectDuration.
2) RowDeletions is using batch size instead of results from ie.ExecEx.

Release justification: Fixes TTL metric reporting.

Release note: None