### PR TITLE
opt: make colset check a test-build-only check

### DIFF
--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -50,7 +50,7 @@ func MakeColSet(vals ...ColumnID) ColSet {
 
 // Add adds a column to the set. No-op if the column is already in the set.
 func (s *ColSet) Add(col ColumnID) {
-	if col <= 0 {
+	if buildutil.CrdbTestBuild && col <= 0 {
 		panic(errors.AssertionFailedf("col must be greater than 0"))
 	}
 	s.set.Add(setVal(col))

--- a/pkg/sql/opt/colset.go
+++ b/pkg/sql/opt/colset.go
@@ -29,12 +29,14 @@ type ColSet struct {
 const offset = 1
 
 // setVal returns the value to store in the internal set for the given ColumnID.
+//gcassert:inline
 func setVal(col ColumnID) int {
 	return int(col - offset)
 }
 
 // retVal returns the ColumnID to return for the given value in the internal
 // set.
+//gcassert:inline
 func retVal(i int) ColumnID {
 	return ColumnID(i + offset)
 }

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2030,6 +2030,7 @@ func TestLint(t *testing.T) {
 			"../../sql/colexec/colexecspan",
 			"../../sql/colexec/colexecwindow",
 			"../../sql/colfetcher",
+			"../../sql/opt",
 			"../../sql/row",
 			"../../kv/kvclient/rangecache",
 			"../../storage",

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -64,7 +64,7 @@ func UnderDeadlockWithIssue(t SkippableTest, githubIssueID int, args ...interfac
 	t.Helper()
 	if syncutil.DeadlockEnabled {
 		t.Skip(append([]interface{}{fmt.Sprintf(
-			"disabled under deadlock detector. issue: https://github.com/cockroachdb/cockroach/issue/%d",
+			"disabled under deadlock detector. issue: https://github.com/cockroachdb/cockroach/issues/%d",
 			githubIssueID,
 		)}, args...))
 	}
@@ -84,7 +84,7 @@ func UnderRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{})
 	t.Helper()
 	if util.RaceEnabled {
 		t.Skip(append([]interface{}{fmt.Sprintf(
-			"disabled under race. issue: https://github.com/cockroachdb/cockroach/issue/%d", githubIssueID,
+			"disabled under race. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
 		)}, args...))
 	}
 }
@@ -95,7 +95,7 @@ func UnderBazelWithIssue(t SkippableTest, githubIssueID int, args ...interface{}
 	t.Helper()
 	if bazel.BuiltWithBazel() {
 		t.Skip(append([]interface{}{fmt.Sprintf(
-			"disabled under bazel. issue: https://github.com/cockroachdb/cockroach/issue/%d", githubIssueID,
+			"disabled under bazel. issue: https://github.com/cockroachdb/cockroach/issues/%d", githubIssueID,
 		)}, args...))
 	}
 }


### PR DESCRIPTION
#### opt: make colset check a test-build-only check

There isn't a convincing reason to make the `col >= 0` check in
`ColSet.Add` run in non-test builds. It's now a test-only build. Without
the panic, it may be inlined in more cases.

Release note: None

Release justification: This is a very low risk change.

#### opt: add inline assertion for ColSet.setVal and ColSet.retVal

Release note: None

Release justification: This is a lint-only change.

#### testutils/skip: fix broken github links

Release note: None

Release justification: This is a test-only change.
