### PR TITLE
changefeedccl: redact user from confluent schema registry

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -786,35 +786,31 @@ func changefeedJobDescription(
 		changefeedbase.SinkParamCACert,
 		changefeedbase.SinkParamClientCert,
 	})
-
 	if err != nil {
 		return "", err
 	}
 
-	cleanedSinkURI = redactUser(cleanedSinkURI)
+	cleanedSinkURI, err = changefeedbase.RedactUserFromURI(cleanedSinkURI)
+	if err != nil {
+		return "", err
+	}
 
 	c := &tree.CreateChangefeed{
 		Targets: changefeed.Targets,
 		SinkURI: tree.NewDString(cleanedSinkURI),
 		Select:  changefeed.Select,
 	}
-	opts.ForEachWithRedaction(func(k string, v string) {
+	if err = opts.ForEachWithRedaction(func(k string, v string) {
 		opt := tree.KVOption{Key: tree.Name(k)}
 		if len(v) > 0 {
 			opt.Value = tree.NewDString(v)
 		}
 		c.Options = append(c.Options, opt)
-	})
+	}); err != nil {
+		return "", err
+	}
 	sort.Slice(c.Options, func(i, j int) bool { return c.Options[i].Key < c.Options[j].Key })
 	return tree.AsString(c), nil
-}
-
-func redactUser(uri string) string {
-	u, _ := url.Parse(uri)
-	if u.User != nil {
-		u.User = url.User(`redacted`)
-	}
-	return u.String()
 }
 
 func validateDetailsAndOptions(

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7330,3 +7330,30 @@ func TestChangefeedKafkaMessageTooLarge(t *testing.T) {
 
 	cdcTest(t, testFn, feedTestForceSink(`kafka`))
 }
+
+// Regression for #85902.
+func TestRedactedSchemaRegistry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE test_table (id INT PRIMARY KEY, i int, j int)`)
+
+		userInfoToRedact := "7JHKUXMWYD374NV:secret-key"
+		registryURI := fmt.Sprintf("https://%s@psrc-x77pq.us-central1.gcp.confluent.cloud:443", userInfoToRedact)
+
+		changefeedDesc := fmt.Sprintf(`CREATE CHANGEFEED FOR TABLE test_table WITH updated,
+					confluent_schema_registry =
+					"%s";`, registryURI)
+		registryURIWithRedaction := strings.Replace(registryURI, userInfoToRedact, "redacted", 1)
+		cf := feed(t, f, changefeedDesc)
+		defer closeFeed(t, cf)
+
+		var description string
+		sqlDB.QueryRow(t, "SELECT description from [SHOW CHANGEFEED JOBS]").Scan(&description)
+
+		assert.Contains(t, description, registryURIWithRedaction)
+	}
+
+	// kafka supports the confluent_schema_registry option.
+	cdcTest(t, testFn, feedTestForceSink("kafka"))
+}

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -10,6 +10,7 @@ package changefeedbase
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -356,8 +357,32 @@ var ExternalConnectionValidOptions = makeStringSet(
 var CaseInsensitiveOpts = makeStringSet(OptFormat, OptEnvelope, OptCompression, OptSchemaChangeEvents,
 	OptSchemaChangePolicy, OptOnError, OptInitialScan)
 
+// redactionFunc is a function applied to a string option which returns its redacted value.
+type redactionFunc func(string) (string, error)
+
+var redactSimple = func(string) (string, error) {
+	return "redacted", nil
+}
+
+// RedactUserFromURI takes a URI string and removes the user from it.
+// If there is no user, the original URI is returned.
+func RedactUserFromURI(uri string) (string, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return "", err
+	}
+	if u.User != nil {
+		u.User = url.User(`redacted`)
+	}
+	return u.String(), nil
+}
+
 // RedactedOptions are options whose values should be replaced with "redacted" in job descriptions and errors.
-var RedactedOptions = makeStringSet(OptWebhookAuthHeader, SinkParamClientKey)
+var RedactedOptions = map[string]redactionFunc{
+	OptWebhookAuthHeader:       redactSimple,
+	SinkParamClientKey:         redactSimple,
+	OptConfluentSchemaRegistry: RedactUserFromURI,
+}
 
 // NoLongerExperimental aliases options prefixed with experimental that no longer need to be
 var NoLongerExperimental = map[string]string{
@@ -408,12 +433,15 @@ func MakeStatementOptions(opts map[string]string) StatementOptions {
 	if opts == nil {
 		return MakeDefaultOptions()
 	}
+	stmtOpts := make(map[string]string)
 	for key, value := range opts {
 		if _, ok := CaseInsensitiveOpts[key]; ok {
-			opts[key] = strings.ToLower(value)
+			stmtOpts[key] = strings.ToLower(value)
+		} else {
+			stmtOpts[key] = value
 		}
 	}
-	return StatementOptions{m: opts}
+	return StatementOptions{m: stmtOpts}
 }
 
 // MakeDefaultOptions creates the StatementOptions you'd get from
@@ -446,18 +474,21 @@ func (s StatementOptions) DeprecationWarnings() []string {
 	return []string{}
 }
 
-var redacted string = "redacted"
-
 // ForEachWithRedaction iterates a function over the raw key/value pairs.
 // Meant for serialization.
-func (s StatementOptions) ForEachWithRedaction(fn func(k string, v string)) {
+func (s StatementOptions) ForEachWithRedaction(fn func(k string, v string)) error {
 	for k, v := range s.m {
-		if _, redact := RedactedOptions[k]; redact {
-			fn(k, redacted)
+		if redactionFunc, redact := RedactedOptions[k]; redact {
+			redactedVal, err := redactionFunc(v)
+			if err != nil {
+				return err
+			}
+			fn(k, redactedVal)
 		} else {
 			fn(k, v)
 		}
 	}
+	return nil
 }
 
 // HasStartCursor returns true if we're starting from a


### PR DESCRIPTION
This change redacts the confluent schema registry key
from the jobs table.

Fixes: https://github.com/cockroachdb/cockroach/issues/85902

Release justification: This change is important because
it prevents a user's secret key from being store in the DB.
The footprint of this change is small as it only touches
a specific changefeed option - confluent schema registry.

Release note (enterprise change): Previously, SHOW CHANGEFEED
JOBS would reveal confluent schema registry user information,
including a user's secret key. This change makes this info
redacted, meaning it will not be stored in CockroachDB
internal tables at all.