### PR TITLE
storage: rename `MVCCRangeKeyStack.FirstAbove/Below`

### DIFF
--- a/pkg/kv/kvserver/gc/gc_iterator.go
+++ b/pkg/kv/kvserver/gc/gc_iterator.go
@@ -198,7 +198,7 @@ func (it *gcIterator) currentRangeTS() hlc.Timestamp {
 	}
 	it.cachedRangeTombstoneKey = append(it.cachedRangeTombstoneKey[:0], rangeTombstoneStartKey...)
 
-	if v, ok := it.it.RangeKeys().FirstBelow(it.threshold); ok {
+	if v, ok := it.it.RangeKeys().FirstAtOrBelow(it.threshold); ok {
 		it.cachedRangeTombstoneTS = v.Timestamp
 	} else {
 		it.cachedRangeTombstoneTS = hlc.Timestamp{}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1184,7 +1184,7 @@ func mvccGetMetadata(
 	// metadata), or the point version's timestamp if it was a tombstone.
 	if hasRange {
 		rangeKeys := iter.RangeKeys()
-		if v, ok := rangeKeys.FirstAbove(unsafeKey.Timestamp); ok {
+		if v, ok := rangeKeys.FirstAtOrAbove(unsafeKey.Timestamp); ok {
 			meta.Deleted = true
 			meta.Timestamp = rangeKeys.Versions[0].Timestamp.ToLegacyTimestamp()
 			keyLastSeen := v.Timestamp
@@ -2681,7 +2681,7 @@ func MVCCClearTimeRange(
 				// is cheap, so we don't need any caching here.
 				if !restoredMeta.Deleted {
 					if rangeKeys := iter.RangeKeysIgnoringTime(); !rangeKeys.IsEmpty() {
-						if v, ok := rangeKeys.FirstAbove(k.Timestamp); ok {
+						if v, ok := rangeKeys.FirstAtOrAbove(k.Timestamp); ok {
 							if v.Timestamp.LessEq(clearedMeta.Timestamp.ToTimestamp()) {
 								restoredMeta.Deleted = true
 								restoredMeta.KeyBytes = 0
@@ -2719,7 +2719,7 @@ func MVCCClearTimeRange(
 		// revealed the key, since it may have been covered by the point key that
 		// we cleared or a different range tombstone below the one we cleared.
 		if !v.IsTombstone() {
-			if v, ok := clearRangeKeys.FirstAbove(k.Timestamp); ok {
+			if v, ok := clearRangeKeys.FirstAtOrAbove(k.Timestamp); ok {
 				if !clearedMetaKey.Key.Equal(k.Key) ||
 					!clearedMeta.Timestamp.ToTimestamp().LessEq(v.Timestamp) {
 					rangeKeys := iter.RangeKeysIgnoringTime()
@@ -4495,7 +4495,7 @@ func mvccResolveWriteIntent(
 			// synthesize a point tombstone at the lowest range tombstone covering it.
 			// This is where the point key ceases to exist, contributing to GCBytesAge.
 			if len(unsafeNextValueRaw) > 0 && hasRange {
-				if v, found := iter.RangeKeys().FirstAbove(unsafeNextKey.Timestamp); found {
+				if v, found := iter.RangeKeys().FirstAtOrAbove(unsafeNextKey.Timestamp); found {
 					unsafeNextKey.Timestamp = v.Timestamp
 					unsafeNextValueRaw = []byte{}
 				}
@@ -5001,7 +5001,7 @@ func MVCCGarbageCollect(
 					// For non deletions, we need to find if we had a range tombstone
 					// between this and next value (prevNanos) to use its timestamp for
 					// computing GCBytesAge.
-					if kv, ok := rangeTombstones.FirstAbove(unsafeIterKey.Timestamp); ok {
+					if kv, ok := rangeTombstones.FirstAtOrAbove(unsafeIterKey.Timestamp); ok {
 						if kv.Timestamp.WallTime < fromNS {
 							fromNS = kv.Timestamp.WallTime
 						}
@@ -5554,7 +5554,7 @@ func computeStatsForIterWithVisitors(
 		var nextRangeTombstone hlc.Timestamp
 		if isValue {
 			if !rangeTombstones.IsEmpty() && unsafeKey.Timestamp.LessEq(rangeTombstones.Newest()) {
-				if v, ok := rangeTombstones.FirstAbove(unsafeKey.Timestamp); ok {
+				if v, ok := rangeTombstones.FirstAtOrAbove(unsafeKey.Timestamp); ok {
 					nextRangeTombstone = v.Timestamp
 				}
 			}

--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -589,16 +589,16 @@ func (s *MVCCRangeKeyStack) Excise(from, to hlc.Timestamp) bool {
 	return s.Versions.Excise(from, to)
 }
 
-// FirstAbove does a binary search for the first range key version at or above
-// the given timestamp. Returns false if no matching range key was found.
-func (s MVCCRangeKeyStack) FirstAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
-	return s.Versions.FirstAbove(ts)
+// FirstAtOrAbove does a binary search for the first range key version at or
+// above the given timestamp. Returns false if no matching range key was found.
+func (s MVCCRangeKeyStack) FirstAtOrAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	return s.Versions.FirstAtOrAbove(ts)
 }
 
-// FirstBelow does a binary search for the first range key version at or below
-// the given timestamp. Returns false if no matching range key was found.
-func (s MVCCRangeKeyStack) FirstBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
-	return s.Versions.FirstBelow(ts)
+// FirstAtOrBelow does a binary search for the first range key version at or
+// below the given timestamp. Returns false if no matching range key was found.
+func (s MVCCRangeKeyStack) FirstAtOrBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+	return s.Versions.FirstAtOrBelow(ts)
 }
 
 // HasBetween checks whether an MVCC range key exists between the two given
@@ -721,9 +721,9 @@ func (v *MVCCRangeKeyVersions) Excise(from, to hlc.Timestamp) bool {
 	return true
 }
 
-// FirstAbove does a binary search for the first range key version at or above
-// the given timestamp. Returns false if no matching range key was found.
-func (v MVCCRangeKeyVersions) FirstAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+// FirstAtOrAbove does a binary search for the first range key version at or
+// above the given timestamp. Returns false if no matching range key was found.
+func (v MVCCRangeKeyVersions) FirstAtOrAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
 	// This is kind of odd due to sort.Search() semantics: we do a binary search
 	// for the first range key that's below the timestamp, then return the
 	// previous range key if any.
@@ -737,9 +737,9 @@ func (v MVCCRangeKeyVersions) FirstAbove(ts hlc.Timestamp) (MVCCRangeKeyVersion,
 	return MVCCRangeKeyVersion{}, false
 }
 
-// FirstBelow does a binary search for the first range key version at or below
-// the given timestamp. Returns false if no matching range key was found.
-func (v MVCCRangeKeyVersions) FirstBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
+// FirstAtOrBelow does a binary search for the first range key version at or
+// below the given timestamp. Returns false if no matching range key was found.
+func (v MVCCRangeKeyVersions) FirstAtOrBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool) {
 	if length := len(v); length > 0 {
 		if i := sort.Search(length, func(i int) bool {
 			return v[i].Timestamp.LessEq(ts)
@@ -753,7 +753,7 @@ func (v MVCCRangeKeyVersions) FirstBelow(ts hlc.Timestamp) (MVCCRangeKeyVersion,
 // HasBetween checks whether an MVCC range key exists between the two given
 // timestamps (both inclusive, in order).
 func (v MVCCRangeKeyVersions) HasBetween(lower, upper hlc.Timestamp) bool {
-	if version, ok := v.FirstAbove(lower); ok {
+	if version, ok := v.FirstAtOrAbove(lower); ok {
 		// Consider equal timestamps to be "between". This shouldn't really happen,
 		// since MVCC enforces point and range keys can't have the same timestamp.
 		return version.Timestamp.LessEq(upper)

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -733,7 +733,7 @@ func TestMVCCRangeKeyStackExcise(t *testing.T) {
 	}
 }
 
-func TestMVCCRangeKeyStackFirstAbove(t *testing.T) {
+func TestMVCCRangeKeyStackFirstAtOrAbove(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rangeKeys := rangeKeyStack("a", "f", map[int]MVCCValue{6: {}, 4: {}, 3: {}, 1: {}})
@@ -753,7 +753,7 @@ func TestMVCCRangeKeyStackFirstAbove(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%d", tc.ts), func(t *testing.T) {
-			v, ok := rangeKeys.FirstAbove(wallTS(tc.ts))
+			v, ok := rangeKeys.FirstAtOrAbove(wallTS(tc.ts))
 			if tc.expect == 0 {
 				require.False(t, ok)
 				require.Empty(t, v)
@@ -765,7 +765,7 @@ func TestMVCCRangeKeyStackFirstAbove(t *testing.T) {
 	}
 }
 
-func TestMVCCRangeKeyStackFirstBelow(t *testing.T) {
+func TestMVCCRangeKeyStackFirstAtOrBelow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	rangeKeys := rangeKeyStack("a", "f", map[int]MVCCValue{6: {}, 4: {}, 3: {}, 1: {}})
@@ -785,7 +785,7 @@ func TestMVCCRangeKeyStackFirstBelow(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		t.Run(fmt.Sprintf("%d", tc.ts), func(t *testing.T) {
-			v, ok := rangeKeys.FirstBelow(wallTS(tc.ts))
+			v, ok := rangeKeys.FirstAtOrBelow(wallTS(tc.ts))
 			if tc.expect == 0 {
 				require.False(t, ok)
 				require.Empty(t, v)

--- a/pkg/storage/read_as_of_iterator.go
+++ b/pkg/storage/read_as_of_iterator.go
@@ -146,7 +146,7 @@ func (f *ReadAsOfIterator) advance(seeked bool) {
 			hasPoint, hasRange := f.iter.HasPointAndRange()
 			f.newestRangeTombstone = hlc.Timestamp{}
 			if hasRange {
-				if v, ok := f.iter.RangeKeys().FirstBelow(f.asOf); ok {
+				if v, ok := f.iter.RangeKeys().FirstAtOrBelow(f.asOf); ok {
 					f.newestRangeTombstone = v.Timestamp
 				}
 			}

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -416,7 +416,7 @@ func CheckSSTConflicts(
 						"ingested range key collides with an existing one: %s", sstTopTombstone)
 				}
 				if !extValueDeleted {
-					sstRangeKeyVersion, ok := sstRangeKeys.FirstAbove(extKey.Timestamp)
+					sstRangeKeyVersion, ok := sstRangeKeys.FirstAtOrAbove(extKey.Timestamp)
 					if !ok {
 						return enginepb.MVCCStats{}, errors.AssertionFailedf("expected range tombstone above timestamp %v", extKey.Timestamp)
 					}


### PR DESCRIPTION
This patch renames `FirstAbove/Below` to `FirstAtOrAbove/Below`, for
clarity.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None