### PR TITLE
release: use `stable` tag for preflight image

### DIFF
--- a/build/release/teamcity-publish-redhat-release.sh
+++ b/build/release/teamcity-publish-redhat-release.sh
@@ -80,6 +80,6 @@ docker run \
   -v $PWD/artifacts:/artifacts \
   -v ~/.docker/config.json:/temp-authfile.json:ro \
   -v ~/.docker/config.json:/tmp/docker/config.json:ro \
-  quay.io/opdev/preflight:1.1.0 check container \
+  quay.io/opdev/preflight:stable check container \
   "${rhel_repository}:${build_name}" --submit
 tc_end_block "Run preflight"


### PR DESCRIPTION
Previously, we used a fixed version of the prflight docker image to
submit certification results to Red Hat Connect.

Unfortunately, their API is not stable yet, so we ended up with failures
submitting the certification result.

This PR changes the preflight docker image tag to `stable` with hope we
don't need to update the pinned image version on the release branches.

Release justification: Blocks the release process

Release note: None