### PR TITLE
release-22.1: ci: add scripting to generate declarative schema changer corpus 

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run SQL Logic Test with Declarative Corpus Generation"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e GOOGLE_EPHEMERAL_CREDENTIALS -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL" \
+  run_bazel build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+tc_end_block "Run SQL Logic Test High VModule"

--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
+source "$dir/teamcity-bazel-support.sh"  # For process_test_json
+source "$dir/teamcity-support.sh"  # For process_test_json
+
+bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=ci
+BAZEL_BIN=$(bazel info bazel-bin --config=ci)
+google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
+
+log_into_gcloud
+
+ARTIFACTS_DIR=/artifacts
+GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
+GO_TEST_GEN_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test-gen.json.txt
+GO_TEST_GEN_CCL_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test-gen-ccl.json.txt
+GO_TEST_VALIDATE_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test-validate.json.txt
+GO_TEST_JSON_OUTPUT_FILE_MIXED=$ARTIFACTS_DIR/test-mixed.json.txt
+GO_TEST_VALIDATE_JSON_OUTPUT_FILE_MIXED=$ARTIFACTS_DIR/test-validate-mixed.json.txt
+
+mkdir -p $ARTIFACTS_DIR/corpus
+mkdir -p $ARTIFACTS_DIR/corpus-mixed
+exit_status=0
+
+# Generate a corpus for all non-mixed version variants
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/sql/logictest:logictest_test -- \
+    --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+    --test_filter='^TestLogic/(local|local-legacy-schema-changer|3node|multiregion).*$' \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
+    --test_timeout=7200 \
+    || exit_status=$?
+
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_JSON_OUTPUT_FILE \
+  $exit_status
+
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/ccl/logictestccl:logictestccl_test -- \
+    --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+    --test_filter='^(TestCCLLogic|TestTenantLogic)/(local|local-legacy-schema-changer|3node|multiregion).*$' \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
+    --test_timeout=7200 \
+    || exit_status=$?
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_JSON_OUTPUT_FILE \
+  $exit_status
+
+# Generate corpuses from end-to-end-schema changer tests
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+  test //pkg/sql/schemachanger:schemachanger_test -- \
+  --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+  --test_filter='^TestGenerateCorpus$' \
+  --test_env=GO_TEST_WRAP_TESTV=1 \
+  --test_env=GO_TEST_WRAP=1 \
+  --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_GEN_JSON_OUTPUT_FILE \
+  --test_timeout=7200 \
+  || exit_status=$?
+
+process_test_json \
+$BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+$BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+$ARTIFACTS_DIR \
+$GO_TEST_GEN_JSON_OUTPUT_FILE \
+$exit_status
+
+# Generate corpuses from end-to-end-schema changer tests
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+  test //pkg/ccl/schemachangerccl:schemachangerccl_test -- \
+  --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+  --test_filter='^TestGenerateCorpus$' \
+  --test_env=GO_TEST_WRAP_TESTV=1 \
+  --test_env=GO_TEST_WRAP=1 \
+  --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_GEN_CCL_JSON_OUTPUT_FILE \
+  --test_timeout=7200 \
+  || exit_status=$?
+
+process_test_json \
+$BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+$BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+$ARTIFACTS_DIR \
+$GO_TEST_GEN_CCL_JSON_OUTPUT_FILE \
+$exit_status
+
+
+# Any generated corpus should be validated on the current version first, which
+# indicates we can replay it on the same version.
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+  test //pkg/sql/schemachanger/corpus:corpus_test -- \
+  --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+  --test_filter='^TestValidateCorpuses$' \
+  --test_env=GO_TEST_WRAP_TESTV=1 \
+  --test_env=GO_TEST_WRAP=1 \
+  --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_VALIDATE_JSON_OUTPUT_FILE \
+  --test_timeout=7200 \
+  || exit_status=$?
+
+process_test_json \
+$BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+$BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+$ARTIFACTS_DIR \
+$GO_TEST_VALIDATE_JSON_OUTPUT_FILE \
+$exit_status
+
+# If validation passes its safe to update the copy in storage.
+if [ $exit_status = 0 ]; then
+  gsutil cp  $ARTIFACTS_DIR/corpus/* gs://cockroach-corpus/corpus-$TC_BUILD_BRANCH/
+fi
+
+# Generate a corpus for all mixed version variants
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/sql/logictest:logictest_test -- \
+    --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed\
+    --test_filter='^TestLogic/(mixed).*$' \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE_MIXED \
+    --test_timeout=7200 \
+    || exit_status=$?
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_JSON_OUTPUT_FILE_MIXED \
+  $exit_status
+
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/ccl/logictestccl:logictestccl_test -- \
+    --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus \
+    --test_filter='^(TestCCLLogic|TestTenantLogic)/(mixed).*$' \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
+    --test_timeout=7200 \
+    || exit_status=$?
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_JSON_OUTPUT_FILE \
+  $exit_status
+
+
+# Any generated corpus should be validated on the current version first, which
+# indicates we can replay it on the same version.
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
+    test //pkg/sql/schemachanger/corpus:corpus_test -- \
+    --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \
+    --test_filter='^TestValidateCorpuses$' \
+    --test_env=GO_TEST_WRAP_TESTV=1 \
+    --test_env=GO_TEST_WRAP=1 \
+    --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_VALIDATE_JSON_OUTPUT_FILE_MIXED \
+    --test_timeout=7200 \
+    || exit_status=$?
+
+process_test_json \
+  $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \
+  $BAZEL_BIN/pkg/cmd/github-post/github-post_/github-post \
+  $ARTIFACTS_DIR \
+  $GO_TEST_VALIDATE_JSON_OUTPUT_FILE_MIXED \
+  $exit_status
+
+# If validation passes its safe to update the copy in storage.
+if [ $exit_status = 0 ]; then
+  gsutil cp  $ARTIFACTS_DIR/corpus-mixed/* gs://cockroach-corpus/corpus-mixed-$TC_BUILD_BRANCH/
+fi

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -333,6 +333,7 @@ ALL_TESTS = [
     "//pkg/sql/scanner:scanner_test",
     "//pkg/sql/scheduledlogging:scheduledlogging_test",
     "//pkg/sql/schemachange:schemachange_test",
+    "//pkg/sql/schemachanger/corpus:corpus_test",
     "//pkg/sql/schemachanger/rel:rel_test",
     "//pkg/sql/schemachanger/scbuild:scbuild_test",
     "//pkg/sql/schemachanger/scdecomp:scdecomp_test",

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/pgwire/pgcode",
-        "//pkg/sql/schemachanger/corpus",
         "//pkg/sql/schemachanger/scop",
         "//pkg/sql/schemachanger/scplan",
         "//pkg/sql/schemachanger/scrun",

--- a/pkg/sql/schemachanger/corpus/BUILD.bazel
+++ b/pkg/sql/schemachanger/corpus/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "corpus",
@@ -14,5 +14,19 @@ go_library(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+    ],
+)
+
+go_test(
+    name = "corpus_test",
+    srcs = ["corpus_test.go"],
+    tags = ["integration"],
+    deps = [
+        ":corpus",
+        "//pkg/jobs/jobspb",
+        "//pkg/sql/schemachanger/scop",
+        "//pkg/sql/schemachanger/scplan",
+        "//pkg/testutils/skip",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/schemachanger/corpus/corpus_test.go
+++ b/pkg/sql/schemachanger/corpus/corpus_test.go
@@ -1,0 +1,55 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package corpus_test
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/corpus"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/stretchr/testify/require"
+)
+
+// Used for reading corpus information in TestValidateCorpuses
+var corpusPath string
+
+func init() {
+	flag.StringVar(&corpusPath, "declarative-corpus", "", "path to the corpus file")
+}
+
+// TestValidateCorpuses validates that any generated corpus file on disk, a
+// path needs to be specified.
+func TestValidateCorpuses(t *testing.T) {
+	if corpusPath == "" {
+		skip.IgnoreLintf(t, "requires declarative-corpus path parameter")
+	}
+	reader, err := corpus.NewCorpusReader(corpusPath)
+	require.NoError(t, err)
+	require.NoError(t, reader.ReadCorpus())
+	for corpusIdx := 0; corpusIdx < reader.GetNumEntries(); corpusIdx++ {
+		jobID := jobspb.InvalidJobID
+		name, state := reader.GetCorpus(corpusIdx)
+		t.Run(name, func(t *testing.T) {
+			_, err := scplan.MakePlan(*state, scplan.Params{
+				ExecutionPhase: scop.LatestPhase,
+				InRollback:     state.InRollback,
+				SchemaChangerJobIDSupplier: func() jobspb.JobID {
+					jobID++
+					return jobID
+				}})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/pkg/sql/schemachanger/end_to_end_test.go
+++ b/pkg/sql/schemachanger/end_to_end_test.go
@@ -14,16 +14,11 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/corpus"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/sctest"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/stretchr/testify/require"
 )
 
 // Used for saving corpus information in TestGenerateCorpus
@@ -61,37 +56,4 @@ func TestGenerateCorpus(t *testing.T) {
 		skip.IgnoreLintf(t, "requires decalarative-corpus path parameter")
 	}
 	sctest.GenerateSchemaChangeCorpus(t, testutils.TestDataPath(t), corpusPath, sctest.SingleNodeCluster)
-}
-
-// TestValidateCorpuses validates that any generated corpus file on disk, a
-// path needs to be specified.
-func TestValidateCorpuses(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	if corpusPath == "" {
-		skip.IgnoreLintf(t, "requires decalarative-corpus path parameter")
-	}
-	t.Run("corpus-validation", func(t *testing.T) {
-		cr, err := corpus.NewCorpusReader(corpusPath)
-		require.NoError(t, err)
-		require.NoError(t, cr.ReadCorpus())
-
-		for idx := 0; idx < cr.GetNumEntries(); idx++ {
-			entryName, state := cr.GetCorpus(idx)
-			t.Run(entryName, func(t *testing.T) {
-				jobID := jobspb.JobID(0)
-				params := scplan.Params{
-					InRollback:     state.InRollback,
-					ExecutionPhase: scop.LatestPhase,
-					SchemaChangerJobIDSupplier: func() jobspb.JobID {
-						jobID++
-						return jobID
-					},
-				}
-				_, err := scplan.MakePlan(*state, params)
-				require.NoError(t, err)
-			})
-		}
-	})
 }


### PR DESCRIPTION
These changes do the following:

Informs: https://github.com/cockroachdb/cockroach/issues/82643

* Move test case for validating schema changer corpuses into the corpus package (done to stay in sync with master)
* More importantly for the dev-infra team an initial approach to collect declarative schema changer states from logictest during nightly builds. The scripts included here will generate a corpus and upload them to GCS storage for a nightly build.

Release justification: low-risk changes to add scripting for nightly artifacts to allow us to do mixed version testing for the declarative schema changer