### PR TITLE
builtins: don't panic on placeholders in bounded staleness function

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/as_of
+++ b/pkg/ccl/logictestccl/testdata/logic_test/as_of
@@ -332,3 +332,9 @@ PREPARE bad_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_tim
 
 statement error unimplemented: cannot use bounded staleness for queries that may touch more than one range or require an index join
 EXECUTE bad_min_timestamp_stmt
+
+statement error expected timestamptz argument for min_timestamp
+PREPARE placeholder_min_timestamp_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_min_timestamp($1)
+
+statement error expected interval argument for max_staleness
+PREPARE placeholder_bounded_staleness_stmt AS SELECT * FROM t AS OF SYSTEM TIME with_max_staleness($1)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2712,7 +2712,11 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return withMinTimestamp(ctx, tree.MustBeDTimestampTZ(args[0]).Time)
+				ts, ok := tree.AsDTimestampTZ(args[0])
+				if !ok {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
+				}
+				return withMinTimestamp(ctx, ts.Time)
 			},
 			Info:       withMinTimestampInfo(false /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2724,7 +2728,11 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return withMinTimestamp(ctx, tree.MustBeDTimestampTZ(args[0]).Time)
+				ts, ok := tree.AsDTimestampTZ(args[0])
+				if !ok {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
+				}
+				return withMinTimestamp(ctx, ts.Time)
 			},
 			Info:       withMinTimestampInfo(true /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2739,7 +2747,11 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return withMaxStaleness(ctx, tree.MustBeDInterval(args[0]).Duration)
+				interval, ok := tree.AsDInterval(args[0])
+				if !ok {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
+				}
+				return withMaxStaleness(ctx, interval.Duration)
 			},
 			Info:       withMaxStalenessInfo(false /* nearestOnly */),
 			Volatility: volatility.Volatile,
@@ -2751,7 +2763,11 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return withMaxStaleness(ctx, tree.MustBeDInterval(args[0]).Duration)
+				interval, ok := tree.AsDInterval(args[0])
+				if !ok {
+					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
+				}
+				return withMaxStaleness(ctx, interval.Duration)
 			},
 			Info:       withMaxStalenessInfo(true /* nearestOnly */),
 			Volatility: volatility.Volatile,

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3027,11 +3027,21 @@ type DInterval struct {
 	duration.Duration
 }
 
+// AsDInterval attempts to retrieve a DInterval from an Expr, panicking if the
+// assertion fails.
+func AsDInterval(e Expr) (*DInterval, bool) {
+	switch t := e.(type) {
+	case *DInterval:
+		return t, true
+	}
+	return nil, false
+}
+
 // MustBeDInterval attempts to retrieve a DInterval from an Expr, panicking if the
 // assertion fails.
 func MustBeDInterval(e Expr) *DInterval {
-	switch t := e.(type) {
-	case *DInterval:
+	t, ok := AsDInterval(e)
+	if ok {
 		return t
 	}
 	panic(errors.AssertionFailedf("expected *DInterval, found %T", e))


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/86243

Release note (bug fix): Fixed a crash/panic that could occur if
placeholder arguments were used with the with_min_timestamp or
with_max_staleness functions.

Release justification: Fix a crash caused by a panic.