### PR TITLE
backupccl: add planning validation to ALTER BACKUP SCHEDULE, emit results

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -147,6 +147,7 @@ go_test(
     name = "backupccl_test",
     size = "enormous",
     srcs = [
+        "alter_backup_schedule_test.go",
         "alter_backup_test.go",
         "backup_cloud_test.go",
         "backup_intents_test.go",

--- a/pkg/ccl/backupccl/alter_backup_schedule_test.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule_test.go
@@ -1,0 +1,144 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package backupccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobstest"
+	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// alterSchedulesTestHelper starts a server, and arranges for job scheduling daemon to
+// use jobstest.JobSchedulerTestEnv.
+// This helper also arranges for the manual override of scheduling logic
+// via executeSchedules callback.
+type execAlterSchedulesFn = func(ctx context.Context, maxSchedules int64) error
+type alterSchedulesTestHelper struct {
+	iodir            string
+	server           serverutils.TestServerInterface
+	env              *jobstest.JobSchedulerTestEnv
+	cfg              *scheduledjobs.JobExecutionConfig
+	sqlDB            *sqlutils.SQLRunner
+	executeSchedules func() error
+}
+
+// newAlterSchedulesTestHelper creates and initializes appropriate state for a test,
+// returning alterSchedulesTestHelper as well as a cleanup function.
+func newAlterSchedulesTestHelper(t *testing.T) (*alterSchedulesTestHelper, func()) {
+	dir, dirCleanupFn := testutils.TempDir(t)
+
+	th := &alterSchedulesTestHelper{
+		env: jobstest.NewJobSchedulerTestEnv(
+			jobstest.UseSystemTables, timeutil.Now(), tree.ScheduledBackupExecutor),
+		iodir: dir,
+	}
+
+	knobs := &jobs.TestingKnobs{
+		JobSchedulerEnv: th.env,
+		TakeOverJobsScheduling: func(fn execAlterSchedulesFn) {
+			th.executeSchedules = func() error {
+				defer th.server.JobRegistry().(*jobs.Registry).TestingNudgeAdoptionQueue()
+				return fn(context.Background(), allSchedules)
+			}
+		},
+		CaptureJobExecutionConfig: func(config *scheduledjobs.JobExecutionConfig) {
+			th.cfg = config
+		},
+		IntervalOverrides: jobs.NewTestingKnobsWithShortIntervals().IntervalOverrides,
+	}
+
+	args := base.TestServerArgs{
+		ExternalIODir: dir,
+		// Some scheduled backup tests fail when run within a tenant. More
+		// investigation is required. Tracked with #76378.
+		DisableDefaultTestTenant: true,
+		Knobs: base.TestingKnobs{
+			JobsTestingKnobs: knobs,
+		},
+	}
+	s, db, _ := serverutils.StartServer(t, args)
+	require.NotNil(t, th.cfg)
+	th.sqlDB = sqlutils.MakeSQLRunner(db)
+	th.server = s
+	th.sqlDB.Exec(t, `SET CLUSTER SETTING bulkio.backup.merge_file_buffer_size = '1MiB'`)
+	th.sqlDB.Exec(t, `SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`) // speeds up test
+
+	return th, func() {
+		dirCleanupFn()
+		s.Stopper().Stop(context.Background())
+	}
+}
+
+func TestAlterBackupScheduleEmitsSummary(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	th, cleanup := newAlterSchedulesTestHelper(t)
+	defer cleanup()
+
+	th.sqlDB.Exec(t, `
+CREATE DATABASE mydb;
+USE mydb;
+
+CREATE TABLE t1(a int);
+INSERT INTO t1 values (1), (10), (100);
+`)
+
+	rows := th.sqlDB.Query(t,
+		`CREATE SCHEDULE FOR BACKUP t1 INTO 'nodelocal://0/backup/alter-schedule' RECURRING '@daily';`)
+	require.NoError(t, rows.Err())
+
+	var scheduleID int64
+	var unusedStr string
+	var unusedTS *time.Time
+	rowCount := 0
+	for rows.Next() {
+		// We just need to retrieve one of the schedule IDs, don't care whether
+		// it's the incremental or full.
+		require.NoError(t, rows.Scan(&scheduleID, &unusedStr, &unusedStr, &unusedTS, &unusedStr, &unusedStr))
+		rowCount++
+	}
+	require.Equal(t, 2, rowCount)
+
+	var status, schedule, backupStmt string
+	var statuses, schedules, backupStmts []string
+	rows = th.sqlDB.Query(t,
+		fmt.Sprintf(`ALTER BACKUP SCHEDULE %d SET FULL BACKUP '@weekly';`, scheduleID))
+	require.NoError(t, rows.Err())
+	for rows.Next() {
+		require.NoError(t, rows.Scan(&scheduleID, &unusedStr, &status, &unusedTS, &schedule, &backupStmt))
+		statuses = append(statuses, status)
+		schedules = append(schedules, schedule)
+		backupStmts = append(backupStmts, backupStmt)
+	}
+
+	// Incremental should be emitted first.
+	require.Equal(t, []string{"PAUSED: Waiting for initial backup to complete", "ACTIVE"}, statuses)
+	require.Equal(t, []string{"@daily", "@weekly"}, schedules)
+	require.Equal(t, []string{
+		"BACKUP TABLE mydb.public.t1 INTO LATEST IN 'nodelocal://0/backup/alter-schedule' WITH detached",
+		"BACKUP TABLE mydb.public.t1 INTO 'nodelocal://0/backup/alter-schedule' WITH detached",
+	},
+		backupStmts)
+
+}

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -224,9 +224,10 @@ func GetRedactedBackupNode(
 	hasBeenPlanned bool,
 ) (*tree.Backup, error) {
 	b := &tree.Backup{
-		AsOf:    backup.AsOf,
-		Targets: backup.Targets,
-		Nested:  backup.Nested,
+		AsOf:           backup.AsOf,
+		Targets:        backup.Targets,
+		Nested:         backup.Nested,
+		AppendToLatest: backup.AppendToLatest,
 	}
 
 	// We set Subdir to the directory resolved during BACKUP planning.

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/backup-options
@@ -19,15 +19,15 @@ $incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached"
 
 # Can't use the same command twice.
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(can specify SET RECURRING at most once)
 alter backup schedule $fullID set recurring '0 0 1 * *', set recurring '@weekly';
 ----
-ignoring expected error
+regex matches error
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(can specify SET FULL BACKUP at most once)
 alter backup schedule $fullID set full backup '0 0 1 * *', set recurring '0 0 1 * *', set full backup '@weekly';
 ----
-ignoring expected error
+regex matches error
 
 # Set an option
 
@@ -53,22 +53,30 @@ with schedules as (show schedules) select id, command->'backup_statement' from s
 $fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
 $incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached"
 
+# Add an incompatible option
+
+exec-sql expect-error-regex=(cannot have both encryption_passphrase and kms option set)
+alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///key2?region=r2'), set with incremental_location = 'inc';
+----
+regex matches error
+
 # Add a list-option
 
 exec-sql
+alter backup schedule $incID set with encryption_passphrase = '';
 alter backup schedule $incID set with kms = ('aws:///key1?region=r1', 'aws:///key2?region=r2'), set with incremental_location = 'inc';
 ----
 
 query-sql
 with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;
 ----
-$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
-$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, encryption_passphrase = '*****', detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
+$fullID "BACKUP INTO 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
+$incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_history = true, detached, kms = ('aws:///redacted?region=r1', 'aws:///redacted?region=r2'), incremental_location = 'inc'"
 
 # Set options to empty (unset).
 
 exec-sql
-alter backup schedule $incID set with kms = '', set with incremental_location = (''), set with encryption_passphrase = '';
+alter backup schedule $incID set with kms = '', set with incremental_location = ('');
 ----
 
 query-sql
@@ -79,15 +87,15 @@ $incID "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH revision_his
 
 # Setting DETACHED throws an error.
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(DETACHED is required for scheduled backups and cannot be altered)
 alter backup schedule $incID set with detached = true;
 ----
-ignoring expected error
+regex matches error
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(DETACHED is required for scheduled backups and cannot be altered)
 alter backup schedule $incID set with detached = false;
 ----
-ignoring expected error
+regex matches error
 
 query-sql
 with schedules as (show schedules) select id, command->'backup_statement' from schedules where label='datatest' order by command->>'backup_type' asc;

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/recurrence
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/recurrence
@@ -177,10 +177,10 @@ $incID Waiting for initial backup to complete @weekly root {"backup_statement": 
 
 # Can't set incremental schedule to be slower than full.
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(incremental backups must occur more often than full backups)
 alter backup schedule $fullID set recurring '@weekly', set full backup '@daily';
 ----
-ignoring expected error
+regex matches error
 
 # Remove incremental backup and change full cadence in the same command.
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/schedule-options
@@ -51,10 +51,10 @@ alter backup schedule $fullID set schedule option updates_cluster_last_backup_ti
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 't';
 ----
 
-exec-sql expect-error-ignore
+exec-sql expect-error-regex=(unexpected value)
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = 'yeah for sure true';
 ----
-ignoring expected error
+regex matches error
 
 exec-sql
 create user testuser;
@@ -74,8 +74,8 @@ let $fullID $incID
 with schedules as (show schedules) select id from schedules where label='datatest3' order by command->>'backup_type' asc;
 ----
 
-exec-sql user=testuser expect-error-ignore
+exec-sql user=testuser expect-error-regex=(only users with the admin role are allowed to updates_cluster_last_backup_time_metric)
 alter backup schedule $fullID set schedule option updates_cluster_last_backup_time_metric = '1';
 ----
-ignoring expected error
+regex matches error
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
+++ b/pkg/ccl/backupccl/testdata/backup-restore/lock-concurrent-backups
@@ -99,7 +99,7 @@ BACKUP TO 'userfile://defaultdb.public.baz/baz';
 ----
 job paused at pausepoint
 
-exec-sql expect-error-regex='userfile://defaultdb.public.baz/baz already contains a `BACKUP-LOCK`'
+exec-sql expect-error-regex=(userfile://defaultdb.public.baz/baz already contains a `BACKUP-LOCK`)
 BACKUP TO 'userfile://defaultdb.public.baz/baz';
 ----
 regex matches error

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
@@ -170,7 +170,7 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with sch
 
 # But verify-backup-table-data catches it
 # TODO(msbutler): refactor the test once this is addressed
-exec-sql expect-error-regex='pebble/table: invalid table 000000'
+exec-sql expect-error-regex=(pebble/table: invalid table 000000)
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, verify_backup_table_data, new_db_name='d4';
 ----
 regex matches error


### PR DESCRIPTION
Release note (enterprise change): Alter Backup Schedule will fail if the new backup statement does not pass planning.

Release justification: Improving reliability on feature launching for 22.2.