### PR TITLE
storage: implement `String()` for `MVCCRangeKeyStack`

### DIFF
--- a/pkg/storage/mvcc_key.go
+++ b/pkg/storage/mvcc_key.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -633,6 +634,11 @@ func (s *MVCCRangeKeyStack) Remove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bool)
 	return s.Versions.Remove(ts)
 }
 
+// String formats the MVCCRangeKeyStack as a string.
+func (s MVCCRangeKeyStack) String() string {
+	return fmt.Sprintf("%s%s", s.Bounds, s.Versions)
+}
+
 // Timestamps returns the timestamps of all versions.
 func (s MVCCRangeKeyStack) Timestamps() []hlc.Timestamp {
 	return s.Versions.Timestamps()
@@ -804,6 +810,20 @@ func (v *MVCCRangeKeyVersions) Remove(ts hlc.Timestamp) (MVCCRangeKeyVersion, bo
 	return MVCCRangeKeyVersion{}, false
 }
 
+// String formats the MVCCRangeKeyVersions as a string.
+func (v MVCCRangeKeyVersions) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, version := range v {
+		if i > 0 {
+			sb.WriteString(" ")
+		}
+		sb.WriteString(version.String())
+	}
+	sb.WriteString("]")
+	return sb.String()
+}
+
 // Timestamps returns the timestamps of all versions.
 func (v MVCCRangeKeyVersions) Timestamps() []hlc.Timestamp {
 	timestamps := make([]hlc.Timestamp, 0, len(v))
@@ -852,4 +872,9 @@ func (v MVCCRangeKeyVersion) Clone() MVCCRangeKeyVersion {
 // Equal returns true if the two versions are equal.
 func (v MVCCRangeKeyVersion) Equal(o MVCCRangeKeyVersion) bool {
 	return v.Timestamp.Equal(o.Timestamp) && bytes.Equal(v.Value, o.Value)
+}
+
+// String formats the MVCCRangeKeyVersion as a string.
+func (v MVCCRangeKeyVersion) String() string {
+	return fmt.Sprintf("%s=%x", v.Timestamp, v.Value)
 }

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -867,6 +867,27 @@ func TestMVCCRangeKeyStackRemove(t *testing.T) {
 	}
 }
 
+func TestMVCCRangeKeyStackString(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	DisableMetamorphicSimpleValueEncoding(t)
+
+	require.Equal(t, "{a-f}[]",
+		rangeKeyStack("a", "f", map[int]MVCCValue{}).String())
+
+	require.Equal(t, "aa{a-f}[]",
+		rangeKeyStack("aaa", "aaf", map[int]MVCCValue{}).String())
+
+	require.Equal(t, "{a-f}[0.000000001,0=]",
+		rangeKeyStack("a", "f", map[int]MVCCValue{1: {}}).String())
+
+	require.Equal(t, "{a-f}[0.000000007,0= 0.000000005,0= 0.000000003,0=]",
+		rangeKeyStack("a", "f", map[int]MVCCValue{7: {}, 5: {}, 3: {}}).String())
+
+	require.Equal(t, "{a-f}[0.000000007,0= 0.000000005,0=00000004650a020809 0.000000003,0=]",
+		rangeKeyStack("a", "f", map[int]MVCCValue{7: {}, 5: tombstoneLocalTS(9), 3: {}}).String())
+}
+
 func TestMVCCRangeKeyStackTrim(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new functionality

Release note: None