### PR TITLE
scbuild, rules: rewrite index handling in scbuild, fix bugs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1414,7 +1414,7 @@ CREATE TABLE public.t (
    k INT8 NOT NULL AS (i + 3:::INT8) STORED,
    j INT8 NULL DEFAULT 42:::INT8,
    CONSTRAINT t_pkey PRIMARY KEY (i ASC),
-   UNIQUE INDEX t_expr_key (k ASC)
+   UNIQUE INDEX t_k_key (k ASC)
 )
 
 query III rowsort

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -168,6 +168,7 @@ func AlterTable(b BuildCtx, n *tree.AlterTable) {
 		if !ok {
 			panic(scerrors.NotImplementedError(n))
 		}
+		b.IncrementSchemaChangeAlterCounter("table", cmd.TelemetryName())
 		// Invoke the callback function, with the concrete types.
 		fn := reflect.ValueOf(info.fn)
 		fn.Call([]reflect.Value{

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_alter_primary_key
@@ -1,5 +1,7 @@
 setup
-CREATE TABLE defaultdb.foo (i INT PRIMARY KEY, j INT NOT NULL);
+CREATE TABLE defaultdb.foo (i INT NOT NULL, j INT NOT NULL, CONSTRAINT pkey PRIMARY KEY (i));
+COMMENT ON INDEX pkey IS 'pkey is an index';
+COMMENT ON CONSTRAINT pkey ON defaultdb.foo IS 'pkey is a constraint';
 CREATE TABLE defaultdb.bar (i INT NOT NULL);
 ----
 
@@ -12,16 +14,24 @@ ALTER TABLE defaultdb.foo ALTER PRIMARY KEY USING COLUMNS (j)
   {columnId: 2, indexId: 1, kind: STORED, tableId: 104}
 - [[PrimaryIndex:{DescID: 104, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC]
   {constraintId: 1, indexId: 1, isUnique: true, tableId: 104}
-- [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 1}, ABSENT], PUBLIC]
-  {indexId: 1, name: foo_pkey, tableId: 104}
+- [[IndexName:{DescID: 104, Name: pkey, IndexID: 1}, ABSENT], PUBLIC]
+  {indexId: 1, name: pkey, tableId: 104}
+- [[IndexComment:{DescID: 104, IndexID: 1, Comment: pkey is an index}, ABSENT], PUBLIC]
+  {comment: pkey is an index, indexId: 1, tableId: 104}
+- [[ConstraintComment:{DescID: 104, ConstraintID: 1, Comment: pkey is a constraint}, ABSENT], PUBLIC]
+  {comment: pkey is a constraint, constraintId: 1, tableId: 104}
 - [[PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC], ABSENT]
   {constraintId: 2, indexId: 2, isUnique: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
-- [[IndexName:{DescID: 104, Name: foo_pkey, IndexID: 2}, PUBLIC], ABSENT]
-  {indexId: 2, name: foo_pkey, tableId: 104}
+- [[IndexName:{DescID: 104, Name: pkey, IndexID: 2}, PUBLIC], ABSENT]
+  {indexId: 2, name: pkey, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT]
   {columnId: 2, indexId: 2, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 2, kind: STORED, tableId: 104}
+- [[IndexComment:{DescID: 104, IndexID: 2, Comment: pkey is an index}, PUBLIC], ABSENT]
+  {comment: pkey is an index, indexId: 2, tableId: 104}
+- [[ConstraintComment:{DescID: 104, ConstraintID: 2, Comment: pkey is a constraint}, PUBLIC], ABSENT]
+  {comment: pkey is a constraint, constraintId: 2, tableId: 104}
 - [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
   {constraintId: 3, indexId: 3, isUnique: true, sourceIndexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
@@ -8,6 +8,7 @@ CREATE TABLE defaultdb.t (
     INDEX (j),
     INDEX (j, k)
 );
+COMMENT ON COLUMN defaultdb.t.j IS 'column will drop';
 ----
 
 build
@@ -21,6 +22,8 @@ ALTER TABLE defaultdb.t DROP COLUMN j
   {columnId: 2, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}}
 - [[ColumnDefaultExpression:{DescID: 104, ColumnID: 2}, ABSENT], PUBLIC]
   {columnId: 2, expr: '42:::INT8', tableId: 104}
+- [[ColumnComment:{DescID: 104, ColumnID: 2, Comment: column will drop}, ABSENT], PUBLIC]
+  {columnId: 2, comment: column will drop, pgAttributeNum: 2, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC]
   {columnId: 1, indexId: 1, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC]

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -552,6 +552,17 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 	} else if err != nil {
 		panic(err)
 	}
+	if constraintID := idx.GetConstraintID(); constraintID != 0 {
+		if comment, ok, err := w.commentCache.GetConstraintComment(w.ctx, tbl.GetID(), constraintID); err == nil && ok {
+			w.ev(scpb.Status_PUBLIC, &scpb.ConstraintComment{
+				TableID:      tbl.GetID(),
+				ConstraintID: constraintID,
+				Comment:      comment,
+			})
+		} else if err != nil {
+			panic(err)
+		}
+	}
 }
 
 func (w *walkCtx) walkUniqueWithoutIndexConstraint(

--- a/pkg/sql/schemachanger/scdecomp/dependencies.go
+++ b/pkg/sql/schemachanger/scdecomp/dependencies.go
@@ -26,23 +26,23 @@ type CommentGetter interface {
 	GetDatabaseComment(ctx context.Context, dbID catid.DescID) (comment string, ok bool, err error)
 
 	// GetSchemaComment returns comment for a schema. `ok` returned indicates if
-	// the 	// comment actually exists or not.
+	// the comment actually exists or not.
 	GetSchemaComment(ctx context.Context, schemaID catid.DescID) (comment string, ok bool, err error)
 
 	// GetTableComment returns comment for a table. `ok` returned indicates if the
-	// 	// comment actually exists or not.
+	// comment actually exists or not.
 	GetTableComment(ctx context.Context, tableID catid.DescID) (comment string, ok bool, err error)
 
 	// GetColumnComment returns comment for a column. `ok` returned indicates if
-	// the 	// comment actually exists or not.
+	// the comment actually exists or not.
 	GetColumnComment(ctx context.Context, tableID catid.DescID, pgAttrNum catid.PGAttributeNum) (comment string, ok bool, err error)
 
 	// GetIndexComment returns comment for an index. `ok` returned indicates if
-	// the 	// comment actually exists or not.
+	// the comment actually exists or not.
 	GetIndexComment(ctx context.Context, tableID catid.DescID, indexID catid.IndexID) (comment string, ok bool, err error)
 
 	// GetConstraintComment returns comment for a constraint. `ok` returned
-	// indicates if the 	// comment actually exists or not.
+	// indicates if the comment actually exists or not.
 	GetConstraintComment(ctx context.Context, tableID catid.DescID, constraintID catid.ConstraintID) (comment string, ok bool, err error)
 }
 

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -12,6 +12,7 @@ COMMENT ON INDEX tbl@tbl_pkey IS 'tbl_pkey is a primary key';
 COMMENT ON COLUMN tbl.id IS 'id is a identifier';
 COMMENT ON CONSTRAINT myfk ON tbl IS 'must have a parent';
 ALTER TABLE tbl CONFIGURE ZONE USING gc.ttlseconds=10;
+COMMENT ON CONSTRAINT tbl_pkey ON tbl IS 'primary key';
 ----
 
 decompose
@@ -551,6 +552,11 @@ ElementState:
 - ConstraintComment:
     comment: must have a parent
     constraintId: 2
+    tableId: 105
+  Status: PUBLIC
+- ConstraintComment:
+    comment: primary key
+    constraintId: 1
     tableId: 105
   Status: PUBLIC
 - Namespace:

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -5,9 +5,11 @@ go_library(
     name = "rules",
     srcs = [
         "dep_add_column.go",
+        "dep_add_constraint.go",
         "dep_add_index.go",
         "dep_add_index_and_column.go",
         "dep_drop_column.go",
+        "dep_drop_constraint.go",
         "dep_drop_index.go",
         "dep_drop_index_and_column.go",
         "dep_drop_object.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_add_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_add_constraint.go
@@ -1,0 +1,36 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rules
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+// These rules ensure that constraint-dependent elements, like a constraint's
+// name, etc. appear once the constraint reaches a suitable state.
+func init() {
+
+	registerDepRule(
+		"constraint dependent public right before constraint",
+		scgraph.SameStagePrecedence,
+		"constraint", "dependent",
+		func(from, to nodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.typeFilter(isConstraint),
+				to.typeFilter(isConstraintDependent),
+				joinOnConstraintID(from, to, "table-id", "constraint-id"),
+				statusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_constraint.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_constraint.go
@@ -1,0 +1,50 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package rules
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+)
+
+// These rules ensure that constraint-dependent elements, like an constraint's
+// name, etc. disappear once the constraint reaches a suitable state.
+func init() {
+
+	registerDepRuleForDrop(
+		"constraint dependent absent right before constraint",
+		scgraph.SameStagePrecedence,
+		"dependent", "constraint",
+		scpb.Status_ABSENT, scpb.Status_ABSENT,
+		func(from, to nodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.typeFilter(isConstraintDependent),
+				to.typeFilter(isConstraint, not(isIndex)),
+				joinOnConstraintID(from, to, "table-id", "constraint-id"),
+			}
+		},
+	)
+
+	registerDepRuleForDrop(
+		"constraint dependent absent right before constraint",
+		scgraph.SameStagePrecedence,
+		"dependent", "constraint",
+		scpb.Status_VALIDATED, scpb.Status_ABSENT,
+		func(from, to nodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.typeFilter(isConstraintDependent),
+				to.typeFilter(isConstraint, isIndex),
+				joinOnConstraintID(from, to, "table-id", "constraint-id"),
+			}
+		},
+	)
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -385,6 +385,32 @@ func isIndexDependent(e scpb.Element) bool {
 	return false
 }
 
+func isConstraint(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.PrimaryIndex, *scpb.SecondaryIndex, *scpb.TemporaryIndex:
+		return true
+	case *scpb.CheckConstraint, *scpb.UniqueWithoutIndexConstraint, *scpb.ForeignKeyConstraint:
+		return true
+	}
+	return false
+}
+
+func isConstraintDependent(e scpb.Element) bool {
+	switch e.(type) {
+	case *scpb.ConstraintName:
+		return true
+	case *scpb.ConstraintComment:
+		return true
+	}
+	return false
+}
+
+func not(predicate func(e scpb.Element) bool) func(e scpb.Element) bool {
+	return func(e scpb.Element) bool {
+		return !predicate(e)
+	}
+}
+
 // registerDepRuleForDrop is a convenience function which calls
 // registerDepRule with the cross-product of (ToAbsent,Transient)^2 target
 // states, which can't easily be composed.

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -151,10 +151,9 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - $column-target[TargetStatus] = ABSENT
+    - toAbsent($column-target, $dependent-target)
     - $column-node[CurrentStatus] = WRITE_ONLY
-    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
-    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
     - joinTargetNode($column, $column-target, $column-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: column no longer public before dependents
@@ -179,8 +178,9 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - transient($column-target, $dependent-target)
-    - $column-node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - $column-target[TargetStatus] = ABSENT
+    - $column-node[CurrentStatus] = WRITE_ONLY
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
     - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($column, $column-target, $column-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
@@ -192,9 +192,9 @@ deprules
     - $column[Type] = '*scpb.Column'
     - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
     - joinOnColumnID($column, $dependent, $table-id, $col-id)
-    - toAbsent($column-target, $dependent-target)
-    - $column-node[CurrentStatus] = WRITE_ONLY
-    - $dependent-node[CurrentStatus] = ABSENT
+    - transient($column-target, $dependent-target)
+    - $column-node[CurrentStatus] = TRANSIENT_WRITE_ONLY
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($column, $column-target, $column-node)
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
 - name: column type dependents removed right before column type
@@ -224,6 +224,141 @@ deprules
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
     - joinTargetNode($column-type, $column-type-target, $column-type-node)
     - joinTargetNode($column, $column-target, $column-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - toAbsent($dependent-target, $constraint-target)
+    - $dependent-node[CurrentStatus] = VALIDATED
+    - $constraint-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - toAbsent($dependent-target, $constraint-target)
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $constraint-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - transient($dependent-target, $constraint-target)
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $constraint-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $constraint-target[TargetStatus] = ABSENT
+    - $constraint-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $constraint-target[TargetStatus] = TRANSIENT_ABSENT
+    - $constraint-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - transient($dependent-target, $constraint-target)
+    - $dependent-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $constraint-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = TRANSIENT_ABSENT
+    - $dependent-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $constraint-target[TargetStatus] = ABSENT
+    - $constraint-node[CurrentStatus] = ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent absent right before constraint
+  from: dependent-node
+  kind: SameStagePrecedence
+  to: constraint-node
+  query:
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
+    - joinOnConstraintID($dependent, $constraint, $table-id, $constraint-id)
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = VALIDATED
+    - $constraint-target[TargetStatus] = TRANSIENT_ABSENT
+    - $constraint-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+- name: constraint dependent public right before constraint
+  from: constraint-node
+  kind: SameStagePrecedence
+  to: dependent-node
+  query:
+    - $constraint[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex', '*scpb.UniqueWithoutIndexConstraint', '*scpb.CheckConstraint', '*scpb.ForeignKeyConstraint']
+    - $dependent[Type] IN ['*scpb.ConstraintName', '*scpb.ConstraintComment']
+    - joinOnConstraintID($constraint, $dependent, $table-id, $constraint-id)
+    - toPublicOrTransient($constraint-target, $dependent-target)
+    - $constraint-node[CurrentStatus] = PUBLIC
+    - $dependent-node[CurrentStatus] = PUBLIC
+    - joinTargetNode($constraint, $constraint-target, $constraint-node)
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+- name: dependents removed before column
+  from: dependent-node
+  kind: Precedence
+  to: column-node
+  query:
+    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
+    - $column[Type] = '*scpb.Column'
+    - joinOnColumnID($dependent, $column, $table-id, $col-id)
+    - $dependent-target[TargetStatus] = ABSENT
+    - $dependent-node[CurrentStatus] = ABSENT
+    - $column-target[TargetStatus] = TRANSIENT_ABSENT
+    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - joinTargetNode($dependent, $dependent-target, $dependent-node)
+    - joinTargetNode($column, $column-target, $column-node)
 - name: dependents removed before column
   from: dependent-node
   kind: Precedence
@@ -247,20 +382,6 @@ deprules
     - joinOnColumnID($dependent, $column, $table-id, $col-id)
     - transient($dependent-target, $column-target)
     - $dependent-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
-    - joinTargetNode($dependent, $dependent-target, $dependent-node)
-    - joinTargetNode($column, $column-target, $column-node)
-- name: dependents removed before column
-  from: dependent-node
-  kind: Precedence
-  to: column-node
-  query:
-    - $dependent[Type] IN ['*scpb.ColumnName', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SequenceOwner', '*scpb.ColumnComment', '*scpb.IndexColumn']
-    - $column[Type] = '*scpb.Column'
-    - joinOnColumnID($dependent, $column, $table-id, $col-id)
-    - $dependent-target[TargetStatus] = ABSENT
-    - $dependent-node[CurrentStatus] = ABSENT
-    - $column-target[TargetStatus] = TRANSIENT_ABSENT
     - $column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($dependent, $dependent-target, $dependent-node)
     - joinTargetNode($column, $column-target, $column-node)
@@ -578,10 +699,9 @@ deprules
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - joinOnColumnID($index-column, $column-type, $table-id, $column-id)
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
-    - $index-target[TargetStatus] = TRANSIENT_ABSENT
+    - transient($index-target, $column-target)
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-target[TargetStatus] = ABSENT
-    - $column-node[CurrentStatus] = ABSENT
+    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: indexes containing column reach absent before column
@@ -596,9 +716,10 @@ deprules
     - joinOnColumnID($index-column, $column, $table-id, $column-id)
     - joinOnColumnID($index-column, $column-type, $table-id, $column-id)
     - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
-    - transient($index-target, $column-target)
+    - $index-target[TargetStatus] = TRANSIENT_ABSENT
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $column-target[TargetStatus] = ABSENT
+    - $column-node[CurrentStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: old index absent before new index public when swapping with transient
@@ -630,10 +751,23 @@ deprules
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - $partial-predicate-target[TargetStatus] = TRANSIENT_ABSENT
-    - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-target[TargetStatus] = ABSENT
+    - toAbsent($partial-predicate-target, $index-target)
+    - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
+    - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
+    - joinTargetNode($index, $index-target, $index-node)
+- name: partial predicate removed right before secondary index when not dropping relation
+  from: partial-predicate-node
+  kind: SameStagePrecedence
+  to: index-node
+  query:
+    - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - $index[Type] = '*scpb.SecondaryIndex'
+    - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
+    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
+    - transient($partial-predicate-target, $index-target)
+    - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: partial predicate removed right before secondary index when not dropping relation
@@ -660,23 +794,10 @@ deprules
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
     - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - toAbsent($partial-predicate-target, $index-target)
-    - $partial-predicate-node[CurrentStatus] = ABSENT
-    - $index-node[CurrentStatus] = ABSENT
-    - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
-    - joinTargetNode($index, $index-target, $index-node)
-- name: partial predicate removed right before secondary index when not dropping relation
-  from: partial-predicate-node
-  kind: SameStagePrecedence
-  to: index-node
-  query:
-    - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
-    - $index[Type] = '*scpb.SecondaryIndex'
-    - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
-    - transient($partial-predicate-target, $index-target)
+    - $partial-predicate-target[TargetStatus] = TRANSIENT_ABSENT
     - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
-    - $index-node[CurrentStatus] = TRANSIENT_ABSENT
+    - $index-target[TargetStatus] = ABSENT
+    - $index-node[CurrentStatus] = ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-target, $partial-predicate-node)
     - joinTargetNode($index, $index-target, $index-node)
 - name: primary index swap
@@ -689,8 +810,8 @@ deprules
     - joinOnDescID($old-index, $new-index, $table-id)
     - $old-index[IndexID] = $old-index-id
     - $new-index[SourceIndexID] = $old-index-id
-    - $old-index-target[TargetStatus] = ABSENT
-    - $old-index-node[CurrentStatus] = VALIDATED
+    - $old-index-target[TargetStatus] = TRANSIENT_ABSENT
+    - $old-index-node[CurrentStatus] = TRANSIENT_VALIDATED
     - $new-index-target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $new-index-node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-index, $old-index-target, $old-index-node)
@@ -705,8 +826,8 @@ deprules
     - joinOnDescID($old-index, $new-index, $table-id)
     - $old-index[IndexID] = $old-index-id
     - $new-index[SourceIndexID] = $old-index-id
-    - $old-index-target[TargetStatus] = TRANSIENT_ABSENT
-    - $old-index-node[CurrentStatus] = TRANSIENT_VALIDATED
+    - $old-index-target[TargetStatus] = ABSENT
+    - $old-index-node[CurrentStatus] = VALIDATED
     - $new-index-target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
     - $new-index-node[CurrentStatus] = PUBLIC
     - joinTargetNode($old-index, $old-index-target, $old-index-node)
@@ -765,9 +886,9 @@ deprules
     - $index[Type] = '*scpb.IndexColumn'
     - $index-column[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - toAbsent($index-target, $index-column-target)
-    - $index-node[CurrentStatus] = DELETE_ONLY
-    - $index-column-node[CurrentStatus] = ABSENT
+    - transient($index-target, $index-column-target)
+    - $index-node[CurrentStatus] = TRANSIENT_DELETE_ONLY
+    - $index-column-node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
 - name: remove columns from index right before removing index
@@ -778,9 +899,9 @@ deprules
     - $index[Type] = '*scpb.IndexColumn'
     - $index-column[Type] IN ['*scpb.PrimaryIndex', '*scpb.SecondaryIndex', '*scpb.TemporaryIndex']
     - joinOnIndexID($index, $index-column, $table-id, $index-id)
-    - transient($index-target, $index-column-target)
-    - $index-node[CurrentStatus] = TRANSIENT_DELETE_ONLY
-    - $index-column-node[CurrentStatus] = TRANSIENT_ABSENT
+    - toAbsent($index-target, $index-column-target)
+    - $index-node[CurrentStatus] = DELETE_ONLY
+    - $index-column-node[CurrentStatus] = ABSENT
     - joinTargetNode($index, $index-target, $index-node)
     - joinTargetNode($index-column, $index-column-target, $index-column-node)
 - name: remove columns from index right before removing index

--- a/pkg/sql/schemachanger/scplan/testdata/drop_index
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_index
@@ -387,13 +387,13 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 6 MutationType ops
     *scop.MakeDroppedColumnDeleteOnly
       ColumnID: 5
       TableID: 104
-    *scop.RemoveCheckConstraint
-      ConstraintID: 2
-      TableID: 104
     *scop.NotImplemented
       ElementType: scpb.ConstraintName
     *scop.MakeDroppedIndexDeleteOnly
       IndexID: 6
+      TableID: 104
+    *scop.RemoveCheckConstraint
+      ConstraintID: 2
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -476,6 +476,10 @@ DROP INDEX idx3 CASCADE
   to:   [Column:{DescID: 104, ColumnID: 5}, ABSENT]
   kind: SameStagePrecedence
   rules: [dependents removed before column; column type removed right before column when not dropping relation]
+- from: [ConstraintName:{DescID: 104, Name: check_crdb_internal_i_shard_16, ConstraintID: 2}, ABSENT]
+  to:   [CheckConstraint:{DescID: 104, ConstraintID: 2}, ABSENT]
+  kind: SameStagePrecedence
+  rule: constraint dependent absent right before constraint
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 6}, ABSENT]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 6, ConstraintID: 0}, ABSENT]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -214,20 +214,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 32 MutationType ops
       TypeIDs:
       - 107
       - 108
-    *scop.RemoveForeignKeyBackReference
-      OriginConstraintID: 2
-      OriginTableID: 109
-      ReferencedTableID: 104
-    *scop.RemoveForeignKeyConstraint
-      ConstraintID: 2
-      TableID: 109
-    *scop.RemoveForeignKeyBackReference
-      OriginConstraintID: 3
-      OriginTableID: 109
-      ReferencedTableID: 105
-    *scop.RemoveForeignKeyConstraint
-      ConstraintID: 3
-      TableID: 109
     *scop.MarkDescriptorAsDropped
       DescID: 110
     *scop.RemoveAllTableComments
@@ -252,6 +238,20 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 32 MutationType ops
       TableID: 109
     *scop.RemoveOwnerBackReferenceInSequence
       SequenceID: 110
+    *scop.RemoveForeignKeyBackReference
+      OriginConstraintID: 2
+      OriginTableID: 109
+      ReferencedTableID: 104
+    *scop.RemoveForeignKeyConstraint
+      ConstraintID: 2
+      TableID: 109
+    *scop.RemoveForeignKeyBackReference
+      OriginConstraintID: 3
+      OriginTableID: 109
+      ReferencedTableID: 105
+    *scop.RemoveForeignKeyConstraint
+      ConstraintID: 3
+      TableID: 109
     *scop.DrainDescriptorName
       Namespace:
         DatabaseID: 100
@@ -754,6 +754,18 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [Column:{DescID: 111, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
+- from: [ConstraintComment:{DescID: 109, ConstraintID: 2, Comment: customer is not god}, ABSENT]
+  to:   [ForeignKeyConstraint:{DescID: 109, ConstraintID: 2, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: constraint dependent absent right before constraint
+- from: [ConstraintName:{DescID: 109, Name: fk_customers, ConstraintID: 2}, ABSENT]
+  to:   [ForeignKeyConstraint:{DescID: 109, ConstraintID: 2, ReferencedDescID: 104}, ABSENT]
+  kind: SameStagePrecedence
+  rule: constraint dependent absent right before constraint
+- from: [ConstraintName:{DescID: 109, Name: fk_orders, ConstraintID: 3}, ABSENT]
+  to:   [ForeignKeyConstraint:{DescID: 109, ConstraintID: 3, ReferencedDescID: 105}, ABSENT]
+  kind: SameStagePrecedence
+  rule: constraint dependent absent right before constraint
 - from: [IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 1}, ABSENT]
   to:   [Column:{DescID: 109, ColumnID: 1}, ABSENT]
   kind: Precedence
@@ -1311,6 +1323,12 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
       TypeIDs:
       - 112
       - 113
+    *scop.DrainDescriptorName
+      Namespace:
+        DatabaseID: 100
+        DescriptorID: 114
+        Name: greeter
+        SchemaID: 101
     *scop.RemoveCheckConstraint
       ConstraintID: 2
       TableID: 114
@@ -1319,12 +1337,6 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 16 MutationType ops
       TypeIDs:
       - 112
       - 113
-    *scop.DrainDescriptorName
-      Namespace:
-        DatabaseID: 100
-        DescriptorID: 114
-        Name: greeter
-        SchemaID: 101
     *scop.SetJobStateOnDescriptor
       DescriptorID: 112
     *scop.SetJobStateOnDescriptor

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid
@@ -11,6 +11,7 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_constraint
 ## StatementPhase stage 1 of 1 with 11 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid
@@ -11,6 +11,7 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.alter_primary_key
 ## StatementPhase stage 1 of 1 with 11 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -12,6 +12,7 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.alter_primary_key
 ## StatementPhase stage 1 of 1 with 12 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain/drop_index_hash_sharded_index
@@ -36,9 +36,9 @@ Schema change plan for DROP INDEX ‹defaultdb›.‹public›.‹t›@‹idx›
       │    │    └── PUBLIC     → ABSENT      ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
       │    └── 6 Mutation operations
       │         ├── MakeDroppedColumnDeleteOnly {"ColumnID":3,"TableID":104}
-      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
       │         ├── NotImplemented {"ElementType":"scpb.ConstraintN..."}
       │         ├── MakeDroppedIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveCheckConstraint {"ConstraintID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 2 of 2 in PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/drop_index_hash_sharded_index
@@ -137,7 +137,10 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │   │   │     VALIDATED → DELETE_ONLY
     │   │   │
     │   │   ├── • CheckConstraint:{DescID: 104, ConstraintID: 2}
-    │   │   │     PUBLIC → ABSENT
+    │   │   │   │ PUBLIC → ABSENT
+    │   │   │   │
+    │   │   │   └── • SameStagePrecedence dependency from ABSENT ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
+    │   │   │         rule: "constraint dependent absent right before constraint"
     │   │   │
     │   │   └── • ConstraintName:{DescID: 104, Name: check_crdb_internal_j_shard_16, ConstraintID: 2}
     │   │         PUBLIC → ABSENT
@@ -148,15 +151,15 @@ EXPLAIN (ddl, verbose) DROP INDEX idx CASCADE;
     │       │     ColumnID: 3
     │       │     TableID: 104
     │       │
-    │       ├── • RemoveCheckConstraint
-    │       │     ConstraintID: 2
-    │       │     TableID: 104
-    │       │
     │       ├── • NotImplemented
     │       │     ElementType: scpb.ConstraintName
     │       │
     │       ├── • MakeDroppedIndexDeleteOnly
     │       │     IndexID: 2
+    │       │     TableID: 104
+    │       │
+    │       ├── • RemoveCheckConstraint
+    │       │     ConstraintID: 2
     │       │     TableID: 104
     │       │
     │       ├── • SetJobStateOnDescriptor


### PR DESCRIPTION
This commit fixes bugs related to constraints and comments in the
declarative schema changer. This commit also rewrites how index targets
are manipulated inside the builder, but otherwise does not change its
output.

This commit is a spin-off from work performed on adding secondary index
support in the ALTER PRIMARY KEY implementation. That work is not going
to be included in the 22.2 release, unlike this.

Relates to #83932.

Release justification: bug fixes with otherwise no functional changes
Release note: None