### PR TITLE
release-22.1: ttl: fix SelectDuration, RowDeletions metrics

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_query_builder.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder.go
@@ -281,10 +281,10 @@ func (b *deleteQueryBuilder) buildQueryAndArgs(rows []tree.Datums) (string, []in
 
 func (b *deleteQueryBuilder) run(
 	ctx context.Context, ie *sql.InternalExecutor, txn *kv.Txn, rows []tree.Datums,
-) error {
+) (int64, error) {
 	q, deleteArgs := b.buildQueryAndArgs(rows)
 	qosLevel := sessiondatapb.TTLLow
-	_, err := ie.ExecEx(
+	rowCount, err := ie.ExecEx(
 		ctx,
 		b.deleteOpName,
 		txn,
@@ -295,7 +295,7 @@ func (b *deleteQueryBuilder) run(
 		q,
 		deleteArgs...,
 	)
-	return err
+	return int64(rowCount), err
 }
 
 // makeColumnNamesSQL converts columns into an escape string


### PR DESCRIPTION
Backport 1/1 commits from #86557.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/86555

Fixes these issues:
1) DeleteDuration is being incorrectly used instead of SelectDuration.
2) RowDeletions is using batch size instead of results from ie.ExecEx.

Release justification: Fixes TTL metric reporting.

Release note: None
