### PR TITLE
sql: Add no-op for UNLISTEN

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -268,6 +268,7 @@ FILES = [
     "values_clause",
     "window_definition",
     "with_clause",
+    "unlisten_stmt",
 ]
 
 genrule(

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -29,6 +29,7 @@ stmt_without_legacy_transaction ::=
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
 	| move_cursor_stmt
+	| unlisten_stmt
 
 legacy_transaction_stmt ::=
 	legacy_begin_stmt
@@ -154,6 +155,10 @@ fetch_cursor_stmt ::=
 
 move_cursor_stmt ::=
 	'MOVE' cursor_movement_specifier
+
+unlisten_stmt ::=
+	'UNLISTEN' type_name
+	| 'UNLISTEN' '*'
 
 legacy_begin_stmt ::=
 	'BEGIN' opt_transaction begin_transaction
@@ -466,6 +471,9 @@ cursor_movement_specifier ::=
 	| 'RELATIVE' signed_iconst64 opt_from_or_in cursor_name
 	| 'FIRST' opt_from_or_in cursor_name
 	| 'LAST' opt_from_or_in cursor_name
+
+type_name ::=
+	db_object_name
 
 opt_transaction ::=
 	'TRANSACTION'
@@ -1362,6 +1370,7 @@ unreserved_keyword ::=
 	| 'UNBOUNDED'
 	| 'UNCOMMITTED'
 	| 'UNKNOWN'
+	| 'UNLISTEN'
 	| 'UNLOGGED'
 	| 'UNSET'
 	| 'UNSPLIT'
@@ -1987,9 +1996,6 @@ unrestricted_name ::=
 function_with_argtypes ::=
 	db_object_name func_args
 	| db_object_name
-
-type_name ::=
-	db_object_name
 
 typename ::=
 	simple_typename opt_array_bounds

--- a/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
+++ b/docs/generated/sql/bnf/stmt_without_legacy_transaction.bnf
@@ -20,3 +20,4 @@ stmt_without_legacy_transaction ::=
 	| declare_cursor_stmt
 	| fetch_cursor_stmt
 	| move_cursor_stmt
+	| unlisten_stmt

--- a/docs/generated/sql/bnf/unlisten_stmt.bnf
+++ b/docs/generated/sql/bnf/unlisten_stmt.bnf
@@ -1,0 +1,3 @@
+unlisten_stmt ::=
+	'UNLISTEN' type_name
+	| 'UNLISTEN' '*'

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -259,6 +259,7 @@ BNF_SRCS = [
   "//docs/generated/sql/bnf:truncate_stmt.bnf",
   "//docs/generated/sql/bnf:unique_column_level.bnf",
   "//docs/generated/sql/bnf:unique_table_level.bnf",
+  "//docs/generated/sql/bnf:unlisten_stmt.bnf",
   "//docs/generated/sql/bnf:unsplit_index_at.bnf",
   "//docs/generated/sql/bnf:unsplit_table_at.bnf",
   "//docs/generated/sql/bnf:update_stmt.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -256,6 +256,7 @@ DIAGRAMS_SRCS = [
   "//docs/generated/sql/bnf:truncate.html",
   "//docs/generated/sql/bnf:unique_column_level.html",
   "//docs/generated/sql/bnf:unique_table_level.html",
+  "//docs/generated/sql/bnf:unlisten.html",
   "//docs/generated/sql/bnf:unsplit_index_at.html",
   "//docs/generated/sql/bnf:unsplit_table_at.html",
   "//docs/generated/sql/bnf:update.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -271,6 +271,7 @@ DOCS_SRCS = [
   "//docs/generated/sql/bnf:truncate_stmt.bnf",
   "//docs/generated/sql/bnf:unique_column_level.bnf",
   "//docs/generated/sql/bnf:unique_table_level.bnf",
+  "//docs/generated/sql/bnf:unlisten_stmt.bnf",
   "//docs/generated/sql/bnf:unsplit_index_at.bnf",
   "//docs/generated/sql/bnf:unsplit_table_at.bnf",
   "//docs/generated/sql/bnf:update_stmt.bnf",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -243,6 +243,7 @@ go_library(
         "type_change.go",
         "unary.go",
         "union.go",
+        "unlisten.go",
         "unsplit.go",
         "unsupported_vars.go",
         "update.go",

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -155,3 +155,6 @@ query I
 SELECT count(*) FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%'
 ----
 1
+
+statement ok
+UNLISTEN temp

--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -51,3 +51,10 @@ query T noticetrace
 REFRESH MATERIALIZED VIEW CONCURRENTLY v
 ----
 NOTICE: CONCURRENTLY is not required as views are refreshed concurrently
+
+query T noticetrace
+UNLISTEN temp
+----
+NOTICE: unimplemented: CRDB does not support LISTEN, making UNLISTEN a no-op
+HINT: You have attempted to use a feature that is not yet implemented.
+See: https://go.crdb.dev/issue-v/41522/v22.2

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -262,6 +262,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.ShowVar(ctx, &tree.ShowVar{Name: "transaction_status"})
 	case *tree.Truncate:
 		return p.Truncate(ctx, n)
+	case *tree.Unlisten:
+		return p.Unlisten(ctx, n)
 	case tree.CCLOnlyStatement:
 		plan, err := p.maybePlanHook(ctx, stmt)
 		if plan == nil && err == nil {
@@ -369,6 +371,7 @@ func init() {
 		&tree.ShowVar{},
 		&tree.ShowTransactionStatus{},
 		&tree.Truncate{},
+		&tree.Unlisten{},
 
 		// CCL statements (without Export which has an optimizer operator).
 		&tree.AlterBackup{},

--- a/pkg/sql/parser/testdata/unlisten
+++ b/pkg/sql/parser/testdata/unlisten
@@ -1,0 +1,15 @@
+parse
+UNLISTEN temp
+----
+UNLISTEN temp
+UNLISTEN temp -- fully parenthesized
+UNLISTEN temp -- literals removed
+UNLISTEN _ -- identifiers removed
+
+parse
+UNLISTEN *
+----
+UNLISTEN *  -- normalized!
+UNLISTEN *  -- fully parenthesized
+UNLISTEN *  -- literals removed
+UNLISTEN *  -- identifiers removed

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -105,6 +105,7 @@ go_library(
         "typing.go",
         "udf.go",
         "union.go",
+        "unlisten.go",
         "unsupported_error.go",
         "update.go",
         "values.go",

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1891,6 +1891,15 @@ func (*UnionClause) StatementType() StatementType { return TypeDML }
 func (*UnionClause) StatementTag() string { return "UNION" }
 
 // StatementReturnType implements the Statement interface.
+func (*Unlisten) StatementReturnType() StatementReturnType { return Ack }
+
+// StatementType implements the Statement interface.
+func (*Unlisten) StatementType() StatementType { return TypeTCL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*Unlisten) StatementTag() string { return "UNLISTEN" }
+
+// StatementReturnType implements the Statement interface.
 func (*ValuesClause) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.

--- a/pkg/sql/sem/tree/unlisten.go
+++ b/pkg/sql/sem/tree/unlisten.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tree
+
+// Unlisten represents a UNLISTEN statement.
+type Unlisten struct {
+	ChannelName *UnresolvedObjectName
+	Star        bool
+}
+
+var _ Statement = &Unlisten{}
+
+// Format implements the NodeFormatter interface.
+func (node *Unlisten) Format(ctx *FmtCtx) {
+	ctx.WriteString("UNLISTEN ")
+	if node.Star {
+		ctx.WriteString("* ")
+	} else if node.ChannelName != nil {
+		ctx.FormatNode(node.ChannelName)
+	}
+}
+
+// String implements the Statement interface.
+func (node *Unlisten) String() string {
+	return AsString(node)
+}

--- a/pkg/sql/unlisten.go
+++ b/pkg/sql/unlisten.go
@@ -1,0 +1,29 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+)
+
+func (p *planner) Unlisten(ctx context.Context, n *tree.Unlisten) (planNode, error) {
+	p.BufferClientNotice(ctx,
+		pgerror.WithSeverity(
+			unimplemented.NewWithIssuef(41522, "CRDB does not support LISTEN, making UNLISTEN a no-op"),
+			"NOTICE",
+		),
+	)
+	return newZeroNode(nil /* columns */), nil
+}


### PR DESCRIPTION
fixes #83061

This commit makes UNLISTEN a no-op to fix issue with npgsql.

Release justification: Low risk, high benefit change to existing functionality
Release note: None