### PR TITLE
kv/kvserver/tenantrate: skip TestCloser

### DIFF
--- a/pkg/kv/kvserver/tenantrate/BUILD.bazel
+++ b/pkg/kv/kvserver/tenantrate/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/metrictestutils",
+        "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/metric",
         "//pkg/util/timeutil",

--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/metrictestutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -38,6 +39,7 @@ import (
 
 func TestCloser(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 86822, "flaky test")
 
 	st := cluster.MakeTestingClusterSettings()
 	start := timeutil.Now()


### PR DESCRIPTION
Refs: #86822

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes
Release note: None