### PR TITLE
gen: add schemachanger to code generation target

### DIFF
--- a/pkg/gen/BUILD.bazel
+++ b/pkg/gen/BUILD.bazel
@@ -57,6 +57,7 @@ gen(
         ":misc",
         ":optgen",
         ":parser",
+        ":schemachanger",
         ":stringer",
     ],
 )


### PR DESCRIPTION
Before this, dev gen go did not regenerate schemachanger code.

Release justification: build tooling only change.

Release note: None