### PR TITLE
ts: fix the pretty-printing of tsd keys

### DIFF
--- a/pkg/ts/keys.go
+++ b/pkg/ts/keys.go
@@ -121,8 +121,8 @@ func prettyPrintKey(key roachpb.Key) string {
 		// it.
 		return encoding.PrettyPrintValue(nil /* dirs */, key, "/")
 	}
-	return fmt.Sprintf("/%s/%s/%s/%s", name, source, resolution,
-		timeutil.Unix(0, timestamp).Format(time.RFC3339Nano))
+	return fmt.Sprintf("/%s/%s/%s/%s", name, resolution,
+		timeutil.Unix(0, timestamp).Format(time.RFC3339Nano), source)
 }
 
 func init() {

--- a/pkg/ts/keys_test.go
+++ b/pkg/ts/keys_test.go
@@ -35,7 +35,7 @@ func TestDataKeys(t *testing.T) {
 			0,
 			Resolution10s,
 			30,
-			"/System/tsd/test.metric/testsource/10s/1970-01-01T00:00:00Z",
+			"/System/tsd/test.metric/10s/1970-01-01T00:00:00Z/testsource",
 		},
 		{
 			"test.no.source",
@@ -43,7 +43,7 @@ func TestDataKeys(t *testing.T) {
 			1429114700000000000,
 			Resolution10s,
 			26,
-			"/System/tsd/test.no.source//10s/2015-04-15T16:00:00Z",
+			"/System/tsd/test.no.source/10s/2015-04-15T16:00:00Z/",
 		},
 		{
 			"",
@@ -51,7 +51,7 @@ func TestDataKeys(t *testing.T) {
 			-1429114700000000000,
 			Resolution10s,
 			12,
-			"/System/tsd///10s/1924-09-18T08:00:00Z",
+			"/System/tsd//10s/1924-09-18T08:00:00Z/",
 		},
 	}
 


### PR DESCRIPTION
Found while working on #86524.

Release justification: bug fix

Release note (bug fix): When printing keys and range start/end
boundaries for time series, the displayed structure of keys
was incorrect. This is now fixed.