### PR TITLE
ui/cluster-ui: fix search filter in active exec overview pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementUtils.ts
@@ -65,8 +65,9 @@ export function filterActiveStatements(
   }
 
   if (search) {
+    const searchCaseInsensitive = search.toLowerCase();
     filteredStatements = filteredStatements.filter(stmt =>
-      stmt.query.includes(search),
+      stmt.query.toLowerCase().includes(searchCaseInsensitive),
     );
   }
 
@@ -211,8 +212,9 @@ export function filterActiveTransactions(
   }
 
   if (search) {
-    filteredTxns = filteredTxns.filter(
-      txn => !search || txn.query?.includes(search),
+    const searchCaseInsensitive = search.toLowerCase();
+    filteredTxns = filteredTxns.filter(txn =>
+      txn.query?.toLowerCase().includes(searchCaseInsensitive),
     );
   }
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -142,7 +142,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
 
   const onSubmitSearch = (newSearch: string): void => {
     if (newSearch === search) return;
-    setSearch(search);
+    setSearch(newSearch);
     resetPagination();
   };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -143,7 +143,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
 
   const onSubmitSearch = (newSearch: string) => {
     if (newSearch === search) return;
-    setSearch(search);
+    setSearch(newSearch);
     resetPagination();
   };
 


### PR DESCRIPTION
Fixes #86556

This commit fixes a bug in the active execution overview pages where
the search filter was not being applied as a filter. This was due to
the search state being erronneously updated to the same value. The
search state is now correctly updated to the new value on change.

Release justification: bug fix
Release note (bug fix): search in active execution overview pages
works as expected, properly filtering out stmts and txns that do
not contain the search string


https://www.loom.com/share/619584d0a50e468da3ee8bbc04f45f75