### PR TITLE
roachpb: add gc hint replica state field and let delete range set it

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -294,4 +294,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.1-62	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.1-64	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -228,6 +228,6 @@
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.span_registry.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://<ui>/#/debug/tracez</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>1000022.1-62</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>1000022.1-64</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -287,6 +287,9 @@ const (
 	// schema changes to complete. After this point, no non-MVCC
 	// AddSSTable calls will be used outside of tenant streaming.
 	NoNonMVCCAddSSTable
+	// GCHintInReplicaState adds GC hint to replica state. When this version is
+	// enabled, replicas will populate GC hint and update them when necessary.
+	GCHintInReplicaState
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -477,6 +480,11 @@ var rawVersionsSingleton = keyedVersions{
 		Key:     NoNonMVCCAddSSTable,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 62},
 	},
+	{
+		Key:     GCHintInReplicaState,
+		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 64},
+	},
+
 	// *************************************************
 	// Step (2): Add new versions here.
 	// Do not add new versions to a patch release.

--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -46,11 +46,12 @@ func _() {
 	_ = x[WaitedForDelRangeInGCJob-34]
 	_ = x[RangefeedUseOneStreamPerNode-35]
 	_ = x[NoNonMVCCAddSSTable-36]
+	_ = x[GCHintInReplicaState-37]
 }
 
-const _Key_name = "invalidVersionKeyV21_2Start22_1ProbeRequestEnableSpanConfigStoreEnableNewStoreRebalancerV22_1Start22_2LocalTimestampsPebbleFormatSplitUserKeysMarkedCompactedEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTableAlterSystemStatementStatisticsAddIndexRecommendationsRoleIDSequenceAddSystemUserIDColumnSystemUsersIDColumnIsBackfilledSetSystemUsersUserIDColumnNotNullSQLSchemaTelemetryScheduledJobsSchemaChangeSupportsCreateFunctionDeleteRequestReturnKeyPebbleFormatPrePebblev1MarkedRoleOptionsTableHasIDColumnRoleOptionsIDColumnIsBackfilledSetRoleOptionsUserIDColumnNotNullUseDelRangeInGCJobWaitedForDelRangeInGCJobRangefeedUseOneStreamPerNodeNoNonMVCCAddSSTable"
+const _Key_name = "invalidVersionKeyV21_2Start22_1ProbeRequestEnableSpanConfigStoreEnableNewStoreRebalancerV22_1Start22_2LocalTimestampsPebbleFormatSplitUserKeysMarkedCompactedEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTableAlterSystemStatementStatisticsAddIndexRecommendationsRoleIDSequenceAddSystemUserIDColumnSystemUsersIDColumnIsBackfilledSetSystemUsersUserIDColumnNotNullSQLSchemaTelemetryScheduledJobsSchemaChangeSupportsCreateFunctionDeleteRequestReturnKeyPebbleFormatPrePebblev1MarkedRoleOptionsTableHasIDColumnRoleOptionsIDColumnIsBackfilledSetRoleOptionsUserIDColumnNotNullUseDelRangeInGCJobWaitedForDelRangeInGCJobRangefeedUseOneStreamPerNodeNoNonMVCCAddSSTableGCHintInReplicaState"
 
-var _Key_index = [...]uint16{0, 17, 22, 31, 43, 64, 88, 93, 102, 117, 157, 191, 225, 247, 267, 286, 319, 338, 358, 379, 414, 448, 478, 531, 545, 566, 597, 630, 661, 695, 717, 746, 773, 804, 837, 855, 879, 907, 926}
+var _Key_index = [...]uint16{0, 17, 22, 31, 43, 64, 88, 93, 102, 117, 157, 191, 225, 247, 267, 286, 319, 338, 358, 379, 414, 448, 478, 531, 545, 566, 597, 630, 661, 695, 717, 746, 773, 804, 837, 855, 879, 907, 926, 946}
 
 func (i Key) String() string {
 	i -= -1

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -67,9 +67,7 @@ func registerAcceptance(r registry.Registry) {
 		registry.OwnerTestEng: {
 			{
 				name: "version-upgrade",
-				fn: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-					runVersionUpgrade(ctx, t, c)
-				},
+				fn:   runVersionUpgrade,
 				// This test doesn't like running on old versions because it upgrades to
 				// the latest released version and then it tries to "head", where head is
 				// the cockroach binary built from the branch on which the test is

--- a/pkg/keys/constants.go
+++ b/pkg/keys/constants.go
@@ -92,6 +92,8 @@ var (
 	// LocalRaftTruncatedStateSuffix for the corresponding unreplicated
 	// RaftTruncatedState.
 	_ = []byte("rftt")
+	// LocalRangeGCHintSuffix is the suffix for the GC hint struct.
+	LocalRangeGCHintSuffix = []byte("rgch")
 	// LocalRangeLeaseSuffix is the suffix for a range lease.
 	LocalRangeLeaseSuffix = []byte("rll-")
 	// LocalRangePriorReadSummarySuffix is the suffix for a range's prior read

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -279,6 +279,12 @@ func RangeGCThresholdKey(rangeID roachpb.RangeID) roachpb.Key {
 	return MakeRangeIDPrefixBuf(rangeID).RangeGCThresholdKey()
 }
 
+// RangeGCHintKey returns a system-local key for GC hint data. This data is used
+// by GC queue to adjust how replicas are being queued for GC.
+func RangeGCHintKey(rangeID roachpb.RangeID) roachpb.Key {
+	return MakeRangeIDPrefixBuf(rangeID).RangeGCHintKey()
+}
+
 // MVCCRangeKeyGCKey returns a range local key protecting range
 // tombstone mvcc stats calculations during range tombstone GC.
 func MVCCRangeKeyGCKey(rangeID roachpb.RangeID) roachpb.Key {
@@ -1018,6 +1024,11 @@ func (b RangeIDPrefixBuf) RangePriorReadSummaryKey() roachpb.Key {
 // RangeGCThresholdKey returns a system-local key for the GC threshold.
 func (b RangeIDPrefixBuf) RangeGCThresholdKey() roachpb.Key {
 	return append(b.replicatedPrefix(), LocalRangeGCThresholdSuffix...)
+}
+
+// RangeGCHintKey returns a range-local key for the GC hint data.
+func (b RangeIDPrefixBuf) RangeGCHintKey() roachpb.Key {
+	return append(b.replicatedPrefix(), LocalRangeGCHintSuffix...)
 }
 
 // RangeVersionKey returns a system-local key for the range version.

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -59,6 +59,7 @@ go_library(
     deps = [
         "//pkg/cloud",
         "//pkg/cloud/cloudpb",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/batcheval/result",
@@ -103,6 +104,7 @@ go_test(
     srcs = [
         "cmd_add_sstable_test.go",
         "cmd_clear_range_test.go",
+        "cmd_delete_range_gchint_test.go",
         "cmd_delete_range_test.go",
         "cmd_end_transaction_test.go",
         "cmd_export_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -14,8 +14,10 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -65,6 +67,13 @@ func declareKeysDeleteRange(
 		latchSpans.AddNonMVCC(spanset.SpanReadOnly, roachpb.Span{
 			Key: keys.MVCCRangeKeyGCKey(rs.GetRangeID()),
 		})
+
+		if args.UpdateRangeDeleteGCHint {
+			// If we are updating GC hint, add it to the latch span.
+			latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{
+				Key: keys.RangeGCHintKey(rs.GetRangeID()),
+			})
+		}
 	}
 }
 
@@ -86,6 +95,13 @@ func DeleteRange(
 			"UseRangeTombstones must be passed with predicate based Delete Range")
 	}
 
+	if args.UpdateRangeDeleteGCHint && !args.UseRangeTombstone {
+		// Check for prerequisite for gc hint. If it doesn't hold, this is incorrect
+		// usage of hint.
+		return result.Result{}, errors.AssertionFailedf(
+			"GCRangeHint must only be used together with UseRangeTombstone")
+	}
+
 	// Use MVCC range tombstone if requested.
 	if args.UseRangeTombstone {
 		if cArgs.Header.Txn != nil {
@@ -98,7 +114,39 @@ func DeleteRange(
 			return result.Result{}, errors.AssertionFailedf(
 				"ReturnKeys can't be used with range tombstones")
 		}
+
 		desc := cArgs.EvalCtx.Desc()
+
+		maybeUpdateGCHint := func(res *result.Result) error {
+			if !args.UpdateRangeDeleteGCHint {
+				return nil
+			}
+			// If GCHint was provided, then we need to check if this request meets
+			// range gc criteria of removing all data. This is not an error as range
+			// might have merged since request was sent and we don't want to fail
+			// deletion.
+			if !args.Key.Equal(desc.StartKey.AsRawKey()) || !args.EndKey.Equal(desc.EndKey.AsRawKey()) {
+				return nil
+			}
+			sl := MakeStateLoader(cArgs.EvalCtx)
+			hint, err := sl.LoadGCHint(ctx, readWriter)
+			if err != nil {
+				return err
+			}
+			if !hint.ForwardLatestRangeDeleteTimestamp(h.Timestamp) {
+				return nil
+			}
+			canUseGCHint := cArgs.EvalCtx.ClusterSettings().Version.IsActive(ctx,
+				clusterversion.GCHintInReplicaState)
+			if updated, err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint, canUseGCHint); err != nil || !updated {
+				return err
+			}
+			res.Replicated.State = &kvserverpb.ReplicaState{
+				GCHint: hint,
+			}
+			return nil
+		}
+
 		leftPeekBound, rightPeekBound := rangeTombstonePeekBounds(
 			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
 		maxIntents := storage.MaxIntentsPerWriteIntentError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
@@ -114,10 +162,14 @@ func DeleteRange(
 				s := cArgs.EvalCtx.GetMVCCStats()
 				statsCovered = &s
 			}
-			err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
+			if err := storage.MVCCDeleteRangeUsingTombstone(ctx, readWriter, cArgs.Stats,
 				args.Key, args.EndKey, h.Timestamp, cArgs.Now, leftPeekBound, rightPeekBound,
-				args.IdempotentTombstone, maxIntents, statsCovered)
-			return result.Result{}, err
+				args.IdempotentTombstone, maxIntents, statsCovered); err != nil {
+				return result.Result{}, err
+			}
+			var res result.Result
+			err := maybeUpdateGCHint(&res)
+			return res, err
 		}
 
 		if h.MaxSpanRequestKeys == 0 {

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range_gchint_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range_gchint_test.go
@@ -1,0 +1,81 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package batcheval_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteRangeTombstoneSetsGCHint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue: true,
+				DisableSplitQueue: true,
+			},
+		},
+	})
+	s := serv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+
+	key := roachpb.Key("b")
+	content := []byte("test")
+
+	repl := store.LookupReplica(roachpb.RKey(key))
+	gcHint := repl.GetGCHint()
+	require.True(t, gcHint.LatestRangeDeleteTimestamp.IsEmpty(), "gc hint should be empty by default")
+
+	pArgs := &roachpb.PutRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key: key,
+		},
+		Value: roachpb.MakeValueFromBytes(content),
+	}
+	if _, pErr := kv.SendWrapped(ctx, s.DistSender(), pArgs); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	r, err := s.LookupRange(key)
+	require.NoError(t, err, "failed to lookup range")
+
+	drArgs := &roachpb.DeleteRangeRequest{
+		UpdateRangeDeleteGCHint: true,
+		UseRangeTombstone:       true,
+		RequestHeader: roachpb.RequestHeader{
+			Key:    r.StartKey.AsRawKey(),
+			EndKey: r.EndKey.AsRawKey(),
+		},
+	}
+	if _, pErr := kv.SendWrapped(ctx, s.DistSender(), drArgs); pErr != nil {
+		t.Fatal(pErr)
+	}
+
+	gcHint = repl.GetGCHint()
+	require.True(t, !gcHint.LatestRangeDeleteTimestamp.IsEmpty(), "gc hint was not set by delete range")
+}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1082,9 +1082,12 @@ func splitTriggerHelper(
 		if gcThreshold.IsEmpty() {
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
-		gcHint, err := sl.LoadGCHint(ctx, batch)
-		if err != nil {
-			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCHint")
+		gcHint := &roachpb.GCHint{}
+		if split.WriteGCHint {
+			gcHint, err = sl.LoadGCHint(ctx, batch)
+			if err != nil {
+				return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCHint")
+			}
 		}
 
 		// Writing the initial state is subtle since this also seeds the Raft
@@ -1137,6 +1140,7 @@ func splitTriggerHelper(
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
 			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
 			*gcThreshold, *gcHint, replicaVersion, writeRaftAppliedIndexTerm,
+			split.WriteGCHint,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")
@@ -1255,11 +1259,14 @@ func mergeTrigger(
 			return result.Result{}, err
 		}
 		if lhsHint.Merge(rhsHint) {
-			if err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint); err != nil {
+			updated, err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint, merge.WriteGCHint)
+			if err != nil {
 				return result.Result{}, err
 			}
-			pd.Replicated.State = &kvserverpb.ReplicaState{
-				GCHint: lhsHint,
+			if updated {
+				pd.Replicated.State = &kvserverpb.ReplicaState{
+					GCHint: lhsHint,
+				}
 			}
 		}
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -176,6 +176,13 @@ func declareKeysEndTxn(
 				latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{
 					Key: keys.RangePriorReadSummaryKey(mt.LeftDesc.RangeID),
 				})
+				// Merge will update GC hint if set, so we need to get a write latch
+				// on the left side and we already have a read latch on RHS for
+				// replicated keys.
+				latchSpans.AddNonMVCC(spanset.SpanReadWrite, roachpb.Span{
+					Key: keys.RangeGCHintKey(mt.LeftDesc.RangeID),
+				})
+
 				// Merges need to adjust MVCC stats for merged MVCC range tombstones
 				// that straddle the ranges, by peeking to the left and right of the RHS
 				// start key. Since Prevish() is imprecise, we must also ensure we don't
@@ -1075,6 +1082,10 @@ func splitTriggerHelper(
 		if gcThreshold.IsEmpty() {
 			log.VEventf(ctx, 1, "LHS's GCThreshold of split is not set")
 		}
+		gcHint, err := sl.LoadGCHint(ctx, batch)
+		if err != nil {
+			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load GCHint")
+		}
 
 		// Writing the initial state is subtle since this also seeds the Raft
 		// group. It becomes more subtle due to proposer-evaluated Raft.
@@ -1125,7 +1136,7 @@ func splitTriggerHelper(
 		}
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
 			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
-			*gcThreshold, replicaVersion, writeRaftAppliedIndexTerm,
+			*gcThreshold, *gcHint, replicaVersion, writeRaftAppliedIndexTerm,
 		)
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to write initial Replica state")
@@ -1227,6 +1238,30 @@ func mergeTrigger(
 	var pd result.Result
 	pd.Replicated.Merge = &kvserverpb.Merge{
 		MergeTrigger: *merge,
+	}
+
+	{
+		// If we have GC hints populated that means we are trying to perform
+		// optimized garbage removal in future.
+		// We will try to merge both hints if possible and set new hint on LHS.
+		lhsLoader := MakeStateLoader(rec)
+		lhsHint, err := lhsLoader.LoadGCHint(ctx, batch)
+		if err != nil {
+			return result.Result{}, err
+		}
+		rhsLoader := stateloader.Make(merge.RightDesc.RangeID)
+		rhsHint, err := rhsLoader.LoadGCHint(ctx, batch)
+		if err != nil {
+			return result.Result{}, err
+		}
+		if lhsHint.Merge(rhsHint) {
+			if err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint); err != nil {
+				return result.Result{}, err
+			}
+			pd.Replicated.State = &kvserverpb.ReplicaState{
+				GCHint: lhsHint,
+			}
+		}
 	}
 	return pd, nil
 }

--- a/pkg/kv/kvserver/batcheval/result/result.go
+++ b/pkg/kv/kvserver/batcheval/result/result.go
@@ -250,6 +250,13 @@ func (p *Result) MergeAndDestroy(q Result) error {
 			q.Replicated.State.GCThreshold = nil
 		}
 
+		if p.Replicated.State.GCHint == nil {
+			p.Replicated.State.GCHint = q.Replicated.State.GCHint
+		} else if q.Replicated.State.GCHint != nil {
+			return errors.AssertionFailedf("conflicting GC hint")
+		}
+		q.Replicated.State.GCHint = nil
+
 		if p.Replicated.State.Version == nil {
 			p.Replicated.State.Version = q.Replicated.State.Version
 		} else if q.Replicated.State.Version != nil {

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5113,3 +5113,78 @@ func BenchmarkStoreRangeMerge(b *testing.B) {
 		}
 	}
 }
+
+// TestStoreMergeGCHint splits the range, puts range tombstones on both ranges
+// with an option to update GC hint. Captures timestamp after first range
+// tombstone is set. Merges ranges back and checks that merged hint timestamp
+// is higher than timestamp after first delete.
+func TestStoreMergeGCHint(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				DisableMergeQueue: true,
+				DisableSplitQueue: true,
+			},
+		},
+	})
+	s := serv.(*server.TestServer)
+	defer s.Stopper().Stop(ctx)
+	store, err := s.Stores().GetStore(s.GetFirstStoreID())
+	require.NoError(t, err)
+
+	leftKey := roachpb.Key("a")
+	splitKey := roachpb.Key("b")
+	rightKey := roachpb.Key("c")
+	content := []byte("test")
+
+	put := func(key roachpb.Key) {
+		pArgs := putArgs(key, content)
+		_, pErr := kv.SendWrapped(ctx, store.TestSender(), pArgs)
+		require.NoError(t, pErr.GoError(), "failed to put value")
+	}
+
+	delRange := func(key roachpb.Key) (wallTime int64) {
+		repl := store.LookupReplica(roachpb.RKey(key))
+		gcHint := repl.GetGCHint()
+		require.True(t, gcHint.IsEmpty(), "GC hint is not empty by default")
+
+		drArgs := &roachpb.DeleteRangeRequest{
+			UpdateRangeDeleteGCHint: true,
+			UseRangeTombstone:       true,
+			RequestHeader: roachpb.RequestHeader{
+				Key:    repl.Desc().StartKey.AsRawKey(),
+				EndKey: repl.Desc().EndKey.AsRawKey(),
+			},
+		}
+		_, pErr := kv.SendWrapped(ctx, store.TestSender(), drArgs)
+		require.NoError(t, pErr.GoError(), "failed to send delete range request")
+
+		return timeutil.Now().UnixNano()
+	}
+
+	splitArgs := adminSplitArgs(splitKey)
+	_, pErr := kv.SendWrapped(ctx, store.TestSender(), splitArgs)
+	require.NoError(t, pErr.GoError(), "failed to send admin split")
+
+	put(leftKey)
+	put(rightKey)
+	beforeSecondDel := delRange(leftKey)
+	delRange(rightKey)
+
+	r, err := s.LookupRange(leftKey)
+	require.NoError(t, err, "failed to lookup range")
+	mergeArgs := adminMergeArgs(r.StartKey.AsRawKey())
+	_, pErr = kv.SendWrapped(ctx, store.TestSender(), mergeArgs)
+	require.NoError(t, pErr.GoError(), "failed to send admin merge")
+
+	repl := store.LookupReplica(roachpb.RKey(leftKey))
+	gcHint := repl.GetGCHint()
+	require.False(t, gcHint.IsEmpty(), "GC hint is empty after range delete")
+	require.Greater(t, gcHint.LatestRangeDeleteTimestamp.WallTime, beforeSecondDel, "highest timestamp wasn't picked up")
+
+	repl.AssertState(ctx, store.Engine())
+}

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -138,6 +138,12 @@ message ReplicaState {
   // RangeAppliedState.RaftAppliedIndexTerm.
   uint64 raft_applied_index_term = 14;
 
+  // GCHint contains GC hint information for the replica. If hint
+  // timestamp is set that means all data in the range is expected to be
+  // garbage at that time and MVCC GC should optimize its removal together
+  // with other related ranges to reduce load on pebble.
+  roachpb.GCHint gc_hint = 15 [(gogoproto.customname) = "GCHint"];
+
   reserved 8, 9, 10;
 }
 

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -213,7 +213,7 @@ func (e *quorumRecoveryEnv) handleReplicationData(t *testing.T, d datadriven.Tes
 		}
 
 		sl := stateloader.Make(replica.RangeID)
-		if _, err := sl.Save(ctx, eng, replicaState); err != nil {
+		if _, err := sl.Save(ctx, eng, replicaState, true /* gcHintsEnabled */); err != nil {
 			t.Fatalf("failed to save raft replica state into store: %v", err)
 		}
 		if err := sl.SetHardState(ctx, eng, hardState); err != nil {

--- a/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
+++ b/pkg/kv/kvserver/loqrecovery/recovery_env_test.go
@@ -293,6 +293,7 @@ func buildReplicaDescriptorFromTestData(
 			Term:  1,
 		},
 		GCThreshold:         &hlc.Timestamp{},
+		GCHint:              &roachpb.GCHint{},
 		Version:             nil,
 		Stats:               &enginepb.MVCCStats{},
 		RaftClosedTimestamp: clock.Now().Add(-30*time.Second.Nanoseconds(), 0),

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -914,6 +914,13 @@ func (r *Replica) GetGCThreshold() hlc.Timestamp {
 	return *r.mu.state.GCThreshold
 }
 
+// GetGCHint returns the GC hint.
+func (r *Replica) GetGCHint() roachpb.GCHint {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return *r.mu.state.GCHint
+}
+
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
 func (r *Replica) ExcludeDataFromBackup() bool {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -318,6 +318,12 @@ func (r *Replica) handleGCThresholdResult(ctx context.Context, thresh *hlc.Times
 	r.mu.Unlock()
 }
 
+func (r *Replica) handleGCHintResult(ctx context.Context, hint *roachpb.GCHint) {
+	r.mu.Lock()
+	r.mu.state.GCHint = hint
+	r.mu.Unlock()
+}
+
 func (r *Replica) handleVersionResult(ctx context.Context, version *roachpb.Version) {
 	if (*version == roachpb.Version{}) {
 		log.Fatal(ctx, "not expecting empty replica version downstream of raft")

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -957,6 +957,11 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 	// serialize on the stats key.
 	deltaStats := res.Delta.ToStats()
 	b.state.Stats.Add(deltaStats)
+
+	if res.State != nil && res.State.GCHint != nil {
+		b.r.handleGCHintResult(ctx, res.State.GCHint)
+		res.State.GCHint = nil
+	}
 }
 
 // ApplyToStateMachine implements the apply.Batch interface. The method handles

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -57,6 +57,7 @@ func WriteInitialReplicaState(
 	gcHint roachpb.GCHint,
 	replicaVersion roachpb.Version,
 	writeRaftAppliedIndexTerm bool,
+	gcHintsAllowed bool,
 ) (enginepb.MVCCStats, error) {
 	rsl := Make(desc.RangeID)
 	var s kvserverpb.ReplicaState
@@ -103,7 +104,7 @@ func WriteInitialReplicaState(
 		log.Fatalf(ctx, "expected trivial version, but found %+v", existingVersion)
 	}
 
-	newMS, err := rsl.Save(ctx, readWriter, s)
+	newMS, err := rsl.Save(ctx, readWriter, s, gcHintsAllowed)
 	if err != nil {
 		return enginepb.MVCCStats{}, err
 	}
@@ -128,6 +129,7 @@ func WriteInitialRangeState(
 	if _, err := WriteInitialReplicaState(
 		ctx, readWriter, initialMS, desc, initialLease, initialGCThreshold, initialGCHint,
 		replicaVersion, true, /* 22.1:AddRaftAppliedIndexTermMigration */
+		true, /* 22.2: GCHintInReplicaState */
 	); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -54,6 +54,7 @@ func WriteInitialReplicaState(
 	desc roachpb.RangeDescriptor,
 	lease roachpb.Lease,
 	gcThreshold hlc.Timestamp,
+	gcHint roachpb.GCHint,
 	replicaVersion roachpb.Version,
 	writeRaftAppliedIndexTerm bool,
 ) (enginepb.MVCCStats, error) {
@@ -73,6 +74,7 @@ func WriteInitialReplicaState(
 	s.Stats = &ms
 	s.Lease = &lease
 	s.GCThreshold = &gcThreshold
+	s.GCHint = &gcHint
 	if (replicaVersion != roachpb.Version{}) {
 		s.Version = &replicaVersion
 	}
@@ -87,6 +89,12 @@ func WriteInitialReplicaState(
 		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading GCThreshold")
 	} else if !existingGCThreshold.IsEmpty() {
 		log.Fatalf(ctx, "expected trivial GCthreshold, but found %+v", existingGCThreshold)
+	}
+
+	if existingGCHint, err := rsl.LoadGCHint(ctx, readWriter); err != nil {
+		return enginepb.MVCCStats{}, errors.Wrap(err, "error reading GCHint")
+	} else if !existingGCHint.IsEmpty() {
+		return enginepb.MVCCStats{}, errors.AssertionFailedf("expected trivial GCHint, but found %+v", existingGCHint)
 	}
 
 	if existingVersion, err := rsl.LoadVersion(ctx, readWriter); err != nil {
@@ -114,10 +122,11 @@ func WriteInitialRangeState(
 ) error {
 	initialLease := roachpb.Lease{}
 	initialGCThreshold := hlc.Timestamp{}
+	initialGCHint := roachpb.GCHint{}
 	initialMS := enginepb.MVCCStats{}
 
 	if _, err := WriteInitialReplicaState(
-		ctx, readWriter, initialMS, desc, initialLease, initialGCThreshold,
+		ctx, readWriter, initialMS, desc, initialLease, initialGCThreshold, initialGCHint,
 		replicaVersion, true, /* 22.1:AddRaftAppliedIndexTermMigration */
 	); err != nil {
 		return err

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1313,6 +1313,7 @@ func SendEmptySnapshot(
 		desc,
 		roachpb.Lease{},
 		hlc.Timestamp{}, // gcThreshold
+		roachpb.GCHint{},
 		st.Version.ActiveVersionOrEmpty(ctx).Version,
 		true, /* 22.1:AddRaftAppliedIndexTermMigration */
 	)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -1299,13 +1300,18 @@ func SendEmptySnapshot(
 		return err
 	}
 
+	supportsGCHints := st.Version.IsActive(ctx, clusterversion.GCHintInReplicaState)
 	// SendEmptySnapshot is only used by the cockroach debug reset-quorum tool.
 	// It is experimental and unlikely to be used in cluster versions that are
-	// older than AddRaftAppliedIndexTermMigration. We do not want the cluster
-	// version to fully dictate the value of the writeAppliedIndexTerm
-	// parameter, since if this node's view of the version is stale we could
-	// regress to a state before the migration. Instead, we return an error if
-	// the cluster version is old.
+	// older than GCHintInReplicaState. We do not want the cluster version to
+	// fully dictate the value of the supportsGCHints parameter, since if this
+	// node's view of the version is stale we could regress to a state before the
+	// migration. Instead, we return an error if the cluster version is old.
+	if !supportsGCHints {
+		return errors.Errorf("cluster version is too old %s",
+			st.Version.ActiveVersionOrEmpty(ctx))
+	}
+
 	ms, err = stateloader.WriteInitialReplicaState(
 		ctx,
 		eng,
@@ -1315,7 +1321,8 @@ func SendEmptySnapshot(
 		hlc.Timestamp{}, // gcThreshold
 		roachpb.GCHint{},
 		st.Version.ActiveVersionOrEmpty(ctx).Version,
-		true, /* 22.1:AddRaftAppliedIndexTermMigration */
+		true,            /* 22.1:AddRaftAppliedIndexTermMigration */
+		supportsGCHints, /* 22.2: GCHintInReplicaState */
 	)
 	if err != nil {
 		return err

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -385,6 +385,10 @@ message DeleteRangeRequest {
   // considers empty spans equivalent to being covered by an MVCC range
   // tombstone, so it will omit the write across an entirely empty span too.
   bool idempotent_tombstone = 7;
+  // If enabled and DeleteRangeRequest is deleting the whole range with a range
+  // tombstone, GCHint on replica will be updated to notify mvcc gc queue
+  // that this range would benefit from optimized GC process.
+  bool update_range_delete_gc_hint = 8 [(gogoproto.customname) = "UpdateRangeDeleteGCHint"];
 
   DeleteRangePredicates predicates = 6 [(gogoproto.nullable) = false];
 }

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -128,6 +128,13 @@ message SplitTrigger {
 
   RangeDescriptor left_desc = 1 [(gogoproto.nullable) = false];
   RangeDescriptor right_desc = 2 [(gogoproto.nullable) = false];
+
+  // WriteGCHint is a version gate to only enable writing GC hints in split
+  // trigger if cluster was upgraded to required version.
+  // TODO(replication): remove this field in the 23.2 cycle (i.e. on master
+  // after 23.1 has been cut).
+  bool write_gc_hint = 4 [(gogoproto.customname) = "WriteGCHint"];
+
   reserved 3;
 }
 
@@ -204,6 +211,12 @@ message MergeTrigger {
   // ensuring correctness in the case where the merge is applied on the LHS's
   // leaseholder through a Raft snapshot.
   kv.kvserver.readsummary.ReadSummary right_read_summary = 7;
+
+  // WriteGCHint is a version gate to only enable writing GC hints in merge
+  // trigger if cluster was upgraded to required version.
+  // TODO(replication): remove this field in the 23.2 cycle (i.e. on master after
+  // 23.1 has been cut).
+  bool write_gc_hint = 8 [(gogoproto.customname) = "WriteGCHint"];
 }
 
 // ReplicaChangeType is a parameter of ChangeReplicasTrigger.

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -787,6 +788,16 @@ func (h *GCHint) Merge(rhs *GCHint) bool {
 		// If right hand side of merge is higher, then use its timestamp and signal
 		// the change to caller.
 		h.LatestRangeDeleteTimestamp = rhs.LatestRangeDeleteTimestamp
+		return true
+	}
+	return false
+}
+
+// ForwardLatestRangeDeleteTimestamp bumps LatestDeleteRangeTimestamp in GC hint
+// if it is greater than previously set.
+func (h *GCHint) ForwardLatestRangeDeleteTimestamp(ts hlc.Timestamp) bool {
+	if h.LatestRangeDeleteTimestamp.Less(ts) {
+		h.LatestRangeDeleteTimestamp = ts
 		return true
 	}
 	return false

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -773,3 +773,21 @@ func (l Locality) AddTier(tier Tier) Locality {
 	}
 	return Locality{Tiers: []Tier{tier}}
 }
+
+// IsEmpty returns true if hint contains no data.
+func (h *GCHint) IsEmpty() bool {
+	return h.LatestRangeDeleteTimestamp.IsEmpty()
+}
+
+// Merge forwards latest delete timestamp of the receiver (lhs) with timestamp of
+// argument (rhs).
+// Returns true if receiver state was changed.
+func (h *GCHint) Merge(rhs *GCHint) bool {
+	if h.LatestRangeDeleteTimestamp.Less(rhs.LatestRangeDeleteTimestamp) {
+		// If right hand side of merge is higher, then use its timestamp and signal
+		// the change to caller.
+		h.LatestRangeDeleteTimestamp = rhs.LatestRangeDeleteTimestamp
+		return true
+	}
+	return false
+}

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -451,3 +451,12 @@ message Version {
   // internal version set to 0.
   optional int32 internal = 4 [(gogoproto.nullable) = false];
 }
+
+// GCHint contains information that MVCC GC could use to optimize data deletion.
+message GCHint {
+  option (gogoproto.equal) = true;
+
+  // LatestRangeDeleteTimestamp indicates timestamp at which all data was deleted
+  // in the range using a range tombstone. No such delete happened if empty.
+  optional util.hlc.Timestamp latest_range_delete_timestamp = 1 [(gogoproto.nullable) = false];
+}


### PR DESCRIPTION
This commit adds a test that peforms range split and merge during
cluster upgrade. This is covering test cases where raft state gets
additional information in new versions and we must ensure that
replicas don't diverge in the process of upgrade.

Release justification: Commit adds extra tests only.
Release note: None

----

When cmd_delete_range deletes the whole range it can give a GC hint so
that mvcc gc could optimize large number ranges that would be collected
using gc clear range requests.
Processing those requests together in a quick succession would reduce
compaction load on pebble.

Release justification: This change is safe as it adds handling for the new
type of request that doesn't interact with any existing functionality.
Release note: None

----

This commit adds a version gate GCHintInReplicaState for GC Hint. This
is needed to avoid divergence of replicas when older followers don't yet 
update state with a new field value.

Release justification: This commit adds a version gate for a new feature
Release note: None

----

This commit adds a gc hint field to replica state that is backed by a
replicated range local key. This field could be set explicitly by client
to indicate that all data in the range is ripe for deletion at hint
timestamp. MVCC GC could use this information to optimize clear range
requests.

Release justification: this commit is safe because it adds a new request
type and a new status field that doesn't interfere with existing
functionality.
Release note: None