### PR TITLE
build: increase timeout of cluster-ui tests

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/BUILD.bazel
+++ b/pkg/ui/workspaces/cluster-ui/BUILD.bazel
@@ -315,6 +315,7 @@ JEST_DEPS = DEPENDENCIES + [
 
 jest_test(
     name = "jest",
+    size = "enormous",
     data = JEST_DEPS,
     templated_args = [
         "--runInBand",


### PR DESCRIPTION
The unit tests for pkg/ui/workspaces/cluster-ui previously used the
default test size in Bazel ("medium"), which times out after five
minutes and assumes peak memory usage of 100MB. Those tests are
significantly slower than that and use well over 1GB of RAM though,
which led to Bazel killing the `jest` process before testing could
complete. Mark the cluster-ui tests as "enormous" (the largest
supported size) to increase the test duration to 60 minutes and peak
memory usage to 800MB.

Release justification: non-production code changes
Release note: None