### PR TITLE
ui: update tooltip of table sizes

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseDetailsPage/databaseDetailsPage.tsx
@@ -307,7 +307,7 @@ export class DatabaseDetailsPage extends React.Component<
         title: (
           <Tooltip
             placement="bottom"
-            title="The approximate total disk size across all replicas of the table."
+            title="The approximate compressed total disk size across all replicas of the table."
           >
             Replication Size
           </Tooltip>
@@ -396,7 +396,7 @@ export class DatabaseDetailsPage extends React.Component<
             placement="bottom"
             title={
               <div className={cx("tooltip__table--title")}>
-                {"% of total logical data that has not been modified (updated or deleted). " +
+                {"% of total uncompressed logical data that has not been modified (updated or deleted). " +
                   "A low percentage can cause statements to scan more data ("}
                 <Anchor href={mvccGarbage} target="_blank">
                   MVCC values


### PR DESCRIPTION
This commit updates the tooltip on Table to
clarify the replication size is compressed data and
the live data is uncompressed data.

<img width="349" alt="Screen Shot 2022-08-24 at 5 52 53 PM" src="https://user-images.githubusercontent.com/1017486/186530300-97b09dcf-d92b-4f19-bed0-385724cf964e.png">

<img width="364" alt="Screen Shot 2022-08-24 at 5 52 58 PM" src="https://user-images.githubusercontent.com/1017486/186530308-2a1be95c-7248-4671-8d5b-67f0ba28bea6.png">


Release justification: low risk change
Release note (ui change): Add clarification of
compression to tooltip of table size.