### PR TITLE
release-22.1: colmem: improve memory accounting when memory limit is exceeded

### DIFF
--- a/pkg/col/coldata/batch.go
+++ b/pkg/col/coldata/batch.go
@@ -63,7 +63,7 @@ type Batch interface {
 	//
 	// NOTE: Reset can allocate a new Batch, so when calling from the vectorized
 	// engine consider either allocating a new Batch explicitly via
-	// colexec.Allocator or calling ResetInternalBatch.
+	// colmem.Allocator or calling ResetInternalBatch.
 	Reset(typs []*types.T, length int, factory ColumnFactory)
 	// ResetInternalBatch resets a batch and its underlying Vecs for reuse. It's
 	// important for callers to call ResetInternalBatch if they own internal

--- a/pkg/col/colserde/main_test.go
+++ b/pkg/col/colserde/main_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	// testAllocator is a colexec.Allocator with an unlimited budget for use in
+	// testAllocator is a colmem.Allocator with an unlimited budget for use in
 	// tests.
 	testAllocator     *colmem.Allocator
 	testColumnFactory coldata.ColumnFactory

--- a/pkg/sql/colcontainer/main_test.go
+++ b/pkg/sql/colcontainer/main_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	// testAllocator is a colexec.Allocator with an unlimited budget for use in
+	// testAllocator is a colmem.Allocator with an unlimited budget for use in
 	// tests.
 	testAllocator     *colmem.Allocator
 	testColumnFactory coldata.ColumnFactory

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -367,12 +367,16 @@ func (r opResult) createDiskBackedSort(
 		// There is a limit specified, so we know exactly how many rows the
 		// sorter should output. Use a top K sorter, which uses a heap to avoid
 		// storing more rows than necessary.
+		opName := opNamePrefix + "topk-sort"
 		var topKSorterMemAccount *mon.BoundAccount
 		topKSorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
-			ctx, flowCtx, spoolMemLimit, opNamePrefix+"topk-sort", processorID,
+			ctx, flowCtx, spoolMemLimit, opName, processorID,
+		)
+		unlimitedMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+			ctx, flowCtx, opName, processorID,
 		)
 		inMemorySorter = colexec.NewTopKSorter(
-			colmem.NewAllocator(ctx, topKSorterMemAccount, factory), input,
+			colmem.NewLimitedAllocator(ctx, topKSorterMemAccount, unlimitedMemAcc, factory), input,
 			inputTypes, ordering.Columns, int(matchLen), uint64(limit), maxOutputBatchMemSize,
 		)
 	} else if matchLen > 0 {
@@ -388,19 +392,27 @@ func (r opResult) createDiskBackedSort(
 		sortChunksMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
 			ctx, flowCtx, spoolMemLimit, opName, processorID,
 		)
+		unlimitedMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+			ctx, flowCtx, opName, processorID,
+		)
 		inMemorySorter = colexec.NewSortChunks(
-			deselectorUnlimitedAllocator, colmem.NewAllocator(ctx, sortChunksMemAccount, factory),
+			deselectorUnlimitedAllocator,
+			colmem.NewLimitedAllocator(ctx, sortChunksMemAccount, unlimitedMemAcc, factory),
 			input, inputTypes, ordering.Columns, int(matchLen), maxOutputBatchMemSize,
 		)
 	} else {
 		// No optimizations possible. Default to the standard sort operator.
 		var sorterMemAccount *mon.BoundAccount
+		opName := opNamePrefix + "sort-all"
 		sorterMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
-			ctx, flowCtx, spoolMemLimit, opNamePrefix+"sort-all", processorID,
+			ctx, flowCtx, spoolMemLimit, opName, processorID,
+		)
+		unlimitedMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+			ctx, flowCtx, opName, processorID,
 		)
 		inMemorySorter = colexec.NewSorter(
-			colmem.NewAllocator(ctx, sorterMemAccount, factory), input,
-			inputTypes, ordering.Columns, maxOutputBatchMemSize,
+			colmem.NewLimitedAllocator(ctx, sorterMemAccount, unlimitedMemAcc, factory),
+			input, inputTypes, ordering.Columns, maxOutputBatchMemSize,
 		)
 	}
 	if args.TestingKnobs.DiskSpillingDisabled {
@@ -906,7 +918,10 @@ func NewColOperator(
 					spillingQueueMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
 						ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID,
 					)
-					newAggArgs.Allocator = colmem.NewAllocator(ctx, hashAggregatorMemAccount, factory)
+					hashAggUnlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+						ctx, flowCtx, opName, spec.ProcessorID,
+					)
+					newAggArgs.Allocator = colmem.NewLimitedAllocator(ctx, hashAggregatorMemAccount, hashAggUnlimitedAcc, factory)
 					newAggArgs.MemAccount = hashAggregatorMemAccount
 					inMemoryHashAggregator := colexec.NewHashAggregator(
 						newAggArgs,
@@ -991,7 +1006,10 @@ func NewColOperator(
 				// ordered distinct, and we should plan it when we have
 				// non-empty ordered columns and we think that the probability
 				// of distinct tuples in the input is about 0.01 or less.
-				allocator := colmem.NewAllocator(ctx, distinctMemAccount, factory)
+				unlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+					ctx, flowCtx, "distinct" /* opName */, spec.ProcessorID,
+				)
+				allocator := colmem.NewLimitedAllocator(ctx, distinctMemAccount, unlimitedAcc, factory)
 				inMemoryUnorderedDistinct := colexec.NewUnorderedDistinct(
 					allocator, inputs[0].Root, core.Distinct.DistinctColumns, result.ColumnTypes,
 					core.Distinct.NullsAreDistinct, core.Distinct.ErrorOnDup,
@@ -1076,8 +1094,11 @@ func NewColOperator(
 					core.HashJoiner.RightEqColumnsAreKey,
 				)
 
+				hashJoinerUnlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
+					ctx, flowCtx, opName, spec.ProcessorID,
+				)
 				inMemoryHashJoiner := colexecjoin.NewHashJoiner(
-					colmem.NewAllocator(ctx, hashJoinerMemAccount, factory),
+					colmem.NewLimitedAllocator(ctx, hashJoinerMemAccount, hashJoinerUnlimitedAcc, factory),
 					hashJoinerUnlimitedAllocator, hjSpec, inputs[0].Root, inputs[1].Root,
 					colexecjoin.HashJoinerInitialNumBuckets,
 				)

--- a/pkg/sql/colexec/hashjoiner_test.go
+++ b/pkg/sql/colexec/hashjoiner_test.go
@@ -1016,9 +1016,10 @@ func TestHashJoiner(t *testing.T) {
 				runHashJoinTestCase(t, tc, func(sources []colexecop.Operator) (colexecop.Operator, error) {
 					spec := createSpecForHashJoiner(tc)
 					args := &colexecargs.NewColOperatorArgs{
-						Spec:            spec,
-						Inputs:          colexectestutils.MakeInputs(sources),
-						MonitorRegistry: &monitorRegistry,
+						Spec:                spec,
+						StreamingMemAccount: monitorRegistry.NewStreamingMemAccount(flowCtx),
+						Inputs:              colexectestutils.MakeInputs(sources),
+						MonitorRegistry:     &monitorRegistry,
 					}
 					args.TestingKnobs.DiskSpillingDisabled = true
 					result, err := colexecargs.TestNewColOperator(ctx, flowCtx, args)

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/mon",
         "@com_github_cockroachdb_errors//:errors",
     ],
@@ -21,9 +22,12 @@ go_library(
 go_test(
     name = "colmem_test",
     size = "small",
-    srcs = ["allocator_test.go"],
+    srcs = [
+        "adjust_memory_usage_test.go",
+        "allocator_test.go",
+    ],
+    embed = [":colmem"],
     deps = [
-        ":colmem",
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/settings/cluster",
@@ -37,8 +41,10 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/mon",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/colmem/adjust_memory_usage_test.go
+++ b/pkg/sql/colmem/adjust_memory_usage_test.go
@@ -1,0 +1,84 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/redact"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdjustMemoryUsage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	unlimitedMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	defer unlimitedMemMonitor.Stop(ctx)
+	unlimitedMemAcc := unlimitedMemMonitor.MakeBoundAccount()
+	defer unlimitedMemAcc.Close(ctx)
+
+	limitedMemMonitorName := "test-limited"
+	limit := int64(100000)
+	limitedMemMonitor := mon.NewMonitorInheritWithLimit(
+		redact.RedactableString(limitedMemMonitorName), limit, unlimitedMemMonitor,
+	)
+	limitedMemMonitor.Start(ctx, unlimitedMemMonitor, mon.BoundAccount{})
+	defer limitedMemMonitor.Stop(ctx)
+	limitedMemAcc := limitedMemMonitor.MakeBoundAccount()
+	defer limitedMemAcc.Close(ctx)
+
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	allocator := NewLimitedAllocator(ctx, &limitedMemAcc, &unlimitedMemAcc, testColumnFactory)
+
+	// Check that no error occurs if the limit is not exceeded.
+	require.NotPanics(t, func() { allocator.AdjustMemoryUsage(limit / 2) })
+	require.Equal(t, limit/2, limitedMemAcc.Used())
+	require.Zero(t, unlimitedMemAcc.Used())
+
+	// Exceed the limit "before" making an allocation and ensure that the
+	// unlimited account has not been grown.
+	err := colexecerror.CatchVectorizedRuntimeError(func() { allocator.AdjustMemoryUsage(limit) })
+	require.NotNil(t, err)
+	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.Equal(t, limit/2, limitedMemAcc.Used())
+	require.Zero(t, unlimitedMemAcc.Used())
+
+	// Now exceed the limit "after" making an allocation and ensure that the
+	// unlimited account has been grown.
+	err = colexecerror.CatchVectorizedRuntimeError(func() { allocator.adjustMemoryUsageAfterAllocation(limit) })
+	require.NotNil(t, err)
+	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.Equal(t, limit/2, limitedMemAcc.Used())
+	require.Equal(t, limit, unlimitedMemAcc.Used())
+
+	// Ensure that the error from the unlimited memory account is returned when
+	// it cannot be grown.
+	err = colexecerror.CatchVectorizedRuntimeError(func() { allocator.adjustMemoryUsageAfterAllocation(math.MaxInt64) })
+	require.NotNil(t, err)
+	require.False(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.Equal(t, limit/2, limitedMemAcc.Used())
+	require.Equal(t, limit, unlimitedMemAcc.Used())
+}

--- a/pkg/sql/sem/tree/eval_test/eval_test.go
+++ b/pkg/sql/sem/tree/eval_test/eval_test.go
@@ -188,8 +188,8 @@ func TestEval(t *testing.T) {
 							batchesReturned++
 							return batch
 						}},
-				},
-				},
+				}},
+				StreamingMemAccount: &acc,
 				// Unsupported post processing specs are wrapped and run through the
 				// row execution engine.
 				ProcessorConstructor: rowexec.NewProcessor,

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -421,6 +421,11 @@ func (mm *BytesMonitor) Name() string {
 	return string(mm.name)
 }
 
+// Limit returns the memory limit of the monitor.
+func (mm *BytesMonitor) Limit() int64 {
+	return mm.limit
+}
+
 const bytesMaxUsageLoggingThreshold = 100 * 1024
 
 func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {


### PR DESCRIPTION
Backport 1/2 commits from #86357.

/cc @cockroachdb/release

---

**colmem: improve memory accounting when memory limit is exceeded**

This commit improves the memory accounting when memory limit is
exceeded. Previously, in several operators we could run into a situation
where we perform some allocations and run into a memory limit error
later, which results in those allocations being unaccounted for. In some
cases this is acceptable (when the query results in an error), but in
others the memory error is caught and spilling to disk occurs. In the
latter scenarios we would under-account, and this commit fixes most of
such situations.

Now, each disk-spilling operator instantiates a "limited" allocator that
will grow an unlimited memory account when a memory error is
encountered. The idea is that even though the denied allocations cannot
be registered with the main memory account (meaning the operator has
exceeded its memory limit), we still will draw from the
`--max-sql-memory` pool since the allocations can be live for
non-trivial amount of time. If an error occurs when growing the
unlimited memory account, then that error is returned (not the original
memory error) so that the disk spiller doesn't catch it.

This commit audits all operators in `execplan` to use the limited
allocator where appropriate. The new accounting method is only used in
a handful of places which cover most of the use cases. The goal is to
make this commit backportable whereas the follow-up commit will audit
usages of `AdjustMemoryUsage` and will not be backported.

Addresses: #64906.
Fixes: #86351.
Addresses: https://github.com/cockroachlabs/support/issues/1762.

Release justification: bug fix.

Release note: None
