### PR TITLE
sql/gcjob: set GC hint when deleting all data in range

### DIFF
--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -253,7 +253,8 @@ func deleteAllSpanData(
 					Key:    lastKey.AsRawKey(),
 					EndKey: endKey.AsRawKey(),
 				},
-				UseRangeTombstone: true,
+				UseRangeTombstone:       true,
+				UpdateRangeDeleteGCHint: true,
 			})
 			log.VEventf(ctx, 2, "delete range %s - %s", lastKey, endKey)
 			if err := db.Run(ctx, &b); err != nil {

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -788,8 +788,9 @@ func (p *planner) ForceDeleteTableData(ctx context.Context, descID int64) error 
 	b := &kv.Batch{}
 	if p.execCfg.Settings.Version.IsActive(ctx, clusterversion.UseDelRangeInGCJob) {
 		b.AddRawRequest(&roachpb.DeleteRangeRequest{
-			RequestHeader:     requestHeader,
-			UseRangeTombstone: true,
+			RequestHeader:           requestHeader,
+			UseRangeTombstone:       true,
+			UpdateRangeDeleteGCHint: true,
 		})
 	} else {
 		b.AddRawRequest(&roachpb.ClearRangeRequest{


### PR DESCRIPTION
When deleting full range spans with range tombstones GC hint
should be set to reduce the work GC does when collecting those
ranges.
This commit add appropriate flag to the request.

Release justification: Enables future optimization for delete range only,
doesn't change current GC or delete range functionality.
Release note: None