### PR TITLE
streamingccl: fix timeout error in TestStreamPartition

### DIFF
--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -99,6 +99,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_jackc_pgx_v4//:pgx",


### PR DESCRIPTION
Previously the test timed out easily under short timeout
and waiting for DelRange emitted from rangefeed.

This PR increased the timeout and also made it race-safe.

Closes: https://github.com/cockroachdb/cockroach/issues/86640

Release justification: category 2
Release note: None