### PR TITLE
colexec: mark some errors as Expected

### DIFF
--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -150,7 +150,7 @@ func (a *avgInt16HashAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -264,7 +264,7 @@ func (a *avgInt32HashAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -378,7 +378,7 @@ func (a *avgInt64HashAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -490,7 +490,7 @@ func (a *avgDecimalHashAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -115,7 +115,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -157,7 +157,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -201,7 +201,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -241,7 +241,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -293,7 +293,7 @@ func (a *avgInt16OrderedAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -373,7 +373,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -415,7 +415,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -459,7 +459,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -499,7 +499,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -551,7 +551,7 @@ func (a *avgInt32OrderedAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -631,7 +631,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -673,7 +673,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -717,7 +717,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -757,7 +757,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -809,7 +809,7 @@ func (a *avgInt64OrderedAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -889,7 +889,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -930,7 +930,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -973,7 +973,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -1012,7 +1012,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -1063,7 +1063,7 @@ func (a *avgDecimalOrderedAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -150,7 +150,7 @@ func (a *avgInt16WindowAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -320,7 +320,7 @@ func (a *avgInt32WindowAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -490,7 +490,7 @@ func (a *avgInt64WindowAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -658,7 +658,7 @@ func (a *avgDecimalWindowAgg) Flush(outputIdx int) {
 
 		col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&col[outputIdx], &a.curSum, &col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -360,7 +360,7 @@ func (s *externalSorter) Next() coldata.Batch {
 				if !s.testingKnobs.delegateFDAcquisitions && s.fdState.fdSemaphore != nil {
 					toAcquire := s.maxNumberPartitions
 					if err := s.fdState.fdSemaphore.Acquire(s.Ctx, toAcquire); err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					s.fdState.acquiredFDs = toAcquire
 				}

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -442,7 +442,7 @@ StateChanged:
 			if !op.testingKnobs.delegateFDAcquisitions && op.fdState.acquiredFDs == 0 {
 				toAcquire := op.maxNumberActivePartitions
 				if err := op.fdState.fdSemaphore.Acquire(op.Ctx, toAcquire); err != nil {
-					colexecerror.InternalError(err)
+					colexecerror.ExpectedError(err)
 				}
 				op.fdState.acquiredFDs = toAcquire
 			}

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -175,7 +175,7 @@ func (b *SpillingBuffer) AppendTuples(
 	if b.diskQueue == nil {
 		if b.fdSemaphore != nil {
 			if err = b.fdSemaphore.Acquire(ctx, numSpillingBufferFDs); err != nil {
-				colexecerror.InternalError(err)
+				colexecerror.ExpectedError(err)
 			}
 		}
 		if b.diskQueue, err = colcontainer.NewRewindableDiskQueue(

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -429,7 +429,7 @@ func (q *SpillingQueue) maybeSpillToDisk(ctx context.Context) error {
 	// one for the read file.
 	if q.fdSemaphore != nil {
 		if err = q.fdSemaphore.Acquire(ctx, q.numFDsOpenAtAnyGivenTime()); err != nil {
-			return err
+			colexecerror.ExpectedError(err)
 		}
 	}
 	log.VEvent(ctx, 1, "spilled to disk")

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -64,7 +64,7 @@ func (a avgTmplInfo) AssignDivInt64(targetElem, leftElem, rightElem, _, _, _ str
 		return fmt.Sprintf(`
 			%s.SetInt64(%s)
 			if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
-				colexecerror.InternalError(err)
+				colexecerror.ExpectedError(err)
 			}`,
 			targetElem, rightElem, targetElem, leftElem, targetElem,
 		)


### PR DESCRIPTION
This commit fixes a couple of oversights where we mistakenly propagated
the errors as "internal" (meaning they would get an assertion failure
annotation and a sentry report):
- an error returned when `Acquire`-ing file descriptors
- an error encountered when performing a decimal division for avg
aggregates.

Fixes: #83059.

Release justification: bug fix.

Release note: None