### PR TITLE
ui: use plan gist instead of plan id

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -121,7 +121,8 @@ function ExplainPlan({
   onChangeSortSetting,
 }: ExplainPlanProps): React.ReactElement {
   const explainPlan =
-    plan.explain_plan === "" ? "unavailable" : plan.explain_plan;
+    `Plan Gist: ${plan.stats.plan_gists[0]} \n\n` +
+    (plan.explain_plan === "" ? "unavailable" : plan.explain_plan);
   const hasInsights = plan.stats.index_recommendations?.length > 0;
   return (
     <div>

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -20,6 +20,7 @@ import {
   RenderCount,
   DATE_FORMAT_24_UTC,
   explainPlan,
+  limitText,
 } from "../../util";
 import { Anchor } from "../../anchor";
 
@@ -35,7 +36,7 @@ const planDetailsColumnLabels = {
   fullScan: "Full Scan",
   insights: "Insights",
   lastExecTime: "Last Execution Time",
-  planID: "Plan ID",
+  planGist: "Plan Gist",
   vectorized: "Vectorized",
 };
 export type PlanDetailsTableColumnKeys = keyof typeof planDetailsColumnLabels;
@@ -45,21 +46,21 @@ type PlanDetailsTableTitleType = {
 };
 
 export const planDetailsTableTitles: PlanDetailsTableTitleType = {
-  planID: () => {
+  planGist: () => {
     return (
       <Tooltip
         style="tableTitle"
         placement="bottom"
         content={
           <p>
-            The ID of the{" "}
+            The Gist of the{" "}
             <Anchor href={explainPlan} target="_blank">
               Explain Plan.
             </Anchor>
           </p>
         }
       >
-        {planDetailsColumnLabels.planID}
+        {planDetailsColumnLabels.planGist}
       </Tooltip>
     );
   },
@@ -170,12 +171,16 @@ export function makeExplainPlanColumns(
   const count = (v: number) => v.toFixed(1);
   return [
     {
-      name: "planID",
-      title: planDetailsTableTitles.planID(),
+      name: "planGist",
+      title: planDetailsTableTitles.planGist(),
       cell: (item: PlanHashStats) => (
-        <a onClick={() => handleDetails(item)}>{longToInt(item.plan_hash)}</a>
+        <Tooltip placement="bottom" content={item.stats.plan_gists[0]}>
+          <a onClick={() => handleDetails(item)}>
+            {limitText(item.stats.plan_gists[0], 25)}
+          </a>
+        </Tooltip>
       ),
-      sort: (item: PlanHashStats) => longToInt(item.plan_hash),
+      sort: (item: PlanHashStats) => item.stats.plan_gists[0],
       alwaysShow: true,
     },
     {


### PR DESCRIPTION
Previously, we were using plan id on the table
listing plans, but that was hard to link back to stats.
This commit changes to use gist instead.
It also adds the plan gist on the display of the actual
plan.

Fixes #85272
<img width="1600" alt="Screen Shot 2022-08-23 at 8 27 29 AM" src="https://user-images.githubusercontent.com/1017486/186157925-dad1e120-a1f6-4f08-a150-ce18076c625a.png">
<img width="338" alt="Screen Shot 2022-08-23 at 8 27 35 AM" src="https://user-images.githubusercontent.com/1017486/186157939-f4753ee5-2d16-481d-94ce-daf3e7c076c1.png">
<img width="718" alt="Screen Shot 2022-08-23 at 8 27 44 AM" src="https://user-images.githubusercontent.com/1017486/186157949-fe37f1b8-900c-4091-9c6f-453387d78fad.png">



Release justification: low risk, high benefit change
Release note (ui change): Use plan gist instead of
plan ID on plans table inside the Explain Plan tab of Statement
Details. Also add the plan gist as the first line on the actual
Explain Plan display.