### PR TITLE
kvserver: disable replica pausing by default

### DIFF
--- a/pkg/kv/kvserver/replica_raft_overload.go
+++ b/pkg/kv/kvserver/replica_raft_overload.go
@@ -28,7 +28,7 @@ var pauseReplicationIOThreshold = settings.RegisterFloatSetting(
 	settings.SystemOnly,
 	"admission.kv.pause_replication_io_threshold",
 	"pause replication to non-essential followers when their I/O admission control score exceeds the given threshold (zero to disable)",
-	0.8,
+	0,
 	func(v float64) error {
 		if v == 0 {
 			return nil


### PR DESCRIPTION
(Morally) reverts #86147. We'll roll this setting out over time.

See: https://github.com/cockroachdb/cockroach/issues/86775

Release justification: more conservative choice for a new cluster setting
Release note (ops change): the
admission.kv.pause_replication_io_threshold cluster setting now default
to zero (off). This supersedes an earlier release note about this
setting.
