### PR TITLE
release-22.1: sql/sem/builtins: add multi-region functions to distsql blocklist

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6285,7 +6285,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		},
 	),
 	DefaultToDatabasePrimaryRegionBuiltinName: makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		stringOverload1(
 			func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
 				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(evalCtx.Context)
@@ -6313,7 +6316,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		),
 	),
 	RehomeRowBuiltinName: makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
@@ -6349,7 +6355,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		},
 	),
 	"crdb_internal.validate_multi_region_zone_configs": makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
@@ -6369,7 +6378,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		},
 	),
 	"crdb_internal.reset_multi_region_zone_configs_for_table": makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
@@ -6391,7 +6403,10 @@ table.`,
 		},
 	),
 	"crdb_internal.reset_multi_region_zone_configs_for_database": makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"id", types.Int}},
 			ReturnType: tree.FixedReturnType(types.Bool),
@@ -6413,7 +6428,10 @@ enabled.`,
 		},
 	),
 	"crdb_internal.filter_multiregion_fields_from_zone_config_sql": makeBuiltin(
-		tree.FunctionProperties{Category: categoryMultiRegion},
+		tree.FunctionProperties{
+			Category:         categoryMultiRegion,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		stringOverload1(
 			func(evalCtx *tree.EvalContext, s string) (tree.Datum, error) {
 				stmt, err := parser.ParseOne(s)


### PR DESCRIPTION
Backport 1/1 commits from #84653.

/cc @cockroachdb/release

---

These functions in some cases look at the gateway region and in others actually
perform schema changes. These operations must not be executed in parallel.

Fixes #80023
Fixes: #86728.

Release justification: bug fix.

Release note: None
