### PR TITLE
backupccl: skip reintroducing spans on some previously offline tables

### DIFF
--- a/pkg/ccl/backupccl/key_rewriter_test.go
+++ b/pkg/ccl/backupccl/key_rewriter_test.go
@@ -83,7 +83,7 @@ func TestKeyRewriter(t *testing.T) {
 	t.Run("normal", func(t *testing.T) {
 		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
 			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -102,7 +102,7 @@ func TestKeyRewriter(t *testing.T) {
 	t.Run("prefix end", func(t *testing.T) {
 		key := roachpb.Key(rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec,
 			systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())).PrefixEnd()
-		newKey, ok, err := kr.RewriteKey(key)
+		newKey, ok, err := kr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -131,7 +131,7 @@ func TestKeyRewriter(t *testing.T) {
 		}
 
 		key := rowenc.MakeIndexKeyPrefix(keys.SystemSQLCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -162,7 +162,7 @@ func TestKeyRewriter(t *testing.T) {
 		require.NoError(t, err)
 
 		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		require.NoError(t, err)
 		if !ok {
 			t.Fatalf("expected rewrite")
@@ -207,7 +207,7 @@ func TestKeyRewriter(t *testing.T) {
 		key := rowenc.MakeIndexKeyPrefix(srcCodec, systemschema.NamespaceTable.GetID(), desc.GetPrimaryIndexID())
 		oldNoTenantKey, oldTenantID, err := keys.DecodeTenantPrefix(key)
 		require.NoError(t, err)
-		newKey, ok, err := newKr.RewriteKey(key)
+		newKey, ok, err := newKr.RewriteKey(key, 0)
 		require.NoError(t, err)
 		if !ok {
 			t.Fatalf("expected rewrite")

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -467,7 +467,10 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		key.Key, ok, err = kr.RewriteKey(key.Key, key.Timestamp.WallTime)
 
 		if errors.Is(err, ErrImportingKeyError) {
-			// Elide importing keys
+			// The keyRewriter returns ErrImportingKeyError iff the key is part of an
+			// in-progress import. Keys from in-progress imports never get restored,
+			// since the key's table gets restored to its pre-import state. Therefore,
+			// elide ingesting this key.
 			continue
 		}
 		if err != nil {

--- a/pkg/ccl/backupccl/restore_data_processor.go
+++ b/pkg/ccl/backupccl/restore_data_processor.go
@@ -464,7 +464,12 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 		valueScratch = append(valueScratch[:0], iter.UnsafeValue()...)
 		value := roachpb.Value{RawBytes: valueScratch}
 
-		key.Key, ok, err = kr.RewriteKey(key.Key)
+		key.Key, ok, err = kr.RewriteKey(key.Key, key.Timestamp.WallTime)
+
+		if errors.Is(err, ErrImportingKeyError) {
+			// Elide importing keys
+			continue
+		}
 		if err != nil {
 			return summary, err
 		}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -879,6 +879,9 @@ func createImportingDescriptors(
 
 	// Set the new descriptors' states to offline.
 	for _, desc := range mutableTables {
+		if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.Start22_2) {
+			desc.SetLastMVCCBulkOp(true)
+		}
 		desc.SetOffline("restoring")
 	}
 	for _, desc := range typesToWrite {

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -95,7 +95,7 @@ var restoreStatsInsertBatchSize = 10
 func rewriteBackupSpanKey(
 	codec keys.SQLCodec, kr *KeyRewriter, key roachpb.Key,
 ) (roachpb.Key, error) {
-	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...), 0)
+	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...) /*wallTime*/, 0)
 	if err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 			"could not rewrite span start key: %s", key)
@@ -660,9 +660,9 @@ func shouldPreRestore(table *tabledesc.Mutable) bool {
 	return ok
 }
 
-// eligibleInProgressImport returns true if the descriptor represents a table with an in progress
-// import that started in a cluster finalized to version 22.2.
-func eligibleInProgressImport(
+// backedUpDescriptorWithInProgressImportInto returns true if the backed up descriptor represents a table with an in
+// progress import that started in a cluster finalized to version 22.2.
+func backedUpDescriptorWithInProgressImportInto(
 	ctx context.Context, p sql.JobExecContext, desc catalog.Descriptor,
 ) (bool, error) {
 	table, ok := desc.(catalog.TableDescriptor)
@@ -672,11 +672,6 @@ func eligibleInProgressImport(
 
 	if table.GetInProgressImportStartTime() == 0 {
 		return false, nil
-	}
-	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.Start22_2) {
-		return false, errors.AssertionFailedf(
-			`Only a finalized 22.2 cluster can set a descriptor's ImportStartTime; therefore, descriptor
-							%v should never get restored on a cluster that has not finalized to 22.2`, table.GetID())
 	}
 	return true, nil
 }
@@ -729,11 +724,19 @@ func createImportingDescriptors(
 	preRestoreTables := make([]catalog.TableDescriptor, 0)
 
 	for _, desc := range sqlDescs {
-
+		// Decide which offline tables to include in the restore:
+		//
+		// -  An offline table created by RESTORE or IMPORT PGDUMP is fully discarded.
+		//    The table will not exist in the restoring cluster.
+		//
+		// -  An offline table undergoing an IMPORT INTO has all importing data
+		//    elided in the restore processor and is restored online to its pre import
+		//    state.
+		//
 		// TODO (msbutler) remove the schema_change condition once the online schema changer
-		// doesn't rely on OFFLINE state
+		// doesn't rely on OFFLINE state (#86626, #86691)
 		if desc.Offline() && desc.GetDeclarativeSchemaChangerState() == nil {
-			if eligible, err := eligibleInProgressImport(ctx, p, desc); err != nil {
+			if eligible, err := backedUpDescriptorWithInProgressImportInto(ctx, p, desc); err != nil {
 				return nil, nil, nil, err
 			} else if !eligible {
 				continue

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -95,7 +95,7 @@ var restoreStatsInsertBatchSize = 10
 func rewriteBackupSpanKey(
 	codec keys.SQLCodec, kr *KeyRewriter, key roachpb.Key,
 ) (roachpb.Key, error) {
-	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...))
+	newKey, rewritten, err := kr.RewriteKey(append([]byte(nil), key...), 0)
 	if err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err,
 			"could not rewrite span start key: %s", key)
@@ -660,6 +660,27 @@ func shouldPreRestore(table *tabledesc.Mutable) bool {
 	return ok
 }
 
+// eligibleInProgressImport returns true if the descriptor represents a table with an in progress
+// import that started in a cluster finalized to version 22.2.
+func eligibleInProgressImport(
+	ctx context.Context, p sql.JobExecContext, desc catalog.Descriptor,
+) (bool, error) {
+	table, ok := desc.(catalog.TableDescriptor)
+	if !ok {
+		return false, nil
+	}
+
+	if table.GetInProgressImportStartTime() == 0 {
+		return false, nil
+	}
+	if !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.Start22_2) {
+		return false, errors.AssertionFailedf(
+			`Only a finalized 22.2 cluster can set a descriptor's ImportStartTime; therefore, descriptor
+							%v should never get restored on a cluster that has not finalized to 22.2`, table.GetID())
+	}
+	return true, nil
+}
+
 // createImportingDescriptors creates the tables that we will restore into and returns up to three
 // configurations for separate restoration flows. The three restoration flows are
 //
@@ -708,6 +729,17 @@ func createImportingDescriptors(
 	preRestoreTables := make([]catalog.TableDescriptor, 0)
 
 	for _, desc := range sqlDescs {
+
+		// TODO (msbutler) remove the schema_change condition once the online schema changer
+		// doesn't rely on OFFLINE state
+		if desc.Offline() && desc.GetDeclarativeSchemaChangerState() == nil {
+			if eligible, err := eligibleInProgressImport(ctx, p, desc); err != nil {
+				return nil, nil, nil, err
+			} else if !eligible {
+				continue
+			}
+		}
+
 		switch desc := desc.(type) {
 		case catalog.TableDescriptor:
 			mut := tabledesc.NewBuilder(desc.TableDesc()).BuildCreatedMutableTable()

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -1,0 +1,290 @@
+# This test ensures that database and cluster backups properly
+# backup and restore an IMPORT INTO of an empty table (foo) and a non empty table (foofoo).
+#
+# On a fully upgraded cluster: the table should get rollback to its pre-import state after RESTORE
+# On an unfinalized cluster:
+#  - a backed up import should not get restored
+# TODO: ALLOW BACKUP/RESTORE TABLE of an in progress import
+#
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+# Ensure Database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+# Ensure incremental backups do NOT re-capture the importing rows while the tables are offline
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+save-cluster-ts tag=t0
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job resume=a
+----
+
+job resume=aa
+----
+
+job tag=a wait-for-state=succeeded
+----
+
+
+job tag=aa wait-for-state=succeeded
+----
+
+
+# NOTE: currently the backups below re-capture the _2_ versions of each imported key:
+#  1: the original data that was already captured in the previous backup because BACKUP currently
+#     re-backs up the whole span once the table goes back online. This will change.
+#  2. when the import job resumes, the data is re-ingested, hence a second version of the imported
+#     data gets ingested into the backing up cluster, and consequently, the incremental backup.
+#
+# TODO (msbutler): add test coverage for a case when incremental backup only captures when the
+# descriptor goes back online.
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history;
+----
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo';
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo';
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+# Ensure all the RESTOREs contain foo (no data) and foofoo (1 row) as of system time t0
+new-server name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+restore aost=t0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+restore aost=t0
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME t0;
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+10 x0
+
+exec-sql
+DROP TABLE d.foo;
+----
+
+
+# Ensure the imported data exists as of latest time
+new-server name=s3 share-io-dir=s1 allow-implicit-access
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+1 x
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+1 x
+10 x0
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
+----
+
+query-sql
+SELECT * FROM d.foo;
+----
+1 x
+
+query-sql
+SELECT * FROM d.foofoo;
+----
+1 x
+10 x0
+
+exec-sql
+DROP TABLE d.foo;
+----
+
+#######################
+# Version Gate Testing
+#######################
+
+# In an unfinalized cluster, back up some in-progress imports. Note that during IMPORT planning, the
+# ImportStartTime is not bound to the table's descriptor, therefore during RESTORE, these tables
+# should get thrown out.
+
+new-server name=s4 share-io-dir=s1 allow-implicit-access beforeVersion=Start22_2
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
+----
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=b
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+import expect-pausepoint tag=bb
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+# Ensure Database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/';
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/';
+----
+
+# Ensure the RESTOREs omit the tables with in progress imports (foo and foofoo)
+new-server name=s5 share-io-dir=s1 allow-implicit-access
+----
+
+restore
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d];
+----
+baz
+
+exec-sql
+DROP DATABASE d;
+----
+
+
+restore
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
+----
+
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d];
+----
+baz

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -98,6 +98,7 @@ BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' WITH revision_history
 ----
 
 
+
 query-sql
 SELECT
   database_name, object_name, object_type, rows, backup_type
@@ -216,9 +217,17 @@ DROP TABLE d.foo;
 # Version Gate Testing
 #######################
 
-# In an unfinalized cluster, back up some in-progress imports. Note that during IMPORT planning, the
-# ImportStartTime is not bound to the table's descriptor, therefore during RESTORE, these tables
-# should get thrown out.
+# In an unfinalized cluster, back up some in-progress imports, and ensure that once the tables come
+# back online we fully back them again.
+#
+# Note that during IMPORT planning on an unfinalized cluster, the
+# ImportStartTime is not bound to the table's descriptor, therefore during
+# RESTORE AOST in-progress IMPORT, these tables should get thrown out.
+
+# TODO (msbutler): Currently, we still incrementally back up data from these
+# "old" jobs. Once the schema changer gets out of the business setting
+# descriptors to offline, consider preventing incremental backups of old
+# jobs, as we always have to re-back up the span once it comes online.
 
 new-server name=s4 share-io-dir=s1 allow-implicit-access beforeVersion=Start22_2
 ----
@@ -233,13 +242,16 @@ CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
 INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
 ----
 
+
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
 ----
 
+
 exec-sql
 EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz WHERE i = 1;
 ----
+
 
 # Pause the import job, in order to back up the importing data.
 import expect-pausepoint tag=b
@@ -247,21 +259,164 @@ IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
+
 import expect-pausepoint tag=bb
 IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
 ----
 job paused at pausepoint
 
-# Ensure Database, and cluster full backups capture importing rows.
+
+# The first backup in the chain will capture data from offline tables
+# NOTE: in a mixed version setting, we don't need to do this. (see todo above)
 exec-sql
-BACKUP INTO 'nodelocal://0/cluster/';
+BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database_upgrade/' with revision_history;
+----
+
+
+save-cluster-ts tag=m0
+----
+
+
+# Conduct another set of incremental backups to ensure that _offline_ tables do _not_ fully backup
+# in a cluster in an unfinalized state
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+CREATE VIEW show_cluster_backup AS
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo';
+----
+
+
+exec-sql
+CREATE VIEW show_database_backup AS
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo';
+----
+
+
+query-sql
+SELECT * FROM show_cluster_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+
+
+query-sql
+SELECT * FROM show_database_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job resume=b
+----
+
+
+job tag=b wait-for-state=succeeded
+----
+
+
+job resume=bb
+----
+
+
+job tag=bb wait-for-state=succeeded
+----
+
+
+# Key Test: Ensure that once the tables come back online, everything gets backed
+# up again, as these imports may have non-mvcc ops in them. Ensure this in the
+# unfinalized cluster and in the finalized cluster.
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+query-sql
+SELECT * FROM show_cluster_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+query-sql
+SELECT * FROM show_database_backup;
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 0 incremental
+d foofoo table 0 incremental
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+
+upgrade-server version=Start22_2
 ----
 
 exec-sql
-BACKUP DATABASE d INTO 'nodelocal://0/database/';
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database_upgrade/' with revision_history;
 ----
 
-# Ensure the RESTOREs omit the tables with in progress imports (foo and foofoo)
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database_upgrade/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo';
+----
+d foo table 1 full
+d foofoo table 2 full
+d foo table 2 incremental
+d foofoo table 3 incremental
+
+# A restore on mixed version cluster should always fail on a backup that contains import times
 new-server name=s5 share-io-dir=s1 allow-implicit-access
 ----
 
@@ -269,16 +424,29 @@ restore
 RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
 ----
 
+# Now actually Restore the backups taken from a mixed version chain
+new-server name=s6 share-io-dir=s1 allow-implicit-access
+----
+
+# Ensure the RESTOREs omit the tables with in progress imports (foo and foofoo)
+# as their descriptor will not have the import start time.
+restore aost=m0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME m0;
+----
+
+
 query-sql
 SELECT table_name FROM [SHOW TABLES FROM d];
 ----
 baz
+
 
 exec-sql
 DROP DATABASE d;
 ----
 
 
+# Restore AOST after the table comes back online
 restore
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
 ----
@@ -287,4 +455,9 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/';
 query-sql
 SELECT table_name FROM [SHOW TABLES FROM d];
 ----
+foo
+foofoo
 baz
+show_cluster_backup
+show_database_backup
+

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -80,10 +80,8 @@ job tag=aa wait-for-state=succeeded
 ----
 
 
-# NOTE: currently the backups below re-capture the _2_ versions of each imported key:
-#  1: the original data that was already captured in the previous backup because BACKUP currently
-#     re-backs up the whole span once the table goes back online. This will change.
-#  2. when the import job resumes, the data is re-ingested, hence a second version of the imported
+# NOTE: currently the backups below re-capture the _1_ version of each imported key:
+#  1. when the import job resumes, the data is re-ingested, hence a second version of the imported
 #     data gets ingested into the backing up cluster, and consequently, the incremental backup.
 #
 # TODO (msbutler): add test coverage for a case when incremental backup only captures when the
@@ -111,8 +109,8 @@ d foo table 1 full
 d foofoo table 2 full
 d foo table 0 incremental
 d foofoo table 0 incremental
-d foo table 2 incremental
-d foofoo table 3 incremental
+d foo table 1 incremental
+d foofoo table 1 incremental
 
 query-sql
 SELECT
@@ -126,9 +124,8 @@ d foo table 1 full
 d foofoo table 2 full
 d foo table 0 incremental
 d foofoo table 0 incremental
-d foo table 2 incremental
-d foofoo table 3 incremental
-
+d foo table 1 incremental
+d foofoo table 1 incremental
 
 # Ensure all the RESTOREs contain foo (no data) and foofoo (1 row) as of system time t0
 new-server name=s2 share-io-dir=s1 allow-implicit-access

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-non-mvcc
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-non-mvcc
@@ -1,0 +1,9 @@
+# test that we properly fully backup an offline span when it can be non-mvcc
+#
+# TODO(msbutler): waiting for https://github.com/cockroachdb/cockroach/pull/86689 to land
+# Part 1 - ensure clear range induces full reintroduction of spans
+# - begin import jobs and pause it
+# - run inc backup - verify inc has captured the data
+# - roll it back it back non-mvcc
+# - run an inc backup and ensure we reintroduce the table spans
+#

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -62,10 +62,8 @@ job tag=a wait-for-state=succeeded
 ----
 
 
-# NOTE: currently the backup below re-capture the _2_ versions of each restored key:
-#  1: the original data that was already captured in the previous backup because BACKUP currently
-#     re-backs up the whole span once the table goes back online. This will change.
-#  2. when the restore job resumes, the data is re-ingested, hence a second version of the restored
+# NOTE: currently the backup below re-capture the _1_ version of each restored key:
+#  1. when the restore job resumes, the data is re-ingested, hence a second version of the restored
 #     data gets ingested into the backing up cluster, and consequently, the incremental backup.
 #
 # TODO (msbutler): add test coverage for a case when incremental backup only captures when the
@@ -89,7 +87,7 @@ b baz table 3 full
 b baz table 0 incremental
 b2 baz table 3 incremental
 b baz table 0 incremental
-b2 baz table 6 incremental
+b2 baz table 3 incremental
 
 
 # Ensure the restored cluster contains nothing from the in-progress restoring database as of system

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-restores
@@ -1,0 +1,132 @@
+# This test ensures that database and cluster backups properly
+# backup and restore an in progress RESTORE
+#
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE b;
+USE b;
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+CREATE DATABASE d;
+USE d;
+----
+
+
+# Ensure Database, and cluster full backups capture restoring rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
+----
+
+
+# Pause the restore job, in order to back up the restoring data.
+restore expect-pausepoint tag=a
+RESTORE DATABASE b FROM LATEST IN 'nodelocal://0/cluster/' with new_db_name=b2;
+----
+job paused at pausepoint
+
+
+
+# Ensure incremental backups capture the offline restoring database
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+save-cluster-ts tag=t0
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that the database is back online
+job resume=a
+----
+
+
+job tag=a wait-for-state=succeeded
+----
+
+
+# NOTE: currently the backup below re-capture the _2_ versions of each restored key:
+#  1: the original data that was already captured in the previous backup because BACKUP currently
+#     re-backs up the whole span once the table goes back online. This will change.
+#  2. when the restore job resumes, the data is re-ingested, hence a second version of the restored
+#     data gets ingested into the backing up cluster, and consequently, the incremental backup.
+#
+# TODO (msbutler): add test coverage for a case when incremental backup only captures when the
+# descriptor goes back online.
+
+# This set of incremental backups captures the online restored database
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' WITH revision_history;
+----
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'baz';
+----
+b baz table 3 full
+b baz table 0 incremental
+b2 baz table 3 incremental
+b baz table 0 incremental
+b2 baz table 6 incremental
+
+
+# Ensure the restored cluster contains nothing from the in-progress restoring database as of system
+# time t0
+new-server name=s2 share-io-dir=s1 allow-implicit-access
+----
+
+
+restore aost=t0
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/' AS OF SYSTEM TIME t0;
+----
+
+
+query-sql
+SELECT database_name FROM [SHOW DATABASES] WHERE database_name = 'b2';
+----
+
+
+# Ensure restored cluster contains the restored database as of latest time
+new-server name=s3 share-io-dir=s1 allow-implicit-access
+----
+
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+
+query-sql
+SELECT database_name FROM [SHOW DATABASES] WHERE database_name = 'b2';
+----
+b2
+
+
+query-sql
+SELECT * FROM b2.baz;
+----
+1 x
+2 y
+3 z

--- a/pkg/ccl/backupccl/utils_test.go
+++ b/pkg/ccl/backupccl/utils_test.go
@@ -102,11 +102,15 @@ func backupRestoreTestSetupWithParams(
 
 	sqlDB = sqlutils.MakeSQLRunner(tc.Conns[0])
 
+	// Lower the initial buffering adder ingest size to allow concurrent import jobs to run without
+	// borking the memory monitor.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.pk_buffer_size = '16MiB'`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.index_buffer_size = '16MiB'`)
+
 	// Set the max buffer size to something low to prevent backup/restore tests
 	// from hitting OOM errors. If any test cares about this setting in
 	// particular, they will override it inline after setting up the test cluster.
 	sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '16MiB'`)
-
 	sqlDB.Exec(t, `CREATE DATABASE data`)
 	l := workloadsql.InsertsDataLoader{BatchSize: 1000, Concurrency: 4}
 	if _, err := workloadsql.Setup(ctx, sqlDB.DB.(*gosql.DB), bankData, l); err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -619,7 +619,7 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
-	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0)
+	rekey, ok, err := sip.rekeyer.RewriteKey(key /*wallTime*/, 0)
 	if !ok {
 		return nil, errors.New("every key is expected to match tenant prefix")
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -619,7 +619,7 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
-	rekey, ok, err := sip.rekeyer.RewriteKey(key)
+	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0)
 	if !ok {
 		return nil, errors.New("every key is expected to match tenant prefix")
 	}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -656,7 +656,7 @@ func registerValidatorWithClient(
 		case streamingccl.KVEvent:
 			keyVal := *event.GetKV()
 			if validator.rekeyer != nil {
-				rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key, 0)
+				rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key /*wallTime*/, 0)
 				if err != nil {
 					panic(err.Error())
 				}

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -656,7 +656,7 @@ func registerValidatorWithClient(
 		case streamingccl.KVEvent:
 			keyVal := *event.GetKV()
 			if validator.rekeyer != nil {
-				rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key)
+				rekey, _, err := validator.rekeyer.RewriteKey(keyVal.Key, 0)
 				if err != nil {
 					panic(err.Error())
 				}

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1184,7 +1184,10 @@ message TableDescriptor {
   // This field is non zero if this table is offline during an import.
   optional int64 import_start_wall_time = 54 [(gogoproto.nullable) = false, (gogoproto.customname) = "ImportStartWallTime"];
 
-  // Next ID: 55
+  // LastMVCCBulkOp indicates the last bulk ingestion to complete on this table was MVCC compatible
+  optional bool last_mvcc_bulk_op = 55 [(gogoproto.nullable) = false, (gogoproto.customname) = "LastMVCCBulkOp"];
+
+  // Next ID: 56
 }
 
 // SurvivalGoal is the survival goal for a database.

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -724,6 +724,9 @@ type TableDescriptor interface {
 	// GetInProgressImportStartTime returns the start wall time of the in progress import,
 	// if it exists.
 	GetInProgressImportStartTime() int64
+
+	// LastMVCCOp is true if the last operation was mvcc.
+	GetLastMVCCBulkOp() bool
 }
 
 // MutableTableDescriptor is both a MutableDescriptor and a TableDescriptor.

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2544,6 +2544,13 @@ func (desc *Mutable) SetOffline(reason string) {
 	desc.OfflineReason = reason
 }
 
+// SetLastMVCCBulkOp implements the MutableDescriptor interface. This function
+// should only get called if the cluster has fully upgraded to 22.2, where all
+// AddSSTable requests are MVCC.
+func (desc *Mutable) SetLastMVCCBulkOp(isMVCC bool) {
+	desc.LastMVCCBulkOp = isMVCC
+}
+
 // IsLocalityRegionalByRow implements the TableDescriptor interface.
 func (desc *wrapper) IsLocalityRegionalByRow() bool {
 	return desc.LocalityConfig.GetRegionalByRow() != nil

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -674,3 +674,8 @@ func (desc *wrapper) GetObjectType() privilege.ObjectType {
 func (desc *wrapper) GetInProgressImportStartTime() int64 {
 	return desc.ImportStartWallTime
 }
+
+// GetLastMVCCBulkOp returns true if last bulk operation was MVCC.
+func (desc *wrapper) GetLastMVCCBulkOp() bool {
+	return desc.LastMVCCBulkOp
+}

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -261,7 +261,7 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 					return errors.Wrap(err, "checking if existing table is empty")
 				}
 				details.Tables[i].WasEmpty = len(res) == 0
-				if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V22_1) {
+				if p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.Start22_2) {
 					// Update the descriptor in the job record and in the database with the ImportStartTime
 					details.Tables[i].Desc.ImportStartWallTime = details.Walltime
 					err := bindImportStartTime(ctx, p, tblDesc.GetID(), details.Walltime)
@@ -453,7 +453,6 @@ func (r *importResumer) prepareTablesForIngestion(
 	// wait for all nodes to see the same descriptor version before doing so.
 	if !hasExistingTables {
 		importDetails.Walltime = p.ExecCfg().Clock.Now().WallTime
-		// TODO(msbutler): add import start time to IMPORT PGDUMP/MYSQL descriptor
 	} else {
 		importDetails.Walltime = 0
 	}


### PR DESCRIPTION
NOTE: only the last commit is relevant


Previously, all tables that were offline as of the previous backup would be
fully backed up (i.e. from ts =0) during the first incremental backup that
observed the table back online. This patch skips fully backing up tables that
did _not_ undergo any non-mvcc operations that altered mvcc history captured in
the previous backup. Specifically, a table requires a full backup iff: 1) the
table was offline in the previous backup; and 2) the table returned online
before this current backup began via a non-mvcc operation. Two specific
examples that would bring a table to this non-mvcc state are:
1. An import rollback conducted via ClearRange
2. A sucessfull restore or import that began on a cluster where non-mvcc
AddSSTable could occur (i.e. a pre 22.2 cluster).

This patch introduces the LastMVCCBulkOps field in the table descriptor which
gets set to true when an MVCC bulk operation is about to begin on a table in a
fully upgraded 22.2 cluster. The field will be set to false when a non-mvcc
operation (i.e. ClearRange in IMPORT rollbacks) brings a table back online.
This field allows backup to track which tables satisfy the above conditions.

Release justification: high impact change to existing functionality

Release note: none