### PR TITLE
sql/schemachanger: version gate element creation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer_mixed
@@ -25,6 +25,9 @@ SET use_declarative_schema_changer = unsafe_always;
 
 # Verify that DDL stmts only supported in v22.2 will cause a panic.
 statement error pq: \*tree\.AlterTable not implemented in the new schema changer
+ALTER TABLE testdb.testsc.t ADD COLUMN j INT NOT NULL DEFAULT 30;
+
+statement error pq: \*tree\.AlterTable not implemented in the new schema changer
 ALTER TABLE testdb.testsc.t DROP COLUMN j;
 
 statement error pq: \*tree\.AlterTable not implemented in the new schema changer
@@ -61,9 +64,6 @@ statement error pq: \*tree\.DropIndex not implemented in the new schema changer
 DROP INDEX testdb.testsc.t@idx
 
 # Verify that DDL stmts supported in v22.1 will succeed.
-statement ok
-ALTER TABLE testdb.testsc.t ADD COLUMN j INT NOT NULL DEFAULT 30;
-
 statement ok
 DROP TYPE testdb.testsc.typ;
 

--- a/pkg/sql/schemachanger/scbuild/build.go
+++ b/pkg/sql/schemachanger/scbuild/build.go
@@ -89,10 +89,16 @@ func Build(
 		Authorization: els.authorization,
 	}
 	current := make([]scpb.Status, 0, len(bs.output))
+	version := dependencies.ClusterSettings().Version.ActiveVersion(ctx)
 	for _, e := range bs.output {
 		if e.metadata.Size() == 0 {
 			// Exclude targets which weren't explicitly set.
 			// Explicitly-set targets have non-zero values in the target metadata.
+			continue
+		}
+		// Exclude targets which are not yet usable in the currently active
+		// cluster version.
+		if !version.IsActive(screl.MinVersion(e.element)) {
 			continue
 		}
 		ts.Targets = append(ts.Targets, scpb.MakeTarget(e.target, e.element, &e.metadata))

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -47,7 +47,7 @@ type supportedAlterTableCommand struct {
 // declarative schema  changer. Operations marked as non-fully supported can
 // only be with the use_declarative_schema_changer session variable.
 var supportedAlterTableStatements = map[reflect.Type]supportedAlterTableCommand{
-	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true, minSupportedClusterVersion: clusterversion.V22_1},
+	reflect.TypeOf((*tree.AlterTableAddColumn)(nil)):       {fn: alterTableAddColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
 	reflect.TypeOf((*tree.AlterTableDropColumn)(nil)):      {fn: alterTableDropColumn, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
 	reflect.TypeOf((*tree.AlterTableAlterPrimaryKey)(nil)): {fn: alterTableAlterPrimaryKey, on: true, minSupportedClusterVersion: clusterversion.Start22_2},
 	reflect.TypeOf((*tree.AlterTableAddConstraint)(nil)): {fn: alterTableAddConstraint, on: true, extraChecks: func(

--- a/pkg/sql/schemachanger/screl/BUILD.bazel
+++ b/pkg/sql/schemachanger/screl/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/schemachanger/screl/scalars.go
+++ b/pkg/sql/schemachanger/screl/scalars.go
@@ -11,6 +11,7 @@
 package screl
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
@@ -90,4 +91,30 @@ func ContainsDescID(haystack scpb.Element, needle catid.DescID) (contains bool) 
 		return nil
 	})
 	return contains
+}
+
+// MinVersion returns the minimum cluster version at which an element may
+// be used.
+func MinVersion(el scpb.Element) clusterversion.Key {
+	switch el.(type) {
+	case *scpb.Database, *scpb.Schema, *scpb.View, *scpb.Sequence, *scpb.Table,
+		*scpb.AliasType, *scpb.ColumnFamily, *scpb.Column, *scpb.PrimaryIndex,
+		*scpb.SecondaryIndex, *scpb.TemporaryIndex, *scpb.EnumType,
+		*scpb.UniqueWithoutIndexConstraint, *scpb.CheckConstraint,
+		*scpb.ForeignKeyConstraint, *scpb.TableComment, *scpb.RowLevelTTL,
+		*scpb.TableLocalityGlobal, *scpb.TableLocalityPrimaryRegion,
+		*scpb.TableLocalitySecondaryRegion, *scpb.TableLocalityRegionalByRow,
+		*scpb.ColumnName, *scpb.ColumnType, *scpb.ColumnDefaultExpression,
+		*scpb.ColumnOnUpdateExpression, *scpb.SequenceOwner, *scpb.ColumnComment,
+		*scpb.IndexName, *scpb.IndexPartitioning, *scpb.SecondaryIndexPartial,
+		*scpb.IndexComment, *scpb.ConstraintName, *scpb.ConstraintComment,
+		*scpb.Namespace, *scpb.Owner, *scpb.UserPrivileges,
+		*scpb.DatabaseRegionConfig, *scpb.DatabaseRoleSetting, *scpb.DatabaseComment,
+		*scpb.SchemaParent, *scpb.SchemaComment, *scpb.ObjectParent:
+		return clusterversion.V22_1
+	case *scpb.IndexColumn, *scpb.EnumTypeValue, *scpb.TableZoneConfig:
+		return clusterversion.UseDelRangeInGCJob
+	default:
+		panic(errors.AssertionFailedf("unknown element %T", el))
+	}
 }

--- a/pkg/sql/schemachanger/screl/scalars_test.go
+++ b/pkg/sql/schemachanger/screl/scalars_test.go
@@ -24,11 +24,24 @@ import (
 
 // TestAllElementsHaveDescID ensures that all element types have a DescID.
 func TestAllElementsHaveDescID(t *testing.T) {
+	forEachElementType(func(elem scpb.Element) {
+		require.Equalf(t, descpb.ID(0), GetDescID(elem), "elem %T", elem)
+	})
+}
+
+func TestAllElementsHaveMinVersion(t *testing.T) {
+	forEachElementType(func(elem scpb.Element) {
+		// If `elem` does not have a min version, the following function call will panic.
+		MinVersion(elem)
+	})
+}
+
+func forEachElementType(f func(element scpb.Element)) {
 	typ := reflect.TypeOf((*scpb.ElementProto)(nil)).Elem()
 	for i := 0; i < typ.NumField(); i++ {
-		f := typ.Field(i)
-		elem := reflect.New(f.Type.Elem()).Interface().(scpb.Element)
-		require.Equal(t, descpb.ID(0), GetDescID(elem))
+		field := typ.Field(i)
+		elem := reflect.New(field.Type.Elem()).Interface().(scpb.Element)
+		f(elem)
 	}
 }
 


### PR DESCRIPTION
Commit 1: fix minSupportedVersion of `ADD COLUMN` in new schema changer
from v22.1 to v22.2
Commit 2: We cannot create elements the old version of the code does not know about.

Release justification: fixed mixed version incompatibility
Release note: None