### PR TITLE
ccl/streamingccl/streamingest: skip TestStreamIngestionFrontierProcessor

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_frontier_processor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/distsqlutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -40,6 +41,7 @@ type partitionToEvent map[string][]streamingccl.Event
 
 func TestStreamIngestionFrontierProcessor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 86763, "flaky test")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Refs: #86763

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None