### PR TITLE
upgrade/upgrades: downgrade precondition validation failure

### DIFF
--- a/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade.go
+++ b/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade.go
@@ -16,9 +16,10 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
-	"github.com/cockroachdb/errors"
 )
 
 func preconditionBeforeStartingAnUpgrade(
@@ -61,7 +62,7 @@ func preconditionNoInvalidDescriptorsBeforeUpgrading(
 			tree.Name(tree.MustBeDString(row[2])),
 			tree.Name(tree.MustBeDString(row[3])),
 		)
-		errMsg.WriteString(fmt.Sprintf("Invalid descriptor: %v (%v) because %v\n", descName.String(), row[0], row[4]))
+		errMsg.WriteString(fmt.Sprintf("invalid descriptor: %v (%v) because %v\n", descName.String(), row[0], row[4]))
 	}
 	if err != nil {
 		return err
@@ -70,6 +71,7 @@ func preconditionNoInvalidDescriptorsBeforeUpgrading(
 	if errMsg.Len() == 0 {
 		return nil
 	}
-	return errors.AssertionFailedf("There exists invalid descriptors as listed below. Fix these descriptors "+
-		"before attempting to upgrade again.\n%v", errMsg.String())
+	return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+		"there exists invalid descriptors as listed below; fix these descriptors "+
+			"before attempting to upgrade again:\n%v", errMsg.String())
 }

--- a/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
+++ b/pkg/upgrade/upgrades/precondition_before_starting_an_upgrade_external_test.go
@@ -104,10 +104,10 @@ func TestPreconditionBeforeStartingAnUpgrade(t *testing.T) {
 		// Attempt to upgrade the cluster version and expect to see a failure
 		_, err := sqlDB.Exec(`SET CLUSTER SETTING version = $1`, v1.String())
 		require.Error(t, err, "upgrade should be refused because precondition is violated.")
-		require.Equal(t, "pq: internal error: verifying precondition for version 22.1-2: "+
-			"There exists invalid descriptors as listed below. Fix these descriptors before attempting to upgrade again.\n"+
-			"Invalid descriptor: defaultdb.public.t (104) because 'relation \"t\" (104): invalid depended-on-by relation back reference: referenced descriptor ID 53: referenced descriptor not found'\n"+
-			"Invalid descriptor: defaultdb.public.temp_tbl (104) because 'no matching name info found in non-dropped relation \"t\"'",
+		require.Equal(t, "pq: verifying precondition for version 22.1-2: "+
+			"there exists invalid descriptors as listed below; fix these descriptors before attempting to upgrade again:\n"+
+			"invalid descriptor: defaultdb.public.t (104) because 'relation \"t\" (104): invalid depended-on-by relation back reference: referenced descriptor ID 53: referenced descriptor not found'\n"+
+			"invalid descriptor: defaultdb.public.temp_tbl (104) because 'no matching name info found in non-dropped relation \"t\"'",
 			strings.ReplaceAll(err.Error(), "1000022", "22"))
 		// The cluster version should remain at `v0`.
 		tdb.CheckQueryResults(t, "SHOW CLUSTER SETTING version", [][]string{{v0.String()}})


### PR DESCRIPTION
The assertion failure lead to sentry reports we did not want to see.

Backport will address #85952. 

Release justification: For backport.

Release note: None