### PR TITLE
kvserver: remove accidentally committed debug logging

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3012,9 +3012,6 @@ func (s *Store) Capacity(ctx context.Context, useCached bool) (roachpb.StoreCapa
 		if wps, dur := r.loadStats.writeKeys.AverageRatePerSecond(); dur >= replicastats.MinStatsDuration {
 			totalWritesPerSecond += wps
 			writesPerReplica = append(writesPerReplica, wps)
-		} else {
-			replCtx := r.AnnotateCtx(ctx)
-			log.Infof(replCtx, "xxx: dur=%s wps=%f", dur, wps)
 		}
 		rankingsAccumulator.addReplica(replicaWithStats{
 			repl: r,


### PR DESCRIPTION
Randomly saw this. It was accidentally introduced in #85629.

Release justification: low-risk logging fix
Release note: None
