### PR TITLE
Nprocs

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -10,6 +10,7 @@ bulkio.backup.file_size	byte size	128 MiB	target size for individual data files 
 bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attempt is considered timed out, which causes the backup to fail
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
+changefeed.consumer_max_workers	integer	0	the maximum number of workers to use when processing events; 0 disables
 changefeed.node_throttle_config	string		specifies node level throttling configuration for all changefeeeds
 changefeed.schema_feed.read_with_priority_after	duration	1m0s	retry with high priority if we were not able to read descriptors for too long; 0 disables
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -16,6 +16,7 @@
 <tr><td><code>bulkio.backup.read_timeout</code></td><td>duration</td><td><code>5m0s</code></td><td>amount of time after which a read attempt is considered timed out, which causes the backup to fail</td></tr>
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
+<tr><td><code>changefeed.consumer_max_workers</code></td><td>integer</td><td><code>0</code></td><td>the maximum number of workers to use when processing events; 0 disables</td></tr>
 <tr><td><code>changefeed.node_throttle_config</code></td><td>string</td><td><code></code></td><td>specifies node level throttling configuration for all changefeeeds</td></tr>
 <tr><td><code>changefeed.schema_feed.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>retry with high priority if we were not able to read descriptors for too long; 0 disables</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -285,7 +285,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 
 	ca.eventConsumer, ca.sink, err = newEventConsumer(
 		ctx, ca.flowCtx, feed, ca.frontier.SpanFrontier(), kvFeedHighWater,
-		ca.sink, feed, ca.spec.Select, ca.knobs)
+		ca.sink, feed, ca.spec.Select, ca.knobs, ca.errCh, ca.cancel)
 
 	if err != nil {
 		// Early abort in the case that there is an error setting up the consumption.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -60,8 +60,6 @@ type changeAggregator struct {
 	kvFeedDoneCh chan struct{}
 	kvFeedMemMon *mon.BytesMonitor
 
-	// encoder is the Encoder to use for key and value serialization.
-	encoder Encoder
 	// sink is the Sink to write rows to. Resolved timestamps are never written
 	// by changeAggregator.
 	sink EventSink
@@ -80,7 +78,7 @@ type changeAggregator struct {
 	// eventProducer produces the next event from the kv feed.
 	eventProducer kvevent.Reader
 	// eventConsumer consumes the event.
-	eventConsumer *kvEventToRowConsumer
+	eventConsumer eventConsumer
 
 	// lastFlush and flushFrequency keep track of the flush frequency.
 	lastFlush      time.Time
@@ -93,7 +91,6 @@ type changeAggregator struct {
 	metrics    *Metrics
 	sliMetrics *sliMetrics
 	knobs      TestingKnobs
-	topicNamer *TopicNamer
 }
 
 type timestampLowerBoundOracle interface {
@@ -162,22 +159,6 @@ func newChangeAggregatorProcessor(
 
 	opts := changefeedbase.MakeStatementOptions(ca.spec.Feed.Opts)
 
-	var err error
-	encodingOpts, err := opts.GetEncodingOptions()
-	if err != nil {
-		return nil, err
-	}
-	if ca.encoder, err = getEncoder(encodingOpts, AllTargets(ca.spec.Feed)); err != nil {
-		return nil, err
-	}
-
-	if encodingOpts.TopicInValue {
-		ca.topicNamer, err = MakeTopicNamer(AllTargets(ca.spec.Feed))
-		if err != nil {
-			return nil, err
-		}
-	}
-
 	// MinCheckpointFrequency controls how frequently the changeAggregator flushes the sink
 	// and checkpoints the local frontier to changeFrontier. It is used as a rough
 	// approximation of how latency-sensitive the changefeed user is. For a high latency
@@ -225,7 +206,6 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 
 	feed := makeChangefeedConfigFromJobDetails(ca.spec.Feed)
 
-	endTime := feed.EndTime
 	opts := feed.Opts
 
 	if err != nil {
@@ -295,7 +275,7 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		kvFeedHighWater = ca.spec.Feed.StatementTime
 	}
 
-	ca.eventProducer, err = ca.startKVFeed(ctx, spans, kvFeedHighWater, needsInitialScan, endTime)
+	ca.eventProducer, err = ca.startKVFeed(ctx, spans, kvFeedHighWater, needsInitialScan, feed)
 	if err != nil {
 		// Early abort in the case that there is an error creating the sink.
 		ca.MoveToDraining(err)
@@ -303,9 +283,9 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 		return
 	}
 
-	ca.eventConsumer, err = newKVEventToRowConsumer(
-		ctx, ca.flowCtx.Cfg, ca.flowCtx.EvalCtx, ca.frontier.SpanFrontier(), kvFeedHighWater,
-		ca.sink, ca.encoder, feed, ca.spec.Select, ca.knobs, ca.topicNamer)
+	ca.eventConsumer, ca.sink, err = newEventConsumer(
+		ctx, ca.flowCtx, feed, ca.frontier.SpanFrontier(), kvFeedHighWater,
+		ca.sink, feed, ca.spec.Select, ca.knobs)
 
 	if err != nil {
 		// Early abort in the case that there is an error setting up the consumption.
@@ -320,7 +300,7 @@ func (ca *changeAggregator) startKVFeed(
 	spans []roachpb.Span,
 	initialHighWater hlc.Timestamp,
 	needsInitialScan bool,
-	endTime hlc.Timestamp,
+	config ChangefeedConfig,
 ) (kvevent.Reader, error) {
 	cfg := ca.flowCtx.Cfg
 	buf := kvevent.NewThrottlingBuffer(
@@ -329,7 +309,7 @@ func (ca *changeAggregator) startKVFeed(
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while
 	// we return the kvevent.Reader part to the caller.
-	kvfeedCfg, err := ca.makeKVFeedCfg(ctx, spans, buf, initialHighWater, needsInitialScan, endTime)
+	kvfeedCfg, err := ca.makeKVFeedCfg(ctx, config, spans, buf, initialHighWater, needsInitialScan)
 	if err != nil {
 		return nil, err
 	}
@@ -359,28 +339,27 @@ func (ca *changeAggregator) startKVFeed(
 
 func (ca *changeAggregator) makeKVFeedCfg(
 	ctx context.Context,
+	config ChangefeedConfig,
 	spans []roachpb.Span,
 	buf kvevent.Writer,
 	initialHighWater hlc.Timestamp,
 	needsInitialScan bool,
-	endTime hlc.Timestamp,
 ) (kvfeed.Config, error) {
-	opts := changefeedbase.MakeStatementOptions(ca.spec.Feed.Opts)
-	schemaChange, err := opts.GetSchemaChangeHandlingOptions()
+	schemaChange, err := config.Opts.GetSchemaChangeHandlingOptions()
 	if err != nil {
 		return kvfeed.Config{}, err
 	}
-	filters := opts.GetFilters()
+	filters := config.Opts.GetFilters()
 	cfg := ca.flowCtx.Cfg
 
-	initialScanOnly := endTime.EqOrdering(initialHighWater)
+	initialScanOnly := config.EndTime.EqOrdering(initialHighWater)
 	var sf schemafeed.SchemaFeed
 
 	if schemaChange.Policy == changefeedbase.OptSchemaChangePolicyIgnore || initialScanOnly {
 		sf = schemafeed.DoNothingSchemaFeed
 	} else {
 		sf = schemafeed.New(ctx, cfg, schemaChange.EventClass, AllTargets(ca.spec.Feed),
-			initialHighWater, &ca.metrics.SchemaFeedMetrics, opts.GetCanHandle())
+			initialHighWater, &ca.metrics.SchemaFeedMetrics, config.Opts.GetCanHandle())
 	}
 
 	return kvfeed.Config{
@@ -399,7 +378,7 @@ func (ca *changeAggregator) makeKVFeedCfg(
 		OnBackfillRangeCallback: ca.sliMetrics.getBackfillRangeCallback(),
 		MM:                      ca.kvFeedMemMon,
 		InitialHighWater:        initialHighWater,
-		EndTime:                 endTime,
+		EndTime:                 config.EndTime,
 		WithDiff:                filters.WithDiff,
 		NeedsInitialScan:        needsInitialScan,
 		SchemaChangeEvents:      schemaChange.EventClass,
@@ -467,12 +446,17 @@ func (ca *changeAggregator) close() {
 	if ca.kvFeedDoneCh != nil {
 		<-ca.kvFeedDoneCh
 	}
+	if ca.eventConsumer != nil {
+		if err := ca.eventConsumer.Close(); err != nil {
+			log.Warningf(ca.Ctx, "error closing event consumer: %s", err)
+		}
+	}
+
 	if ca.sink != nil {
 		if err := ca.sink.Close(); err != nil {
 			log.Warningf(ca.Ctx, `error closing sink. goroutines may have leaked: %v`, err)
 		}
 	}
-
 	ca.memAcc.Close(ca.Ctx)
 	if ca.kvFeedMemMon != nil {
 		ca.kvFeedMemMon.Stop(ca.Ctx)

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
+        "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
-        "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -238,6 +237,6 @@ var EventConsumerMaxWorkers = settings.RegisterIntSetting(
 	settings.TenantWritable,
 	"changefeed.consumer_max_workers",
 	"the maximum number of workers to use when processing events; 0 disables",
-	int64(util.ConstantWithMetamorphicTestRange("changefeed.consumer_max_workers", 0, 0, 32)),
+	32,
 	settings.NonNegativeInt,
 ).WithPublic()

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -230,3 +231,13 @@ var UseMuxRangeFeed = settings.RegisterBoolSetting(
 	"if true, changefeed uses multiplexing rangefeed RPC",
 	false,
 )
+
+// EventConsumerMaxWorkers specifies the maximum number of workers to use when
+// processing events
+var EventConsumerMaxWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"changefeed.consumer_max_workers",
+	"the maximum number of workers to use when processing events; 0 disables",
+	int64(util.ConstantWithMetamorphicTestRange("changefeed.consumer_max_workers", 0, 0, 32)),
+	settings.NonNegativeInt,
+).WithPublic()

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -10,9 +10,12 @@ package changefeedccl
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
@@ -20,9 +23,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -31,6 +37,11 @@ type eventContext struct {
 	updated, mvcc hlc.Timestamp
 	// topic is set to the string to be included if TopicInValue is true
 	topic string
+}
+
+type eventConsumer interface {
+	ConsumeEvent(ctx context.Context, ev kvevent.Event) error
+	Close() error
 }
 
 type kvEventToRowConsumer struct {
@@ -47,6 +58,72 @@ type kvEventToRowConsumer struct {
 
 	topicDescriptorCache map[TopicIdentifier]TopicDescriptor
 	topicNamer           *TopicNamer
+}
+
+func newEventConsumer(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	feed ChangefeedConfig,
+	frontier *span.Frontier,
+	cursor hlc.Timestamp,
+	sink EventSink,
+	details ChangefeedConfig,
+	expr execinfrapb.Expression,
+	knobs TestingKnobs,
+) (eventConsumer, EventSink, error) {
+	cfg := flowCtx.Cfg
+	evalCtx := flowCtx.EvalCtx
+
+	makeConsumer := func(s EventSink) (eventConsumer, error) {
+		var err error
+		encodingOpts, err := feed.Opts.GetEncodingOptions()
+		if err != nil {
+			return nil, err
+		}
+		encoder, err := getEncoder(encodingOpts, feed.Targets)
+		if err != nil {
+			return nil, err
+		}
+
+		var topicNamer *TopicNamer
+		if encodingOpts.TopicInValue {
+			topicNamer, err = MakeTopicNamer(feed.Targets)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return newKVEventToRowConsumer(ctx, cfg, evalCtx, frontier, cursor, s,
+			encoder, details, expr, knobs, topicNamer)
+	}
+
+	if changefeedbase.EventConsumerMaxWorkers.Get(&cfg.Settings.SV) == 0 {
+		c, err := makeConsumer(sink)
+		if err != nil {
+			return nil, nil, err
+		}
+		return c, sink, err
+	}
+
+	ss := &safeSink{wrapped: sink}
+	c := &parallelEventConsumer{
+		g:          ctxgroup.WithContext(ctx),
+		spawnAfter: timeutil.NewTimer(),
+		eventCh:    make(chan kvevent.Event, 128),
+		termCh:     make(chan struct{}),
+		doneCh:     make(chan struct{}),
+		makeConsumer: func() (eventConsumer, error) {
+			return makeConsumer(ss)
+		},
+		maxWorkers: func() int64 {
+			return changefeedbase.EventConsumerMaxWorkers.Get(&cfg.Settings.SV)
+		},
+	}
+
+	if err := c.trySpawn(); err != nil {
+		return nil, nil, err
+	}
+	return c, ss, nil
 }
 
 func newKVEventToRowConsumer(
@@ -241,4 +318,126 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		log.Infof(ctx, `r %s: %s -> %s`, updatedRow.TableName, keyCopy, valueCopy)
 	}
 	return nil
+}
+
+func (c *kvEventToRowConsumer) Close() error {
+	return nil
+}
+
+type parallelEventConsumer struct {
+	g            ctxgroup.Group
+	spawnAfter   *timeutil.Timer
+	eventCh      chan kvevent.Event
+	termCh       chan struct{}
+	doneCh       chan struct{}
+	maxWorkers   func() int64
+	makeConsumer func() (eventConsumer, error)
+
+	mu struct {
+		syncutil.Mutex
+		numWorkers int64
+		termErr    error
+	}
+}
+
+var _ eventConsumer = (*parallelEventConsumer)(nil)
+
+const spawnWorkerDelay = 50 * time.Millisecond
+
+func (c *parallelEventConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Event) error {
+	c.spawnAfter.Reset(spawnWorkerDelay)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.termCh:
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			return c.mu.termErr
+		case c.eventCh <- ev:
+			return nil
+		case <-c.spawnAfter.C:
+			c.spawnAfter.Read = true
+			if err := c.trySpawn(); err != nil {
+				return err
+			}
+			c.spawnAfter.Reset(spawnWorkerDelay)
+		}
+	}
+}
+
+func (c *parallelEventConsumer) trySpawn() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.mu.numWorkers > c.maxWorkers() {
+		return nil
+	}
+
+	c.mu.numWorkers++
+	c.g.GoCtx(c.workerLoop)
+	return nil
+}
+
+// jitter adds a small jitter in the given duration.
+func idleAfter() time.Duration {
+	const idleAfter = 2 * time.Minute
+	const jitter = 1.0 / 6.0
+	jitterFraction := 1 + (2*rand.Float64()-1)*jitter // 1 + [-1/6, +1/6)
+	return time.Duration(float64(idleAfter) * jitterFraction)
+}
+
+func (c *parallelEventConsumer) workerLoop(ctx context.Context) error {
+	consumer, err := c.makeConsumer()
+	if err != nil {
+		return c.setWorkerError(err)
+	}
+
+	idleTimer := timeutil.NewTimer()
+	defer idleTimer.Stop()
+
+	for {
+		idleTimer.Reset(idleAfter())
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.doneCh:
+			return nil
+		case e := <-c.eventCh:
+			if err := consumer.ConsumeEvent(ctx, e); err != nil {
+				return c.setWorkerError(err)
+			}
+		case <-idleTimer.C:
+			idleTimer.Read = true
+
+			c.mu.Lock()
+			shutDown := c.mu.numWorkers > 1
+			if shutDown {
+				c.mu.numWorkers--
+			}
+			c.mu.Unlock()
+			if shutDown {
+				return nil
+			}
+		}
+	}
+}
+
+func (c *parallelEventConsumer) setWorkerError(err error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mu.termErr == nil {
+		c.mu.termErr = err
+		close(c.termCh)
+	}
+
+	return err
+}
+
+func (c *parallelEventConsumer) Close() error {
+	defer c.spawnAfter.Stop()
+	close(c.doneCh)
+	return c.g.Wait()
 }

--- a/pkg/ccl/changefeedccl/sink.go
+++ b/pkg/ccl/changefeedccl/sink.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
@@ -535,4 +536,41 @@ func (n *nullSink) Close() error {
 // Dial implements Sink interface.
 func (n *nullSink) Dial() error {
 	return nil
+}
+
+type safeSink struct {
+	syncutil.Mutex
+	wrapped EventSink
+}
+
+var _ EventSink = (*safeSink)(nil)
+
+func (s *safeSink) Dial() error {
+	s.Lock()
+	defer s.Unlock()
+	return s.wrapped.Dial()
+}
+
+func (s *safeSink) Close() error {
+	s.Lock()
+	defer s.Unlock()
+	return s.wrapped.Close()
+}
+
+func (s *safeSink) EmitRow(
+	ctx context.Context,
+	topic TopicDescriptor,
+	key, value []byte,
+	updated, mvcc hlc.Timestamp,
+	alloc kvevent.Alloc,
+) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.wrapped.EmitRow(ctx, topic, key, value, updated, mvcc, alloc)
+}
+
+func (s *safeSink) Flush(ctx context.Context) error {
+	s.Lock()
+	defer s.Unlock()
+	return s.wrapped.Flush(ctx)
 }

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "//pkg/util/interval",
+        "//pkg/util/syncutil",
     ],
 )
 

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // frontierEntry represents a timestamped span. It is used as the nodes in both
@@ -91,6 +92,7 @@ func (h *frontierHeap) Pop() interface{} {
 
 // Frontier tracks the minimum timestamp of a set of spans.
 type Frontier struct {
+	syncutil.Mutex
 	// tree contains `*frontierEntry` items for the entire current tracked
 	// span set. Any tracked spans that have never been `Forward`ed will have a
 	// zero timestamp. If any entries needed to be split along a tracking
@@ -145,6 +147,12 @@ func MakeFrontierAt(startAt hlc.Timestamp, spans ...roachpb.Span) (*Frontier, er
 
 // Frontier returns the minimum timestamp being tracked.
 func (f *Frontier) Frontier() hlc.Timestamp {
+	f.Lock()
+	defer f.Unlock()
+	return f.frontierLocked()
+}
+
+func (f *Frontier) frontierLocked() hlc.Timestamp {
 	if f.minHeap.Len() == 0 {
 		return hlc.Timestamp{}
 	}
@@ -153,6 +161,8 @@ func (f *Frontier) Frontier() hlc.Timestamp {
 
 // PeekFrontierSpan returns one of the spans at the Frontier.
 func (f *Frontier) PeekFrontierSpan() roachpb.Span {
+	f.Lock()
+	defer f.Unlock()
 	if f.minHeap.Len() == 0 {
 		return roachpb.Span{}
 	}
@@ -168,11 +178,13 @@ func (f *Frontier) PeekFrontierSpan() roachpb.Span {
 // set boundary). Similarly, an entry created by a previous Forward may be
 // partially overlapped and have to be split into two entries.
 func (f *Frontier) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
-	prevFrontier := f.Frontier()
+	f.Lock()
+	defer f.Unlock()
+	prevFrontier := f.frontierLocked()
 	if err := f.insert(span, ts); err != nil {
 		return false, err
 	}
-	return prevFrontier.Less(f.Frontier()), nil
+	return prevFrontier.Less(f.frontierLocked()), nil
 }
 
 // extendRangeToTheLeft extends the range to the left of the range, provided those
@@ -382,6 +394,8 @@ type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 // Entries invokes the given callback with the current timestamp for each
 // component span in the tracked span set.
 func (f *Frontier) Entries(fn Operation) {
+	f.Lock()
+	defer f.Unlock()
 	f.tree.Do(func(i interval.Interface) bool {
 		spe := i.(*frontierEntry)
 		return fn(spe.span, spe.ts).asBool()
@@ -404,6 +418,8 @@ func (f *Frontier) Entries(fn Operation) {
 // Note: neither [a-b) nor [m, q) will be emitted since they fall outside the spans
 // tracked by this frontier.
 func (f *Frontier) SpanEntries(span roachpb.Span, op Operation) {
+	f.Lock()
+	defer f.Unlock()
 	todoRange := span.AsRange()
 
 	f.tree.DoMatching(func(i interval.Interface) bool {
@@ -429,6 +445,8 @@ func (f *Frontier) SpanEntries(span roachpb.Span, op Operation) {
 
 // String implements Stringer.
 func (f *Frontier) String() string {
+	f.Lock()
+	defer f.Unlock()
 	var buf strings.Builder
 	f.tree.Do(func(i interval.Interface) bool {
 		if buf.Len() != 0 {


### PR DESCRIPTION
### span: make span.Frontier thread safe
Make `span.Frontier` thread safe by default.

Release justification: low impact data structure change.
Release note: None

### changefeedccl: parallelize event consumption
Previously, KV events were consumed and processed
by changefeed aggregator using a single, synchronous Go routine.
This PR makes it possible to run up to `changefeed.consumer_max_workers`
consumers to consume events concurrently.
The default of 0 keeps existing single threaded implementation.

Release justification: performance improvement, disabled by default.
Release note (enterprise change): Changefeeds can process events
concurrently, with up to `changefeed.consumer_max_workers` workers.
