### PR TITLE
ui/cluster-ui: create statements insights api

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -18,6 +18,7 @@ import {
   InsightEventDetails,
   InsightExecEnum,
   InsightNameEnum,
+  StatementInsightEvent,
 } from "src/insights";
 import moment from "moment";
 
@@ -30,10 +31,7 @@ export type InsightEventsResponse = InsightEventState[];
 type InsightQuery<ResponseColumnType, State> = {
   name: InsightNameEnum;
   query: string;
-  toState: (
-    response: SqlExecutionResponse<ResponseColumnType>,
-    results: Record<string, State>,
-  ) => State[];
+  toState: (response: SqlExecutionResponse<ResponseColumnType>) => State;
 };
 
 type TransactionContentionResponseColumns = {
@@ -48,31 +46,30 @@ type TransactionContentionResponseColumns = {
 
 function transactionContentionResultsToEventState(
   response: SqlExecutionResponse<TransactionContentionResponseColumns>,
-  results: Record<string, InsightEventState>,
 ): InsightEventState[] {
-  response.execution.txn_results[0].rows.forEach(row => {
-    const key = row.blocking_txn_id;
-    if (!results[key]) {
-      results[key] = {
-        executionID: row.blocking_txn_id,
-        fingerprintID: row.blocking_txn_fingerprint_id,
-        queries: row.blocking_queries,
-        startTime: moment(row.collection_ts),
-        elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
-        contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
-        application: row.app_name,
-        insightName: highWaitTimeQuery.name,
-        execType: InsightExecEnum.TRANSACTION,
-      };
-    }
-  });
+  if (!response.execution.txn_results[0].rows) {
+    // No data.
+    return [];
+  }
 
-  return Object.values(results);
+  return response.execution.txn_results[0].rows.map(row => ({
+    transactionID: row.blocking_txn_id,
+    fingerprintID: row.blocking_txn_fingerprint_id,
+    queries: row.blocking_queries,
+    startTime: moment(row.collection_ts),
+    elapsedTimeMillis: moment
+      .duration(row.contention_duration)
+      .asMilliseconds(),
+    contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
+    application: row.app_name,
+    insightName: highWaitTimeQuery.name,
+    execType: InsightExecEnum.TRANSACTION,
+  }));
 }
 
 const highWaitTimeQuery: InsightQuery<
   TransactionContentionResponseColumns,
-  InsightEventState
+  InsightEventsResponse
 > = {
   name: InsightNameEnum.highWaitTime,
   query: `SELECT * FROM (SELECT
@@ -118,13 +115,7 @@ export function getInsightEventState(): Promise<InsightEventsResponse> {
   };
   return executeSql<TransactionContentionResponseColumns>(request).then(
     result => {
-      if (!result.execution.txn_results[0].rows) {
-        // No data.
-        return [];
-      }
-
-      const results: Record<string, InsightEventState> = {};
-      return highWaitTimeQuery.toState(result, results);
+      return highWaitTimeQuery.toState(result);
     },
   );
 }
@@ -157,41 +148,37 @@ type TransactionContentionDetailsResponseColumns = {
 
 function transactionContentionDetailsResultsToEventState(
   response: SqlExecutionResponse<TransactionContentionDetailsResponseColumns>,
-  results: Record<string, InsightEventDetailsState>,
 ): InsightEventDetailsState[] {
-  response.execution.txn_results[0].rows.forEach(row => {
-    const key = row.blocking_txn_id;
-    if (!results[key]) {
-      results[key] = {
-        executionID: row.blocking_txn_id,
-        queries: row.blocking_queries,
-        startTime: moment(row.collection_ts),
-        elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
-        contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
-        application: row.app_name,
-        fingerprintID: row.blocking_txn_fingerprint_id,
-        waitingExecutionID: row.waiting_txn_id,
-        waitingFingerprintID: row.waiting_txn_fingerprint_id,
-        waitingQueries: row.waiting_queries,
-        schemaName: row.schema_name,
-        databaseName: row.database_name,
-        tableName: row.table_name,
-        indexName: row.index_name,
-        contendedKey: row.key,
-        insightName: highWaitTimeQuery.name,
-        execType: InsightExecEnum.TRANSACTION,
-      };
-    }
-  });
-
-  return Object.values(results);
+  if (!response.execution.txn_results[0].rows) {
+    // No data.
+    return [];
+  }
+  return response.execution.txn_results[0].rows.map(row => ({
+    executionID: row.blocking_txn_id,
+    queries: row.blocking_queries,
+    startTime: moment(row.collection_ts),
+    elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
+    contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
+    application: row.app_name,
+    fingerprintID: row.blocking_txn_fingerprint_id,
+    waitingExecutionID: row.waiting_txn_id,
+    waitingFingerprintID: row.waiting_txn_fingerprint_id,
+    waitingQueries: row.waiting_queries,
+    schemaName: row.schema_name,
+    databaseName: row.database_name,
+    tableName: row.table_name,
+    indexName: row.index_name,
+    contendedKey: row.key,
+    insightName: highWaitTimeQuery.name,
+    execType: InsightExecEnum.TRANSACTION,
+  }));
 }
 
 const highWaitTimeDetailsQuery = (
   id: string,
 ): InsightQuery<
   TransactionContentionDetailsResponseColumns,
-  InsightEventDetailsState
+  InsightEventDetailsResponse
 > => {
   return {
     name: InsightNameEnum.highWaitTime,
@@ -257,12 +244,119 @@ export function getInsightEventDetailsState(
   };
   return executeSql<TransactionContentionDetailsResponseColumns>(request).then(
     result => {
-      if (!result.execution.txn_results[0].rows) {
-        // No data.
-        return [];
-      }
-      const results: Record<string, InsightEventDetailsState> = {};
-      return detailsQuery.toState(result, results);
+      return detailsQuery.toState(result);
     },
   );
+}
+
+type ExecutionInsightsResponseRow = {
+  session_id: string;
+  txn_id: string;
+  txn_fingerprint_id: string; // hex string
+  stmt_id: string;
+  stmt_fingerprint_id: string; // hex string
+  query: string;
+  start_time: string; // Timestamp
+  end_time: string; // Timestamp
+  full_scan: boolean;
+  user_name: string;
+  app_name: string;
+  database_name: string;
+  rows_read: number;
+  rows_written: number;
+  priority: string;
+  retries: number;
+  exec_node_ids: number[];
+  contention: string; // interval
+  last_retry_reason?: string;
+  problems: string[];
+};
+
+export type StatementInsights = StatementInsightEvent[];
+
+function getStatementInsightsFromClusterExecutionInsightsResponse(
+  response: SqlExecutionResponse<ExecutionInsightsResponseRow>,
+): StatementInsights {
+  if (!response.execution.txn_results[0].rows) {
+    // No data.
+    return [];
+  }
+
+  return response.execution.txn_results[0].rows.map(row => {
+    const start = moment.utc(row.start_time);
+    const end = moment.utc(row.end_time);
+    return {
+      transactionID: row.txn_id,
+      transactionFingerprintID: row.txn_fingerprint_id,
+      query: row.query,
+      startTime: start,
+      endTime: end,
+      databaseName: row.database_name,
+      elapsedTimeMillis: end.diff(start, "milliseconds"),
+      application: row.app_name,
+      statementID: row.stmt_id,
+      statementFingerprintID: row.stmt_fingerprint_id,
+      sessionID: row.session_id,
+      isFullScan: row.full_scan,
+      rowsRead: row.rows_read,
+      rowsWritten: row.rows_written,
+      priority: row.priority,
+      retries: row.retries,
+      lastRetryReason: row.last_retry_reason,
+      timeSpentWaiting: row.contention ? moment.duration(row.contention) : null,
+      problems: row.problems,
+    };
+  });
+}
+
+const statementInsightsQuery: InsightQuery<
+  ExecutionInsightsResponseRow,
+  StatementInsights
+> = {
+  name: InsightNameEnum.highWaitTime,
+  // We only surface the most recently observed problem for a given statement.
+  query: `SELECT * from (
+    SELECT
+      session_id,
+      txn_id,
+      encode(txn_fingerprint_id, 'hex') AS txn_fingerprint_id,
+      stmt_id,
+      encode(stmt_fingerprint_id, 'hex') AS stmt_fingerprint_id,
+      query,
+      start_time,
+      end_time,
+      full_scan,
+      app_name,
+      database_name,
+      rows_read,
+      rows_written,
+      priority,
+      retries,
+      contention,
+      last_retry_reason,
+      problems,
+      row_number() OVER (
+        PARTITION BY txn_fingerprint_id
+        ORDER BY end_time DESC
+      ) AS rank
+    FROM crdb_internal.cluster_execution_insights
+    WHERE array_length(problems, 1) > 0
+  ) WHERE rank = 1
+  `,
+  toState: getStatementInsightsFromClusterExecutionInsightsResponse,
+};
+
+export function getStatementInsightsApi(): Promise<StatementInsights> {
+  const request: SqlExecutionRequest = {
+    statements: [
+      {
+        sql: `${statementInsightsQuery.query}`,
+      },
+    ],
+    execute: true,
+    max_result_size: 50000, // 50 kib
+  };
+  return executeSql<ExecutionInsightsResponseRow>(request).then(result => {
+    return statementInsightsQuery.toState(result);
+  });
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -21,12 +21,12 @@ export enum InsightExecEnum {
 }
 
 export type InsightEvent = {
-  executionID: string;
+  transactionID: string;
   fingerprintID: string;
   queries: string[];
   insights: Insight[];
   startTime: Moment;
-  elapsedTime: number;
+  elapsedTimeMillis: number;
   contentionThreshold: number;
   application: string;
   execType: InsightExecEnum;
@@ -50,6 +50,29 @@ export type InsightEventDetails = {
   tableName: string;
   indexName: string;
   execType: InsightExecEnum;
+};
+
+export type StatementInsightEvent = {
+  // Some of these can be moved to a common InsightEvent type if txn query is updated.
+  statementID: string;
+  transactionID: string;
+  statementFingerprintID: string;
+  transactionFingerprintID: string;
+  startTime: Moment;
+  elapsedTimeMillis: number;
+  sessionID: string;
+  timeSpentWaiting?: moment.Duration;
+  isFullScan: boolean;
+  endTime: Moment;
+  databaseName: string;
+  rowsRead: number;
+  rowsWritten: number;
+  lastRetryReason?: string;
+  priority: string;
+  retries: number;
+  problems: string[];
+  query: string;
+  application: string;
 };
 
 export type Insight = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -55,12 +55,12 @@ export function getInsightsFromState(
       return;
     } else {
       insightEvents.push({
-        executionID: e.executionID,
+        transactionID: e.transactionID,
         fingerprintID: e.fingerprintID,
         queries: e.queries,
         insights: insightsForEvent,
         startTime: e.startTime,
-        elapsedTime: e.elapsedTime,
+        elapsedTimeMillis: e.elapsedTimeMillis,
         application: e.application,
         execType: InsightExecEnum.TRANSACTION,
         contentionThreshold: e.contentionThreshold,
@@ -121,7 +121,7 @@ export const filterTransactionInsights = (
     filteredTransactions = filteredTransactions.filter(
       txn =>
         !search ||
-        txn.executionID.toLowerCase()?.includes(search) ||
+        txn.transactionID.toLowerCase()?.includes(search) ||
         txn.queries?.find(query => query.toLowerCase().includes(search)),
     );
   }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsights.fixture.ts
@@ -15,20 +15,20 @@ import { InsightExecEnum } from "../../types";
 export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
   transactions: [
     {
-      executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      transactionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
       fingerprintID: "\\x76245b7acd82d39d",
       queries: [
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       ],
       insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
-      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      elapsedTimeMillis: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
       contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),
     },
     {
-      executionID: "e72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
+      transactionID: "e72f37ea-b3a0-451f-80b8-dfb27d0bc2a5",
       fingerprintID: "\\x76245b7acd82d39e",
       queries: [
         "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
@@ -36,20 +36,20 @@ export const transactionInsightsPropsFixture: TransactionInsightsViewProps = {
       ],
       insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
-      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      elapsedTimeMillis: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
       contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),
     },
     {
-      executionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a0",
+      transactionID: "f72f37ea-b3a0-451f-80b8-dfb27d0bc2a0",
       fingerprintID: "\\x76245b7acd82d39f",
       queries: [
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       ],
       insightName: "HIGH_WAIT_TIME",
       startTime: moment.utc("2022.08.10"),
-      elapsedTime: moment.duration("00:00:00.25").asMilliseconds(),
+      elapsedTimeMillis: moment.duration("00:00:00.25").asMilliseconds(),
       application: "demo",
       execType: InsightExecEnum.TRANSACTION,
       contentionThreshold: moment.duration("00:00:00.1").asMilliseconds(),

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -35,11 +35,11 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<InsightEvent>
       name: "executionID",
       title: insightsTableTitles.executionID(execType),
       cell: (item: InsightEvent) => (
-        <Link to={`/insights/${item.executionID}`}>
-          {String(item.executionID)}
+        <Link to={`/insights/${item.transactionID}`}>
+          {String(item.transactionID)}
         </Link>
       ),
-      sort: (item: InsightEvent) => item.executionID,
+      sort: (item: InsightEvent) => item.transactionID,
     },
     {
       name: "fingerprintID",
@@ -73,8 +73,8 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<InsightEvent>
     {
       name: "elapsedTime",
       title: insightsTableTitles.elapsedTime(execType),
-      cell: (item: InsightEvent) => Duration(item.elapsedTime * 1e6),
-      sort: (item: InsightEvent) => item.elapsedTime,
+      cell: (item: InsightEvent) => Duration(item.elapsedTimeMillis * 1e6),
+      sort: (item: InsightEvent) => item.elapsedTimeMillis,
     },
     {
       name: "applicationName",

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -403,6 +403,14 @@ const insightsReducerObj = new CachedDataReducer(
 );
 export const refreshInsights = insightsReducerObj.refresh;
 
+const statementInsightsReducerObj = new CachedDataReducer(
+  clusterUiApi.getStatementInsightsApi,
+  "statementInsights",
+  null,
+  moment.duration(30, "s"), // Timeout
+);
+export const refreshStatementInsights = statementInsightsReducerObj.refresh;
+
 export const insightRequestKey = (
   req: clusterUiApi.InsightEventDetailsRequest,
 ): string => `${req.id}`;
@@ -451,6 +459,7 @@ export interface APIReducersState {
   clusterLocks: CachedDataReducerState<clusterUiApi.ClusterLocksResponse>;
   insights: CachedDataReducerState<clusterUiApi.InsightEventsResponse>;
   insightDetails: KeyedCachedDataReducerState<clusterUiApi.InsightEventDetailsResponse>;
+  statementInsights: CachedDataReducerState<clusterUiApi.StatementInsights>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -494,6 +503,8 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [clusterLocksReducerObj.actionNamespace]: clusterLocksReducerObj.reducer,
   [insightsReducerObj.actionNamespace]: insightsReducerObj.reducer,
   [insightDetailsReducerObj.actionNamespace]: insightDetailsReducerObj.reducer,
+  [statementInsightsReducerObj.actionNamespace]:
+    statementInsightsReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };


### PR DESCRIPTION
This commit adds a function to the `cluster-ui` pkg that queries
`crdb_internal.cluster_execution_insights` to surface slow running
queries. The information retrieved  is intended to be used in the
insights statement overview and details pages. A new field
`statementInsights` is added to the `cachedData` object in the
db-console redux store, and the corresponding function to issue the
data fetch is also added in `apiReducers`. This commit does not add
any reducers  or sagas to CC to fetch and store this data.

Release justification: non-production code change
Release note: None