### PR TITLE
colexec: make sure to init child op chains in AND and OR operators

### DIFF
--- a/pkg/sql/colexec/and_or_projection.eg.go
+++ b/pkg/sql/colexec/and_or_projection.eg.go
@@ -174,6 +174,8 @@ func (o *andProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.
@@ -607,6 +609,8 @@ func (o *andRightNullProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.
@@ -1007,6 +1011,8 @@ func (o *andLeftNullProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.
@@ -1388,6 +1394,8 @@ func (o *orProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.
@@ -1822,6 +1830,8 @@ func (o *orRightNullProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.
@@ -2223,6 +2233,8 @@ func (o *orLeftNullProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.

--- a/pkg/sql/colexec/and_or_projection_tmpl.go
+++ b/pkg/sql/colexec/and_or_projection_tmpl.go
@@ -151,6 +151,8 @@ func (o *_OP_LOWERProjOp) Init(ctx context.Context) {
 		return
 	}
 	o.input.Init(o.Ctx)
+	o.leftProjOpChain.Init(o.Ctx)
+	o.rightProjOpChain.Init(o.Ctx)
 }
 
 // Next is part of the colexecop.Operator interface.


### PR DESCRIPTION
Previously, we forgot to call `Init` on the side operator chains of AND
and OR projection operators, and this is now fixed. The impact of the
bug is minor though (like a nil context when the tracing is enabled).

Release justification: bug fix.

Release note: None