### PR TITLE
release-21.2: ccl/backupccl: do not backup spans for views

### DIFF
--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -160,6 +160,19 @@ func (e *encryptedDataKeyMap) rangeOverMap(fn func(masterKeyID hashedMasterKeyID
 func getPublicIndexTableSpans(
 	table catalog.TableDescriptor, added map[tableAndIndex]bool, codec keys.SQLCodec,
 ) ([]roachpb.Span, error) {
+	// We do not backup spans for views here as they do not contain data.
+	//
+	// Additionally, because we do not split ranges at view boundaries, it is
+	// possible that the range the view span belongs to is shared by another
+	// object in the cluster (that we may or may not be backing up) that might
+	// have its own bespoke zone configurations, namely one with a short GC TTL.
+	// This could lead to a situation where the short GC TTL on the range we are
+	// not backing up causes our protectedts verification to fail when attempting
+	// to backup the view span.
+	if !table.IsPhysicalTable() {
+		return nil, nil
+	}
+
 	publicIndexSpans := make([]roachpb.Span, 0)
 	if err := catalog.ForEachActiveIndex(table, func(idx catalog.Index) error {
 		key := tableAndIndex{tableID: table.GetID(), indexID: idx.GetID()}

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -9238,3 +9238,155 @@ func TestRestoreOnFailOrCancelAfterPause(t *testing.T) {
 	sqlDBRestore.Exec(t, `CANCEL JOB $1`, id)
 	jobutils.WaitForJobToCancel(t, sqlDBRestore, id)
 }
+
+// This is a regression test ensuring that the spans represented by views are
+// not included in backups when their descriptors are included in descriptor
+// revisions.
+func TestViewRevisions(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, _, sqlDB, _, cleanup := BackupRestoreTestSetup(t, singleNode, 10, InitManualReplication)
+	defer cleanup()
+
+	sqlDB.Exec(t, `
+		CREATE DATABASE test;
+		USE test;
+		CREATE VIEW v AS SELECT 1;
+	`)
+	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/foo' WITH revision_history;`)
+	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/foo' WITH revision_history;`)
+	sqlDB.Exec(t, `
+		USE test;
+		ALTER VIEW v RENAME TO v2;
+	`)
+	sqlDB.Exec(t, `BACKUP TO 'nodelocal://1/foo' WITH revision_history;`)
+}
+
+// This tests checks that backups do not contain spans of views, but do contain
+// view descriptors.
+func TestBackupDoNotIncludeViewSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, tc, sqlDB, dir, cleanupFn := BackupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
+	defer cleanupFn()
+	kvDB := tc.Server(0).DB()
+
+	// Generate some testdata and back it up.
+	sqlDB.Exec(t, "CREATE DATABASE d")
+	sqlDB.Exec(t, "CREATE TABLE d.t (k INT, a INT, b INT)")
+	sqlDB.Exec(t, "INSERT INTO d.t VALUES(1, 100, 101), (2, 200, 202)")
+	sqlDB.Exec(t, "CREATE VIEW d.tview AS SELECT k, b FROM d.t")
+	sqlDB.Exec(t, `BACKUP DATABASE d INTO $1`, LocalFoo)
+
+	res := sqlDB.QueryStr(t, `SHOW BACKUPS IN $1`, LocalFoo)
+	if len(res) != 1 {
+		t.Fatal("expected 1 backup")
+	}
+
+	// Read the backup manifest.
+	var backupManifest BackupManifest
+	{
+		backupManifestBytes, err := ioutil.ReadFile(filepath.Join(dir, "foo", res[0][0], backupManifestName))
+		if err != nil {
+			t.Fatalf("%+v", err)
+		}
+		if isGZipped(backupManifestBytes) {
+			backupManifestBytes, err = decompressData(backupManifestBytes)
+			require.NoError(t, err)
+		}
+		if err := protoutil.Unmarshal(backupManifestBytes, &backupManifest); err != nil {
+			t.Fatalf("%+v", err)
+		}
+	}
+
+	// Verify that the manifest doesn't contain any spans that intersect the span
+	// for the view.
+	tbDesc := catalogkv.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "d", "tview")
+	viewSpan := tbDesc.TableSpan(keys.SystemSQLCodec)
+
+	for _, sp := range backupManifest.Spans {
+		if sp.Overlaps(viewSpan) {
+			t.Fatalf("backup span %v overlaps view span %v", sp, viewSpan)
+		}
+	}
+
+	sqlDB.Exec(t, "DROP DATABASE d")
+	sqlDB.Exec(t, "RESTORE DATABASE d FROM LATEST IN $1", LocalFoo)
+	sqlDB.CheckQueryResults(t, "SHOW CREATE VIEW d.tview", [][]string{{"d.public.tview", "CREATE VIEW public.tview (k, b) AS SELECT k, b FROM d.public.t"}})
+	sqlDB.CheckQueryResults(t, "SELECT * from d.tview", [][]string{{"1", "101"}, {"2", "202"}})
+}
+
+// Because we do not split ranges at view boundaries, it is possible that the
+// range the view span belongs to is shared by another object in the cluster
+// (that we may or may not be backing up) that might have its own bespoke zone
+// configurations, namely one with a short GC TTL. This could lead to a
+// situation where the short GC TTL on the range we are not backing up causes
+// our protectedts verification to fail when attempting to backup the view span.
+//
+// This test verifies that backups succeed on a database with a view that's on
+// another database's range because we are no longer backing up that view's
+// span.
+func TestBackupDBWithViewOnAdjacentDBRange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	_, tc, sqlDB, _, cleanupFn := BackupRestoreTestSetup(t, singleNode, 0, InitManualReplication)
+	defer cleanupFn()
+	s0 := tc.Servers[0]
+
+	waitForTableSplit := func(conn *gosql.DB, tableName string, dbName string) {
+		testutils.SucceedsSoon(t, func() error {
+			count := 0
+			if err := conn.QueryRow(
+				"SELECT count(*) "+
+					"FROM crdb_internal.ranges_no_leases "+
+					"WHERE table_name = $1 "+
+					"AND database_name = $2",
+				tableName, dbName).Scan(&count); err != nil {
+				return err
+			}
+			if count == 0 {
+				return errors.New("waiting for table split")
+			}
+			return nil
+		})
+
+	}
+
+	// Speeds up the test.
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.rangefeed.enabled = true`)
+	sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`)
+
+	// Create two databases da and db, and tables in such a way that the view
+	// db.dbview is on the same range as db.t2. Set da to have a short GC TTL of 1
+	// second.
+	sqlDB.Exec(t, `
+		CREATE DATABASE da;
+		CREATE TABLE da.t1 (k INT PRIMARY KEY, v INT);
+		CREATE DATABASE db;
+		CREATE TABLE db.t2 (k INT PRIMARY KEY, v INT);
+		CREATE TABLE da.t2 (k INT PRIMARY KEY, v INT);
+		CREATE VIEW db.dbview AS SELECT k, v FROM db.t2;
+		ALTER DATABASE da CONFIGURE ZONE USING gc.ttlseconds=1;
+
+		INSERT INTO da.t2 VALUES (1, 100), (2, 200), (3, 300);
+		UPDATE da.t2 SET v = 101 WHERE k = 1;
+	`)
+
+	// Wait for splits to be created on the new tables.
+	waitForTableSplit(tc.Conns[0], "t2", "da")
+
+	sqlDB.Exec(t, `BACKUP DATABASE db INTO 'userfile:///a' WITH revision_history;`)
+
+	time.Sleep(5 * time.Second)
+
+	// Force GC on da.t2 to advance its GC threshold.
+	err := s0.ForceTableGC(context.Background(), "da", "t2", s0.Clock().Now().Add(-int64(1*time.Second), 0))
+	require.NoError(t, err)
+
+	// This statement should succeed as we are not backing up the span for dbview,
+	// but would fail if it was backed up.
+	sqlDB.Exec(t, `BACKUP database db into latest in 'userfile:///a' with revision_history;`)
+}


### PR DESCRIPTION
Backport 1/1 commits from #85158.

/cc @cockroachdb/release

---

Backups currently backup spans corresponding to views. These spans should not
be backed up as they do not contain data.

Additionally, because we do not split ranges at view boundaries, it is possible
that the range the view span belongs to is shared by another object in the
cluster (that we may or may not be backing up) that might have its own bespoke
zone configurations, namely one with a short GC TTL. This could lead to a
situation where the short GC TTL on the range we are not backing up causes our
protectedts verification to fail when attempting to backup the view span.

Release note (bug fix): Fix a bug in backup where spans for views were being
backed up. Because ranges are not split at view boundaries, this can cause the
backup to send export requests to ranges that do not belong to any backup
target.

Release justification: bug fixes and low-risk updates to new functionality
