### PR TITLE
sql/schemachanger/sctest: randomly skip some backup tests

### DIFF
--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
+        "//pkg/util/randutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
The backup-restore tests are very slow because they run each test case to each
rollback bound and take backups at each stage, and then restore each of those
backups. This is sort of cubic in the number of stages. That makes it the
longest part of schema change testing by a good margin. To trim its cost, we
randomly choose to skip some of the backup tests and some of the restores. This
reduces the chance of running a given backup by a factor of 2 and of running
a restory by a factor of 4. All in all, this cuts the test time by more than
50%. If we look at unit test profiles, this package dominates the test time.

Release justification: testing only change.

Release note: None