### PR TITLE
sql: prevent DROP OWNED BY with synthetic privileges

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/drop_owned_by
@@ -624,3 +624,11 @@ SHOW GRANTS ON DATABASE d3
 d3  admin     ALL      true
 d3  public    CONNECT  false
 d3  root      ALL      true
+
+# Drop owned by should not work if the user has synthetic privileges.
+
+statement ok
+GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser
+
+statement error pq: cannot perform drop owned by if role has synthetic privileges; testuser has entries in system.privileges
+DROP OWNED BY testuser

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -3248,3 +3248,16 @@ func isCurrentMutationDiscarded(
 	// Not discarded by any later operation.
 	return false, descpb.InvalidMutationID
 }
+
+// CanPerformDropOwnedBy returns if we can perform DROP OWNED BY in the new
+// schema changer. Currently, we do not have an element in the new schema
+// changer for system.privileges, thus we cannot properly support drop
+// owned by if the user has entries in the system.privileges table.
+func (p *planner) CanPerformDropOwnedBy(
+	ctx context.Context, role username.SQLUsername,
+) (bool, error) {
+	row, err := p.QueryRowEx(ctx, `role-has-synthetic-privileges`, sessiondata.NodeUserSessionDataOverride,
+		`SELECT count(1) FROM system.privileges WHERE username = $1`, role.Normalized())
+
+	return tree.MustBeDInt(row[0]) == 0, err
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/dependencies.go
@@ -160,6 +160,12 @@ type SchemaFeatureChecker interface {
 	// CheckFeature returns if the feature name specified is allowed or disallowed,
 	// by the database administrator.
 	CheckFeature(ctx context.Context, featureName tree.SchemaFeatureName) error
+
+	// CanPerformDropOwnedBy returns if we can do DROP OWNED BY for the
+	// given role.
+	CanPerformDropOwnedBy(
+		ctx context.Context, role username.SQLUsername,
+	) (bool, error)
 }
 
 // PrivilegeChecker checks an element's privileges.

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -177,6 +178,13 @@ func (s *TestState) AstFormatter() scbuild.AstFormatter {
 func (s *TestState) CheckFeature(ctx context.Context, featureName tree.SchemaFeatureName) error {
 	s.LogSideEffectf("checking for feature: %s", featureName)
 	return nil
+}
+
+// CanPerformDropOwnedBy implements scbuild.SchemaFeatureCheck.
+func (s *TestState) CanPerformDropOwnedBy(
+	ctx context.Context, role username.SQLUsername,
+) (bool, error) {
+	return true, nil
 }
 
 // FeatureChecker implements scbuild.Dependencies


### PR DESCRIPTION
Release justification: disallowing certain case within new schema change, bug fix

Release note (sql change): DROP OWNED BY cannot be performed if the
user has synthetic privileges (in system.privileges)

Fixes https://github.com/cockroachdb/cockroach/pull/86499