### PR TITLE
sql: index rec with NotVisible indexes

### DIFF
--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -57,11 +57,9 @@ func BuildOptAndHypTableMaps(
 			)
 
 			// Do not add hypothetical inverted indexes for which there is an existing
-			// index with the same key. Inverted indexes do not have stored columns,
-			// so we should not make a recommendation if the same index already
-			// exists.
-			// TODO(wenyihu6): We should still consider not visible indexes and make a
-			// recommendation to mark the index as visible if it is chosen.
+			// visible index with the same key. Inverted indexes do not have stored
+			// columns, so we should not make a recommendation if the same index
+			// already exists.
 			if !(inverted && hypTable.redundantHypotheticalIndex(&hypIndex)) {
 				hypIndexes = append(hypIndexes, hypIndex)
 			}

--- a/pkg/sql/opt/indexrec/testdata/geospatial-index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/geospatial-index-candidates-recommendations
@@ -1789,3 +1789,70 @@ inner-join (cross)
  │         └── t1.k:1 = (~t1.k:1) [outer=(1), immutable, constraints=(/1: (/NULL - ])]
  └── filters
       └── t1.s:4 ~ t2.s:10 [outer=(4,10), immutable, constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
+
+# The following tests check for not visible indexes.
+exec-ddl
+CREATE INDEX ON t1 (k) STORING (i, f, s) NOT VISIBLE
+----
+
+# If the index recommendation stores the same columns as a not visible index,
+# recommendation.
+index-recommendations
+SELECT * FROM t1, t2 WHERE t1.s ~ t2.s AND ~t1.k = t1.k
+----
+index recommendations: 1
+1. type: alter index visibility
+   SQL command: ALTER INDEX t1@t1_k_idx VISIBLE;
+--
+Optimal Plan.
+inner-join (cross)
+ ├── columns: k:1!null i:2 f:3 s:4!null k:8 i:9 s:10!null geom1:11 geog1:12 bbox1:13 bbox2:14 geom2:15 geog2:16 inet1:17
+ ├── immutable
+ ├── cost: 5657.48872
+ ├── scan t2
+ │    ├── columns: t2.k:8 t2.i:9 t2.s:10 geom1:11 geog1:12 bbox1:13 bbox2:14 geom2:15 geog2:16 inet1:17
+ │    └── cost: 1236.12
+ ├── select
+ │    ├── columns: t1.k:1!null t1.i:2 f:3 t1.s:4
+ │    ├── immutable
+ │    ├── cost: 1103.05
+ │    ├── scan t1@_hyp_2
+ │    │    ├── columns: t1.k:1!null t1.i:2 f:3 t1.s:4
+ │    │    ├── constraint: /1/5: (/NULL - ]
+ │    │    └── cost: 1093.12
+ │    └── filters
+ │         └── t1.k:1 = (~t1.k:1) [outer=(1), immutable, constraints=(/1: (/NULL - ])]
+ └── filters
+      └── t1.s:4 ~ t2.s:10 [outer=(4,10), immutable, constraints=(/4: (/NULL - ]; /10: (/NULL - ])]
+
+exec-ddl
+CREATE INDEX ON t1 (k) STORING (i, f, s) VISIBLE
+----
+
+# If there exists both not visible and visible indexes storing same column as
+# index rec, no index recommendation.
+index-recommendations
+SELECT * FROM t1, t2 WHERE t1.s ~ t2.s AND ~t1.k = t1.k
+----
+No index recommendations.
+--
+Optimal Plan.
+inner-join (cross)
+ ├── columns: k:1!null i:2 f:3 s:4!null k:8 i:9 s:10!null geom1:11 geog1:12 bbox1:13 bbox2:14 geom2:15 geog2:16 inet1:17
+ ├── immutable
+ ├── cost: 5657.48872
+ ├── scan t2
+ │    ├── columns: t2.k:8 t2.i:9 t2.s:10 geom1:11 geog1:12 bbox1:13 bbox2:14 geom2:15 geog2:16 inet1:17
+ │    └── cost: 1236.12
+ ├── select
+ │    ├── columns: t1.k:1!null t1.i:2 f:3 t1.s:4
+ │    ├── immutable
+ │    ├── cost: 1103.05
+ │    ├── scan t1@t1_k_idx1
+ │    │    ├── columns: t1.k:1!null t1.i:2 f:3 t1.s:4
+ │    │    ├── constraint: /1/5: (/NULL - ]
+ │    │    └── cost: 1093.12
+ │    └── filters
+ │         └── t1.k:1 = (~t1.k:1) [outer=(1), immutable, constraints=(/1: (/NULL - ])]
+ └── filters
+      └── t1.s:4 ~ t2.s:10 [outer=(4,10), immutable, constraints=(/4: (/NULL - ]; /10: (/NULL - ])]

--- a/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
+++ b/pkg/sql/opt/indexrec/testdata/index-candidates-recommendations
@@ -1854,3 +1854,80 @@ scalar-group-by
  └── aggregations
       └── bool-and [as=bool_and:26, outer=(25)]
            └── column25:25
+
+# The following tests check for not visible indexes. Note that for alter index
+# visibility, the optimal plan uses the hypothetical indexes created instead of
+# using the visible version of the original indexes. This is not ideal, but we
+# will accept this behaviour as of now since it is not user-facing.
+
+exec-ddl
+CREATE TABLE t_notvisible (k INT PRIMARY KEY, v INT, i INT, INDEX idx_i_visible(i) VISIBLE, INDEX idx_v_invisible(v) NOT VISIBLE)
+----
+
+# If the index is visible and stores the same column, no recommendation.
+index-recommendations
+SELECT i FROM t_notvisible WHERE i > 1
+----
+No index recommendations.
+--
+Optimal Plan.
+scan t_notvisible@idx_i_visible
+ ├── columns: i:3!null
+ ├── constraint: /3/1: [/2 - ]
+ └── cost: 357.353333
+
+# If the index is not visible and stores the same column, recommend alter index.
+# visible.
+index-recommendations
+SELECT v FROM t_notvisible WHERE v > 1
+----
+index recommendations: 1
+1. type: alter index visibility
+   SQL command: ALTER INDEX t_notvisible@idx_v_invisible VISIBLE;
+--
+Optimal Plan.
+scan t_notvisible@_hyp_3
+ ├── columns: v:2!null
+ ├── constraint: /2/1: [/2 - ]
+ └── cost: 360.686667
+
+# If the index recommendation is to update the existing index to store new
+# columns, recommend drop index and recreate index.
+index-recommendations
+SELECT i FROM t_notvisible WHERE v > 1
+----
+index recommendations: 1
+1. type: index replacement
+   SQL commands: CREATE INDEX ON t_notvisible (v) STORING (i); DROP INDEX t_notvisible@idx_v_invisible;
+--
+Optimal Plan.
+project
+ ├── columns: i:3
+ ├── cost: 367.373333
+ └── scan t_notvisible@_hyp_3
+      ├── columns: v:2!null i:3
+      ├── constraint: /2/1: [/2 - ]
+      └── cost: 364.02
+
+# If there exists both not visible and visible indexes storing the same explicit
+# column, the index recommendation should not recommend alter index.
+exec-ddl
+DROP INDEX idx_i_visible
+----
+
+exec-ddl
+CREATE INDEX idx_i_invisible ON t_notvisible(i) NOT VISIBLE
+----
+
+index-recommendations
+SELECT i FROM t_notvisible WHERE i > 1
+----
+index recommendations: 1
+1. type: alter index visibility
+   SQL command: ALTER INDEX t_notvisible@idx_i_invisible VISIBLE;
+--
+Optimal Plan.
+scan t_notvisible@_hyp_3
+ ├── columns: i:3!null
+ ├── constraint: /3/1: [/2 - ]
+ └── cost: 360.686667


### PR DESCRIPTION
**sql: introduce different index rec types**

Prior to this commit, the logic for index recommendation output string is
handled by checking if the existing index is not nil. This logic can become
really complicated if more index recommendation types are added in the future.
This commit cleans this up by introducing an interface outputCommand to
distinguish different types of index recommendations.

Assists: https://github.com/cockroachdb/cockroach/issues/85477

Release justification: low risk changes to existing functionality

Release note: None

**sql: index rec with NotVisible indexes**

Now that we have introduced a not visible index feature, we should update index
recommendations accordingly. Prior to this commit, the index recommendation
engine treats all indexes as they are visible. If an index already exists in the
table and stores the same explicit column as an index recommendation, this index
recommendation is removed as it is redundant. However, it is possible that this
index is not visible now. This commits fixes this by adding not visible indexes
to the logic. Instead of removing the redundant index directly, it performs a
check to see if the index is not visible.

Fixes: https://github.com/cockroachdb/cockroach/issues/85477

Release justification: this commit does not interfere with existing
functionality and fixes index recommendation to take index visibility into
account.

Release note: None