### PR TITLE
insights: report high contention time

### DIFF
--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -30,7 +30,7 @@ enum Problem {
   SuboptimalPlan = 2;
 
   // This statement was slow because of contention.
-  HighWaitTime = 3;
+  HighContentionTime = 3;
 
   // This statement was slow because of being retried multiple times, again due
   // to contention. The "high" threshold may be configured by the

--- a/pkg/sql/sqlstats/insights/problems.go
+++ b/pkg/sql/sqlstats/insights/problems.go
@@ -21,6 +21,10 @@ func (p *problems) examine(stmt *Statement) (result []Problem) {
 		result = append(result, Problem_SuboptimalPlan)
 	}
 
+	if stmt.Contention != nil && *stmt.Contention >= LatencyThreshold.Get(&p.st.SV) {
+		result = append(result, Problem_HighContentionTime)
+	}
+
 	if stmt.Retries >= HighRetryCountThreshold.Get(&p.st.SV) {
 		result = append(result, Problem_HighRetryCount)
 	}


### PR DESCRIPTION
This change aims to align with the logic for selecting transactions with
"high contention time"[^1] in the transaction insights UI, but in practice,
it's a best effort:

Because of the sampling nature of tracing and because a transaction with
"high" contention may be composed of many statements, each with only a
little contention, there's not a guarantee that a highly contented
transaction will be composed of highly contended statements.

But, on balance, the best effort is still valuable, and we will call out
actionable statements with high contention.

[^1]: Note that the protobuf enum name change is safe here as we haven't
  yet deployed this code.

Release justification: Category 2: Bug fixes and low-risk updates to new
functionality.

Release note: None