### PR TITLE
roachpb: add nil check in BatchRequest.Summary()

### DIFF
--- a/pkg/roachpb/batch_generated.go
+++ b/pkg/roachpb/batch_generated.go
@@ -761,6 +761,10 @@ func (ba *BatchRequest) Summary() string {
 // WriteSummary writes a short summary of the requests in a batch
 // to the provided builder.
 func (ba *BatchRequest) WriteSummary(b *strings.Builder) {
+	if ba == nil {
+		b.WriteString("nil batch")
+		return
+	}
 	if len(ba.Requests) == 0 {
 		b.WriteString("empty batch")
 		return

--- a/pkg/roachpb/gen/main.go
+++ b/pkg/roachpb/gen/main.go
@@ -340,6 +340,10 @@ func (ba *BatchRequest) Summary() string {
 // WriteSummary writes a short summary of the requests in a batch
 // to the provided builder.
 func (ba *BatchRequest) WriteSummary(b *strings.Builder) {
+	if ba == nil {
+		b.WriteString("nil batch")
+		return
+	}
 	if len(ba.Requests) == 0 {
 		b.WriteString("empty batch")
 		return


### PR DESCRIPTION
fixes #83690

We've observed the following stack trace: (https://github.com/cockroachdb/cockroach/issues/83690#issuecomment-1208200276)
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13394b9]

goroutine 2973215 [running]:
github.com/cockroachdb/cockroach/pkg/roachpb.(*BatchRequest).WriteSummary(0x0, 0xc018fe3ba8)
	github.com/cockroachdb/cockroach/pkg/roachpb/bazel-out/k8-dbg/bin/pkg/roachpb/batch_generated.go:753 +0x39
github.com/cockroachdb/cockroach/pkg/roachpb.(*BatchRequest).Summary(0x0)
	github.com/cockroachdb/cockroach/pkg/roachpb/bazel-out/k8-dbg/bin/pkg/roachpb/batch_generated.go:746 +0x3a
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord.(*TxnCoordSender).maybeRejectClientLocked(0xc016d36b00, {0x660a708, 0xc00e976a50}, 0x0)
	github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_coord_sender.go:702 +0x19a
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord.(*TxnCoordSender).checkTxnStatusLocked(0xc016d36b00, {0x660a708, 0xc00e976a50}, 0x1)
	github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_coord_sender.go:1212 +0x6b
github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord.(*TxnCoordSender).GetLeafTxnInputState(0xc016d36b00, {0x660a708, 0xc00e976a50}, 0x1)
	github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord/txn_coord_sender.go:1158 +0x114
github.com/cockroachdb/cockroach/pkg/kv.(*Txn).GetLeafTxnInputStateOrRejectClient(0xc00cd10f20, {0x660a708, 0xc00e976a50})
	github.com/cockroachdb/cockroach/pkg/kv/txn.go:1297 +0x1d7
github.com/cockroachdb/cockroach/pkg/sql.(*DistSQLPlanner).Run(0xc00c62af00, {0x660a708, 0xc00e976a50}, 0xc01559a4b0, 0xc00cd10f20, 0xc0032a8500, 0xc0225f1180, 0xc0012bbf08, 0x0)
	github.com/cockroachdb/cockroach/pkg/sql/distsql_running.go:586 +0x1357
```

This patch will prevent the node from crashing.

Release justification: fix a panic
Release note: None