### PR TITLE
ccl/changefeedccl: skip TestChangefeedReplanning

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -99,6 +99,7 @@ var testServerRegion = "us-east-1"
 
 func TestChangefeedReplanning(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 86763, "flaky test")
 	defer log.Scope(t).Close(t)
 	skip.UnderStressRace(t, "multinode setup doesn't work under testrace")
 


### PR DESCRIPTION
Refs: #86763

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None