### PR TITLE
ccl/changefeedccl: skip TestAlterChangefeedAddTargetsDuringSchemaChan…

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -897,6 +897,7 @@ func TestAlterChangefeedAlterTableName(t *testing.T) {
 
 func TestAlterChangefeedAddTargetsDuringSchemaChangeError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 86763, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	rnd, _ := randutil.NewPseudoRand()


### PR DESCRIPTION
…geError

Refs: #86763

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None