### PR TITLE
kvserver: rework memory allocation in replicastats

### DIFF
--- a/pkg/kv/kvserver/replica_load.go
+++ b/pkg/kv/kvserver/replica_load.go
@@ -29,13 +29,17 @@ type ReplicaLoad struct {
 // NewReplicaLoad returns a new ReplicaLoad, which may be used to track the
 // request throughput of a replica.
 func NewReplicaLoad(clock *hlc.Clock, getNodeLocality replicastats.LocalityOracle) *ReplicaLoad {
+	// NB: We only wish to record the locality of a request for QPS, where it
+	// as only follow-the-workload lease transfers use this per-locality
+	// request count. Maintaining more than one bucket for client requests
+	// increases the memory footprint O(localities).
 	return &ReplicaLoad{
 		batchRequests: replicastats.NewReplicaStats(clock, getNodeLocality),
-		requests:      replicastats.NewReplicaStats(clock, getNodeLocality),
-		writeKeys:     replicastats.NewReplicaStats(clock, getNodeLocality),
-		readKeys:      replicastats.NewReplicaStats(clock, getNodeLocality),
-		writeBytes:    replicastats.NewReplicaStats(clock, getNodeLocality),
-		readBytes:     replicastats.NewReplicaStats(clock, getNodeLocality),
+		requests:      replicastats.NewReplicaStats(clock, nil),
+		writeKeys:     replicastats.NewReplicaStats(clock, nil),
+		readKeys:      replicastats.NewReplicaStats(clock, nil),
+		writeBytes:    replicastats.NewReplicaStats(clock, nil),
+		readBytes:     replicastats.NewReplicaStats(clock, nil),
 	}
 }
 


### PR DESCRIPTION
This patch removes some unused fields within the replica stats object.
It also opts to allocate all the memory needed upfront for a replica
stats object for better cache locality and less GC overhead.

This patch also removes locality tracking for the other throughput trackers
to reduce per-replica memory footprint.

resolves #85112

Release justification: low risk, lowers memory footprint to avoid oom.
Release note: None