### PR TITLE
kv: Add a catchup scan duration metric.

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -496,10 +496,12 @@ func (ds *DistSender) singleRangeFeed(
 		return hlc.Timestamp{}, err
 	}
 	ds.metrics.RangefeedCatchupRanges.Inc(1)
+	catchupStart := timeutil.Now()
 	finishCatchupScan := func() {
 		if catchupRes != nil {
 			catchupRes.Release()
 			ds.metrics.RangefeedCatchupRanges.Dec(1)
+			ds.metrics.RangefeedCatchupDuration.RecordValue(timeutil.Since(catchupStart).Nanoseconds())
 			catchupRes = nil
 		}
 	}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -291,6 +291,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Catchup Scans",
+				Metrics: []string{
+					"distsender.rangefeed.catchup_duration",
+				},
+			},
+			{
 				Title: "RPCs",
 				Metrics: []string{
 					"distsender.rpc.sent.local",

--- a/pkg/ts/catalog/metrics.go
+++ b/pkg/ts/catalog/metrics.go
@@ -102,6 +102,7 @@ var histogramMetricsNames = map[string]struct{}{
 	"streaming.flush_hist_nanos":                {},
 	"kv.replica_read_batch_evaluate.latency":    {},
 	"kv.replica_write_batch_evaluate.latency":   {},
+	"distsender.rangefeed.catchup_duration":     {},
 }
 
 func allInternalTSMetricsNames() []string {


### PR DESCRIPTION
Add a `distsender.rangefeed.catchup_duration` catchup scan
duration histogram to improve observability into catchup scan performance.

Release justification: low danger, metrics only change.
Release note: None