### PR TITLE
storage: remove `DisableFilesystemMiddlewareTODO`

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -596,7 +596,6 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 					storage.CacheSize(cfg.CacheSize),
 					storage.MaxSize(sizeInBytes),
 					storage.EncryptionAtRest(spec.EncryptionOptions),
-					storage.DisableFilesystemMiddlewareTODO,
 					storage.Settings(cfg.Settings))
 				if err != nil {
 					return Engines{}, err

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -62,15 +62,6 @@ var ForceWriterParallelism ConfigOption = func(cfg *engineConfig) error {
 	return nil
 }
 
-// DisableFilesystemMiddlewareTODO configures an engine to not include
-// filesystem middleware like disk-health checking and ENOSPC-detection. This is
-// a temporary option while some units leak file descriptors, and by extension,
-// disk-health checking goroutines.
-var DisableFilesystemMiddlewareTODO = func(cfg *engineConfig) error {
-	cfg.DisableFilesystemMiddlewareTODO = true
-	return nil
-}
-
 // ForTesting configures the engine for use in testing. It may randomize some
 // config options to improve test coverage.
 var ForTesting ConfigOption = func(cfg *engineConfig) error {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -628,9 +628,6 @@ type PebbleConfig struct {
 	base.StorageConfig
 	// Pebble specific options.
 	Opts *pebble.Options
-	// Temporary option while there exist file descriptor leaks. See the
-	// DisableFilesystemMiddlewareTODO ConfigOption that sets this, and #81389.
-	DisableFilesystemMiddlewareTODO bool
 }
 
 // EncryptionStatsHandler provides encryption related stats.
@@ -813,15 +810,12 @@ func NewPebble(ctx context.Context, cfg PebbleConfig) (p *Pebble, err error) {
 
 	// Initialize the FS, wrapping it with disk health-checking and
 	// ENOSPC-detection.
-	var filesystemCloser io.Closer
-	if !cfg.DisableFilesystemMiddlewareTODO {
-		filesystemCloser = wrapFilesystemMiddleware(cfg.Opts)
-		defer func() {
-			if err != nil {
-				filesystemCloser.Close()
-			}
-		}()
-	}
+	filesystemCloser := wrapFilesystemMiddleware(cfg.Opts)
+	defer func() {
+		if err != nil {
+			filesystemCloser.Close()
+		}
+	}()
 
 	cfg.Opts.EnsureDefaults()
 	cfg.Opts.ErrorIfNotExists = cfg.MustExist


### PR DESCRIPTION
The `DisableFilesystemMiddlewareTODO` Pebble option was added as a
temporary workaround to suppress errors arising from file descriptor
leaks in unit tests, when the disk-health checking filesystem is used.

Remove the temporary config option.

Touches #84437.

Release justification: Low risk, high benefit changes to existing
functionality.

Release note: None.