### PR TITLE
opt: reduce allocations in extracting join condition columns

### DIFF
--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -832,11 +832,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	on := join.Child(2).(*memo.FiltersExpr)
 	leftCols := join.Child(0).(memo.RelExpr).Relational().OutputCols
 	rightCols := join.Child(1).(memo.RelExpr).Relational().OutputCols
-	var filtersToSkip util.FastIntSet
-	_, _, toSkip := memo.ExtractJoinEqualityColumns(leftCols, rightCols, *on)
-	for _, idx := range toSkip {
-		filtersToSkip.Add(idx)
-	}
+	filtersToSkip := memo.ExtractJoinEqualityFilterOrds(leftCols, rightCols, *on)
 	filterSetup, filterPerRow := c.computeFiltersCost(*on, filtersToSkip)
 	cost += filterSetup
 

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -329,7 +329,7 @@ func canGenerateLookupJoins(
 	if joinFlags.Has(memo.DisallowLookupJoinIntoRight) {
 		return false
 	}
-	if leftEq, _, _ := memo.ExtractJoinEqualityColumns(leftCols, rightCols, on); len(leftEq) > 0 {
+	if memo.HasJoinEqualityFilters(leftCols, rightCols, on) {
 		// There is at least one valid equality between left and right columns.
 		return true
 	}
@@ -339,8 +339,7 @@ func canGenerateLookupJoins(
 	// when the input has one row, or if a lookup join is forced.
 	if input.Relational().Cardinality.IsZeroOrOne() ||
 		joinFlags.Has(memo.AllowOnlyLookupJoinIntoRight) {
-		cmp, _, _ := memo.ExtractJoinConditionColumns(leftCols, rightCols, on, true /* inequality */)
-		return len(cmp) > 0
+		return memo.HasJoinInequalityFilters(leftCols, rightCols, on)
 	}
 	return false
 }


### PR DESCRIPTION
This reduces total allocations for some of the slow queries benchmarks.

```
name                         old time/op    new time/op    delta
SlowQueries/slow-query-1-24    29.0ms ± 0%    28.7ms ± 1%  -1.17%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-24     414ms ± 1%     411ms ± 1%    ~     (p=0.095 n=5+5)
SlowQueries/slow-query-3-24    79.1ms ± 1%    78.6ms ± 0%    ~     (p=0.222 n=5+5)

name                         old alloc/op   new alloc/op   delta
SlowQueries/slow-query-1-24    12.1MB ± 0%    12.0MB ± 0%  -1.34%  (p=0.016 n=5+4)
SlowQueries/slow-query-2-24     155MB ± 0%     154MB ± 0%  -0.65%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-24    47.4MB ± 0%    47.4MB ± 0%  -0.01%  (p=0.008 n=5+5)

name                         old allocs/op  new allocs/op  delta
SlowQueries/slow-query-1-24      129k ± 0%      118k ± 0%  -9.02%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-24     1.24M ± 0%     1.18M ± 0%  -5.05%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-24      359k ± 0%      359k ± 0%  -0.06%  (p=0.008 n=5+5)
```

Release justification: This is a low-risk change that improves
performance.

Release note: None