### PR TITLE
sql/schemachanger/rel: support not-join subqueries

### DIFF
--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/iterutil",
         "//pkg/util/syncutil",
+        "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_btree//:btree",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/sql/schemachanger/rel/internal/entitynodetest/tests.go
+++ b/pkg/sql/schemachanger/rel/internal/entitynodetest/tests.go
@@ -37,6 +37,45 @@ var (
 	nb = r.Register("nb", &node{Value: b, Left: na}).(*node)
 	nc = r.Register("nc", &node{Value: c, Right: nb}).(*node)
 
+	entityHasi16 = schema.Def3("entityHasI16Eq", "node", "entity", "i16", func(
+		node, entity, i16v rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{
+			node.AttrEqVar(value, entity),
+			entity.AttrEqVar(i16, i16v),
+		}
+	})
+	entityNoti16 = schema.DefNotJoin2("nodeWithValuei16NotEq", "node", "i16", func(
+		node, i16v rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{entityHasi16(node, "entity", i16v)}
+	})
+	joinParentLeft = schema.Def2("joinParentLeft", "parent", "child", func(
+		parent, child rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{parent.AttrEqVar(left, child)}
+	})
+	joinParentRight = schema.Def2("joinParentRight", "parent", "child", func(
+		parent, child rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{parent.AttrEqVar(right, child)}
+	})
+	notExistsLeft = schema.DefNotJoin1("leftNotExists", "node", func(
+		node rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{joinParentLeft("parent", node)}
+	})
+	notExistsRight = schema.DefNotJoin1("rightNotExists", "node", func(
+		node rel.Var,
+	) rel.Clauses {
+		return rel.Clauses{joinParentRight("parent", node)}
+	})
+	hasNoChildren = schema.Def1("hasNoChildren", "node", func(node rel.Var) rel.Clauses {
+		return rel.Clauses{
+			notExistsLeft(node),
+			notExistsRight(node),
+		}
+	})
 	nodeEntity = schema.Def2("nodeEntity", "node", "entity", func(
 		node, entity rel.Var,
 	) rel.Clauses {
@@ -130,6 +169,21 @@ var (
 				{ // 6
 					{Attrs: []rel.Attr{rel.Self}, Exists: []rel.Attr{rel.Self}},
 				},
+				{ // 7
+					{
+						Where: []rel.IndexWhere{
+							{Attr: rel.Type, Eq: reflect.TypeOf((*node)(nil))},
+						},
+					},
+					{
+						Attrs:  []rel.Attr{left},
+						Exists: []rel.Attr{left},
+					},
+					{
+						Attrs:  []rel.Attr{right},
+						Exists: []rel.Attr{right},
+					},
+				},
 			},
 			QueryCases: []reltest.QueryTest{
 				{
@@ -145,7 +199,7 @@ var (
 					Results: [][]interface{}{
 						{a, int8(1), int8(1)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "a-c-b join",
@@ -161,7 +215,7 @@ var (
 					Results: [][]interface{}{
 						{a, b, c},
 					},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "nil values don't show up",
@@ -173,7 +227,7 @@ var (
 					Results: [][]interface{}{
 						{a},
 					},
-					UnsatisfiableIndexes: []int{2, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 4, 5, 6, 7},
 				},
 				{
 					Name: "nil values don't show up, scalar pointers same as pointers",
@@ -185,7 +239,7 @@ var (
 					Results: [][]interface{}{
 						{a},
 					},
-					UnsatisfiableIndexes: []int{2, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 4, 5, 6, 7},
 				},
 				{
 					Name: "list all the values",
@@ -199,7 +253,7 @@ var (
 						{b, int8(2)},
 						{c, int8(2)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "list all the values with type constraint",
@@ -214,7 +268,7 @@ var (
 						{b, int8(2)},
 						{c, int8(2)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "nodes with elements where i8=2",
@@ -229,7 +283,7 @@ var (
 						{nb, b},
 						{nc, c},
 					},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "nodes with elements where i8=2 (rule)",
@@ -244,7 +298,7 @@ var (
 						{nb, b},
 						{nc, c},
 					},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "list all the i8 values",
@@ -261,7 +315,7 @@ var (
 						{int8(2)},
 						{int8(2)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "use a filter",
@@ -276,7 +330,7 @@ var (
 					Results: [][]interface{}{
 						{a},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "types of all the entities",
@@ -293,7 +347,7 @@ var (
 						{nb, reflect.TypeOf((*node)(nil))},
 						{nc, reflect.TypeOf((*node)(nil))},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "nodes by type",
@@ -351,7 +405,7 @@ var (
 						{nb},
 						{nc},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "self eq value",
@@ -363,7 +417,7 @@ var (
 					Results: [][]interface{}{
 						{c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3},
+					UnsatisfiableIndexes: []int{1, 2, 3, 7},
 				},
 				{
 					Name: "contradiction due to missing attribute",
@@ -374,7 +428,7 @@ var (
 					Entities:             []v{"entity"},
 					ResVars:              []v{"entity", "pi8"},
 					Results:              [][]interface{}{},
-					UnsatisfiableIndexes: []int{1, 2, 3},
+					UnsatisfiableIndexes: []int{1, 2, 3, 7},
 				},
 				{
 					Name: "self eq self",
@@ -386,7 +440,7 @@ var (
 					Results: [][]interface{}{
 						{a}, {b}, {c}, {na}, {nb}, {nc},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "variable type mismatch",
@@ -412,7 +466,7 @@ var (
 						{na, a, na, a},
 						{na, a, nc, c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "entity bound via variable with ne filter",
@@ -432,7 +486,7 @@ var (
 					Results: [][]interface{}{
 						{na, a, nc, c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "any value type mismatch",
@@ -452,7 +506,7 @@ var (
 					Entities:             []v{"e"},
 					ResVars:              []v{"e", "i8"},
 					Results:              [][]interface{}{},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "pointer scalar values any",
@@ -464,7 +518,7 @@ var (
 					Results: [][]interface{}{
 						{a}, {b}, {c},
 					},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "pointer scalar values",
@@ -476,7 +530,7 @@ var (
 					Results: [][]interface{}{
 						{a},
 					},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "nil pointer scalar values any",
@@ -500,7 +554,7 @@ var (
 					Entities:             []v{"e"},
 					ResVars:              []v{"e"},
 					Results:              [][]interface{}{},
-					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "any clause no match on variable eq",
@@ -511,7 +565,7 @@ var (
 					Entities:             []v{"e"},
 					ResVars:              []v{"e", "i8"},
 					Results:              [][]interface{}{},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "using blank, bind all",
@@ -523,7 +577,7 @@ var (
 					Results: [][]interface{}{
 						{a}, {b}, {c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "using blank, bind non-nil pointer",
@@ -535,7 +589,7 @@ var (
 					Results: [][]interface{}{
 						{a},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6, 7},
 				},
 				{
 					Name: "e[i8] != 1",
@@ -549,7 +603,7 @@ var (
 						{b},
 						{c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "e != a",
@@ -563,7 +617,7 @@ var (
 						{b},
 						{c},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "e[i8] = v; v != 1",
@@ -578,7 +632,7 @@ var (
 						{b, int8(2)},
 						{c, int8(2)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					Name: "e[i8] = v; v != 2",
@@ -592,7 +646,7 @@ var (
 					Results: [][]interface{}{
 						{a, int8(1)},
 					},
-					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
 				},
 				{
 					// This case flexes the semantics of Neq to note that Neq forces
@@ -610,6 +664,62 @@ var (
 					Entities:             []rel.Var{"e"},
 					ResVars:              []v{"e", "v"},
 					Results:              [][]interface{}{},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6, 7},
+				},
+				{
+					Name: "node which is neither the left or right of another node (not-join)",
+					Query: rel.Clauses{
+						v("n").Type((*node)(nil)),
+						notExistsLeft("n"),
+						notExistsRight("n"),
+					},
+					Entities: []rel.Var{"n"},
+					ResVars:  []v{"n"},
+					Results: [][]interface{}{
+						{nc},
+					},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+				},
+				{
+					Name: "node which is neither the left or right of another node (not-join), composed",
+					Query: rel.Clauses{
+						v("n").Type((*node)(nil)),
+						hasNoChildren("n"),
+					},
+					Entities: []rel.Var{"n"},
+					ResVars:  []v{"n"},
+					Results: [][]interface{}{
+						{nc},
+					},
+					UnsatisfiableIndexes: []int{1, 2, 3, 4, 5, 6},
+				},
+				{
+					Name: "node with entity with i16 not 1",
+					Query: rel.Clauses{
+						v("n").Type((*node)(nil)),
+						v("i16").Eq(int16(1)),
+						entityNoti16("n", "i16"),
+					},
+					Entities: []rel.Var{"n"},
+					ResVars:  []v{"n", "i16"},
+					Results: [][]interface{}{
+						{nb, int16(1)},
+					},
+					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
+				},
+				{
+					Name: "node with entity with i16 not 2",
+					Query: rel.Clauses{
+						v("n").Type((*node)(nil)),
+						v("i16").Eq(int16(2)),
+						entityNoti16("n", "i16"),
+					},
+					Entities: []rel.Var{"n"},
+					ResVars:  []v{"n", "i16"},
+					Results: [][]interface{}{
+						{na, int16(2)},
+						{nc, int16(2)},
+					},
 					UnsatisfiableIndexes: []int{1, 2, 3, 5, 6},
 				},
 			},

--- a/pkg/sql/schemachanger/rel/query.go
+++ b/pkg/sql/schemachanger/rel/query.go
@@ -37,12 +37,20 @@ type Query struct {
 	// filters are the set of predicate filters to evaluate.
 	filters []filter
 
+	subQueries []subQuery
+
 	// cache one evalContext for reuse to accelerate benchmarks and deal with
 	// the common case.
 	mu struct {
 		syncutil.Mutex
 		cached *evalContext
 	}
+}
+
+type subQuery struct {
+	query             *Query
+	inputSlotMappings util.FastIntMap
+	depth             int
 }
 
 // Result represents A setting of entities which fulfills the

--- a/pkg/sql/schemachanger/rel/query_build.go
+++ b/pkg/sql/schemachanger/rel/query_build.go
@@ -49,7 +49,7 @@ func newQuery(sc *Schema, clauses Clauses) *Query {
 	}
 
 	// Order the facts for unification. The ordering is first by variable
-	// variable and then by attribute.
+	// and then by attribute.
 	//
 	// TODO(ajwerner): For disjunctions using Any, the code currently uses
 	// the index to constrain the search for each value in the "first"

--- a/pkg/sql/schemachanger/rel/query_eval.go
+++ b/pkg/sql/schemachanger/rel/query_eval.go
@@ -29,10 +29,9 @@ type evalContext struct {
 	// depth and cur relate to the join depth in the entities list.
 	depth, cur int
 
-	// numIterateCalls is the number of calls to iterate which have occurred.
-
 	slots             []slot
 	filterSliceCaches map[int][]reflect.Value
+	curSubQuery       int
 }
 
 func newEvalContext(q *Query) *evalContext {
@@ -77,7 +76,14 @@ func (ec *evalContext) Iterate(db *Database, ri ResultIterator) error {
 // filters and pass along the result or that we need to go on and
 // join the next entity.
 func (ec *evalContext) iterateNext() error {
-
+	nextSubQuery, done, err := ec.maybeVisitSubqueries()
+	if done || err != nil {
+		return err
+	}
+	if curSubQuery := ec.curSubQuery; nextSubQuery != curSubQuery {
+		defer func() { ec.curSubQuery = curSubQuery }()
+		ec.curSubQuery = nextSubQuery
+	}
 	// We're at the bottom of the iteration, check if all conditions have
 	// been satisfied, and then invoke the iterator.
 	if ec.cur == ec.depth {
@@ -383,3 +389,67 @@ func (ec *evalContext) getFilterInput(i int) (ins []reflect.Value) {
 	}
 	return c
 }
+
+func (ec *evalContext) maybeVisitSubqueries() (nextSubQuery int, done bool, error error) {
+	nextSubQuery = ec.curSubQuery
+	for nextSubQuery < len(ec.q.subQueries) && ec.q.subQueries[nextSubQuery].depth <= ec.cur {
+		if done, err := ec.visitSubquery(nextSubQuery); done || err != nil {
+			return ec.curSubQuery, done, err
+		}
+		nextSubQuery++
+	}
+	return nextSubQuery, false, nil
+}
+
+func (ec *evalContext) visitSubquery(query int) (done bool, _ error) {
+	sub := ec.q.subQueries[query]
+	sec := sub.query.getEvalContext()
+	defer sub.query.putEvalContext(sec)
+	defer func() { // reset the slots populated to run the subquery
+		sub.inputSlotMappings.ForEach(func(_, subSlot int) {
+			sec.slots[subSlot].typedValue = typedValue{}
+		})
+	}()
+	if err := ec.bindSubQuerySlots(sub.inputSlotMappings, sec); err != nil {
+		return false, err
+	}
+	switch err := sec.Iterate(ec.db, func(r Result) error {
+		return sentinelError
+	}); err {
+	case sentinelError:
+		return true, nil
+	case nil:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func (ec *evalContext) bindSubQuerySlots(mapping util.FastIntMap, sec *evalContext) (err error) {
+	mapping.ForEach(func(src, dst int) {
+		if err != nil {
+			return
+		}
+		if ec.slots[src].empty() {
+			// TODO(ajwerner): Find a way to prove statically that this cannot
+			// happen and make it an assertion failure.
+			err = errors.Errorf(
+				"subquery invocation references unbound variable %q",
+				ec.findSlotVariable(src),
+			)
+		}
+		sec.slots[dst].typedValue = ec.slots[src].typedValue
+	})
+	return err
+}
+
+func (ec *evalContext) findSlotVariable(src int) Var {
+	for v, slot := range ec.q.variableSlots {
+		if src == int(slot) {
+			return v
+		}
+	}
+	return ""
+}
+
+var sentinelError = errors.New("sentinel")

--- a/pkg/sql/schemachanger/rel/query_lang_clauses.go
+++ b/pkg/sql/schemachanger/rel/query_lang_clauses.go
@@ -34,9 +34,11 @@ func replaceVars(replacements, before []Var, cl Clause) Clause {
 func expanded(c Clauses) Clauses {
 	needsExpansion := func() bool {
 		for _, cl := range c {
-			switch cl.(type) {
-			case and, ruleInvocation:
+			switch cl := cl.(type) {
+			case and:
 				return true
+			case ruleInvocation:
+				return !cl.rule.isNotJoin
 			}
 		}
 		return false

--- a/pkg/sql/schemachanger/rel/query_lang_yaml.go
+++ b/pkg/sql/schemachanger/rel/query_lang_yaml.go
@@ -82,13 +82,13 @@ func ruleInvocationStr(name string, args []Var) string {
 // MarshalYAML marshals a rule to YAML.
 func (r RuleDef) MarshalYAML() (interface{}, error) {
 	var cl yaml.Node
-	if err := cl.Encode(r.Clauses); err != nil {
+	if err := cl.Encode(r.Clauses()); err != nil {
 		return nil, err
 	}
 	return &yaml.Node{
 		Kind: yaml.MappingNode,
 		Content: []*yaml.Node{
-			{Kind: yaml.ScalarNode, Value: ruleInvocationStr(r.Name, r.Params)},
+			{Kind: yaml.ScalarNode, Value: ruleInvocationStr(r.Name, r.Params())},
 			&cl,
 		},
 	}, nil

--- a/pkg/sql/schemachanger/rel/schema_rules.go
+++ b/pkg/sql/schemachanger/rel/schema_rules.go
@@ -11,20 +11,31 @@
 package rel
 
 import (
+	"encoding/hex"
 	"reflect"
 	"sort"
 
+	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 )
 
 // RuleDef describes a rule.
 type RuleDef struct {
-	Name    string
-	Params  []Var
-	Clauses Clauses
-	Func    interface{} `yaml:"-"`
+	Name       string
+	paramVars  []Var
+	paramNames []Var
+	clauses    Clauses
+	Func       interface{} `yaml:"-"`
 
 	sc *Schema
+}
+
+func (rd *RuleDef) Params() []Var {
+	return rd.paramNames
+}
+
+func (rd *RuleDef) Clauses() Clauses {
+	return Clauses(replaceVars(rd.paramNames, rd.paramVars, and(rd.clauses)).(and))
 }
 
 // ForEachRule iterates the schema's rules.
@@ -87,19 +98,29 @@ var (
 	clausesType = reflect.TypeOf((*Clauses)(nil)).Elem()
 )
 
+func makeRandomVars(n int) (ret []Var) {
+	ret = make([]Var, n)
+	for i := range ret {
+		ret[i] = Var(hex.EncodeToString(uuid.MakeV4().GetBytes()))
+	}
+	return ret
+}
+
 // rule is used to define a pattern of clauses for reuse.
-func (sc *Schema) rule(name string, inFunc interface{}, vars ...Var) interface{} {
+func (sc *Schema) rule(name string, inFunc interface{}, paramNames ...Var) interface{} {
 	if _, exists := sc.rulesByName[name]; exists {
 		panic(errors.AssertionFailedf("already registered rule with name %s", name))
 	}
-	inT, clauses := buildRuleClauses(vars, inFunc)
+	paramVars := makeRandomVars(len(paramNames))
+	inT, clauses := buildRuleClauses(paramVars, inFunc)
 	clauses = flattened(clauses)
-	validateRuleClauses(name, clauses, vars)
+	validateRuleClauses(name, clauses, paramVars, paramNames)
 	rd := &RuleDef{
-		Name:    name,
-		Params:  vars,
-		Clauses: clauses,
-		sc:      sc,
+		Name:       name,
+		paramNames: paramNames,
+		paramVars:  paramVars,
+		clauses:    clauses,
+		sc:         sc,
 	}
 	rd.Func = makeRuleFunc(inT, rd)
 	sc.rules = append(sc.rules, rd)
@@ -144,16 +165,24 @@ func validateBuildRuleFunctionValue(inT []reflect.Type, f interface{}) reflect.V
 	return fv
 }
 
-func validateRuleClauses(name string, clauses Clauses, vars []Var) {
+func validateRuleClauses(name string, clauses Clauses, paramVars, paramNames []Var) {
 	vs := varsUsedInClauses(clauses)
-	if missing := vs.removed(vars...); len(missing) != 0 {
+	if missing := vs.removed(paramVars...); len(missing) != 0 {
 		panic(errors.Errorf(
 			"invalid rule %s: %v are not defined variables", name, missing.ordered(),
 		))
 	}
-	if unused := makeVarSet(vars...).removed(vs.ordered()...); len(unused) > 0 {
+	if unused := makeVarSet(paramVars...).removed(vs.ordered()...); len(unused) > 0 {
+		mapping := make(map[Var]int, len(paramVars))
+		for i, v := range paramVars {
+			mapping[v] = i
+		}
+		mapped := make(varSet, len(unused))
+		for v := range unused {
+			mapped.add(paramNames[mapping[v]])
+		}
 		panic(errors.Errorf(
-			"invalid rule %s: %v input variable are not used", name, unused.ordered(),
+			"invalid rule %s: %v input variable are not used", name, mapped.ordered(),
 		))
 	}
 }

--- a/pkg/sql/schemachanger/rel/schema_rules.go
+++ b/pkg/sql/schemachanger/rel/schema_rules.go
@@ -22,6 +22,7 @@ import (
 // RuleDef describes a rule.
 type RuleDef struct {
 	Name       string
+	isNotJoin  bool
 	paramVars  []Var
 	paramNames []Var
 	clauses    Clauses
@@ -60,36 +61,53 @@ type (
 	Rule6 = func(a, b, c, d, e, f Var) Clause
 )
 
+type ruleKind bool
+
+const (
+	regular ruleKind = true
+	notJoin ruleKind = false
+)
+
 // Def1 defines a Rule1.
 func (sc *Schema) Def1(name string, a Var, def func(a Var) Clauses) Rule1 {
-	return sc.rule(name, def, a).(Rule1)
+	return sc.rule(name, regular, def, a).(Rule1)
+}
+
+// DefNotJoin1 defines a not-join rule with one bound variable argument.
+func (sc *Schema) DefNotJoin1(name string, a Var, def func(a Var) Clauses) Rule1 {
+	return sc.rule(name, notJoin, def, a).(Rule1)
+}
+
+// DefNotJoin2 defines a not-join rule with two bound variable arguments.
+func (sc *Schema) DefNotJoin2(name string, a, b Var, def func(a, b Var) Clauses) Rule2 {
+	return sc.rule(name, notJoin, def, a, b).(Rule2)
 }
 
 // Def2 defines a Rule2.
 func (sc *Schema) Def2(name string, a, b Var, def func(a, b Var) Clauses) Rule2 {
-	return sc.rule(name, def, a, b).(Rule2)
+	return sc.rule(name, regular, def, a, b).(Rule2)
 }
 
 // Def3 defines a Rule3.
 func (sc *Schema) Def3(name string, a, b, c Var, def func(a, b, c Var) Clauses) Rule3 {
-	return sc.rule(name, def, a, b, c).(Rule3)
+	return sc.rule(name, regular, def, a, b, c).(Rule3)
 }
 
 // Def4 defines a Rule4.
 func (sc *Schema) Def4(name string, a, b, c, d Var, def func(a, b, c, d Var) Clauses) Rule4 {
-	return sc.rule(name, def, a, b, c, d).(Rule4)
+	return sc.rule(name, regular, def, a, b, c, d).(Rule4)
 }
 
 // Def5 defines a Rule5.
 func (sc *Schema) Def5(name string, a, b, c, d, e Var, def func(a, b, c, d, e Var) Clauses) Rule5 {
-	return sc.rule(name, def, a, b, c, d, e).(Rule5)
+	return sc.rule(name, regular, def, a, b, c, d, e).(Rule5)
 }
 
 // Def6 defines a Rule6.
 func (sc *Schema) Def6(
 	name string, a, b, c, d, e, f Var, def func(a, b, c, d, e, f Var) Clauses,
 ) Rule6 {
-	return sc.rule(name, def, a, b, c, d, e, f).(Rule6)
+	return sc.rule(name, regular, def, a, b, c, d, e, f).(Rule6)
 }
 
 var (
@@ -107,16 +125,19 @@ func makeRandomVars(n int) (ret []Var) {
 }
 
 // rule is used to define a pattern of clauses for reuse.
-func (sc *Schema) rule(name string, inFunc interface{}, paramNames ...Var) interface{} {
+func (sc *Schema) rule(
+	name string, kind ruleKind, inFunc interface{}, paramNames ...Var,
+) interface{} {
 	if _, exists := sc.rulesByName[name]; exists {
 		panic(errors.AssertionFailedf("already registered rule with name %s", name))
 	}
 	paramVars := makeRandomVars(len(paramNames))
 	inT, clauses := buildRuleClauses(paramVars, inFunc)
 	clauses = flattened(clauses)
-	validateRuleClauses(name, clauses, paramVars, paramNames)
+	validateRuleClauses(name, kind, clauses, paramVars, paramNames)
 	rd := &RuleDef{
 		Name:       name,
+		isNotJoin:  kind == notJoin,
 		paramNames: paramNames,
 		paramVars:  paramVars,
 		clauses:    clauses,
@@ -165,13 +186,22 @@ func validateBuildRuleFunctionValue(inT []reflect.Type, f interface{}) reflect.V
 	return fv
 }
 
-func validateRuleClauses(name string, clauses Clauses, paramVars, paramNames []Var) {
+func validateRuleClauses(name string, kind ruleKind, clauses Clauses, paramVars, paramNames []Var) {
 	vs := varsUsedInClauses(clauses)
-	if missing := vs.removed(paramVars...); len(missing) != 0 {
-		panic(errors.Errorf(
-			"invalid rule %s: %v are not defined variables", name, missing.ordered(),
-		))
+	{
+		missing := vs.removed(paramVars...)
+		if len(missing) != 0 && kind == regular {
+			panic(errors.Errorf(
+				"invalid rule %s: %v are not defined variables", name, missing.ordered(),
+			))
+		}
+		if len(missing) == 0 && kind == notJoin {
+			panic(errors.Errorf(
+				"invalid not-join %s: no additional variables are defined: %v", name, vs, clauses,
+			))
+		}
 	}
+
 	if unused := makeVarSet(paramVars...).removed(vs.ordered()...); len(unused) > 0 {
 		mapping := make(map[Var]int, len(paramVars))
 		for i, v := range paramVars {

--- a/pkg/sql/schemachanger/rel/testdata/entitynode
+++ b/pkg/sql/schemachanger/rel/testdata/entitynode
@@ -14,6 +14,22 @@ attributes:
     nb: {left: na, value: b}
     nc: {right: nb, value: c}
 rules:
+    - entityHasI16Eq($node, $entity, $i16):
+        - $node[value] = $entity
+        - $entity[i16] = $i16
+    - nodeWithValuei16NotEq($node, $i16):
+        - entityHasI16Eq($node, $entity, $i16)
+    - joinParentLeft($parent, $child):
+        - $parent[left] = $child
+    - joinParentRight($parent, $child):
+        - $parent[right] = $child
+    - leftNotExists($node):
+        - joinParentLeft($parent, $node)
+    - rightNotExists($node):
+        - joinParentRight($parent, $node)
+    - hasNoChildren($node):
+        - leftNotExists($n)
+        - rightNotExists($n)
     - nodeEntity($node, $entity):
         - $node[value] = $entity
     - rightLeft($root, $right, $right-left, $v):
@@ -49,6 +65,10 @@ queries:
             - {attrs: [Self]}
         6:
             - {attrs: [Self], exists: [Self]}
+        7:
+            - {attrs: [], where: {Type: '*entitynodetest.node'}}
+            - {attrs: [left], exists: [left]}
+            - {attrs: [right], exists: [right]}
       data: [a, b, c, na, nb, nc]
       queries:
         a fields:
@@ -61,7 +81,7 @@ queries:
             result-vars: [$a, $ai8, $api8]
             results:
                 - [a, 1, 1]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         a-c-b join:
             query:
                 - $a[i8] = 1
@@ -73,7 +93,7 @@ queries:
             result-vars: [$a, $b, $c]
             results:
                 - [a, b, c]
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         nil values don't show up:
             query:
                 - $value[pi8] = 1
@@ -81,7 +101,7 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
-            unsatisfiableIndexes: [2, 4, 5, 6]
+            unsatisfiableIndexes: [2, 4, 5, 6, 7]
         nil values don't show up, scalar pointers same as pointers:
             query:
                 - $value[pi8] = 1
@@ -89,7 +109,7 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
-            unsatisfiableIndexes: [2, 4, 5, 6]
+            unsatisfiableIndexes: [2, 4, 5, 6, 7]
         list all the values:
             query:
                 - $value[i8] = $i8
@@ -99,7 +119,7 @@ queries:
                 - [a, 1]
                 - [b, 2]
                 - [c, 2]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         list all the values with type constraint:
             query:
                 - $value[i8] = $i8
@@ -110,7 +130,7 @@ queries:
                 - [a, 1]
                 - [b, 2]
                 - [c, 2]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         nodes with elements where i8=2:
             query:
                 - $i8 = 2
@@ -121,7 +141,7 @@ queries:
             results:
                 - [nb, b]
                 - [nc, c]
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         nodes with elements where i8=2 (rule):
             query:
                 - $i8 = 2
@@ -132,7 +152,7 @@ queries:
             results:
                 - [nb, b]
                 - [nc, c]
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         list all the i8 values:
             query:
                 - $value[i8] = $i8
@@ -143,7 +163,7 @@ queries:
                 - [1]
                 - [2]
                 - [2]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         use a filter:
             query:
                 - $value[Self] = $_
@@ -152,7 +172,7 @@ queries:
             result-vars: [$value]
             results:
                 - [a]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         types of all the entities:
             query:
                 - $value[Type] = $typ
@@ -165,7 +185,7 @@ queries:
                 - [na, '*entitynodetest.node']
                 - [nb, '*entitynodetest.node']
                 - [nc, '*entitynodetest.node']
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         nodes by type:
             query:
                 - $na[Type] = '*entitynodetest.node'
@@ -207,7 +227,7 @@ queries:
                 - [na]
                 - [nb]
                 - [nc]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         self eq value:
             query:
                 - '$entity[Self] = {i8: 2, pi8: null, i16: 1}'
@@ -215,7 +235,7 @@ queries:
             result-vars: [$entity]
             results:
                 - [c]
-            unsatisfiableIndexes: [1, 2, 3]
+            unsatisfiableIndexes: [1, 2, 3, 7]
         contradiction due to missing attribute:
             query:
                 - '$entity[Self] = {i8: 2, pi8: null, i16: 1}'
@@ -223,7 +243,7 @@ queries:
             entities: [$entity]
             result-vars: [$entity, $pi8]
             results: []
-            unsatisfiableIndexes: [1, 2, 3]
+            unsatisfiableIndexes: [1, 2, 3, 7]
         self eq self:
             query:
                 - $entity[Self] = $entity
@@ -236,7 +256,7 @@ queries:
                 - [na]
                 - [nb]
                 - [nc]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         variable type mismatch:
             query:
                 - $entity[pi8] = 0
@@ -253,7 +273,7 @@ queries:
             results:
                 - [na, a, na, a]
                 - [na, a, nc, c]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         entity bound via variable with ne filter:
             query:
                 - $n1[value] = $e1
@@ -266,7 +286,7 @@ queries:
             result-vars: [$n1, $e1, $n2, $e2]
             results:
                 - [na, a, nc, c]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         any value type mismatch:
             query:
                 - $value[i8] IN [1, 2, 1]
@@ -278,7 +298,7 @@ queries:
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         pointer scalar values any:
             query:
                 - $e[i8] IN [1, 2]
@@ -288,7 +308,7 @@ queries:
                 - [a]
                 - [b]
                 - [c]
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         pointer scalar values:
             query:
                 - $e[i8] = 1
@@ -296,7 +316,7 @@ queries:
             result-vars: [$e]
             results:
                 - [a]
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         nil pointer scalar values any:
             query:
                 - $e[i8] IN [1, 1, null]
@@ -311,7 +331,7 @@ queries:
             entities: [$e]
             result-vars: [$e]
             results: []
-            unsatisfiableIndexes: [2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [2, 3, 4, 5, 6, 7]
         any clause no match on variable eq:
             query:
                 - $e[i8] = $i8
@@ -319,7 +339,7 @@ queries:
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         using blank, bind all:
             query:
                 - $e[i8] = $_
@@ -329,7 +349,7 @@ queries:
                 - [a]
                 - [b]
                 - [c]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         using blank, bind non-nil pointer:
             query:
                 - $e[pi8] = $_
@@ -337,7 +357,7 @@ queries:
             result-vars: [$e]
             results:
                 - [a]
-            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         e[i8] != 1:
             query:
                 - $e[Type] = '*entitynodetest.entity'
@@ -347,7 +367,7 @@ queries:
             results:
                 - [b]
                 - [c]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e != a:
             query:
                 - $e[Type] = '*entitynodetest.entity'
@@ -357,7 +377,7 @@ queries:
             results:
                 - [b]
                 - [c]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != 1:
             query:
                 - $e[Type] = '*entitynodetest.entity'
@@ -368,7 +388,7 @@ queries:
             results:
                 - [b, 2]
                 - [c, 2]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != 2:
             query:
                 - $e[Type] = '*entitynodetest.entity'
@@ -378,7 +398,7 @@ queries:
             result-vars: [$e, $v]
             results:
                 - [a, 1]
-            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != int16(2):
             query:
                 - $e[Type] = '*entitynodetest.entity'
@@ -387,5 +407,45 @@ queries:
             entities: [$e]
             result-vars: [$e, $v]
             results: []
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
+        node which is neither the left or right of another node (not-join):
+            query:
+                - $n[Type] = '*entitynodetest.node'
+                - leftNotExists($n)
+                - rightNotExists($n)
+            entities: [$n]
+            result-vars: [$n]
+            results:
+                - [nc]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+        node which is neither the left or right of another node (not-join), composed:
+            query:
+                - $n[Type] = '*entitynodetest.node'
+                - hasNoChildren($n)
+            entities: [$n]
+            result-vars: [$n]
+            results:
+                - [nc]
+            unsatisfiableIndexes: [1, 2, 3, 4, 5, 6]
+        node with entity with i16 not 1:
+            query:
+                - $n[Type] = '*entitynodetest.node'
+                - $i16 = 1
+                - nodeWithValuei16NotEq($n, $i16)
+            entities: [$n]
+            result-vars: [$n, $i16]
+            results:
+                - [nb, 1]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6]
+        node with entity with i16 not 2:
+            query:
+                - $n[Type] = '*entitynodetest.node'
+                - $i16 = 2
+                - nodeWithValuei16NotEq($n, $i16)
+            entities: [$n]
+            result-vars: [$n, $i16]
+            results:
+                - [na, 2]
+                - [nc, 2]
             unsatisfiableIndexes: [1, 2, 3, 5, 6]
 comparisons: []


### PR DESCRIPTION
This patch endows rel with the ability to define not-join rules which allow
extra variables to be introduced inside the clauses. When a not-join rule is
invoked, it leads to the outer query finding a contradiction if the rule fully
unifies.

Fixes https://github.com/cockroachdb/cockroach/issues/77148

Release justification: part of a broader bug-fix

Release note: None