### PR TITLE
ui: custom sql box height

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -18,7 +18,7 @@ import "antd/lib/row/style";
 import moment from "moment";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
-import { SqlBox } from "src/sql";
+import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { Duration } from "src/util";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
@@ -131,10 +131,10 @@ export class InsightDetails extends React.Component<InsightDetailsProps> {
     ];
     return (
       <>
-        <section>
+        <section className={tableCx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={insightQueries} />
+              <SqlBox value={insightQueries} size={SqlBoxSize.custom} />
             </Col>
           </Row>
           <Row gutter={24}>
@@ -163,7 +163,7 @@ export class InsightDetails extends React.Component<InsightDetailsProps> {
             <InsightsSortedTable columns={insightsColumns} data={tableData} />
           </Row>
         </section>
-        <section>
+        <section className={tableCx("section")}>
           <WaitTimeInsightsPanel
             execType={insightDetails.execType}
             executionID={insightDetails.executionID}

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -23,3 +23,8 @@
 .margin-bottom-large {
   margin-bottom: 30px;
 }
+
+.section {
+  flex: 0 0 auto;
+  padding: 12px 24px 12px 0px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -19,7 +19,7 @@ import { RouteComponentProps } from "react-router-dom";
 import { JobRequest, JobResponse } from "src/api/jobsApi";
 import { Button } from "src/button";
 import { Loading } from "src/loading";
-import { SqlBox } from "src/sql";
+import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import { TimestampToMoment } from "src/util";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
@@ -82,7 +82,7 @@ export class JobDetails extends React.Component<JobDetailsProps> {
       <>
         <Row gutter={24}>
           <Col className="gutter-row" span={24}>
-            <SqlBox value={job.description} />
+            <SqlBox value={job.description} size={SqlBoxSize.custom} />
           </Col>
         </Row>
         <Row gutter={24}>

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -40,7 +40,7 @@ import TerminateQueryModal, {
 import { Button } from "../button";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { Text, TextTypes } from "../text";
-import { SqlBox } from "src/sql/box";
+import { SqlBox, SqlBoxSize } from "src/sql/box";
 import { NodeLink } from "src/statementsTable/statementsTableContent";
 
 import {
@@ -308,7 +308,7 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
       const stmt = session.active_queries[0];
       curStmtInfo = (
         <React.Fragment>
-          <SqlBox value={stmt.sql} />
+          <SqlBox value={stmt.sql} size={SqlBoxSize.custom} />
           <SummaryCard className={cx("details-section")}>
             <Row>
               <Col className="gutter-row" span={10}>

--- a/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/box.tsx
@@ -18,6 +18,7 @@ import * as protos from "@cockroachlabs/crdb-protobuf-client";
 export enum SqlBoxSize {
   small = "small",
   large = "large",
+  custom = "custom",
 }
 
 export interface SqlBoxProps {

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -58,6 +58,12 @@
   height: 400px;
 }
 
+.custom {
+  min-height: 100px;
+  max-height: 400px;
+  height: auto;
+}
+
 .highlight-divider {
   width: 100%;
   height: 1px;

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/activeStatementDetails.tsx
@@ -30,7 +30,7 @@ import {
 import { StatusIcon } from "src/activeExecutions/statusIcon";
 
 import styles from "./statementDetails.module.scss";
-import { SqlBox } from "src/sql/box";
+import { SqlBox, SqlBoxSize } from "src/sql/box";
 import { WaitTimeInsightsPanel } from "src/detailsPanels/waitTimeInsightsPanel";
 const cx = classNames.bind(styles);
 const summaryCardStylesCx = classNames.bind(summaryCardStyles);
@@ -90,7 +90,10 @@ export const ActiveStatementDetails: React.FC<ActiveStatementDetailsProps> = ({
       <section className={cx("section", "section--container")}>
         <Row gutter={24}>
           <Col className="gutter-row" span={24}>
-            <SqlBox value={statement?.query || "SQL Execution not found."} />
+            <SqlBox
+              value={statement?.query || "SQL Execution not found."}
+              size={SqlBoxSize.custom}
+            />
           </Col>
         </Row>
         {statement && (

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -136,7 +136,7 @@ function ExplainPlan({
       >
         All Plans
       </Button>
-      <SqlBox value={explainPlan} size={SqlBoxSize.large} />
+      <SqlBox value={explainPlan} size={SqlBoxSize.custom} />
       {hasInsights && (
         <Insights
           idxRecommendations={plan.stats.index_recommendations}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -446,7 +446,7 @@ export class StatementDetails extends React.Component<
             <Col className="gutter-row" span={24}>
               <SqlBox
                 value={this.props.latestFormattedQuery}
-                size={SqlBoxSize.small}
+                size={SqlBoxSize.custom}
               />
             </Col>
           </Row>
@@ -578,7 +578,7 @@ export class StatementDetails extends React.Component<
             <Col className="gutter-row" span={24}>
               <SqlBox
                 value={this.props.latestFormattedQuery}
-                size={SqlBoxSize.small}
+                size={SqlBoxSize.custom}
               />
             </Col>
           </Row>
@@ -712,7 +712,7 @@ export class StatementDetails extends React.Component<
         <section className={cx("section")}>
           <Row gutter={24}>
             <Col className="gutter-row" span={24}>
-              <SqlBox value={formatted_query} size={SqlBoxSize.small} />
+              <SqlBox value={formatted_query} size={SqlBoxSize.custom} />
             </Col>
           </Row>
           <p className={summaryCardStylesCx("summary--card__divider")} />

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
@@ -18,7 +18,7 @@ import Helmet from "react-helmet";
 import { Link, match, useHistory } from "react-router-dom";
 import { Button } from "src/button";
 import { commonStyles } from "src/common";
-import { SqlBox } from "src/sql/box";
+import { SqlBox, SqlBoxSize } from "src/sql/box";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 
 import {
@@ -111,6 +111,7 @@ export const ActiveTransactionDetails: React.FC<
           <Col className="gutter-row" span={24}>
             <SqlBox
               value={transaction?.query || RECENT_STATEMENT_NOT_FOUND_MESSAGE}
+              size={SqlBoxSize.custom}
             />
           </Col>
         </Row>


### PR DESCRIPTION
Creating new custom SQL Box height, to use when text is
small. Creating less empty space.

PArtially addresses #85229

https://www.loom.com/share/9b20d616d8e54e4ea4275ce40ad2a9d1

Release justification: low risk change
Release note (ui change): Changing the height of SQL Box
usage on Session Details, Active Transaction Details, Job Details
and Active Statement Details.