### PR TITLE
builtins: fix json_build_object for enums and void in the key

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -562,6 +562,20 @@ SELECT json_build_object('a', '0100110'::varbit)
 ----
 {"a": "0100110"}
 
+# Regression for an internal error when using an enum and void in the key.
+statement ok
+CREATE TYPE e AS ENUM ('e');
+
+query T
+SELECT json_build_object('e'::e, 1)
+----
+{"e": 1}
+
+query T
+SELECT json_build_object(''::void, 1)
+----
+{"": 1}
+
 # even number of arguments
 query error pq: json_build_object\(\): argument list must have even number of elements
 SELECT json_build_object(1,2,3)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -9621,13 +9621,13 @@ func asJSONBuildObjectKey(
 	d tree.Datum, dcc sessiondatapb.DataConversionConfig, loc *time.Location,
 ) (string, error) {
 	switch t := d.(type) {
-	case *tree.DJSON, *tree.DArray, *tree.DTuple:
+	case *tree.DArray, *tree.DJSON, *tree.DTuple:
 		return "", pgerror.New(pgcode.InvalidParameterValue,
 			"key value must be scalar, not array, tuple, or json")
-	case *tree.DString:
-		return string(*t), nil
 	case *tree.DCollatedString:
 		return t.Contents, nil
+	case *tree.DString:
+		return string(*t), nil
 	case *tree.DTimestampTZ:
 		ts, err := tree.MakeDTimestampTZ(t.Time.In(loc), time.Microsecond)
 		if err != nil {
@@ -9638,9 +9638,11 @@ func asJSONBuildObjectKey(
 			tree.FmtBareStrings,
 			tree.FmtDataConversionConfig(dcc),
 		), nil
-	case *tree.DBool, *tree.DInt, *tree.DFloat, *tree.DDecimal, *tree.DTimestamp,
-		*tree.DDate, *tree.DUuid, *tree.DInterval, *tree.DBytes, *tree.DIPAddr, *tree.DOid,
-		*tree.DTime, *tree.DTimeTZ, *tree.DBitArray, *tree.DGeography, *tree.DGeometry, *tree.DBox2D:
+	case *tree.DBitArray, *tree.DBool, *tree.DBox2D, *tree.DBytes, *tree.DDate,
+		*tree.DDecimal, *tree.DEnum, *tree.DFloat, *tree.DGeography,
+		*tree.DGeometry, *tree.DIPAddr, *tree.DInt, *tree.DInterval, *tree.DOid,
+		*tree.DOidWrapper, *tree.DTime, *tree.DTimeTZ, *tree.DTimestamp,
+		*tree.DUuid, *tree.DVoid:
 		return tree.AsStringWithFlags(d, tree.FmtBareStrings), nil
 	default:
 		return "", errors.AssertionFailedf("unexpected type %T for key value", d)


### PR DESCRIPTION
Previously, we would run into an internal error with `json_build_object`
builtin if an enum or void was passed for the key part, and this is now
fixed. This commit also sorts all datums lexicographically to make it
easier to see whether all scalar datums are mentioned.

Fixes: #84368.

Release justification: bug fix.

Release note (bug fix): Previously, CockroachDB would return an internal
error when evaluating `json_build_object` builtin when an enum or a void
datums were passed as the first argument, and this is now fixed.