### PR TITLE
ui: txn insights to group by fingerprint ID, use sql.insights.latency_threshold

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import { Moment } from "moment";
-import { HIGH_WAIT_CONTENTION_THRESHOLD } from "../api";
 import { Filters } from "../queryFilter";
 
 export enum InsightNameEnum {
@@ -23,10 +22,12 @@ export enum InsightExecEnum {
 
 export type InsightEvent = {
   executionID: string;
+  fingerprintID: string;
   queries: string[];
   insights: Insight[];
   startTime: Moment;
   elapsedTime: number;
+  contentionThreshold: number;
   application: string;
   execType: InsightExecEnum;
 };
@@ -37,6 +38,7 @@ export type InsightEventDetails = {
   insights: Insight[];
   startTime: Moment;
   elapsedTime: number;
+  contentionThreshold: number;
   application: string;
   fingerprintID: string;
   waitingExecutionID: string;
@@ -68,9 +70,9 @@ export type EventExecution = {
 
 const highWaitTimeInsight = (
   execType: InsightExecEnum = InsightExecEnum.TRANSACTION,
+  latencyThreshold: number,
 ): Insight => {
-  const threshold = HIGH_WAIT_CONTENTION_THRESHOLD.asMilliseconds();
-  const description = `This ${execType} has been waiting for more than ${threshold}ms on other ${execType}s to execute.`;
+  const description = `This ${execType} has been waiting for more than ${latencyThreshold}ms on other ${execType}s to execute.`;
   return {
     name: InsightNameEnum.highWaitTime,
     label: "High Wait Time",

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -29,8 +29,13 @@ export const getInsights = (
 ): Insight[] => {
   const insights: Insight[] = [];
   InsightTypes.forEach(insight => {
-    if (insight(eventState.execType).name == eventState.insightName) {
-      insights.push(insight(eventState.execType));
+    if (
+      insight(eventState.execType, eventState.contentionThreshold).name ==
+      eventState.insightName
+    ) {
+      insights.push(
+        insight(eventState.execType, eventState.contentionThreshold),
+      );
     }
   });
   return insights;
@@ -51,12 +56,14 @@ export function getInsightsFromState(
     } else {
       insightEvents.push({
         executionID: e.executionID,
+        fingerprintID: e.fingerprintID,
         queries: e.queries,
         insights: insightsForEvent,
         startTime: e.startTime,
         elapsedTime: e.elapsedTime,
         application: e.application,
         execType: InsightExecEnum.TRANSACTION,
+        contentionThreshold: e.contentionThreshold,
       });
     }
   });

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -180,7 +180,7 @@ export class InsightDetails extends React.Component<InsightDetailsProps> {
             <Col>
               <Row>
                 <Heading type="h5">
-                  {WaitTimeInsightsLabels.BLOCKING_TXNS_TABLE_TITLE(
+                  {WaitTimeInsightsLabels.WAITING_TXNS_TABLE_TITLE(
                     insightDetails.executionID,
                     insightDetails.execType,
                   )}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -16,6 +16,7 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
   transactions: [
     {
       executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      fingerprintID: "\\x76245b7acd82d39d",
       queries: [
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       ],
@@ -24,9 +25,11 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
+      contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),
     },
     {
       executionID: "e72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      fingerprintID: "\\x76245b7acd82d39e",
       queries: [
         "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
         "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
@@ -36,9 +39,11 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
+      contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),
     },
     {
       executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a0",
+      fingerprintID: "\\x76245b7acd82d39f",
       queries: [
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       ],
@@ -47,6 +52,7 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
+      contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),
     },
   ],
   transactionsError: null,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -42,6 +42,12 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<InsightEvent>
       sort: (item: InsightEvent) => item.executionID,
     },
     {
+      name: "fingerprintID",
+      title: insightsTableTitles.fingerprintID(execType),
+      cell: (item: InsightEvent) => String(item.fingerprintID),
+      sort: (item: InsightEvent) => item.fingerprintID,
+    },
+    {
       name: "query",
       title: insightsTableTitles.query(execType),
       cell: (item: InsightEvent) =>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -43,12 +43,28 @@ export function getLabel(
 }
 
 export const insightsTableTitles: InsightsTableTitleType = {
+  fingerprintID: (execType: InsightExecEnum) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={<p>The {execType} fingerprint ID.</p>}
+      >
+        {getLabel("fingerprintID", execType)}
+      </Tooltip>
+    );
+  },
   executionID: (execType: InsightExecEnum) => {
     return (
       <Tooltip
         placement="bottom"
         style="tableTitle"
-        content={<p>The {execType} execution ID.</p>}
+        content={
+          <p>
+            The execution ID of the latest execution with the {execType}{" "}
+            fingerprint.
+          </p>
+        }
       >
         {getLabel("executionID", execType)}
       </Tooltip>
@@ -112,17 +128,6 @@ export const insightsTableTitles: InsightsTableTitleType = {
         content={<p>The name of the application that ran the {execType}.</p>}
       >
         {getLabel("applicationName")}
-      </Tooltip>
-    );
-  },
-  fingerprintID: (execType: InsightExecEnum) => {
-    return (
-      <Tooltip
-        style="tableTitle"
-        placement="bottom"
-        content={<p>The {execType} fingerprint ID.</p>}
-      >
-        {getLabel("fingerprintID", execType)}
       </Tooltip>
     );
   },


### PR DESCRIPTION
This PR updates the query for the transaction workload insights SQL API call to group results by fingerprint ID (returning the latest execution), and to filter the results based on the value of the `sql.insights.latency_threshold value`.

Fixes #86447.

https://www.loom.com/share/1f0dd856d8914b23bfeb5e9440108cb2

Release justification: low-risk updates to new functionality
Release note: None