### PR TITLE
kvserver: fix slow raft proposal gauge

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -634,6 +634,8 @@ type Replica struct {
 		// Never mutated in place (always replaced wholesale), so can be leaked
 		// outside the surrounding mutex.
 		pausedFollowers map[roachpb.ReplicaID]struct{}
+
+		slowProposalCount int64 // updated in refreshProposalsLocked
 	}
 
 	// The raft log truncations that are pending. Access is protected by its own

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9363,12 +9363,18 @@ func TestReplicaMetrics(t *testing.T) {
 			// quiescent metric.
 			c.expected.Quiescent = i%2 == 0
 			c.expected.Ticking = !c.expected.Quiescent
-			metrics := calcReplicaMetrics(
-				ctx, hlc.Timestamp{}, &cfg.RaftConfig, spanConfig,
-				c.liveness, 0, &c.desc, c.raftStatus, kvserverpb.LeaseStatus{},
-				c.storeID, c.expected.Quiescent, c.expected.Ticking,
-				concurrency.LatchMetrics{}, concurrency.LockTableMetrics{}, c.raftLogSize,
-				true, 0, 0, nil /* overloadMap */)
+			metrics := calcReplicaMetrics(ctx, calcReplicaMetricsInput{
+				raftCfg:            &cfg.RaftConfig,
+				conf:               spanConfig,
+				livenessMap:        c.liveness,
+				desc:               &c.desc,
+				raftStatus:         c.raftStatus,
+				storeID:            c.storeID,
+				quiescent:          c.expected.Quiescent,
+				ticking:            c.expected.Ticking,
+				raftLogSize:        c.raftLogSize,
+				raftLogSizeTrusted: true,
+			})
 			require.Equal(t, c.expected, metrics)
 		})
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -9363,7 +9363,7 @@ func TestReplicaMetrics(t *testing.T) {
 			// quiescent metric.
 			c.expected.Quiescent = i%2 == 0
 			c.expected.Ticking = !c.expected.Quiescent
-			metrics := calcReplicaMetrics(ctx, calcReplicaMetricsInput{
+			metrics := calcReplicaMetrics(calcReplicaMetricsInput{
 				raftCfg:            &cfg.RaftConfig,
 				conf:               spanConfig,
 				livenessMap:        c.liveness,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3127,6 +3127,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		overreplicatedRangeCount  int64
 		behindCount               int64
 		pausedFollowerCount       int64
+		slowRaftProposalCount     int64
 
 		locks                          int64
 		totalLockHoldDurationNanos     int64
@@ -3186,6 +3187,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			}
 		}
 		pausedFollowerCount += metrics.PausedFollowerCount
+		slowRaftProposalCount += metrics.SlowRaftProposalCount
 		behindCount += metrics.BehindCount
 		if qps, dur := rep.loadStats.batchRequests.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
 			averageQueriesPerSecond += qps
@@ -3247,6 +3249,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 	s.metrics.OverReplicatedRangeCount.Update(overreplicatedRangeCount)
 	s.metrics.RaftLogFollowerBehindCount.Update(behindCount)
 	s.metrics.RaftPausedFollowerCount.Update(pausedFollowerCount)
+	s.metrics.SlowRaftRequests.Update(slowRaftProposalCount)
 
 	var averageLockHoldDurationNanos int64
 	var averageLockWaitDurationNanos int64


### PR DESCRIPTION
There were three problems.

First, we weren't actually counting all slow proposals on each range,
since we were only updating the counter whenever we'd see a new max. If
the maximum proposal was visited first, we'd only record one; in
general the count was anywhere between one and the correct one

The second, bigger, problem is that we were updating a per-Store gauge
in a per-Replica method. So even if some Replica would record a nonzero
value, some other Replica would in all likelihood immediately clobber
that value with a zero again. So in practice, we'd see a zero here most
of the time unless many ranges had slow proposals.

The third problem is the opposite (but is masked by the first two):
since refreshProposalsLocked is the driver of the updates, we need to be
careful to have called it after slow proposals clear out and before we
quiesce. Otherwise, we would still have slow proposals reflected in the
gauge even though they have already completed and the range they were
on has since quiesced.

All of this is now fixed: we record the proper count of slow proposals
per Replica, and sum that up into the per-Store gauge, like we do for
all other Replica-sourced metrics.

We also prevent ranges from quiescing unless the slow count is zero;
this prevents leaking a count if there were slow proposals but they then
resolved but refreshProposalsLocked hasn't been re-invoked yet to clear
the count. This delays quiescing by up to a few ticks (after slow
proposals resolved), which is around a second and thus doesn't matter.

I verified manually, creating a three-node local cluster, and stopping
two nodes. The gauge kept climbing slowly (printouts minute over minute)

> requests_slow_raft{store="1"} 0
> requests_slow_raft{store="1"} 3
> requests_slow_raft{store="1"} 10
> requests_slow_raft{store="1"} 17

In particular note the monotonicity. Before the patch, we would've seen
out-of-order numbers here, since we'd see essentially a "random" Replica's
count (problem 2), which in itself was also "random" (problem 1).

(Note that the replica circuit breakers fail-fast most proposals before
they enter the replication layer, but the probes are still tracked; this
is why the number isn't increasing faster).

Restarting n2 and n3 let the gauge drop back to zero (10s intervals):

> requests_slow_raft{store="1"} 21
> requests_slow_raft{store="1"} 4
> requests_slow_raft{store="1"} 0

Release note: None

Release justification: none, will merge once no justification necessary
