### PR TITLE
release-22.1: colexecdisk: extend allowed range for memory usage in a test

### DIFF
--- a/pkg/sql/colexec/external_sort_test.go
+++ b/pkg/sql/colexec/external_sort_test.go
@@ -345,7 +345,7 @@ func TestExternalSortMemoryAccounting(t *testing.T) {
 	}
 	// We cannot guarantee a fixed value, so we use an allowed range.
 	expMin := memoryLimit
-	expMax := int64(float64(memoryLimit) * 1.6)
+	expMax := int64(float64(memoryLimit) * 1.8)
 	require.GreaterOrEqualf(t, totalMaxMemUsage, expMin, "minimum memory bound not satisfied: "+
 		"actual %d, expected min %d", totalMaxMemUsage, expMin)
 	require.GreaterOrEqualf(t, expMax, totalMaxMemUsage, "maximum memory bound not satisfied: "+


### PR DESCRIPTION
Backport 1/1 commits from #86765.

/cc @cockroachdb/release

---

Recently merged a532aac0beb15cfe496f92d8e717d7cc51aec294 added more
precise accounting when an operator spills to disk, so we need to extend
the allowed range for the memory usage in
`TestExternalSortMemoryAccounting` since we now account for more things.

Fixes: #86716.

Release justification: test-only change.

Release note: None
