### PR TITLE
roachpb: remove deprecated error fields

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -3791,12 +3791,11 @@ func TestErrorIndexAlignment(t *testing.T) {
 			var testFn simpleSendFn = func(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 				reply := ba.CreateReply()
 				if nthRequest == tc.nthPartialBatch {
-					reply.Error = &roachpb.Error{
-						// The relative index is always 0 since
-						// we return an error for the first
-						// request of the nthPartialBatch.
-						Index: &roachpb.ErrPosition{Index: 0},
-					}
+					reply.Error = roachpb.NewErrorf("foo")
+					// The relative index is always 0 since
+					// we return an error for the first
+					// request of the nthPartialBatch.
+					reply.Error.Index = &roachpb.ErrPosition{Index: 0}
 				}
 				nthRequest++
 				return reply, nil

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -2223,7 +2223,7 @@ func TestStoreRangeMergeCheckConsistencyAfterSubsumption(t *testing.T) {
 	close(abortMergeTxn)
 
 	pErr := <-mergeErr
-	require.IsType(t, &roachpb.Error{}, pErr)
+	require.IsType(t, (*roachpb.Error)(nil), pErr)
 	require.Regexp(t, "abort the merge for test", pErr.String())
 
 	testutils.SucceedsSoon(t, func() error {

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -168,7 +168,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [4] sequence req1r: detected pusher aborted
 [4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
-[4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3r: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3r: lock wait-queue event: done waiting
 [6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
@@ -402,7 +402,7 @@ on-txn-updated txn=txn1 status=aborted
 [4] sequence req4w: sequencing complete, returned guard
 [5] sequence req1w2: detected pusher aborted
 [5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on "b" for 0.000s
-[5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [7] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [7] sequence req3w2: lock wait-queue event: wait for (distinguished) txn 00000004 running request @ key "a" (queuedWriters: 1, queuedReaders: 0)
 [7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
@@ -651,7 +651,7 @@ on-txn-updated txn=txn4 status=aborted
 [-] update txn: aborting txn4
 [4] sequence req4w: detected pusher aborted
 [4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on "c" for 0.000s
-[4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [5] sequence req1w2: lock wait-queue event: done waiting
 [5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
 [5] sequence req1w2: acquiring latches
@@ -889,7 +889,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [5] sequence req1w2: detected pusher aborted
 [5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on "b" for 0.000s
-[5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3w2: resolving intent "a" for txn 00000001 with ABORTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
 [6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on "a" for 0.000s
@@ -1154,7 +1154,7 @@ on-txn-updated txn=txn4 status=aborted
 [-] update txn: aborting txn4
 [5] sequence req4w: detected pusher aborted
 [5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on "b" for 0.000s
-[5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED): <nil>
+[5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3w2: lock wait-queue event: done waiting
 [6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on "a" for 0.000s
 [6] sequence req3w2: acquiring latches

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -222,6 +222,8 @@ func TestMaybeWaitForPushWithContextCancellation(t *testing.T) {
 	cancel()
 	pErr := <-waitingRes
 	require.NotNil(t, pErr)
+	s := pErr.String()
+	_ = s
 	require.Regexp(t, context.Canceled.Error(), pErr)
 	require.Equal(t, 0, q.mu.txns[txn.ID].waitingPushes.Len())
 

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_errors//extgrpc",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/roachpb/errors.proto
+++ b/pkg/roachpb/errors.proto
@@ -674,17 +674,6 @@ message ErrPosition {
 message Error {
   option (gogoproto.goproto_stringer) = false;
 
-  // message is a human-readable error message.
-  //
-  // DEPRECATED.
-  optional string message = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "deprecatedMessage"];
-
-  // If transaction_restart is not NONE, the error condition may be handled by
-  // restarting the transaction.
-  //
-  // DEPRECATED.
-  optional TransactionRestart transaction_restart = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "deprecatedTransactionRestart"];
-
   // An optional updated transaction. This is to be used by the client in case
   // of retryable errors.
   //
@@ -693,12 +682,6 @@ message Error {
 
   // Node at which the error was generated (zero if does not apply).
   optional int32 origin_node = 5 [(gogoproto.nullable) = false, (gogoproto.casttype) = "NodeID"];
-
-  // If an ErrorDetail is present, it may contain additional structured data
-  // about the error.
-  //
-  // DEPRECATED - consult encoded_error instead.
-  optional ErrorDetail detail = 6 [(gogoproto.nullable) = false, (gogoproto.customname) = "deprecatedDetail"];
 
   // encoded_error is the Go error that caused this Error.
   optional errorspb.EncodedError encoded_error = 9 [(gogoproto.nullable) = false];
@@ -712,7 +695,7 @@ message Error {
   optional util.hlc.Timestamp now = 8 [(gogoproto.nullable) = false,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.ClockTimestamp"];
 
-  reserved 2;
+  reserved 1, 2, 3, 6 ;
 }
 
 


### PR DESCRIPTION
It turns out these unexported fields can cause pain. As far as I can tell,
these deprecated fields haven't been needed for a whole release. I'll note
that we probably ought to more generally fix gogoproto to not try to marshal
unexported fields and we should probably disallow them, but, alas, this is
the most expedient thing for me to do here.

Fixes #86664
Fixes #86509

Release justification: Important bug fix.

Release note: None