### PR TITLE
spanconfigtestutils: copy gc job testing knobs to tenant

### DIFF
--- a/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
+++ b/pkg/spanconfig/spanconfigtestutils/spanconfigtestcluster/cluster.go
@@ -63,13 +63,17 @@ func (h *Handle) InitializeTenant(ctx context.Context, tenID roachpb.TenantID) *
 		tenantState.db = sqlutils.MakeSQLRunner(h.tc.ServerConn(0))
 		tenantState.cleanup = func() {} // noop
 	} else {
+		serverGCJobKnobs := testServer.TestingKnobs().GCJob
+		tenantGCJobKnobs := sql.GCJobTestingKnobs{SkipWaitingForMVCCGC: true}
+		if serverGCJobKnobs != nil {
+			tenantGCJobKnobs = *serverGCJobKnobs.(*sql.GCJobTestingKnobs)
+			tenantGCJobKnobs.SkipWaitingForMVCCGC = true
+		}
 		tenantArgs := base.TestTenantArgs{
 			TenantID: tenID,
 			TestingKnobs: base.TestingKnobs{
 				SpanConfig: h.scKnobs,
-				GCJob: &sql.GCJobTestingKnobs{
-					SkipWaitingForMVCCGC: true,
-				},
+				GCJob:      &tenantGCJobKnobs,
 			},
 		}
 		var err error


### PR DESCRIPTION
Some of the sqltranslator tests require that we can disable the GC job
related to an index creation so that we can observe the span
configuration on the temporary indexes.  We pause the GC job via a
testing knob.

Fixes #85507

Release justification: Test-only change

Release note: None