### PR TITLE
release-22.1: opt: cache not-null columns in the metadata

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -321,7 +321,7 @@ func init() {
 // on what each phase includes.
 func BenchmarkPhases(b *testing.B) {
 	for _, query := range queriesToTest(b) {
-		h := newHarness(b, query)
+		h := newHarness(b, query, schemas)
 		b.Run(query.name, func(b *testing.B) {
 			b.Run("Simple", func(b *testing.B) {
 				for _, phase := range SimplePhases {
@@ -360,7 +360,7 @@ type harness struct {
 	optimizer xform.Optimizer
 }
 
-func newHarness(tb testing.TB, query benchQuery) *harness {
+func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
 	h := &harness{
 		ctx:     context.Background(),
 		semaCtx: tree.MakeSemaContext(),
@@ -647,7 +647,7 @@ func queriesToTest(b *testing.B) []benchQuery {
 func BenchmarkChain(b *testing.B) {
 	for i := 1; i < 20; i++ {
 		q := makeChain(i)
-		h := newHarness(b, q)
+		h := newHarness(b, q, schemas)
 		b.Run(q.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				h.runSimple(b, q, Explore)
@@ -688,6 +688,235 @@ func BenchmarkEndToEnd(b *testing.B) {
 					}
 				}
 			})
+		})
+	}
+}
+
+var slowSchemas = []string{
+	`
+	CREATE TABLE table64793_1 (
+		col1_0 CHAR NOT NULL, col1_1 BOOL NOT NULL, col1_2 REGPROC NOT NULL,
+		col1_3 REGPROCEDURE NOT NULL, col1_4 TIMETZ NOT NULL, col1_5 FLOAT8 NULL,
+		col1_6 INT2 NOT NULL, col1_7 BOOL, col1_8 BOX2D NOT NULL,
+		col1_9 REGNAMESPACE NOT NULL,
+		PRIMARY KEY (
+			col1_8 DESC, col1_9 DESC, col1_4 DESC, col1_1, col1_2 ASC, col1_3 DESC,
+			col1_0 DESC, col1_6
+		),
+		col1_10 INT2 NOT NULL AS (col1_6 + 22798:::INT8) VIRTUAL,
+		FAMILY (col1_4), FAMILY (col1_0, col1_5), FAMILY (col1_1),
+		FAMILY (col1_8, col1_3, col1_9, col1_7), FAMILY (col1_2), FAMILY (col1_6))
+`,
+	`
+	CREATE TYPE greeting64793 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
+`,
+	`
+	CREATE TABLE seed64793 (
+		_int2 INT2,
+		_int4 INT4,
+		_int8 INT8,
+		_float4 FLOAT4,
+		_float8 FLOAT8,
+		_date DATE,
+		_timestamp TIMESTAMP,
+		_timestamptz TIMESTAMPTZ,
+		_interval INTERVAL,
+		_bool BOOL,
+		_decimal DECIMAL,
+		_string STRING,
+		_bytes BYTES,
+		_uuid UUID,
+		_inet INET,
+		_jsonb JSONB,
+		_enum greeting64793
+	);
+`,
+	`
+	CREATE INDEX on seed64793 (_int8, _float8, _date);
+`,
+	`
+	CREATE INVERTED INDEX on seed64793 (_jsonb);
+`,
+	`
+	CREATE TABLE table64793_2 (
+		col1_0 "char" NOT NULL, col1_1 OID NOT NULL, col1_2 BIT(38) NOT NULL,
+		col1_3 BIT(18) NOT NULL, col1_4 BYTES NOT NULL, col1_5 INT8 NOT NULL,
+		col1_6 INTERVAL NOT NULL, col1_7 BIT(33) NOT NULL, col1_8 INTERVAL NULL,
+		col1_9 GEOMETRY NOT NULL, col1_10 BOOL NOT NULL, col1_11 INT2,
+		PRIMARY KEY (
+			col1_4 ASC, col1_7 DESC, col1_1 ASC, col1_2 ASC, col1_10 ASC, col1_5,
+			col1_0 ASC, col1_3, col1_6
+		),
+		UNIQUE (
+			col1_8 DESC, col1_11, col1_3 DESC, col1_7, col1_6 DESC, col1_4 ASC,
+			col1_1 DESC
+		)
+	);
+`,
+	`
+	CREATE TABLE table64793_3 (
+		col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL,
+		PRIMARY KEY (col2_0 ASC, col2_1),
+		col2_2 STRING NOT NULL AS (lower(col2_0)) VIRTUAL,
+		UNIQUE (col2_0 DESC, col2_2 DESC, col2_1)
+		WHERE (table64793_3.col2_2 > e'\U00002603':::STRING)
+		OR (table64793_3.col2_0 != '"':::STRING),
+		UNIQUE (col2_1 ASC, col2_2, col2_0),
+		UNIQUE (col2_0 DESC,col2_1, col2_2),
+		INDEX (col2_1 DESC),
+		UNIQUE (col2_2 DESC, col2_0 ASC)
+		WHERE table64793_3.col2_2 = '"':::STRING
+	);
+`,
+	`
+	CREATE TABLE table64793_4 (
+		col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL, col3_2 REGPROC NOT NULL,
+		col3_3 "char", col3_4 BOX2D, col3_5 INT8 NULL, col3_6 TIMESTAMP NOT NULL,
+		col3_7 FLOAT8, col3_8 INT4 NULL, col3_9 INET NULL, col3_10 UUID NOT NULL,
+		col3_11 UUID NULL, col3_12 INT2 NOT NULL, col3_13 BIT(34),
+		col3_14 REGPROCEDURE NULL, col3_15 FLOAT8 NULL,
+		PRIMARY KEY (
+			col2_0 ASC, col2_1, col3_11 DESC, col3_13, col3_6, col3_3 DESC,
+			col3_15 ASC, col3_2 ASC, col3_4 ASC, col3_9 DESC, col3_12 ASC,
+			col3_8 ASC, col3_5, col3_14 ASC
+		),
+		UNIQUE (col3_2, col3_8 ASC)
+		WHERE ((((table64793_4.col3_5 < 0:::INT8)
+		AND (table64793_4.col3_3 != '':::STRING))
+		AND (table64793_4.col2_1 < '00:00:00+15:59:00':::TIMETZ))
+		AND (table64793_4.col3_12 > 0:::INT8))
+		AND (table64793_4.col3_15 <= 1.7976931348623157e+308:::FLOAT8),
+		UNIQUE (col3_10 DESC, col3_3 ASC, col2_1 DESC, col3_9 ASC)
+	);
+`,
+}
+
+var slowQueries = [...]benchQuery{
+	// 1. The first long-running query taken from #64793.
+	// 2. The most recent long-running query from #64793 (as of July 2022).
+	{
+		name: "slow-query-1",
+		query: `
+			WITH with_186941 (col_1103773, col_1103774) AS (
+				SELECT 
+					* 
+				FROM 
+					(
+						VALUES 
+							('clvl', 3 :: INT2), 
+							(
+								'n', 
+								(
+									SELECT 
+										tab_455284.col1_6 AS col_1103772 
+									FROM 
+										table64793_1@[0] AS tab_455284 
+									ORDER BY 
+										tab_455284.col1_2 DESC, 
+										tab_455284.col1_1 DESC 
+									LIMIT 
+										1 ::: INT8
+								)
+							), 
+							(NULL, 6736 ::: INT8)
+					) AS tab_455285 (col_1103773, col_1103774)
+			), 
+			with_186942 (col_1103775) AS (
+				SELECT 
+					* 
+				FROM 
+					(
+						VALUES 
+							('yk'), 
+							(NULL)
+					) AS tab_455286 (col_1103775)
+			) 
+			SELECT 
+				0 ::: OID AS col_1103776, 
+				(
+					(-32244820164.24410487)::: DECIMAL :: DECIMAL + tab_455291.col1_10 :: INT8
+				):: DECIMAL AS col_1103777, 
+				tab_455287._bool AS col_1103778 
+			FROM 
+				with_186942 AS cte_ref_54113, 
+				seed64793@[0] AS tab_455287 
+				JOIN seed64793 AS tab_455288 
+				JOIN seed64793 AS tab_455289 ON (tab_455288._int8) = (tab_455289._int8) 
+				AND (tab_455288._date) = (tab_455289._date) 
+				AND (tab_455288._float8) = (tab_455289._float8) 
+				JOIN table64793_1@[0] AS tab_455290 
+				JOIN table64793_1@primary AS tab_455291 
+				JOIN table64793_1@[0] AS tab_455295 
+				JOIN seed64793 AS tab_455296 
+				JOIN seed64793 AS tab_455297 ON (tab_455296._int8) = (tab_455297._int8) 
+				AND (tab_455296._date) = (tab_455297._date) ON (tab_455295.col1_5) = (tab_455297._float8) 
+				AND (tab_455295.col1_5) = (tab_455296._float8) 
+				AND (tab_455295.col1_5) = (tab_455297._float8) 
+				AND (tab_455295.col1_5) = (tab_455297._float8) ON (tab_455291.col1_2) = (tab_455295.tableoid) 
+				AND (tab_455291.col1_7) = (tab_455295.col1_1) ON (tab_455290.col1_2) = (tab_455291.col1_9) 
+				AND (tab_455290.col1_7) = (tab_455291.col1_7) ON (tab_455289._float8) = (tab_455296._float8) ON (tab_455287._float4) = (tab_455290.col1_5) 
+				AND (tab_455287.tableoid) = (tab_455295.col1_9) 
+				AND (tab_455287._bool) = (tab_455295.col1_7);
+		`,
+		args: []interface{}{},
+	},
+	{
+		name: "slow-query-2",
+		query: `
+			WITH with_121707 (col_692430) AS (
+				SELECT 
+					* 
+				FROM 
+					(
+						VALUES 
+							(
+								(-0.19099748134613037)::: FLOAT8
+							), 
+							(0.9743397235870361 ::: FLOAT8), 
+							(
+								(-1.6944892406463623)::: FLOAT8
+							)
+					) AS tab_297691 (col_692430)
+			) 
+			SELECT 
+				'-35 years -11 mons -571 days -08:18:57.001029' ::: INTERVAL AS col_692441 
+			FROM 
+				table64793_2@table64793_2_col1_8_col1_11_col1_3_col1_7_col1_6_col1_4_col1_1_key AS tab_297692 
+				JOIN table64793_3@table64793_3_col2_0_col2_1_col2_2_key AS tab_297693 
+				JOIN table64793_2@[0] AS tab_297694 
+				JOIN seed64793@seed64793__int8__float8__date_idx AS tab_297695 
+				RIGHT JOIN table64793_3@[0] AS tab_297696 
+				JOIN table64793_4@table64793_4_col3_10_col3_3_col2_1_col3_9_key AS tab_297697 ON (tab_297696.col2_0) = (tab_297697.col3_3) CROSS 
+				JOIN table64793_4@[0] AS tab_297698 
+				JOIN table64793_3 AS tab_297699 ON (tab_297698.col2_0) = (tab_297699.col2_0) ON TRUE 
+				JOIN table64793_4@[0] AS tab_297700 ON (tab_297697.col3_12) = (tab_297700.col3_8) ON (tab_297694.tableoid) = (tab_297695.tableoid) 
+				AND (tab_297694.col1_5) = (tab_297698.col3_8) 
+				AND (tab_297694.tableoid) = (tab_297698.col3_2) 
+				AND (tab_297694.col1_5) = (tab_297697.col3_12) ON (tab_297693.col2_2) = (tab_297700.col3_3) 
+				AND (tab_297693.col2_1) = (tab_297698.col2_1) 
+				AND (tab_297693.tableoid) = (tab_297699.tableoid) 
+				AND (tab_297693.col2_1) = (tab_297697.col2_1) 
+				AND (tab_297693.tableoid) = (tab_297694.col1_1) 
+				AND (tab_297693.col2_2) = (tab_297695._string) 
+				AND (tab_297693.col2_2) = (tab_297696.col2_0) 
+				AND (tab_297693.col2_2) = (tab_297698.col3_3) ON (tab_297692.col1_11) = (tab_297694.col1_11) 
+			ORDER BY 
+				tab_297695._enum DESC 
+			LIMIT 
+				57 ::: INT8;
+		`,
+		args: []interface{}{},
+	},
+}
+
+func BenchmarkSlowQueries(b *testing.B) {
+	for _, query := range slowQueries {
+		h := newHarness(b, query, slowSchemas)
+		h.evalCtx.SessionData().ReorderJoinsLimit = 8
+		b.Run(query.name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				h.runSimple(b, query, Explore)
+			}
 		})
 	}
 }

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -694,168 +694,1002 @@ func BenchmarkEndToEnd(b *testing.B) {
 
 var slowSchemas = []string{
 	`
-	CREATE TABLE table64793_1 (
-		col1_0 CHAR NOT NULL, col1_1 BOOL NOT NULL, col1_2 REGPROC NOT NULL,
-		col1_3 REGPROCEDURE NOT NULL, col1_4 TIMETZ NOT NULL, col1_5 FLOAT8 NULL,
-		col1_6 INT2 NOT NULL, col1_7 BOOL, col1_8 BOX2D NOT NULL,
-		col1_9 REGNAMESPACE NOT NULL,
-		PRIMARY KEY (
-			col1_8 DESC, col1_9 DESC, col1_4 DESC, col1_1, col1_2 ASC, col1_3 DESC,
-			col1_0 DESC, col1_6
-		),
-		col1_10 INT2 NOT NULL AS (col1_6 + 22798:::INT8) VIRTUAL,
-		FAMILY (col1_4), FAMILY (col1_0, col1_5), FAMILY (col1_1),
-		FAMILY (col1_8, col1_3, col1_9, col1_7), FAMILY (col1_2), FAMILY (col1_6))
-`,
+    CREATE TABLE tab1 (
+        col1 INT8 NOT NULL,
+        col2 INT8 NOT NULL,
+        col3 INT8 NOT NULL,
+        col4 INT8 NULL,
+        col5 INT8 NULL,
+        col6 INT8 NOT NULL,
+        col7 INT8 NOT NULL,
+        col8 INT8 NOT NULL,
+        col9 INT8 NOT NULL,
+        col10 INT8 NOT NULL,
+        col11 INT8 NULL,
+        col12 INT8 NULL,
+        col13 INT8 NULL,
+        col14 INT8 NULL,
+        col15 INT8 NULL,
+        col16 INT8 NOT NULL,
+        col17 INT8 NOT NULL,
+        col18 INT8 NULL,
+        col19 INT8 NOT NULL,
+        col20 INT8 NOT NULL,
+        col21 INT8 NOT NULL,
+        col22 INT8 NULL,
+        col23 INT8 NULL,
+        col24 INT8 NOT NULL,
+        col25 INT8 NOT NULL,
+        col26 INT8 NULL,
+        col27 INT8 NULL,
+        col28 INT8 NOT NULL,
+        col29 INT8 NULL,
+        col30 INT8 NOT NULL,
+        col31 INT8 NOT NULL,
+        col32 INT8 NULL,
+        col33 INT8 NULL,
+        col34 INT8 NULL,
+        col35 INT8 NULL,
+        col36 INT8 NULL,
+        col37 INT8 NOT NULL,
+        col38 INT8 NULL,
+        col39 INT8 NULL,
+        col40 INT8 NOT NULL,
+        col41 INT8 NULL,
+        col42 INT8 NULL,
+        col43 INT8 NULL,
+        col44 INT8 NULL,
+        col45 INT8 NULL,
+        col46 INT8 NULL,
+        col47 INT8 NULL,
+        col48 INT8 NULL,
+        col49 INT8 NULL,
+        col50 INT8 NULL,
+        col51 INT8 NULL,
+        col52 INT8 NULL,
+        col53 INT8 NULL,
+        col54 INT8 NULL,
+        col55 INT8 NULL,
+        col56 INT8 NULL,
+        col57 INT8 NULL,
+        col58 INT8 NULL,
+        col59 INT8 NOT NULL,
+        col60 INT8 NOT NULL,
+        col61 INT8 NULL,
+        col62 INT8 NOT NULL,
+        col63 INT8 NULL,
+        col64 INT8 NULL,
+        col65 INT8 NULL,
+        col66 INT8 NULL,
+        col67 INT8 NOT NULL,
+        col68 INT8 NULL,
+        col69 INT8 NULL,
+        col70 INT8 NULL,
+        col71 INT8 NULL,
+        col72 INT8 NULL,
+        col73 INT8 NULL,
+        col74 INT8 NULL,
+        col75 INT8 NULL,
+        col76 INT8 NULL,
+        col77 INT8 NULL,
+        col78 INT8 NULL,
+        col79 INT8 NULL,
+        col80 INT8 NULL,
+        col81 INT8 NULL,
+        col82 INT8 NULL,
+        col83 INT8 NULL,
+        col84 INT8 NULL,
+        col85 INT8 NOT NULL,
+        col86 INT8 NULL,
+        col87 INT8 NULL,
+        col88 INT8 NULL,
+        col89 INT8 NULL,
+        col90 INT8 NULL,
+        col91 INT8 NULL,
+        col92 INT8 NULL,
+        col93 INT8 NULL,
+        col94 INT8 NULL,
+        col95 INT8 NULL,
+        col96 INT8 NULL,
+        col97 INT8 NULL,
+        col98 INT8 NULL,
+        col99 INT8 NULL,
+        col100 INT8 NULL,
+        col101 INT8 NULL,
+        col102 INT8 NULL,
+        col103 INT8 NULL,
+        col104 INT8 NULL,
+        col105 INT8 NULL,
+        col106 INT8 NULL,
+        col107 INT8 NULL,
+        col108 INT8 NULL,
+        col109 INT8 NULL,
+        col110 INT8 NULL,
+        col111 INT8 NULL,
+        col112 INT8 NOT NULL,
+        col113 INT8 NOT NULL,
+        col114 INT8 NULL,
+        col115 INT8 NULL,
+        col116 INT8 NULL,
+        col117 INT8 NULL,
+        col118 INT8 NULL,
+        col119 INT8 NOT NULL,
+        col120 INT8 NOT NULL,
+        col121 INT8 NULL,
+        col122 INT8 NULL,
+        col123 INT8 NULL,
+        col124 INT8 NULL,
+        col125 INT8 NULL,
+        col126 INT8 NULL,
+        col127 INT8 NULL,
+        col128 INT8 NULL,
+        col129 INT8 NULL,
+        col130 INT8 NULL,
+        col131 INT8 NULL,
+        col132 INT8 NULL,
+        col133 INT8 NULL,
+        col134 INT8 NULL,
+        col135 INT8 NULL,
+        col136 INT8 NOT NULL,
+        col137 INT8 NOT NULL,
+        col138 INT8 NULL,
+        col139 INT8 NULL,
+        col140 INT8 NULL,
+        col141 INT8 NULL,
+        col142 INT8 NULL,
+        col143 INT8 NULL,
+        col144 INT8 NULL,
+        col145 INT8 NULL,
+        col146 INT8 NULL,
+        col147 INT8 NULL,
+        col148 INT8 NULL,
+        col149 INT8 NULL,
+        col150 INT8 NULL,
+        CONSTRAINT "primary" PRIMARY KEY (col2 ASC, col1 ASC),
+        INDEX index1 (col2 ASC, col20 ASC, col40 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index2 (col2 ASC, col18 ASC, col6 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index3 (col2 ASC, col87 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index4 (col2 ASC, col8 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index5 (col2 ASC, col4 ASC, col7 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index6 (col2 ASC, col20 ASC, col40 ASC, col30 ASC, col8 DESC) STORING (col18) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index7 (col2 ASC, col30 ASC, col8 ASC, col1 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index8 (col2 ASC, col56 ASC, col1 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index9 (col2 ASC, col8 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index10 (col2 ASC, col20 ASC, col40 ASC, col1 ASC, col8 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        CONSTRAINT check1 CHECK (col2 IN (1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8, 16:::INT8, 17:::INT8, 18:::INT8, 19:::INT8, 20:::INT8, 21:::INT8, 22:::INT8, 23:::INT8, 24:::INT8))
+    ) PARTITION BY LIST (col2) (
+        PARTITION p1 VALUES IN ((1)),
+        PARTITION p2 VALUES IN ((2)),
+        PARTITION p3 VALUES IN ((3)),
+        PARTITION p4 VALUES IN ((4)),
+        PARTITION p5 VALUES IN ((5)),
+        PARTITION p6 VALUES IN ((6)),
+        PARTITION p7 VALUES IN ((7)),
+        PARTITION p8 VALUES IN ((8)),
+        PARTITION p9 VALUES IN ((9)),
+        PARTITION p10 VALUES IN ((10)),
+        PARTITION p11 VALUES IN ((11)),
+        PARTITION p12 VALUES IN ((12)),
+        PARTITION p13 VALUES IN ((13)),
+        PARTITION p14 VALUES IN ((14)),
+        PARTITION p15 VALUES IN ((15)),
+        PARTITION p16 VALUES IN ((16)),
+        PARTITION p17 VALUES IN ((17)),
+        PARTITION p18 VALUES IN ((18)),
+        PARTITION p19 VALUES IN ((19)),
+        PARTITION p20 VALUES IN ((20)),
+        PARTITION p21 VALUES IN ((21)),
+        PARTITION p22 VALUES IN ((22)),
+        PARTITION p23 VALUES IN ((23)),
+        PARTITION p24 VALUES IN ((24))
+    )
+  `,
 	`
-	CREATE TYPE greeting64793 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
-`,
+    CREATE TABLE tab2 (
+        col1 INT8 NOT NULL,
+        col2 INT8 NOT NULL,
+        col3 INT8 NOT NULL,
+        col4 INT8 NOT NULL,
+        col5 INT8 NOT NULL,
+        col6 INT8 NULL,
+        col7 INT8 NULL,
+        col8 INT8 NOT NULL,
+        col9 INT8 NULL,
+        col10 INT8 NULL,
+        col11 INT8 NOT NULL,
+        col12 INT8 NOT NULL,
+        col13 INT8 NULL,
+        col14 INT8 NOT NULL,
+        col15 INT8 NOT NULL,
+        col16 INT8 NULL,
+        col17 INT8 NULL,
+        col18 INT8 NULL,
+        col19 INT8 NULL,
+        col20 INT8 NULL,
+        col21 INT8 NULL,
+        col22 INT8 NULL,
+        col23 INT8 NULL,
+        col24 INT8 NULL,
+        col25 INT8 NULL,
+        col26 INT8 NULL,
+        col27 INT8 NULL,
+        col28 INT8 NULL,
+        col29 INT8 NOT NULL,
+        col30 INT8 NULL,
+        col31 INT8 NOT NULL,
+        col32 INT8 NULL,
+        col33 INT8 NOT NULL,
+        col34 INT8 NULL,
+        col35 INT8 NULL,
+        col36 INT8 NULL,
+        col37 INT8 NOT NULL,
+        col38 INT8 NULL,
+        col39 INT8 NULL,
+        col40 INT8 NULL,
+        col41 INT8 NULL,
+        col42 INT8 NULL,
+        col43 INT8 NULL,
+        col44 INT8 NULL,
+        col45 INT8 NULL,
+        col46 INT8 NULL,
+        col47 INT8 NULL,
+        col48 INT8 NULL,
+        col49 INT8 NULL,
+        col50 INT8 NULL,
+        col51 INT8 NULL,
+        col52 INT8 NULL,
+        col53 INT8 NULL,
+        col54 INT8 NULL,
+        col55 INT8 NULL,
+        col56 INT8 NULL,
+        col57 INT8 NULL,
+        col58 INT8 NULL,
+        col59 INT8 NULL,
+        col60 INT8 NULL,
+        col61 INT8 NULL,
+        col62 INT8 NULL,
+        col63 INT8 NULL,
+        col64 INT8 NULL,
+        col65 INT8 NULL,
+        col66 INT8 NULL,
+        col67 INT8 NULL,
+        col68 INT8 NULL,
+        col69 INT8 NULL,
+        col70 INT8 NULL,
+        col71 INT8 NULL,
+        col72 INT8 NULL,
+        col73 INT8 NULL,
+        col74 INT8 NULL,
+        col75 INT8 NULL,
+        col76 INT8 NULL,
+        col77 INT8 NULL,
+        col78 INT8 NOT NULL,
+        col79 INT8 NULL,
+        col80 INT8 NULL,
+        col81 INT8 NULL,
+        col82 INT8 NULL,
+        col83 INT8 NULL,
+        col84 INT8 NULL,
+        col85 INT8 NULL,
+        col86 INT8 NULL,
+        col87 INT8 NULL,
+        col88 INT8 NULL,
+        col89 INT8 NOT NULL,
+        col90 INT8 NOT NULL,
+        col91 INT8 NOT NULL,
+        col92 INT8 NOT NULL,
+        col93 INT8 NOT NULL,
+        col94 INT8 NOT NULL,
+        col95 INT8 NOT NULL,
+        col96 INT8 NOT NULL,
+        col97 INT8 NOT NULL,
+        col98 INT8 NOT NULL,
+        col99 INT8 NOT NULL,
+        col100 INT8 NOT NULL,
+        CONSTRAINT "primary" PRIMARY KEY (col2 ASC, col1 ASC, col1 ASC),
+        CONSTRAINT fk1 FOREIGN KEY (col2, col1) REFERENCES tab1(col2, col1),
+        UNIQUE INDEX index1 (col2 ASC, col1 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index2 (col2 ASC, col1 ASC, col38 ASC, col33 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index3 (col2 ASC, col11 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index4 (col2 ASC, col17 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index5 (col2 ASC, col18 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index6 (col2 ASC, col1 ASC) STORING (col38, col9, col10, col42, col40) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index7 (col2 ASC, col11 ASC, col17 ASC, col38 ASC, col8 ASC) STORING (col3, col35) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index8 (col2 ASC, col51 ASC, col17 ASC, col33 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index9 (col2 ASC, col1 ASC, col33 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        INDEX index10 (col2 ASC, col18 ASC, col1 ASC, col33 ASC) PARTITION BY LIST (col2) (
+            PARTITION p1 VALUES IN ((1)),
+            PARTITION p2 VALUES IN ((2)),
+            PARTITION p3 VALUES IN ((3)),
+            PARTITION p4 VALUES IN ((4)),
+            PARTITION p5 VALUES IN ((5)),
+            PARTITION p6 VALUES IN ((6)),
+            PARTITION p7 VALUES IN ((7)),
+            PARTITION p8 VALUES IN ((8)),
+            PARTITION p9 VALUES IN ((9)),
+            PARTITION p10 VALUES IN ((10)),
+            PARTITION p11 VALUES IN ((11)),
+            PARTITION p12 VALUES IN ((12)),
+            PARTITION p13 VALUES IN ((13)),
+            PARTITION p14 VALUES IN ((14)),
+            PARTITION p15 VALUES IN ((15)),
+            PARTITION p16 VALUES IN ((16)),
+            PARTITION p17 VALUES IN ((17)),
+            PARTITION p18 VALUES IN ((18)),
+            PARTITION p19 VALUES IN ((19)),
+            PARTITION p20 VALUES IN ((20)),
+            PARTITION p21 VALUES IN ((21)),
+            PARTITION p22 VALUES IN ((22)),
+            PARTITION p23 VALUES IN ((23)),
+            PARTITION p24 VALUES IN ((24))
+        ),
+        CONSTRAINT check1 CHECK (col2 IN (1:::INT8, 2:::INT8, 3:::INT8, 4:::INT8, 5:::INT8, 6:::INT8, 7:::INT8, 8:::INT8, 9:::INT8, 10:::INT8, 11:::INT8, 12:::INT8, 13:::INT8, 14:::INT8, 15:::INT8, 16:::INT8, 17:::INT8, 18:::INT8, 19:::INT8, 20:::INT8, 21:::INT8, 22:::INT8, 23:::INT8, 24:::INT8))
+    ) PARTITION BY LIST (col2) (
+        PARTITION p1 VALUES IN ((1)),
+        PARTITION p2 VALUES IN ((2)),
+        PARTITION p3 VALUES IN ((3)),
+        PARTITION p4 VALUES IN ((4)),
+        PARTITION p5 VALUES IN ((5)),
+        PARTITION p6 VALUES IN ((6)),
+        PARTITION p7 VALUES IN ((7)),
+        PARTITION p8 VALUES IN ((8)),
+        PARTITION p9 VALUES IN ((9)),
+        PARTITION p10 VALUES IN ((10)),
+        PARTITION p11 VALUES IN ((11)),
+        PARTITION p12 VALUES IN ((12)),
+        PARTITION p13 VALUES IN ((13)),
+        PARTITION p14 VALUES IN ((14)),
+        PARTITION p15 VALUES IN ((15)),
+        PARTITION p16 VALUES IN ((16)),
+        PARTITION p17 VALUES IN ((17)),
+        PARTITION p18 VALUES IN ((18)),
+        PARTITION p19 VALUES IN ((19)),
+        PARTITION p20 VALUES IN ((20)),
+        PARTITION p21 VALUES IN ((21)),
+        PARTITION p22 VALUES IN ((22)),
+        PARTITION p23 VALUES IN ((23)),
+        PARTITION p24 VALUES IN ((24))
+    )
+  `,
 	`
-	CREATE TABLE seed64793 (
-		_int2 INT2,
-		_int4 INT4,
-		_int8 INT8,
-		_float4 FLOAT4,
-		_float8 FLOAT8,
-		_date DATE,
-		_timestamp TIMESTAMP,
-		_timestamptz TIMESTAMPTZ,
-		_interval INTERVAL,
-		_bool BOOL,
-		_decimal DECIMAL,
-		_string STRING,
-		_bytes BYTES,
-		_uuid UUID,
-		_inet INET,
-		_jsonb JSONB,
-		_enum greeting64793
-	);
-`,
+		CREATE TABLE table64793_1 (
+			col1_0 CHAR NOT NULL, col1_1 BOOL NOT NULL, col1_2 REGPROC NOT NULL,
+			col1_3 REGPROCEDURE NOT NULL, col1_4 TIMETZ NOT NULL, col1_5 FLOAT8 NULL,
+			col1_6 INT2 NOT NULL, col1_7 BOOL, col1_8 BOX2D NOT NULL,
+			col1_9 REGNAMESPACE NOT NULL,
+			PRIMARY KEY (
+				col1_8 DESC, col1_9 DESC, col1_4 DESC, col1_1, col1_2 ASC, col1_3 DESC,
+				col1_0 DESC, col1_6
+			),
+			col1_10 INT2 NOT NULL AS (col1_6 + 22798:::INT8) VIRTUAL,
+			FAMILY (col1_4), FAMILY (col1_0, col1_5), FAMILY (col1_1),
+			FAMILY (col1_8, col1_3, col1_9, col1_7), FAMILY (col1_2), FAMILY (col1_6))
+	`,
 	`
-	CREATE INDEX on seed64793 (_int8, _float8, _date);
-`,
+		CREATE TYPE greeting64793 AS ENUM ('hello', 'howdy', 'hi', 'good day', 'morning');
+	`,
 	`
-	CREATE INVERTED INDEX on seed64793 (_jsonb);
-`,
+		CREATE TABLE seed64793 (
+			_int2 INT2,
+			_int4 INT4,
+			_int8 INT8,
+			_float4 FLOAT4,
+			_float8 FLOAT8,
+			_date DATE,
+			_timestamp TIMESTAMP,
+			_timestamptz TIMESTAMPTZ,
+			_interval INTERVAL,
+			_bool BOOL,
+			_decimal DECIMAL,
+			_string STRING,
+			_bytes BYTES,
+			_uuid UUID,
+			_inet INET,
+			_jsonb JSONB,
+			_enum greeting64793
+		);
+	`,
 	`
-	CREATE TABLE table64793_2 (
-		col1_0 "char" NOT NULL, col1_1 OID NOT NULL, col1_2 BIT(38) NOT NULL,
-		col1_3 BIT(18) NOT NULL, col1_4 BYTES NOT NULL, col1_5 INT8 NOT NULL,
-		col1_6 INTERVAL NOT NULL, col1_7 BIT(33) NOT NULL, col1_8 INTERVAL NULL,
-		col1_9 GEOMETRY NOT NULL, col1_10 BOOL NOT NULL, col1_11 INT2,
-		PRIMARY KEY (
-			col1_4 ASC, col1_7 DESC, col1_1 ASC, col1_2 ASC, col1_10 ASC, col1_5,
-			col1_0 ASC, col1_3, col1_6
-		),
-		UNIQUE (
-			col1_8 DESC, col1_11, col1_3 DESC, col1_7, col1_6 DESC, col1_4 ASC,
-			col1_1 DESC
-		)
-	);
-`,
+		CREATE INDEX on seed64793 (_int8, _float8, _date);
+	`,
 	`
-	CREATE TABLE table64793_3 (
-		col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL,
-		PRIMARY KEY (col2_0 ASC, col2_1),
-		col2_2 STRING NOT NULL AS (lower(col2_0)) VIRTUAL,
-		UNIQUE (col2_0 DESC, col2_2 DESC, col2_1)
-		WHERE (table64793_3.col2_2 > e'\U00002603':::STRING)
-		OR (table64793_3.col2_0 != '"':::STRING),
-		UNIQUE (col2_1 ASC, col2_2, col2_0),
-		UNIQUE (col2_0 DESC,col2_1, col2_2),
-		INDEX (col2_1 DESC),
-		UNIQUE (col2_2 DESC, col2_0 ASC)
-		WHERE table64793_3.col2_2 = '"':::STRING
-	);
-`,
+		CREATE INVERTED INDEX on seed64793 (_jsonb);
+	`,
 	`
-	CREATE TABLE table64793_4 (
-		col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL, col3_2 REGPROC NOT NULL,
-		col3_3 "char", col3_4 BOX2D, col3_5 INT8 NULL, col3_6 TIMESTAMP NOT NULL,
-		col3_7 FLOAT8, col3_8 INT4 NULL, col3_9 INET NULL, col3_10 UUID NOT NULL,
-		col3_11 UUID NULL, col3_12 INT2 NOT NULL, col3_13 BIT(34),
-		col3_14 REGPROCEDURE NULL, col3_15 FLOAT8 NULL,
-		PRIMARY KEY (
-			col2_0 ASC, col2_1, col3_11 DESC, col3_13, col3_6, col3_3 DESC,
-			col3_15 ASC, col3_2 ASC, col3_4 ASC, col3_9 DESC, col3_12 ASC,
-			col3_8 ASC, col3_5, col3_14 ASC
-		),
-		UNIQUE (col3_2, col3_8 ASC)
-		WHERE ((((table64793_4.col3_5 < 0:::INT8)
-		AND (table64793_4.col3_3 != '':::STRING))
-		AND (table64793_4.col2_1 < '00:00:00+15:59:00':::TIMETZ))
-		AND (table64793_4.col3_12 > 0:::INT8))
-		AND (table64793_4.col3_15 <= 1.7976931348623157e+308:::FLOAT8),
-		UNIQUE (col3_10 DESC, col3_3 ASC, col2_1 DESC, col3_9 ASC)
-	);
-`,
+		CREATE TABLE table64793_2 (
+			col1_0 "char" NOT NULL, col1_1 OID NOT NULL, col1_2 BIT(38) NOT NULL,
+			col1_3 BIT(18) NOT NULL, col1_4 BYTES NOT NULL, col1_5 INT8 NOT NULL,
+			col1_6 INTERVAL NOT NULL, col1_7 BIT(33) NOT NULL, col1_8 INTERVAL NULL,
+			col1_9 GEOMETRY NOT NULL, col1_10 BOOL NOT NULL, col1_11 INT2,
+			PRIMARY KEY (
+				col1_4 ASC, col1_7 DESC, col1_1 ASC, col1_2 ASC, col1_10 ASC, col1_5,
+				col1_0 ASC, col1_3, col1_6
+			),
+			UNIQUE (
+				col1_8 DESC, col1_11, col1_3 DESC, col1_7, col1_6 DESC, col1_4 ASC,
+				col1_1 DESC
+			)
+		);
+	`,
+	`
+		CREATE TABLE table64793_3 (
+			col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL,
+			PRIMARY KEY (col2_0 ASC, col2_1),
+			col2_2 STRING NOT NULL AS (lower(col2_0)) VIRTUAL,
+			UNIQUE (col2_0 DESC, col2_2 DESC, col2_1)
+			WHERE (table64793_3.col2_2 > e'\U00002603':::STRING)
+			OR (table64793_3.col2_0 != '"':::STRING),
+			UNIQUE (col2_1 ASC, col2_2, col2_0),
+			UNIQUE (col2_0 DESC,col2_1, col2_2),
+			INDEX (col2_1 DESC),
+			UNIQUE (col2_2 DESC, col2_0 ASC)
+			WHERE table64793_3.col2_2 = '"':::STRING
+		);
+	`,
+	`
+		CREATE TABLE table64793_4 (
+			col2_0 NAME NOT NULL, col2_1 TIMETZ NOT NULL, col3_2 REGPROC NOT NULL,
+			col3_3 "char", col3_4 BOX2D, col3_5 INT8 NULL, col3_6 TIMESTAMP NOT NULL,
+			col3_7 FLOAT8, col3_8 INT4 NULL, col3_9 INET NULL, col3_10 UUID NOT NULL,
+			col3_11 UUID NULL, col3_12 INT2 NOT NULL, col3_13 BIT(34),
+			col3_14 REGPROCEDURE NULL, col3_15 FLOAT8 NULL,
+			PRIMARY KEY (
+				col2_0 ASC, col2_1, col3_11 DESC, col3_13, col3_6, col3_3 DESC,
+				col3_15 ASC, col3_2 ASC, col3_4 ASC, col3_9 DESC, col3_12 ASC,
+				col3_8 ASC, col3_5, col3_14 ASC
+			),
+			UNIQUE (col3_2, col3_8 ASC)
+			WHERE ((((table64793_4.col3_5 < 0:::INT8)
+			AND (table64793_4.col3_3 != '':::STRING))
+			AND (table64793_4.col2_1 < '00:00:00+15:59:00':::TIMETZ))
+			AND (table64793_4.col3_12 > 0:::INT8))
+			AND (table64793_4.col3_15 <= 1.7976931348623157e+308:::FLOAT8),
+			UNIQUE (col3_10 DESC, col3_3 ASC, col2_1 DESC, col3_9 ASC)
+		);
+	`,
 }
 
 var slowQueries = [...]benchQuery{
 	// 1. The first long-running query taken from #64793.
 	// 2. The most recent long-running query from #64793 (as of July 2022).
+	// 3. A long-running query inspired by support issue #1710.
 	{
 		name: "slow-query-1",
 		query: `
 			WITH with_186941 (col_1103773, col_1103774) AS (
-				SELECT 
-					* 
-				FROM 
+				SELECT
+					*
+				FROM
 					(
-						VALUES 
-							('clvl', 3 :: INT2), 
+						VALUES
+							('clvl', 3 :: INT2),
 							(
-								'n', 
+								'n',
 								(
-									SELECT 
-										tab_455284.col1_6 AS col_1103772 
-									FROM 
-										table64793_1@[0] AS tab_455284 
-									ORDER BY 
-										tab_455284.col1_2 DESC, 
-										tab_455284.col1_1 DESC 
-									LIMIT 
+									SELECT
+										tab_455284.col1_6 AS col_1103772
+									FROM
+										table64793_1@[0] AS tab_455284
+									ORDER BY
+										tab_455284.col1_2 DESC,
+										tab_455284.col1_1 DESC
+									LIMIT
 										1 ::: INT8
 								)
-							), 
+							),
 							(NULL, 6736 ::: INT8)
 					) AS tab_455285 (col_1103773, col_1103774)
-			), 
+			),
 			with_186942 (col_1103775) AS (
-				SELECT 
-					* 
-				FROM 
+				SELECT
+					*
+				FROM
 					(
-						VALUES 
-							('yk'), 
+						VALUES
+							('yk'),
 							(NULL)
 					) AS tab_455286 (col_1103775)
-			) 
-			SELECT 
-				0 ::: OID AS col_1103776, 
+			)
+			SELECT
+				0 ::: OID AS col_1103776,
 				(
 					(-32244820164.24410487)::: DECIMAL :: DECIMAL + tab_455291.col1_10 :: INT8
-				):: DECIMAL AS col_1103777, 
-				tab_455287._bool AS col_1103778 
-			FROM 
-				with_186942 AS cte_ref_54113, 
-				seed64793@[0] AS tab_455287 
-				JOIN seed64793 AS tab_455288 
-				JOIN seed64793 AS tab_455289 ON (tab_455288._int8) = (tab_455289._int8) 
-				AND (tab_455288._date) = (tab_455289._date) 
-				AND (tab_455288._float8) = (tab_455289._float8) 
-				JOIN table64793_1@[0] AS tab_455290 
-				JOIN table64793_1@primary AS tab_455291 
-				JOIN table64793_1@[0] AS tab_455295 
-				JOIN seed64793 AS tab_455296 
-				JOIN seed64793 AS tab_455297 ON (tab_455296._int8) = (tab_455297._int8) 
-				AND (tab_455296._date) = (tab_455297._date) ON (tab_455295.col1_5) = (tab_455297._float8) 
-				AND (tab_455295.col1_5) = (tab_455296._float8) 
-				AND (tab_455295.col1_5) = (tab_455297._float8) 
-				AND (tab_455295.col1_5) = (tab_455297._float8) ON (tab_455291.col1_2) = (tab_455295.tableoid) 
-				AND (tab_455291.col1_7) = (tab_455295.col1_1) ON (tab_455290.col1_2) = (tab_455291.col1_9) 
-				AND (tab_455290.col1_7) = (tab_455291.col1_7) ON (tab_455289._float8) = (tab_455296._float8) ON (tab_455287._float4) = (tab_455290.col1_5) 
-				AND (tab_455287.tableoid) = (tab_455295.col1_9) 
+				):: DECIMAL AS col_1103777,
+				tab_455287._bool AS col_1103778
+			FROM
+				with_186942 AS cte_ref_54113,
+				seed64793@[0] AS tab_455287
+				JOIN seed64793 AS tab_455288
+				JOIN seed64793 AS tab_455289 ON (tab_455288._int8) = (tab_455289._int8)
+				AND (tab_455288._date) = (tab_455289._date)
+				AND (tab_455288._float8) = (tab_455289._float8)
+				JOIN table64793_1@[0] AS tab_455290
+				JOIN table64793_1@primary AS tab_455291
+				JOIN table64793_1@[0] AS tab_455295
+				JOIN seed64793 AS tab_455296
+				JOIN seed64793 AS tab_455297 ON (tab_455296._int8) = (tab_455297._int8)
+				AND (tab_455296._date) = (tab_455297._date) ON (tab_455295.col1_5) = (tab_455297._float8)
+				AND (tab_455295.col1_5) = (tab_455296._float8)
+				AND (tab_455295.col1_5) = (tab_455297._float8)
+				AND (tab_455295.col1_5) = (tab_455297._float8) ON (tab_455291.col1_2) = (tab_455295.tableoid)
+				AND (tab_455291.col1_7) = (tab_455295.col1_1) ON (tab_455290.col1_2) = (tab_455291.col1_9)
+				AND (tab_455290.col1_7) = (tab_455291.col1_7) ON (tab_455289._float8) = (tab_455296._float8) ON (tab_455287._float4) = (tab_455290.col1_5)
+				AND (tab_455287.tableoid) = (tab_455295.col1_9)
 				AND (tab_455287._bool) = (tab_455295.col1_7);
 		`,
 		args: []interface{}{},
@@ -864,47 +1698,119 @@ var slowQueries = [...]benchQuery{
 		name: "slow-query-2",
 		query: `
 			WITH with_121707 (col_692430) AS (
-				SELECT 
-					* 
-				FROM 
+				SELECT
+					*
+				FROM
 					(
-						VALUES 
+						VALUES
 							(
 								(-0.19099748134613037)::: FLOAT8
-							), 
-							(0.9743397235870361 ::: FLOAT8), 
+							),
+							(0.9743397235870361 ::: FLOAT8),
 							(
 								(-1.6944892406463623)::: FLOAT8
 							)
 					) AS tab_297691 (col_692430)
-			) 
-			SELECT 
-				'-35 years -11 mons -571 days -08:18:57.001029' ::: INTERVAL AS col_692441 
-			FROM 
-				table64793_2@table64793_2_col1_8_col1_11_col1_3_col1_7_col1_6_col1_4_col1_1_key AS tab_297692 
-				JOIN table64793_3@table64793_3_col2_0_col2_1_col2_2_key AS tab_297693 
-				JOIN table64793_2@[0] AS tab_297694 
-				JOIN seed64793@seed64793__int8__float8__date_idx AS tab_297695 
-				RIGHT JOIN table64793_3@[0] AS tab_297696 
-				JOIN table64793_4@table64793_4_col3_10_col3_3_col2_1_col3_9_key AS tab_297697 ON (tab_297696.col2_0) = (tab_297697.col3_3) CROSS 
-				JOIN table64793_4@[0] AS tab_297698 
-				JOIN table64793_3 AS tab_297699 ON (tab_297698.col2_0) = (tab_297699.col2_0) ON TRUE 
-				JOIN table64793_4@[0] AS tab_297700 ON (tab_297697.col3_12) = (tab_297700.col3_8) ON (tab_297694.tableoid) = (tab_297695.tableoid) 
-				AND (tab_297694.col1_5) = (tab_297698.col3_8) 
-				AND (tab_297694.tableoid) = (tab_297698.col3_2) 
-				AND (tab_297694.col1_5) = (tab_297697.col3_12) ON (tab_297693.col2_2) = (tab_297700.col3_3) 
-				AND (tab_297693.col2_1) = (tab_297698.col2_1) 
-				AND (tab_297693.tableoid) = (tab_297699.tableoid) 
-				AND (tab_297693.col2_1) = (tab_297697.col2_1) 
-				AND (tab_297693.tableoid) = (tab_297694.col1_1) 
-				AND (tab_297693.col2_2) = (tab_297695._string) 
-				AND (tab_297693.col2_2) = (tab_297696.col2_0) 
-				AND (tab_297693.col2_2) = (tab_297698.col3_3) ON (tab_297692.col1_11) = (tab_297694.col1_11) 
-			ORDER BY 
-				tab_297695._enum DESC 
-			LIMIT 
+			)
+			SELECT
+				'-35 years -11 mons -571 days -08:18:57.001029' ::: INTERVAL AS col_692441
+			FROM
+				table64793_2@table64793_2_col1_8_col1_11_col1_3_col1_7_col1_6_col1_4_col1_1_key AS tab_297692
+				JOIN table64793_3@table64793_3_col2_0_col2_1_col2_2_key AS tab_297693
+				JOIN table64793_2@[0] AS tab_297694
+				JOIN seed64793@seed64793__int8__float8__date_idx AS tab_297695
+				RIGHT JOIN table64793_3@[0] AS tab_297696
+				JOIN table64793_4@table64793_4_col3_10_col3_3_col2_1_col3_9_key AS tab_297697 ON (tab_297696.col2_0) = (tab_297697.col3_3) CROSS
+				JOIN table64793_4@[0] AS tab_297698
+				JOIN table64793_3 AS tab_297699 ON (tab_297698.col2_0) = (tab_297699.col2_0) ON TRUE
+				JOIN table64793_4@[0] AS tab_297700 ON (tab_297697.col3_12) = (tab_297700.col3_8) ON (tab_297694.tableoid) = (tab_297695.tableoid)
+				AND (tab_297694.col1_5) = (tab_297698.col3_8)
+				AND (tab_297694.tableoid) = (tab_297698.col3_2)
+				AND (tab_297694.col1_5) = (tab_297697.col3_12) ON (tab_297693.col2_2) = (tab_297700.col3_3)
+				AND (tab_297693.col2_1) = (tab_297698.col2_1)
+				AND (tab_297693.tableoid) = (tab_297699.tableoid)
+				AND (tab_297693.col2_1) = (tab_297697.col2_1)
+				AND (tab_297693.tableoid) = (tab_297694.col1_1)
+				AND (tab_297693.col2_2) = (tab_297695._string)
+				AND (tab_297693.col2_2) = (tab_297696.col2_0)
+				AND (tab_297693.col2_2) = (tab_297698.col3_3) ON (tab_297692.col1_11) = (tab_297694.col1_11)
+			ORDER BY
+				tab_297695._enum DESC
+			LIMIT
 				57 ::: INT8;
 		`,
+		args: []interface{}{},
+	},
+	{
+		name: "slow-query-3",
+		query: `
+      SELECT
+        *
+      FROM
+        tab1
+        INNER JOIN tab2 ON
+            tab1.col1 = tab2.col1 AND tab1.col2 = tab2.col2
+      WHERE
+        tab1.col1
+        IN (
+            10:::INT8,
+            20:::INT8,
+            30:::INT8,
+            40:::INT8,
+            50:::INT8,
+            60:::INT8,
+            70:::INT8,
+            80:::INT8,
+            90:::INT8,
+            100:::INT8,
+            110:::INT8,
+            120:::INT8,
+            130:::INT8,
+            140:::INT8,
+            150:::INT8,
+            160:::INT8,
+            170:::INT8,
+            180:::INT8,
+            190:::INT8,
+            200:::INT8,
+            210:::INT8,
+            220:::INT8,
+            230:::INT8,
+            240:::INT8,
+            250:::INT8,
+            260:::INT8,
+            270:::INT8,
+            280:::INT8,
+            290:::INT8,
+            300:::INT8,
+            310:::INT8,
+            320:::INT8,
+            330:::INT8,
+            340:::INT8,
+            350:::INT8,
+            360:::INT8,
+            370:::INT8,
+            380:::INT8,
+            390:::INT8,
+            400:::INT8,
+            410:::INT8,
+            420:::INT8,
+            430:::INT8,
+            440:::INT8,
+            450:::INT8,
+            460:::INT8,
+            470:::INT8,
+            480:::INT8,
+            490:::INT8,
+            500:::INT8
+          )
+        AND tab1.col8 > 0
+        AND tab1.col8 < 10
+        AND tab1.col20 = 4500
+        AND tab1.col40 = 10
+      ORDER BY
+        tab1.col8 DESC;
+    `,
 		args: []interface{}{},
 	},
 }

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -86,7 +86,7 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	// Not Null Columns
 	// ----------------
 	// Initialize not-NULL columns from the table schema.
-	rel.NotNullCols = tableNotNullCols(md, scan.Table)
+	rel.NotNullCols = makeTableNotNullCols(md, scan.Table).Copy()
 	// Union not-NULL columns with not-NULL columns in the constraint.
 	if scan.Constraint != nil {
 		rel.NotNullCols.UnionWith(scan.Constraint.ExtractNotNullCols(b.evalCtx))
@@ -474,7 +474,7 @@ func (b *logicalPropsBuilder) buildIndexJoinProps(indexJoin *IndexJoinExpr, rel 
 	// ----------------
 	// Add not-NULL columns from the table schema, and filter out any not-NULL
 	// columns from the input that are not projected by the index join.
-	rel.NotNullCols = tableNotNullCols(md, indexJoin.Table)
+	rel.NotNullCols = makeTableNotNullCols(md, indexJoin.Table).Copy()
 	rel.NotNullCols.IntersectionWith(rel.OutputCols)
 
 	// Outer Columns
@@ -2095,7 +2095,7 @@ func ensureLookupJoinInputProps(join *LookupJoinExpr, sb *statisticsBuilder) *pr
 			}
 		}
 
-		relational.NotNullCols = tableNotNullCols(md, join.Table)
+		relational.NotNullCols = makeTableNotNullCols(md, join.Table).Copy()
 		relational.NotNullCols.IntersectionWith(relational.OutputCols)
 		relational.Cardinality = props.AnyCardinality
 		relational.FuncDeps.CopyFrom(MakeTableFuncDep(md, join.Table))
@@ -2112,7 +2112,7 @@ func ensureInvertedJoinInputProps(join *InvertedJoinExpr, sb *statisticsBuilder)
 	if relational.OutputCols.Empty() {
 		md := join.Memo().Metadata()
 		relational.OutputCols = join.Cols.Difference(join.Input.Relational().OutputCols)
-		relational.NotNullCols = tableNotNullCols(md, join.Table)
+		relational.NotNullCols = makeTableNotNullCols(md, join.Table).Copy()
 		relational.NotNullCols.IntersectionWith(relational.OutputCols)
 		relational.Cardinality = props.AnyCardinality
 
@@ -2162,7 +2162,7 @@ func ensureInputPropsForIndex(
 	if relProps.OutputCols.Empty() {
 		relProps.OutputCols = md.TableMeta(tabID).IndexColumns(indexOrd)
 		relProps.OutputCols.IntersectionWith(outputCols)
-		relProps.NotNullCols = tableNotNullCols(md, tabID)
+		relProps.NotNullCols = makeTableNotNullCols(md, tabID).Copy()
 		relProps.NotNullCols.IntersectionWith(relProps.OutputCols)
 		relProps.Cardinality = props.AnyCardinality
 		relProps.FuncDeps.CopyFrom(MakeTableFuncDep(md, tabID))
@@ -2171,9 +2171,17 @@ func ensureInputPropsForIndex(
 	}
 }
 
-// tableNotNullCols returns the set of not-NULL non-mutation columns from the given table.
-func tableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
-	cs := opt.ColSet{}
+// makeTableNotNullCols returns the set of not-NULL non-mutation columns from
+// the given table. The set is derived lazily and is cached in the metadata,
+// since it may be accessed multiple times during query optimization.
+func makeTableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
+	cs, ok := md.TableAnnotation(tabID, opt.NotNullAnnID).(opt.ColSet)
+	if ok {
+		// Already made.
+		return cs
+	}
+
+	cs = opt.ColSet{}
 	tab := md.Table(tabID)
 
 	// Only iterate over non-mutation columns, since even non-null mutation
@@ -2185,6 +2193,8 @@ func tableNotNullCols(md *opt.Metadata, tabID opt.TableID) opt.ColSet {
 			cs.Add(tabID.ColumnID(i))
 		}
 	}
+
+	md.SetTableAnnotation(tabID, opt.NotNullAnnID, cs)
 	return cs
 }
 

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -718,7 +718,7 @@ func (sb *statisticsBuilder) colStatTable(
 ) *props.ColumnStatistic {
 	tableStats := sb.makeTableStatistics(tabID)
 	tableFD := MakeTableFuncDep(sb.md, tabID)
-	tableNotNullCols := tableNotNullCols(sb.md, tabID)
+	tableNotNullCols := makeTableNotNullCols(sb.md, tabID)
 	return sb.colStatLeaf(colSet, tableStats, tableFD, tableNotNullCols)
 }
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -617,6 +617,11 @@ func (md *Metadata) UpdateTableMeta(tables map[cat.StableID]cat.Table) {
 			for j, n := md.tables[i].Table.ColumnCount(), tab.ColumnCount(); j < n; j++ {
 				md.AddColumn(string(tab.Column(j).ColName()), types.Bytes)
 			}
+			if tab.ColumnCount() > md.tables[i].Table.ColumnCount() {
+				// If we added any new columns, we need to recalculate the not null
+				// column set.
+				md.SetTableAnnotation(md.tables[i].MetaID, NotNullAnnID, nil)
+			}
 			md.tables[i].Table = tab
 		}
 	}

--- a/pkg/sql/opt/table_meta.go
+++ b/pkg/sql/opt/table_meta.go
@@ -96,8 +96,9 @@ func (t TableID) index() int {
 //   ann := md.TableAnnotation(TableID(1), myAnnID)
 //
 // Currently, the following annotations are in use:
-//   - WeakKeys: weak keys derived from the base table
+//   - FuncDeps: functional dependencies derived from the base table
 //   - Stats: statistics derived from the base table
+//   - NotNullCols: not null columns derived from the base table
 //
 // To add an additional annotation, increase the value of maxTableAnnIDCount and
 // add a call to NewTableAnnID.
@@ -110,7 +111,10 @@ var tableAnnIDCount TableAnnID
 // called. Calling more than this number of times results in a panic. Having
 // a maximum enables a static annotation array to be inlined into the metadata
 // table struct.
-const maxTableAnnIDCount = 2
+const maxTableAnnIDCount = 3
+
+// NotNullAnnID is the annotation ID for table not null columns.
+var NotNullAnnID = NewTableAnnID()
 
 // TableMeta stores information about one of the tables stored in the metadata.
 //


### PR DESCRIPTION
Backport 2/2 commits from #86606.

/cc @cockroachdb/release

---

**opt: add a new query to the slow queries benchmark**

Release justification: non-production code changes

Release note: None

**opt: cache not-null columns in the metadata**

This commit adds a new table annotation for not null columns to avoid
rediscovering them multiple times per table. This improves performance
for queries over tables with a large number of columns and indexes.

Benchmark results:
```
name                         old time/op    new time/op    delta
SlowQueries/slow-query-3-10     123ms ± 1%      63ms ± 2%  -48.62%  (p=0.000 n=10+9)
SlowQueries/slow-query-1-10    20.3ms ± 1%    20.2ms ± 2%     ~     (p=0.353 n=10+10)
SlowQueries/slow-query-2-10     312ms ± 2%     313ms ± 4%     ~     (p=0.842 n=10+9)

name                         old alloc/op   new alloc/op   delta
SlowQueries/slow-query-3-10    59.3MB ± 0%    49.0MB ± 0%  -17.38%  (p=0.000 n=10+10)
SlowQueries/slow-query-1-10    12.3MB ± 0%    12.3MB ± 0%   -0.27%  (p=0.000 n=10+10)
SlowQueries/slow-query-2-10     181MB ± 0%     181MB ± 0%     ~     (p=0.739 n=10+10)

name                         old allocs/op  new allocs/op  delta
SlowQueries/slow-query-3-10      542k ± 0%      381k ± 0%  -29.72%  (p=0.000 n=9+10)
SlowQueries/slow-query-1-10      131k ± 0%      131k ± 0%   -0.39%  (p=0.000 n=10+10)
SlowQueries/slow-query-2-10     1.65M ± 0%     1.65M ± 0%     ~     (p=0.345 n=9+10)
```
Release justification: low risk, high benefit changes to existing
functionality

Release note (performance improvement): Planning time has been reduced
for queries over tables with a large number of columns and/or indexes.
