### PR TITLE
sql/catalog/lease,descs: do not cross validate when waiting for leases

### DIFF
--- a/pkg/sql/catalog/descs/testdata/drop_and_alter_in_txn
+++ b/pkg/sql/catalog/descs/testdata/drop_and_alter_in_txn
@@ -1,0 +1,10 @@
+exec db=defaultdb
+CREATE DATABASE mydb;
+----
+0	
+
+exec db=defaultdb
+ALTER ROLE ALL IN DATABASE mydb SET timezone = 'America/New_York';
+DROP DATABASE mydb;
+----
+0	0	

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -138,6 +138,10 @@ func (cf *CollectionFactory) TxnWithExecutor(
 				}
 			} else {
 				_, err := cf.leaseMgr.WaitForOneVersion(ctx, ld.ID, retryOpts)
+				// If the descriptor has been deleted, just wait for leases to drain.
+				if errors.Is(err, catalog.ErrDescriptorNotFound) {
+					err = cf.leaseMgr.WaitForNoVersion(ctx, ld.ID, retryOpts)
+				}
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -113,19 +113,40 @@ func (m *Manager) WaitForNoVersion(
 
 // WaitForOneVersion returns once there are no unexpired leases on the
 // previous version of the descriptor. It returns the descriptor with the
-// current version.
+// current version, though note that it will not be validated or hydrated.
+//
 // After returning there can only be versions of the descriptor >= to the
 // returned version. Lease acquisition (see acquire()) maintains the
 // invariant that no new leases for desc.Version-1 will be granted once
 // desc.Version exists.
+//
+// If the descriptor is not found, an error will be returned. The error
+// can be detected by using errors.Is(err, catalog.ErrDescriptorNotFound).
 func (m *Manager) WaitForOneVersion(
 	ctx context.Context, id descpb.ID, retryOpts retry.Options,
 ) (desc catalog.Descriptor, _ error) {
 	for lastCount, r := 0, retry.Start(retryOpts); r.Next(); {
-		if err := m.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) (err error) {
+		if err := m.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			version := m.storage.settings.Version.ActiveVersion(ctx)
-			desc, err = catkv.MustGetDescriptorByID(ctx, version, m.Codec(), txn, nil /* vd */, id, catalog.Any)
-			return err
+			// Use the lower-level GetCrossReferencedDescriptorsForValidation to avoid
+			// performing cross-descriptor validation while waiting for leases to
+			// drain. On the one hand, it's somewhat expensive. More importantly,
+			// there are valid cases where descriptors can be removed or made invalid,
+			// and we don't particularly care about them when using this method.
+			//
+			// An example of this situation would be if the descriptor is a type or
+			// schema and a subsequent, concurrent schema change drops it.
+			got, err := catkv.GetCrossReferencedDescriptorsForValidation(
+				ctx, version, m.Codec(), txn, []descpb.ID{id},
+			)
+			if err != nil {
+				return err
+			}
+			if len(got) == 0 || got[0] == nil {
+				return errors.Wrapf(catalog.ErrDescriptorNotFound, "waiting for leases to drain on descriptor %d", id)
+			}
+			desc = got[0]
+			return nil
 		}); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1304,11 +1304,10 @@ func WaitToUpdateLeases(
 	start := timeutil.Now()
 	log.Infof(ctx, "waiting for a single version...")
 	desc, err := leaseMgr.WaitForOneVersion(ctx, descID, retryOpts)
-	var version descpb.DescriptorVersion
-	if desc != nil {
-		version = desc.GetVersion()
+	if err != nil {
+		return nil, err
 	}
-	log.Infof(ctx, "waiting for a single version... done (at v %d), took %v", version, timeutil.Since(start))
+	log.Infof(ctx, "waiting for a single version... done (at v %d), took %v", desc.GetVersion(), timeutil.Since(start))
 	return desc, err
 }
 


### PR DESCRIPTION
This change removes descriptor cross-validation when waiting for one version.
It also means that an `ErrDescriptorNotFound` now definitively means that the
descriptor in question does not exist. Lastly, it extends the logic in the
descs.Txn loop to fall back to just waiting for leases to drain if a descriptor
is not found. This will be used as part of #86340.

Release justification: Needed for bug fixes.

Release note: None