### PR TITLE
bulk: fix incorrect memory handling in the kvBuf

### DIFF
--- a/pkg/kv/bulk/kv_buf.go
+++ b/pkg/kv/bulk/kv_buf.go
@@ -188,7 +188,7 @@ func (b *kvBuf) Swap(i, j int) {
 	b.entries[i], b.entries[j] = b.entries[j], b.entries[i]
 }
 
-func (b kvBuf) MemSize() sz {
+func (b *kvBuf) MemSize() sz {
 	return sz(cap(b.entries)<<entrySizeShift) + sz(cap(b.slab))
 }
 

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -41,8 +41,8 @@ func TestAddBatched(t *testing.T) {
 	t.Run("batch=default", func(t *testing.T) {
 		runTestImport(t, 32<<20)
 	})
-	t.Run("batch=1", func(t *testing.T) {
-		runTestImport(t, 1)
+	t.Run("batch=smaller", func(t *testing.T) {
+		runTestImport(t, 1<<20)
 	})
 }
 


### PR DESCRIPTION
This change fixes a memory accounting bug where
we were appending a KV to the kvBuf without accounting
for its memory.

Release note (bug fix): adds a missing memory accounting
call when appending a KV to the underlying kvBuf

Release justification: low risk bug fix that prevents an
import from panicking on non-release builds