### PR TITLE
test: add a testingutils method to use succeedssoon with things that …

### DIFF
--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -72,7 +72,8 @@
     "fmtsafe": {
         "exclude_files": {
             "cockroach/pkg/roachprod/logger/log\\.go$": "format argument is not a constant expression",
-            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression"
+            "cockroach/pkg/util/log/channels\\.go$": "format argument is not a constant expression",
+            "cockroach/pkg/testutils/soon\\.go$": "argument is not a constant expression"
         },
         "only_files": {
             "cockroach/pkg/.*$": "first-party code"

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -268,10 +268,8 @@ func TestChangefeedIdleness(t *testing.T) {
 		registry := s.Server.JobRegistry().(*jobs.Registry)
 		currentlyIdle := registry.MetricsStruct().JobMetrics[jobspb.TypeChangefeed].CurrentlyIdle
 		waitForIdleCount := func(numIdle int64) {
-			testutils.SucceedsSoon(t, func() error {
-				if currentlyIdle.Value() != numIdle {
-					return fmt.Errorf("expected (%+v) idle changefeeds, found (%+v)", numIdle, currentlyIdle.Value())
-				}
+			testutils.RequireSoon(t, func(t testutils.TB) error {
+				require.Equal(t, numIdle, currentlyIdle.Value())
 				return nil
 			})
 		}
@@ -913,22 +911,16 @@ func TestChangefeedBackfillObservability(t *testing.T) {
 		for i := 0; i < numRanges/2; i++ {
 			scanChan <- struct{}{}
 		}
-		testutils.SucceedsSoon(t, func() error {
-			count := pendingRanges.Value()
-			if count != int64(numRanges/2) {
-				return fmt.Errorf("range count %d should be %d", count, numRanges/2)
-			}
+		testutils.RequireSoon(t, func(t testutils.TB) error {
+			require.Equal(t, numRanges/2, pendingRanges.Value())
 			return nil
 		})
 
 		// Ensure that the pending count is cleared if the backfill completes
 		// regardless of successful scans
 		scanCancel()
-		testutils.SucceedsSoon(t, func() error {
-			count := pendingRanges.Value()
-			if count > 0 {
-				return fmt.Errorf("range count %d should be 0", count)
-			}
+		testutils.RequireSoon(t, func(t testutils.TB) error {
+			require.Zero(t, pendingRanges.Value())
 			return nil
 		})
 	}
@@ -3169,10 +3161,8 @@ func TestChangefeedTruncateOrDrop(t *testing.T) {
 		if strings.Contains(t.Name(), `sinkless`) {
 			return
 		}
-		testutils.SucceedsSoon(t, func() error {
-			if got := m.Failures.Count(); got != exp {
-				return errors.Errorf("expected %d failures, got %d", exp, got)
-			}
+		testutils.RequireSoon(t, func(t testutils.TB) error {
+			require.Equal(t, exp, m.Failures.Count())
 			return nil
 		})
 	}
@@ -3272,31 +3262,17 @@ func TestChangefeedMonitoring(t *testing.T) {
 		_, err = foo.Next()
 		require.NoError(t, err)
 
-		testutils.SucceedsSoon(t, func() error {
-			if c := s.Server.MustGetSQLCounter(`changefeed.emitted_messages`); c != 1 {
-				return errors.Errorf(`expected 1 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.emitted_bytes`); c != 22 {
-				return errors.Errorf(`expected 22 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.flushed_bytes`); c != 22 {
-				return errors.Errorf(`expected 22 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.flushes`); c <= 0 {
-				return errors.Errorf(`expected > 0 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.running`); c != 1 {
-				return errors.Errorf(`expected 1 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.max_behind_nanos`); c <= 0 {
-				return errors.Errorf(`expected > 0 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.in`); c <= 0 {
-				return errors.Errorf(`expected > 0 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.buffer_entries.out`); c <= 0 {
-				return errors.Errorf(`expected > 0 got %d`, c)
-			}
+		metric := func(c string) int { return int(s.Server.MustGetSQLCounter(c)) }
+
+		testutils.RequireSoon(t, func(t testutils.TB) error {
+			require.Equal(t, 1, metric(`changefeed.emitted_messages`))
+			require.Equal(t, 22, metric(`changefeed.emitted_bytes`))
+			require.Equal(t, 22, metric(`changefeed.flushed_bytes`))
+			require.Greater(t, metric(`changefeed.flushes`), 0)
+			require.Equal(t, 1, metric(`changefeed.running`))
+			require.Greater(t, metric(`changefeed.max_behind_nanos`), 0)
+			require.Greater(t, metric(`changefeed.buffer_entries.in`), 0)
+			require.Greater(t, metric(`changefeed.buffer_entries.out`), 0)
 			return nil
 		})
 
@@ -3308,15 +3284,11 @@ func TestChangefeedMonitoring(t *testing.T) {
 		fooCopy := feed(t, f, `CREATE CHANGEFEED FOR foo`)
 		_, _ = fooCopy.Next()
 		_, _ = fooCopy.Next()
-		testutils.SucceedsSoon(t, func() error {
+		testutils.RequireSoon(t, func(t testutils.TB) error {
 			// We can't assert exactly 4 or 88 in case we get (allowed) duplicates
 			// from RangeFeed.
-			if c := s.Server.MustGetSQLCounter(`changefeed.emitted_messages`); c < 4 {
-				return errors.Errorf(`expected >= 4 got %d`, c)
-			}
-			if c := s.Server.MustGetSQLCounter(`changefeed.emitted_bytes`); c < 88 {
-				return errors.Errorf(`expected >= 88 got %d`, c)
-			}
+			require.GreaterOrEqual(t, metric(`changefeed.emitted_messages`), 4)
+			require.GreaterOrEqual(t, metric(`changefeed.emitted_bytes`), 88)
 			return nil
 		})
 

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
         "//pkg/util/netutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2250,6 +2250,8 @@ func TestLint(t *testing.T) {
 			// instead of ...interface{}.
 			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: logfDepth\(\): format argument is not a constant expression`),
 			stream.GrepNot(`pkg/util/log/channels\.go:\d+:\d+: logfDepthInternal\(\): format argument is not a constant expression`),
+			// testutils/soon doesn't end in _test so can't skip this lint, but is used exclusively in tests.
+			stream.GrepNot(`pkg/testutils/soon\.go:\d+:\d+:.* argument is not a constant expression`),
 			// roachprod/logger is not collecting redactable logs so we don't care
 			// about printf hygiene there as much.
 			stream.GrepNot(`pkg/roachprod/logger/log\.go:.*format argument is not a constant expression`),

--- a/pkg/testutils/soon_test.go
+++ b/pkg/testutils/soon_test.go
@@ -8,28 +8,59 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-package testutils
+package testutils_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSucceedsSoon(t *testing.T) {
 	// Try a method which always succeeds.
-	SucceedsSoon(t, func() error { return nil })
+	testutils.SucceedsSoon(t, func() error { return nil })
 
 	// Try a method which succeeds after a known duration.
 	start := timeutil.Now()
 	duration := time.Millisecond * 10
-	SucceedsSoon(t, func() error {
+	testutils.SucceedsSoon(t, func() error {
 		elapsed := timeutil.Since(start)
 		if elapsed > duration {
 			return nil
 		}
 		return errors.Errorf("%s elapsed, waiting until %s elapses", elapsed, duration)
 	})
+}
+func TestRequireSoon(t *testing.T) {
+	// Try a method which always succeeds.
+	testutils.RequireSoon(t, func(t testutils.TB) error { return nil })
+
+	// Try a method which succeeds after a known duration.
+	start := timeutil.Now()
+	duration := time.Millisecond * 10
+	testutils.RequireSoon(t, func(t testutils.TB) error {
+		assert.Greater(t, timeutil.Since(start), duration)
+		return nil
+	})
+
+	// Ensure that helpers that call FailNow halt execution immediately,
+	// then retry, while helpers that just call Errorf don't halt execution.
+	postAssertCount := 0
+	postRequireCount := 0
+	testutils.RequireSoon(t, func(t testutils.TB) error {
+		assert.Greater(t, postAssertCount, 1)
+		postAssertCount++
+		require.Equal(t, postAssertCount, 3)
+		postRequireCount++
+		return nil
+	})
+
+	require.Equal(t, 3, postAssertCount)
+	require.Equal(t, 1, postRequireCount)
+
 }


### PR DESCRIPTION
…call failnow

SucceedsSoon() is great. testify's require.Equals() and friends are great. But I can't use
a require.Equals() in a SucceedsSoon() because it needs a *testing.T, and the only one around
is the one that fails the test immediately. So this commit adds a method that works like
SucceedsSoon but takes a funcn(t testutils.TB) instead of a func() so it can use t like
normal.

Release note: None

Release justification: