### PR TITLE
ui: refactor transaction insights SQL API queries

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -24,103 +24,264 @@ import moment from "moment";
 
 const apiAppName = "$ api-v2-sql";
 
+// Transaction insight events.
+
+// There are three transaction contention event insight queries:
+// 1. A query that selects transaction contention events from crdb_internal.cluster_contention_events.
+// 2. A query that selects statement fingerprint IDS from crdb_internal.transaction_statistics, filtering on the
+// fingerprint IDs recorded in the contention events.
+// 3. A query that selects statement queries from crdb_internal.statement_statistics, filtering on the fingerprint IDs
+// recorded in the contention event rows.
+// After we get the results from these tables, we combine them on the frontend.
+
+// These types describe the final transaction contention event state, as it is stored in Redux.
 export type TransactionInsightEventState = Omit<
   TransactionInsightEvent,
   "insights"
 > & {
   insightName: string;
 };
-
 export type TransactionInsightEventsResponse = TransactionInsightEventState[];
 
-type InsightQuery<ResponseColumnType, State> = {
-  name: InsightNameEnum;
-  query: string;
-  toState: (response: SqlExecutionResponse<ResponseColumnType>) => State;
-};
+export type TransactionContentionEventState = Omit<
+  TransactionInsightEventState,
+  "application" | "queries"
+>;
+
+export type TransactionContentionEventsResponse =
+  TransactionContentionEventState[];
+
+// txnContentionQuery selects all relevant transaction contention events.
+const txnContentionQuery = `SELECT *
+                            FROM (SELECT blocking_txn_id,
+                                         encode(
+                                           blocking_txn_fingerprint_id, 'hex'
+                                           ) AS blocking_txn_fingerprint_id,
+                                         collection_ts,
+                                         contention_duration,
+                                         row_number() over (
+                                           PARTITION BY blocking_txn_fingerprint_id
+                                           ORDER BY
+                                             collection_ts DESC
+                                           ) AS rank,
+                                         threshold
+                                  FROM (SELECT "sql.insights.latency_threshold" :: INTERVAL AS threshold
+                                        FROM
+                                          [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
+                                       (SELECT DISTINCT ON (blocking_txn_id) *
+                                        FROM crdb_internal.transaction_contention_events tce),
+                                       (SELECT txn_id FROM crdb_internal.cluster_execution_insights)
+                                  WHERE contention_duration > threshold
+                                     OR waiting_txn_id = txn_id)
+                            WHERE rank = 1`;
 
 type TransactionContentionResponseColumns = {
   blocking_txn_id: string;
   blocking_txn_fingerprint_id: string;
-  blocking_queries: string[];
   collection_ts: string;
   contention_duration: string;
   threshold: string;
-  app_name: string;
 };
 
 function transactionContentionResultsToEventState(
   response: SqlExecutionResponse<TransactionContentionResponseColumns>,
-): TransactionInsightEventState[] {
+): TransactionContentionEventState[] {
   if (!response.execution.txn_results[0].rows) {
-    // No data.
+    // No transaction contention events.
     return [];
   }
 
   return response.execution.txn_results[0].rows.map(row => ({
     transactionID: row.blocking_txn_id,
     fingerprintID: row.blocking_txn_fingerprint_id,
-    queries: row.blocking_queries,
     startTime: moment(row.collection_ts),
     contentionDuration: moment.duration(row.contention_duration),
     contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
-    application: row.app_name,
-    insightName: highContentionQuery.name,
+    insightName: InsightNameEnum.highContention,
     execType: InsightExecEnum.TRANSACTION,
   }));
 }
 
-const highContentionQuery: InsightQuery<
-  TransactionContentionResponseColumns,
-  TransactionInsightEventsResponse
-> = {
-  name: InsightNameEnum.highContention,
-  query: `SELECT *
-          FROM (SELECT blocking_txn_id,
-                       encode(blocking_txn_fingerprint_id, 'hex') AS blocking_txn_fingerprint_id,
-                       blocking_queries,
-                       collection_ts,
-                       contention_duration,
-                       app_name,
-                       row_number()                                  over (
-    PARTITION BY
-    blocking_txn_fingerprint_id
-    ORDER BY collection_ts DESC ) AS rank, threshold
-                FROM (SELECT "sql.insights.latency_threshold"::INTERVAL as threshold
-                      FROM [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
-                     crdb_internal.transaction_contention_events AS tce
-                       JOIN (SELECT transaction_fingerprint_id,
-                                    app_name,
-                                    array_agg(metadata ->> 'query') AS blocking_queries
-                             FROM crdb_internal.statement_statistics
-                             GROUP BY transaction_fingerprint_id,
-                                      app_name) AS bqs
-                            ON bqs.transaction_fingerprint_id = tce.blocking_txn_fingerprint_id
-                WHERE contention_duration > threshold AND app_name != '${apiAppName}')
-          WHERE rank = 1`,
-  toState: transactionContentionResultsToEventState,
+export type TxnStmtFingerprintEventState = Pick<
+  TransactionInsightEventState,
+  "application" | "fingerprintID"
+> & {
+  queryIDs: string[];
 };
 
-// getTransactionInsightEventState is currently hardcoded to use the High Contention insight type
-// for transaction contention events.
+export type TxnStmtFingerprintEventsResponse = TxnStmtFingerprintEventState[];
+
+type TxnStmtFingerprintsResponseColumns = {
+  transaction_fingerprint_id: string;
+  query_ids: string[];
+  app_name: string;
+};
+
+// txnStmtFingerprintsQuery selects all statement fingerprints for each recorded transaction fingerprint.
+const txnStmtFingerprintsQuery = (
+  txn_fingerprint_ids: string[] | string,
+) => `SELECT DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS transaction_fingerprint_id,
+                                          app_name,
+                                          ARRAY(
+                                            SELECT jsonb_array_elements_text(metadata -> 'stmtFingerprintIDs')
+                                            ) AS query_ids
+      FROM crdb_internal.transaction_statistics
+      WHERE app_name != '${apiAppName}'
+        AND encode(fingerprint_id, 'hex') = ANY (string_to_array('${txn_fingerprint_ids}'
+        , ','))`;
+
+function txnStmtFingerprintsResultsToEventState(
+  response: SqlExecutionResponse<TxnStmtFingerprintsResponseColumns>,
+): TxnStmtFingerprintEventsResponse {
+  if (!response.execution.txn_results[0].rows) {
+    // No transaction fingerprint results.
+    return [];
+  }
+
+  return response.execution.txn_results[0].rows.map(row => ({
+    fingerprintID: row.transaction_fingerprint_id,
+    queryIDs: row.query_ids,
+    application: row.app_name,
+  }));
+}
+
+type FingerprintStmtsEventState = {
+  query: string;
+  stmtFingerprintID: string;
+};
+
+type FingerprintStmtsEventsResponse = FingerprintStmtsEventState[];
+
+type FingerprintStmtsResponseColumns = {
+  statement_fingerprint_id: string;
+  query: string;
+};
+
+// fingerprintStmtsQuery selects all statement queries for each recorded statement fingerprint.
+const fingerprintStmtsQuery = (
+  stmt_fingerprint_ids: string[],
+) => `SELECT DISTINCT ON (fingerprint_id) encode(fingerprint_id, 'hex') AS statement_fingerprint_id,
+                                          prettify_statement(metadata ->> 'query', 108, 2, 1) AS query
+      FROM crdb_internal.statement_statistics
+      WHERE encode(fingerprint_id, 'hex') = ANY (string_to_array('${stmt_fingerprint_ids}'
+        , ','))`;
+
+function fingerprintStmtsResultsToEventState(
+  response: SqlExecutionResponse<FingerprintStmtsResponseColumns>,
+): FingerprintStmtsEventsResponse {
+  if (!response.execution.txn_results[0].rows) {
+    // No statement fingerprint results.
+    return [];
+  }
+  return response.execution.txn_results[0].rows.map(row => ({
+    stmtFingerprintID: row.statement_fingerprint_id,
+    query: row.query,
+  }));
+}
+
+// getTransactionInsightEventState is the API function that executes the queries and returns the results.
 export function getTransactionInsightEventState(): Promise<TransactionInsightEventsResponse> {
-  const request: SqlExecutionRequest = {
+  const txnContentionRequest: SqlExecutionRequest = {
     statements: [
       {
-        sql: `${highContentionQuery.query}`,
+        sql: `${txnContentionQuery}`,
       },
     ],
     execute: true,
+    max_result_size: 50000, // 50 kib
   };
-  return executeSql<TransactionContentionResponseColumns>(request).then(
-    result => {
-      return highContentionQuery.toState(result);
-    },
-  );
+  return executeSql<TransactionContentionResponseColumns>(
+    txnContentionRequest,
+  ).then(contentionResults => {
+    const res = contentionResults.execution.txn_results[0].rows;
+    if (!res || res.length < 1) {
+      return;
+    }
+    const txnFingerprintIDs = res.map(row => row.blocking_txn_fingerprint_id);
+    const txnFingerprintRequest: SqlExecutionRequest = {
+      statements: [
+        {
+          sql: `${txnStmtFingerprintsQuery(txnFingerprintIDs)}`,
+        },
+      ],
+      execute: true,
+      max_result_size: 50000, // 50 kib
+    };
+    return executeSql<TxnStmtFingerprintsResponseColumns>(
+      txnFingerprintRequest,
+    ).then(txnStmtFingerprintResults => {
+      const stmtFingerprintIDs =
+        txnStmtFingerprintResults.execution.txn_results[0].rows?.map(
+          row => row.query_ids,
+        );
+      const fingerprintStmtsRequest: SqlExecutionRequest = {
+        statements: [
+          {
+            sql: `${fingerprintStmtsQuery(
+              [].concat([], ...stmtFingerprintIDs),
+            )}`,
+          },
+        ],
+        execute: true,
+        max_result_size: 50000, // 50 kib
+      };
+      return executeSql<FingerprintStmtsResponseColumns>(
+        fingerprintStmtsRequest,
+      ).then(fingerprintStmtResults => {
+        return combineTransactionInsightEventState(
+          transactionContentionResultsToEventState(contentionResults),
+          txnStmtFingerprintsResultsToEventState(txnStmtFingerprintResults),
+          fingerprintStmtsResultsToEventState(fingerprintStmtResults),
+        );
+      });
+    });
+  });
 }
 
-// Details.
+export function combineTransactionInsightEventState(
+  txnContentionState: TransactionContentionEventState[],
+  txnFingerprintState: TxnStmtFingerprintEventsResponse,
+  fingerprintStmtState: FingerprintStmtsEventsResponse,
+): TransactionInsightEventState[] {
+  let res: TransactionInsightEventState[];
+  if (txnContentionState && txnFingerprintState && fingerprintStmtState) {
+    const queries = txnFingerprintState.map(txnRow => ({
+      fingerprintID: txnRow.fingerprintID,
+      app_name: txnRow.application,
+      queries: txnRow.queryIDs.map(
+        stmtID =>
+          fingerprintStmtState.find(row => row.stmtFingerprintID === stmtID)
+            ?.query,
+      ),
+    }));
+    if (queries) {
+      res = txnContentionState.map(row => {
+        const qa = queries.find(
+          query => query.fingerprintID === row.fingerprintID,
+        );
+        if (qa) {
+          return {
+            ...row,
+            queries: qa.queries,
+            application: qa.app_name,
+            insightName: InsightNameEnum.highContention,
+            execType: InsightExecEnum.TRANSACTION,
+          };
+        }
+      });
+    }
+  }
+  return res;
+}
 
+// Transaction insight details.
+
+// To get details on a specific transaction contention event:
+// 1. Query the crdb_internal.transaction_contention_events table, filtering on the ID specified in the API request.
+// 2. Reuse the queries/types defined above to get the waiting and blocking queries.
+// After we get the results from these tables, we combine them on the frontend.
+
+// These types describe the final event state, as it is stored in Redux
 export type TransactionInsightEventDetailsState = Omit<
   TransactionInsightEventDetails,
   "insights"
@@ -128,20 +289,53 @@ export type TransactionInsightEventDetailsState = Omit<
   insightName: string;
 };
 export type TransactionInsightEventDetailsResponse =
-  TransactionInsightEventDetailsState[];
+  TransactionInsightEventDetailsState;
 export type TransactionInsightEventDetailsRequest = { id: string };
 
-type TransactionContentionDetailsResponseColumns = {
+// Query 1 types, functions.
+export type TransactionContentionEventDetailsState = Omit<
+  TransactionInsightEventDetailsState,
+  "application" | "queries" | "waitingQueries"
+>;
+
+export type TransactionContentionEventDetailsResponse =
+  TransactionContentionEventDetailsState;
+
+// txnContentionDetailsQuery selects information about a specific transaction contention event.
+const txnContentionDetailsQuery = (id: string) => `SELECT collection_ts,
+                                                          blocking_txn_id,
+                                                          encode(
+                                                            blocking_txn_fingerprint_id, 'hex'
+                                                            ) AS blocking_txn_fingerprint_id,
+                                                          waiting_txn_id,
+                                                          encode(
+                                                            waiting_txn_fingerprint_id, 'hex'
+                                                            ) AS waiting_txn_fingerprint_id,
+                                                          contention_duration,
+                                                          crdb_internal.pretty_key(contending_key, 0) AS key,
+                                                          database_name,
+                                                          schema_name,
+                                                          table_name,
+                                                          index_name,
+                                                          threshold
+                                                   FROM (SELECT "sql.insights.latency_threshold" :: INTERVAL AS threshold
+                                                         FROM
+                                                           [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
+                                                        crdb_internal.transaction_contention_events AS tce
+                                                          LEFT OUTER JOIN crdb_internal.ranges AS ranges
+                                                                          ON tce.contending_key BETWEEN ranges.start_key
+                                                                            AND ranges.end_key
+                                                   WHERE blocking_txn_id = '${id}'
+`;
+
+type TxnContentionDetailsResponseColumns = {
   blocking_txn_id: string;
-  blocking_queries: string[];
   collection_ts: string;
   contention_duration: string;
   threshold: string;
-  app_name: string;
   blocking_txn_fingerprint_id: string;
   waiting_txn_id: string;
   waiting_txn_fingerprint_id: string;
-  waiting_queries: string[];
   schema_name: string;
   database_name: string;
   table_name: string;
@@ -150,106 +344,165 @@ type TransactionContentionDetailsResponseColumns = {
 };
 
 function transactionContentionDetailsResultsToEventState(
-  response: SqlExecutionResponse<TransactionContentionDetailsResponseColumns>,
-): TransactionInsightEventDetailsState[] {
+  response: SqlExecutionResponse<TxnContentionDetailsResponseColumns>,
+): TransactionContentionEventDetailsResponse {
   if (!response.execution.txn_results[0].rows) {
     // No data.
-    return [];
+    return;
   }
-  return response.execution.txn_results[0].rows.map(row => ({
+  const row = response.execution.txn_results[0].rows[0];
+  return {
     executionID: row.blocking_txn_id,
-    queries: row.blocking_queries,
     startTime: moment(row.collection_ts),
     elapsedTime: moment.duration(row.contention_duration).asMilliseconds(),
     contentionThreshold: moment.duration(row.threshold).asMilliseconds(),
-    application: row.app_name,
     fingerprintID: row.blocking_txn_fingerprint_id,
     waitingExecutionID: row.waiting_txn_id,
     waitingFingerprintID: row.waiting_txn_fingerprint_id,
-    waitingQueries: row.waiting_queries,
     schemaName: row.schema_name,
     databaseName: row.database_name,
     tableName: row.table_name,
     indexName: row.index_name,
     contendedKey: row.key,
-    insightName: highContentionQuery.name,
+    insightName: InsightNameEnum.highContention,
     execType: InsightExecEnum.TRANSACTION,
-  }));
+  };
 }
 
-const highContentionDetailsQuery = (
-  id: string,
-): InsightQuery<
-  TransactionContentionDetailsResponseColumns,
-  TransactionInsightEventDetailsResponse
-> => {
-  return {
-    name: InsightNameEnum.highContention,
-    query: `SELECT collection_ts,
-                   blocking_txn_id,
-                   encode(blocking_txn_fingerprint_id, 'hex') AS blocking_txn_fingerprint_id,
-                   waiting_txn_id,
-                   encode(waiting_txn_fingerprint_id, 'hex')  AS waiting_txn_fingerprint_id,
-                   contention_duration,
-                   crdb_internal.pretty_key(contending_key, 0) as key, 
-  database_name, 
-  schema_name, 
-  table_name, 
-  index_name,
-  app_name, 
-  blocking_queries, 
-  waiting_queries,
-  threshold
-            FROM
-  (SELECT "sql.insights.latency_threshold"::INTERVAL as threshold FROM [SHOW CLUSTER SETTING sql.insights.latency_threshold]),
-  crdb_internal.transaction_contention_events AS tce 
-  LEFT OUTER JOIN crdb_internal.ranges AS ranges ON tce.contending_key BETWEEN ranges.start_key 
-  AND ranges.end_key 
-  JOIN (
-    SELECT 
-      transaction_fingerprint_id,
-      array_agg(metadata ->> 'query') AS waiting_queries 
-    FROM 
-      crdb_internal.statement_statistics 
-    GROUP BY 
-      transaction_fingerprint_id
-  ) AS wqs ON wqs.transaction_fingerprint_id = tce.waiting_txn_fingerprint_id 
-  JOIN (
-    SELECT 
-      transaction_fingerprint_id,
-      app_name,
-      array_agg(metadata ->> 'query') AS blocking_queries 
-    FROM 
-      crdb_internal.statement_statistics 
-    GROUP BY 
-      transaction_fingerprint_id,
-      app_name
-  ) AS bqs ON bqs.transaction_fingerprint_id = tce.blocking_txn_fingerprint_id
-            WHERE blocking_txn_id = '${id}'`,
-    toState: transactionContentionDetailsResultsToEventState,
-  };
-};
-
-// getTransactionInsightEventState is currently hardcoded to use the High Contention insight type
-// for transaction contention events.
+// getTransactionInsightEventState is the API function that executes the queries and returns the results.
 export function getTransactionInsightEventDetailsState(
   req: TransactionInsightEventDetailsRequest,
 ): Promise<TransactionInsightEventDetailsResponse> {
-  const detailsQuery = highContentionDetailsQuery(req.id);
-  const request: SqlExecutionRequest = {
+  const txnContentionDetailsRequest: SqlExecutionRequest = {
     statements: [
       {
-        sql: `${detailsQuery.query}`,
+        sql: `${txnContentionDetailsQuery(req.id)}`,
       },
     ],
     execute: true,
+    max_result_size: 50000, // 50 kib
   };
-  return executeSql<TransactionContentionDetailsResponseColumns>(request).then(
-    result => {
-      return detailsQuery.toState(result);
-    },
-  );
+  return executeSql<TxnContentionDetailsResponseColumns>(
+    txnContentionDetailsRequest,
+  ).then(contentionResults => {
+    const res = contentionResults.execution.txn_results[0].rows;
+    if (!res || res.length < 1) {
+      return;
+    }
+    const blockingTxnFingerprintId = res[0].blocking_txn_fingerprint_id;
+    const blockingTxnFingerprintRequest: SqlExecutionRequest = {
+      statements: [
+        {
+          sql: `${txnStmtFingerprintsQuery(blockingTxnFingerprintId)}`,
+        },
+      ],
+      execute: true,
+      max_result_size: 50000, // 50 kib
+    };
+    return executeSql<TxnStmtFingerprintsResponseColumns>(
+      blockingTxnFingerprintRequest,
+    ).then(blockingTxnStmtFingerprintIDs => {
+      const blockingStmtFingerprintIDs =
+        blockingTxnStmtFingerprintIDs.execution.txn_results[0].rows[0]
+          .query_ids;
+      const blockingFingerprintStmtsRequest: SqlExecutionRequest = {
+        statements: [
+          {
+            sql: `${fingerprintStmtsQuery(blockingStmtFingerprintIDs)}`,
+          },
+        ],
+        execute: true,
+        max_result_size: 50000, // 50 kib
+      };
+      return executeSql<FingerprintStmtsResponseColumns>(
+        blockingFingerprintStmtsRequest,
+      ).then(blockingTxnStmtQueries => {
+        const waitingTxnFingerprintId =
+          contentionResults.execution.txn_results[0].rows[0]
+            .waiting_txn_fingerprint_id;
+        const waitingTxnFingerprintRequest: SqlExecutionRequest = {
+          statements: [
+            {
+              sql: `${txnStmtFingerprintsQuery(waitingTxnFingerprintId)}`,
+            },
+          ],
+          execute: true,
+          max_result_size: 50000, // 50 kib
+        };
+        return executeSql<TxnStmtFingerprintsResponseColumns>(
+          waitingTxnFingerprintRequest,
+        ).then(waitingTxnStmtFingerprintIDs => {
+          const waitingStmtFingerprintIDs =
+            waitingTxnStmtFingerprintIDs.execution.txn_results[0].rows[0]
+              .query_ids;
+          const waitingFingerprintStmtsRequest: SqlExecutionRequest = {
+            statements: [
+              {
+                sql: `${fingerprintStmtsQuery(waitingStmtFingerprintIDs)}`,
+              },
+            ],
+            execute: true,
+            max_result_size: 50000, // 50 kib
+          };
+          return executeSql<FingerprintStmtsResponseColumns>(
+            waitingFingerprintStmtsRequest,
+          ).then(waitingTxnStmtQueries => {
+            return combineTransactionInsightEventDetailsState(
+              transactionContentionDetailsResultsToEventState(
+                contentionResults,
+              ),
+              txnStmtFingerprintsResultsToEventState(
+                blockingTxnStmtFingerprintIDs,
+              ),
+              txnStmtFingerprintsResultsToEventState(
+                waitingTxnStmtFingerprintIDs,
+              ),
+              fingerprintStmtsResultsToEventState(blockingTxnStmtQueries),
+              fingerprintStmtsResultsToEventState(waitingTxnStmtQueries),
+            );
+          });
+        });
+      });
+    });
+  });
 }
+
+export function combineTransactionInsightEventDetailsState(
+  txnContentionDetailsState: TransactionContentionEventDetailsResponse,
+  blockingTxnFingerprintState: TxnStmtFingerprintEventsResponse,
+  waitingTxnFingerprintState: TxnStmtFingerprintEventsResponse,
+  blockingFingerprintStmtState: FingerprintStmtsEventsResponse,
+  waitingFingerprintStmtState: FingerprintStmtsEventsResponse,
+): TransactionInsightEventDetailsState {
+  let res: TransactionInsightEventDetailsState;
+  if (
+    txnContentionDetailsState &&
+    blockingTxnFingerprintState &&
+    waitingTxnFingerprintState &&
+    blockingFingerprintStmtState &&
+    waitingFingerprintStmtState
+  ) {
+    res = {
+      ...txnContentionDetailsState,
+      application: blockingTxnFingerprintState[0].application,
+      queries: blockingTxnFingerprintState[0].queryIDs.map(
+        id =>
+          blockingFingerprintStmtState.find(
+            stmt => stmt.stmtFingerprintID === id,
+          )?.query,
+      ),
+      waitingQueries: waitingTxnFingerprintState[0].queryIDs.map(
+        id =>
+          waitingFingerprintStmtState.find(
+            stmt => stmt.stmtFingerprintID === id,
+          )?.query,
+      ),
+    };
+  }
+  return res;
+}
+
+// Statements
 
 type ExecutionInsightsResponseRow = {
   session_id: string;
@@ -317,20 +570,26 @@ function getStatementInsightsFromClusterExecutionInsightsResponse(
   });
 }
 
+type InsightQuery<ResponseColumnType, State> = {
+  name: InsightNameEnum;
+  query: string;
+  toState: (response: SqlExecutionResponse<ResponseColumnType>) => State;
+};
+
 const statementInsightsQuery: InsightQuery<
   ExecutionInsightsResponseRow,
   StatementInsights
 > = {
   name: InsightNameEnum.highContention,
   // We only surface the most recently observed problem for a given statement.
-  query: `SELECT *, prettify_statement(non_prettified_query, 108, 2, 1) as query from (
+  query: `SELECT *, prettify_statement(non_prettified_query, 108, 2, 1) AS query from (
     SELECT
       session_id,
       txn_id,
       encode(txn_fingerprint_id, 'hex')  AS txn_fingerprint_id,
       stmt_id,
       encode(stmt_fingerprint_id, 'hex') AS stmt_fingerprint_id,
-      query as non_prettified_query,
+      query AS non_prettified_query,
       start_time,
       end_time,
       full_scan,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -37,16 +37,18 @@ export const getTransactionInsights = (
     | TransactionInsightEventDetailsState,
 ): Insight[] => {
   const insights: Insight[] = [];
-  InsightTypes.forEach(insight => {
-    if (
-      insight(eventState.execType, eventState.contentionThreshold).name ==
-      eventState.insightName
-    ) {
-      insights.push(
-        insight(eventState.execType, eventState.contentionThreshold),
-      );
-    }
-  });
+  if (eventState) {
+    InsightTypes.forEach(insight => {
+      if (
+        insight(eventState.execType, eventState.contentionThreshold).name ==
+        eventState.insightName
+      ) {
+        insights.push(
+          insight(eventState.execType, eventState.contentionThreshold),
+        );
+      }
+    });
+  }
   return insights;
 };
 
@@ -85,12 +87,12 @@ export function getTransactionInsightEventDetailsFromState(
 ): TransactionInsightEventDetails {
   let insightEventDetails: TransactionInsightEventDetails = null;
   const insightsForEventDetails = getTransactionInsights(
-    insightEventDetailsResponse[0],
+    insightEventDetailsResponse,
   );
   if (insightsForEventDetails.length > 0) {
-    delete insightEventDetailsResponse[0].insightName;
+    delete insightEventDetailsResponse.insightName;
     insightEventDetails = {
-      ...insightEventDetailsResponse[0],
+      ...insightEventDetailsResponse,
       insights: insightsForEventDetails,
     };
   }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -95,15 +95,7 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
     if (!insightDetails) {
       return null;
     }
-    const insightQueries = insightDetails.queries
-      .map((query, idx) => {
-        if (idx != 0) {
-          return "\n" + query;
-        } else {
-          return query;
-        }
-      })
-      .toString();
+    const insightQueries = insightDetails.queries.join("");
     const isCockroachCloud = useContext(CockroachCloudContext);
     const insightsColumns = makeInsightsColumns(isCockroachCloud);
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -176,7 +176,6 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     });
 
   const transactionInsights = getInsightsFromState(transactions);
-
   const apps = getAppsFromTransactionInsights(
     transactionInsights,
     INTERNAL_APP_NAME_PREFIX,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -85,7 +85,7 @@ export const insightsTableTitles: InsightsTableTitleType = {
     if (execType == InsightExecEnum.TRANSACTION) {
       tooltipText = "The queries attempted in the transaction.";
     }
-    return makeToolTip(<p>tooltipText</p>, "query", execType);
+    return makeToolTip(<p>{tooltipText}</p>, "query", execType);
   },
   insights: (execType: InsightExecEnum) => {
     return makeToolTip(


### PR DESCRIPTION
This commit refactors the SQL API queries for the transaction insights pages.

Previously, the transaction insights SQL API query was aggregating duplicate queries. This commit fixes that bug.

Fixes https://github.com/cockroachdb/cockroach/issues/87026.

Before:

https://www.loom.com/share/b03c7ce1924c40088ae69664780debb7

After:

https://www.loom.com/share/78e6cde5a00449e6bc3f8b9f47dab87e

Release justification: bug fixes and low-risk updates to new functionality
Release note: None