### PR TITLE
sql: cleanup for NotVisible indexes

### DIFF
--- a/pkg/internal/sqlsmith/alter.go
+++ b/pkg/internal/sqlsmith/alter.go
@@ -363,9 +363,7 @@ func makeCreateIndex(s *Smither) (tree.Statement, bool) {
 		Storing:      storing,
 		Inverted:     inverted,
 		Concurrently: s.coin(),
-		// TODO(wenyihu6): uncomment the following line after we support not visible
-		// index.
-		// NotVisible:   s.d6() == 1, // NotVisible index is rare 1/6 chance.
+		NotVisible:   s.d6() == 1, // NotVisible index is rare 1/6 chance.
 	}, true
 }
 

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -175,7 +175,6 @@ func indexForDisplay(
 		}
 	}
 
-	// TODO(wenyihu6): add test cases for SHOW CREATE TABLE once not visible indexes can be added.
 	if index.NotVisible {
 		f.WriteString(" NOT VISIBLE")
 	}

--- a/pkg/sql/randgen/schema.go
+++ b/pkg/sql/randgen/schema.go
@@ -201,9 +201,7 @@ func RandCreateTableWithColumnIndexNumberGenerator(
 			// Due to parsing issue with creating unique indexes in a CREATE TABLE
 			// definition, we are only supporting not visible non-unique indexes for
 			// now. Make non-unique indexes not visible 1/6 of the time.
-			// TODO(wenyihu6): uncomment the following line after we support not visible
-			// index.
-			// indexDef.NotVisible = rng.Intn(6) == 0
+			indexDef.NotVisible = rng.Intn(6) == 0
 			defs = append(defs, &indexDef)
 		}
 	}

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -940,9 +940,7 @@ func (og *operationGenerator) createIndex(ctx context.Context, tx pgx.Tx) (*opSt
 		Unique:      og.randIntn(4) == 0,  // 25% UNIQUE
 		Inverted:    og.randIntn(10) == 0, // 10% INVERTED
 		IfNotExists: og.randIntn(2) == 0,  // 50% IF NOT EXISTS
-		// TODO(wenyihu6): uncomment the following line after we support not visible
-		// index.
-		// NotVisible:  og.randIntn(20) == 0, // 5% NOT VISIBLE
+		NotVisible:  og.randIntn(20) == 0, // 5% NOT VISIBLE
 	}
 
 	regionColumn := ""


### PR DESCRIPTION
Now that we have supported not visible index feature, this commit adds not
visible indexes logic to other parts of sql, such as sql smith, randgen,
operation generator.

Fixes: https://github.com/cockroachdb/cockroach/issues/86624

Release justification: low risk changes to existing functionality

Release note: None