### PR TITLE
scbuildstmt: added cluster version gating for declarative schema changer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer_mixed
@@ -1,0 +1,83 @@
+# LogicTest: local-mixed-22.1-22.2
+
+# This logic test tests that in a mixed-version cluster
+# (v22.1 and v22.2), all DDL statement supported in v22.1
+# will succeed and all supported in v22.2 will incur a panic.
+
+# Setup
+statement ok
+SET use_declarative_schema_changer = off;
+
+user root
+
+statement ok
+CREATE DATABASE testdb;
+CREATE SCHEMA testdb.testsc;
+CREATE TYPE testdb.testsc.typ AS enum ('a', 'b');
+CREATE SEQUENCE testdb.testsc.s;
+CREATE TABLE testdb.testsc.t (i INT NOT NULL, CONSTRAINT check_i_positive CHECK (i > 0));
+CREATE VIEW testdb.testsc.v AS (SELECT i+1 FROM testdb.testsc.t);
+CREATE INDEX idx ON testdb.testsc.t(i);
+
+# Turn on declarative schema changer.
+statement ok
+SET use_declarative_schema_changer = unsafe_always;
+
+# Verify that DDL stmts only supported in v22.2 will cause a panic.
+statement error pq: \*tree\.AlterTable not implemented in the new schema changer
+ALTER TABLE testdb.testsc.t DROP COLUMN j;
+
+statement error pq: \*tree\.AlterTable not implemented in the new schema changer
+ALTER TABLE testdb.testsc.t ALTER PRIMARY KEY USING COLUMNS (i);
+
+statement error pq: \*tree\.AlterTable not implemented in the new schema changer
+ALTER TABLE testdb.testsc.t ADD PRIMARY KEY (i);
+
+statement error pq: \*tree\.CreateIndex not implemented in the new schema changer
+CREATE INDEX another_idx ON testdb.testsc.t(i);
+
+statement error pq: \*tree\.DropOwnedBy not implemented in the new schema changer
+DROP OWNED BY root;
+
+statement error pq: \*tree\.CommentOnDatabase not implemented in the new schema changer
+COMMENT ON DATABASE testdb IS 'I am a comment on testdb';
+
+statement error pq: \*tree\.CommentOnSchema not implemented in the new schema changer
+COMMENT ON SCHEMA testsc IS 'I am a comment on testsc';
+
+statement error pq: \*tree\.CommentOnTable not implemented in the new schema changer
+COMMENT ON TABLE testdb.testsc.t IS 'I am a comment on testdb.testsc.t';
+
+statement error pq: \*tree\.CommentOnColumn not implemented in the new schema changer
+COMMENT ON COLUMN testdb.testsc.t.i IS 'I am a comment on testdb.testsc.t.i';
+
+statement error pq: \*tree\.CommentOnIndex not implemented in the new schema changer
+COMMENT ON INDEX testdb.testsc.t@idx IS 'I am a comment on testdb.testsc.t.idx';
+
+statement error pq: \*tree\.CommentOnConstraint not implemented in the new schema changer
+COMMENT ON CONSTRAINT check_i_positive ON testdb.testsc.t IS 'I am a comment on testdb.testsc.t.check_i_positive';
+
+statement error pq: \*tree\.DropIndex not implemented in the new schema changer
+DROP INDEX testdb.testsc.t@idx
+
+# Verify that DDL stmts supported in v22.1 will succeed.
+statement ok
+ALTER TABLE testdb.testsc.t ADD COLUMN j INT NOT NULL DEFAULT 30;
+
+statement ok
+DROP TYPE testdb.testsc.typ;
+
+statement ok
+DROP VIEW testdb.testsc.v;
+
+statement ok
+DROP SEQUENCE testdb.testsc.s;
+
+statement ok
+DROP TABLE testdb.testsc.t;
+
+statement ok
+DROP SCHEMA testdb.testsc;
+
+statement ok
+DROP DATABASE testdb;

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-22.1-22.2/generated_test.go
@@ -72,6 +72,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestLogic_new_schema_changer_mixed(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "new_schema_changer_mixed")
+}
+
 func TestLogic_system_privileges_mixed(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -13,6 +13,7 @@ package scbuildstmt
 import (
 	"reflect"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -37,21 +38,24 @@ type supportedAlterTableCommand struct {
 	// extra round-trips to resolve the descriptor and its elements if we know
 	// that we cannot process the command.
 	extraChecks interface{}
+	// minSupportedClusterVersion is the minimal binary version that supports this
+	// ALTER TABLE command in the declarative schema changer.
+	minSupportedClusterVersion clusterversion.Key
 }
 
 // supportedAlterTableStatements tracks alter table operations fully supported by
 // declarative schema  changer. Operations marked as non-fully supported can
 // only be with the use_declarative_schema_changer session variable.
 var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
-	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true},
-	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {fn: alterTableDropColumn, on: true},
-	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {fn: alterTableAlterPrimaryKey, on: true},
+	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {fn: alterTableDropColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {fn: alterTableAlterPrimaryKey, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
 	reflect.TypeOf((*tree.AlterTableAddConstraint)(nil)): {fn: alterTableAddConstraint, on: true, extraChecks: func(
 		t *tree.AlterTableAddConstraint,
 	) bool {
 		d, ok := t.ConstraintDef.(*tree.UniqueConstraintTableDef)
 		return ok && d.PrimaryKey && t.ValidationBehavior == tree.ValidationDefault
-	}},
+	}, minSupportedClusterVersion: clusterversion.Start22_2},
 }
 
 func init() {
@@ -105,6 +109,18 @@ func alterTableIsSupported(n *tree.AlterTable, mode sessiondatapb.NewSchemaChang
 		// determine enablement,
 		if !info.on &&
 			mode == sessiondatapb.UseNewSchemaChangerOn {
+			return false
+		}
+	}
+	return true
+}
+
+// alterTableAllCmdsSupportedInCurrentClusterVersion determines if all commands
+// in this `ALTER TABLE` statement are supported under the current cluster version.
+func alterTableAllCmdsSupportedInCurrentClusterVersion(b BuildCtx, n *tree.AlterTable) bool {
+	for _, cmd := range n.Cmds {
+		minSupportedClusterVersion := supportedAlterTableStatements[reflect.TypeOf(cmd)].minSupportedClusterVersion
+		if !b.EvalCtx().Settings.Version.IsActive(b, minSupportedClusterVersion) {
 			return false
 		}
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -13,6 +13,7 @@ package scbuildstmt
 import (
 	"reflect"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
@@ -31,6 +32,9 @@ type supportedStatement struct {
 	// extra round-trips to resolve the descriptor and its elements if we know
 	// that we cannot process the command.
 	extraChecks interface{}
+	// minSupportedClusterVersion is the minimal binary version that supports this
+	// statement in the declarative schema changer.
+	minSupportedClusterVersion clusterversion.Key
 }
 
 // isFullySupported returns if this statement type is supported, where the
@@ -65,22 +69,22 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	// supportedAlterTableStatements list, so wwe will consider it fully supported
 	// here.
 	reflect.TypeOf((*tree.AlterTable)(nil)):          {fn: AlterTable, on: true, extraChecks: alterTableIsSupported},
-	reflect.TypeOf((*tree.CreateIndex)(nil)):         {fn: CreateIndex, on: false},
-	reflect.TypeOf((*tree.DropDatabase)(nil)):        {fn: DropDatabase, on: true},
-	reflect.TypeOf((*tree.DropOwnedBy)(nil)):         {fn: DropOwnedBy, on: true},
-	reflect.TypeOf((*tree.DropSchema)(nil)):          {fn: DropSchema, on: true},
-	reflect.TypeOf((*tree.DropSequence)(nil)):        {fn: DropSequence, on: true},
-	reflect.TypeOf((*tree.DropTable)(nil)):           {fn: DropTable, on: true},
-	reflect.TypeOf((*tree.DropType)(nil)):            {fn: DropType, on: true},
-	reflect.TypeOf((*tree.DropView)(nil)):            {fn: DropView, on: true},
-	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, on: true},
-	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {fn: CommentOnSchema, on: true},
-	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {fn: CommentOnTable, on: true},
-	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {fn: CommentOnColumn, on: true},
-	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {fn: CommentOnIndex, on: true},
-	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, on: true},
+	reflect.TypeOf((*tree.CreateIndex)(nil)):         {fn: CreateIndex, on: false, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.DropDatabase)(nil)):        {fn: DropDatabase, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.DropOwnedBy)(nil)):         {fn: DropOwnedBy, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.DropSchema)(nil)):          {fn: DropSchema, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.DropSequence)(nil)):        {fn: DropSequence, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.DropTable)(nil)):           {fn: DropTable, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.DropType)(nil)):            {fn: DropType, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.DropView)(nil)):            {fn: DropView, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.CommentOnDatabase)(nil)):   {fn: CommentOnDatabase, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnSchema)(nil)):     {fn: CommentOnSchema, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnTable)(nil)):      {fn: CommentOnTable, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnColumn)(nil)):     {fn: CommentOnColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnIndex)(nil)):      {fn: CommentOnIndex, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
+	reflect.TypeOf((*tree.CommentOnConstraint)(nil)): {fn: CommentOnConstraint, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
 	// TODO (Xiang): turn on `DROP INDEX` as fully supported.
-	reflect.TypeOf((*tree.DropIndex)(nil)): {fn: DropIndex, on: false},
+	reflect.TypeOf((*tree.DropIndex)(nil)): {fn: DropIndex, on: false, minSupportedClusterVersion: clusterversion.Start22_2},
 }
 
 func init() {
@@ -148,6 +152,12 @@ func Process(b BuildCtx, n tree.Statement) {
 	) {
 		panic(scerrors.NotImplementedError(n))
 	}
+
+	// Check if the statement is supported in the current cluster version.
+	if !stmtSupportedInCurrentClusterVersion(b, n) {
+		panic(scerrors.NotImplementedError(n))
+	}
+
 	// Next invoke the callback function, with the concrete types.
 	fn := reflect.ValueOf(info.fn)
 	in := []reflect.Value{reflect.ValueOf(b), reflect.ValueOf(n)}
@@ -157,4 +167,15 @@ func Process(b BuildCtx, n tree.Statement) {
 		panic(err)
 	}
 	fn.Call(in)
+}
+
+// stmtSupportedInCurrentClusterVersion checks whether the statement is supported
+// in current cluster version.
+func stmtSupportedInCurrentClusterVersion(b BuildCtx, n tree.Statement) bool {
+	if alterTableStmt, isAlterTable := n.(*tree.AlterTable); isAlterTable {
+		return alterTableAllCmdsSupportedInCurrentClusterVersion(b, alterTableStmt)
+	}
+	minSupportedClusterVersion := supportedStatements[reflect.TypeOf(n)].minSupportedClusterVersion
+	return b.EvalCtx().Settings.Version.IsActive(b, minSupportedClusterVersion)
+
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -134,10 +134,6 @@ func CheckIfStmtIsSupported(n tree.Statement, mode sessiondatapb.NewSchemaChange
 // Process dispatches on the statement type to populate the BuilderState
 // embedded in the BuildCtx. Any error will be panicked.
 func Process(b BuildCtx, n tree.Statement) {
-	// If a statement is not supported throw a not implemented error.
-	if !CheckIfStmtIsSupported(n, b.EvalCtx().SessionData().NewSchemaChangerMode) {
-		panic(scerrors.NotImplementedError(n))
-	}
 	// Check if an entry exists for the statement type, in which
 	// case it is either fully or partially supported.
 	info, ok := supportedStatements[reflect.TypeOf(n)]


### PR DESCRIPTION
For each implemented DDL stmt in the new schema changer, we added a
    minimal supported cluster version so that we can return an unimplemented
    error when the cluster version is lower than the minimal supported
    cluster version of that DDL statement.

 This will be useful in mixed-version cluster where we make sure we don't
    use new schema changer for statements that are only supported in v22.2,
    but not in v22.1.

Partially fix #79840

 Release justification: improve safety and prevent issues in
    mixed-version cluster.

 Release note: None