### PR TITLE
distsql: finish the tracing span later in an error case

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -241,13 +241,15 @@ func (ds *ServerImpl) setupFlow(
 	// cleaned up in Flow.Cleanup()) if an error is encountered.
 	defer func() {
 		if retErr != nil {
-			if sp != nil {
-				sp.Finish()
-			}
 			if monitor != nil {
 				monitor.Stop(ctx)
 			}
 			onFlowCleanup()
+			// We finish the span after performing other cleanup in case that
+			// cleanup accesses the context with the span.
+			if sp != nil {
+				sp.Finish()
+			}
 			retCtx = tracing.ContextWithSpan(ctx, nil)
 		}
 	}()


### PR DESCRIPTION
Previously, it was possible to run the finished tracing span when
setting up the remote DistSQL flow if that setup encounters an error. In
such a scenario, we need to clean up the resources explicitly, and the
order of that cleanup was incorrect - we would finish the span before
possibly using the context that is still referencing the finished span.
This is now fixed.

Fixes: #86369.

Release justification: bug fix.

Release note: None