### PR TITLE
sql: add COPY to sampled_query logging

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -48,6 +48,7 @@ var copyBatchRowSize = util.ConstantWithMetamorphicTestRange("copy-batch-size", 
 
 type copyMachineInterface interface {
 	run(ctx context.Context) error
+	numInsertedRows() int
 
 	// Close closes memory accounts associated with copy.
 	Close(ctx context.Context)
@@ -264,6 +265,10 @@ func newCopyMachine(
 	c.rows.Init(c.rowsMemAcc, colinfo.ColTypeInfoFromResCols(c.resultColumns), copyBatchRowSize)
 	c.scratchRow = make(tree.Datums, len(c.resultColumns))
 	return c, nil
+}
+
+func (c *copyMachine) numInsertedRows() int {
+	return c.insertedRows
 }
 
 func (c *copyMachine) initMonitoring(ctx context.Context, parentMon *mon.BytesMonitor) {

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -170,6 +170,10 @@ func CopyInFileStmt(destination, schema, table string) string {
 	)
 }
 
+func (f *fileUploadMachine) numInsertedRows() int {
+	return f.c.numInsertedRows()
+}
+
 func (f *fileUploadMachine) Close(ctx context.Context) {
 	f.c.Close(ctx)
 }


### PR DESCRIPTION
As requested by product, we want COPY to show up on sampled_query. This
commit adds this, whilst fudging a few things presumably more relevant
to "regular" DDL statements.

Release justification: telemetry only change

Release note: None