### PR TITLE
linter: add synchronization detection to loopvarcapture

### DIFF
--- a/pkg/cmd/github-pull-request-make/main.go
+++ b/pkg/cmd/github-pull-request-make/main.go
@@ -292,7 +292,9 @@ func main() {
 				// to strip out the unnecessary calls to `bazel`, but that might
 				// better be saved for when we no longer need `make` support and
 				// don't have to worry about accidentally breaking it.
-				out, err := exec.Command("bazel", "query", fmt.Sprintf("kind(go_test, //%s:all)", name), "--output=label").Output()
+				queryArgs := []string{"query", fmt.Sprintf("kind(go_test, //%s:all)", name), "--output=label"}
+				log.Printf("bazel query: %v", queryArgs)
+				out, err := exec.Command("bazel", queryArgs...).Output()
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/pkg/testutils/lint/passes/loopvarcapture/loop.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loop.go
@@ -18,8 +18,9 @@ import (
 // Loop abstracts away the type of loop (`for` loop with index
 // variable vs `range` loops)
 type Loop struct {
-	Vars []*ast.Ident
-	Body *ast.BlockStmt
+	Vars      []*ast.Ident
+	RangeExpr ast.Expr
+	Body      *ast.BlockStmt
 }
 
 // NewLoop creates a new Loop struct according to the node passed. If
@@ -60,7 +61,7 @@ func newForLoop(stmt *ast.ForStmt) *Loop {
 }
 
 func newRange(stmt *ast.RangeStmt) *Loop {
-	loop := Loop{Body: stmt.Body}
+	loop := Loop{Body: stmt.Body, RangeExpr: stmt.X}
 	loop.addVar(stmt.Key)
 	loop.addVar(stmt.Value)
 

--- a/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
@@ -77,10 +77,12 @@ var (
 	}
 
 	// function definitions that wrap `go` calls
-	errgroupGo    = Function{Pkg: "golang.org/x/sync/errgroup", Type: "Group", Name: "Go"}
-	ctxgroupGo    = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/ctxgroup", Type: "Group", Name: "Go"}
-	ctxgroupGoCtx = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/ctxgroup", Type: "Group", Name: "GoCtx"}
-	monitorGo     = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster", Type: "Monitor", Name: "Go"}
+	errgroupGo         = Function{Pkg: "golang.org/x/sync/errgroup", Type: "Group", Name: "Go"}
+	ctxgroupGo         = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/ctxgroup", Type: "Group", Name: "Go"}
+	ctxgroupGoCtx      = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/ctxgroup", Type: "Group", Name: "GoCtx"}
+	monitorGo          = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster", Type: "Monitor", Name: "Go"}
+	stopperAsyncTask   = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/stop", Type: "Stopper", Name: "RunAsyncTask"}
+	stopperAsyncTaskEx = Function{Pkg: "github.com/cockroachdb/cockroach/pkg/util/stop", Type: "Stopper", Name: "RunAsyncTaskEx"}
 
 	// GoRoutineFunctions is a collection of `go` wrappers that are
 	// known to take closures as parameters and invoke them
@@ -93,6 +95,8 @@ var (
 		{Func: ctxgroupGo, WaitFuncName: "Wait"},
 		{Func: ctxgroupGoCtx, WaitFuncName: "Wait"},
 		{Func: monitorGo, WaitFuncName: "Wait"},
+		{Func: stopperAsyncTask},
+		{Func: stopperAsyncTaskEx},
 	}
 
 	// test-related function locations. We are interested in calls to

--- a/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture.go
@@ -321,26 +321,28 @@ func (v *Visitor) runOnStatementBlock(block *ast.BlockStmt) {
 // waits for the go routines to finish:
 //
 // 1:
-//     for k, v := range myMap {
-//         var wg sync.WaitGroup
-//         // same for `defer`, errgroup.Group.Go(), etc
-//         go func() {
-//            defer wg.Done()
-//            fmt.Printf("k = %v, v = %v\n", k, v)
-//         }()
-//         wg.Wait() // loop variable will not change until Go routine is finished
-//     }
+//
+//	for k, v := range myMap {
+//	    var wg sync.WaitGroup
+//	    // same for `defer`, errgroup.Group.Go(), etc
+//	    go func() {
+//	       defer wg.Done()
+//	       fmt.Printf("k = %v, v = %v\n", k, v)
+//	    }()
+//	    wg.Wait() // loop variable will not change until Go routine is finished
+//	}
 //
 // 2:
-//     for k, v := range myMap {
-//         ch := make(chan error)
-//         // same for `defer`, errgroup.Group.Go(), etc
-//         go func() {
-//            defer close(ch)
-//            fmt.Printf("k = %v, v = %v\n", k, v)
-//         }()
-//         <-ch // loop variable will not change until Go routine is finished
-//     }
+//
+//	for k, v := range myMap {
+//	    ch := make(chan error)
+//	    // same for `defer`, errgroup.Group.Go(), etc
+//	    go func() {
+//	       defer close(ch)
+//	       fmt.Printf("k = %v, v = %v\n", k, v)
+//	    }()
+//	    <-ch // loop variable will not change until Go routine is finished
+//	}
 //
 // If a `go` routine (or `defer`) calls a previously-defined closure
 // that captures a loop variable, that is also reported.
@@ -586,10 +588,10 @@ type positionedIdent struct {
 
 // visitFuncLit inspects a closure's body. This function returns:
 //
-// 1. A collection of references to loop variables present in the closure.
-// 2. A collection of objects that could be used to wait for the Go
-//    routine to finish (synchronization objects). These could be wait
-//    groups, channels, etc.
+//  1. A collection of references to loop variables present in the closure.
+//  2. A collection of objects that could be used to wait for the Go
+//     routine to finish (synchronization objects). These could be wait
+//     groups, channels, etc.
 func (v *Visitor) visitFuncLit(funcLit *ast.FuncLit) ([]positionedIdent, []positionedIdent) {
 	var refs, syncObjs []positionedIdent
 
@@ -940,9 +942,12 @@ func (v *Visitor) isLoopVar(ident *ast.Ident) bool {
 // type of `obj`.
 //
 // In other words, it will return `true` for calls of
-//     func (t *T) F() { ... }
+//
+//	func (t *T) F() { ... }
+//
 // and `false` for calls of
-//     func (t T) F() {...}
+//
+//	func (t T) F() {...}
 //
 // Note that this function *assumes*, for simplicity, that the call
 // expression given is already of the form `obj.Foo()`. Ensuring that

--- a/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture_test.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture_test.go
@@ -20,10 +20,28 @@ import (
 	"golang.org/x/tools/go/analysis/analysistest"
 )
 
-var extraGoRoutineFunctions = []loopvarcapture.Function{
-	{Pkg: "example.org/concurrency", Type: "Group", Name: "Go"}, // test non-pointer receiver
-	{Pkg: "example.org/concurrency", Name: "Go"},                // test a package-level function
-	{Pkg: "example.org/concurrency", Name: "GoWithError"},       // test a function with a return value
+var extraGoRoutineFunctions = []loopvarcapture.GoWrapper{
+	{
+		// test non-pointer receiver
+		Func: loopvarcapture.Function{
+			Pkg: "example.org/concurrency", Type: "Group", Name: "Go",
+		},
+		WaitFuncName: "Wait",
+	},
+	{
+		// test a package-level function
+		Func: loopvarcapture.Function{
+			Pkg: "example.org/concurrency", Name: "Go",
+		},
+		WaitFuncName: "Wait1",
+	},
+	{
+		// test a function with a return value
+		Func: loopvarcapture.Function{
+			Pkg: "example.org/concurrency", Name: "GoWithError",
+		},
+		WaitFuncName: "Await",
+	},
 }
 
 func init() {

--- a/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture_test.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/loopvarcapture_test.go
@@ -53,17 +53,11 @@ func init() {
 func TestAnalyzer(t *testing.T) {
 	skip.UnderStress(t)
 
-	// The test fails unless RunDespiteErrors is set to true.
-	// This is not fully understood, something to do with missing metadata
-	// for the "C" pseudo-package.
-	// See comments on #84867 and https://github.com/golang/go/issues/36547.
-	testAnalyzer := *loopvarcapture.Analyzer
-	testAnalyzer.RunDespiteErrors = true
 	originalGoRoutineFunctions := loopvarcapture.GoRoutineFunctions
 	loopvarcapture.GoRoutineFunctions = append(originalGoRoutineFunctions, extraGoRoutineFunctions...)
 	defer func() { loopvarcapture.GoRoutineFunctions = originalGoRoutineFunctions }()
 
 	testdata := testutils.TestDataPath(t)
 	analysistest.TestData = func() string { return testdata }
-	analysistest.Run(t, testdata, &testAnalyzer, "p")
+	analysistest.Run(t, testdata, loopvarcapture.Analyzer, "p")
 }

--- a/pkg/testutils/lint/passes/loopvarcapture/testdata/src/example.org/concurrency/concurrency.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/testdata/src/example.org/concurrency/concurrency.go
@@ -21,9 +21,13 @@ func (g Group) Go(f func()) {
 	go f()
 }
 
+func (g Group) Wait() {}
+
 func Go(f func()) {
 	go f()
 }
+
+func Wait1() {}
 
 func GoWithError(f func()) error {
 	if rand.Float64() < 0.5 {
@@ -33,6 +37,8 @@ func GoWithError(f func()) error {
 	go f()
 	return nil
 }
+
+func Await() {}
 
 func SafeFunction(f func()) {
 	f()

--- a/pkg/testutils/lint/passes/loopvarcapture/testdata/src/golang.org/x/sync/errgroup/errgroup.go
+++ b/pkg/testutils/lint/passes/loopvarcapture/testdata/src/golang.org/x/sync/errgroup/errgroup.go
@@ -15,3 +15,5 @@ type Group struct{}
 func (g *Group) Go(f func() error) {
 	go f()
 }
+
+func (g *Group) Wait() {}


### PR DESCRIPTION
This adds a number of improvements to the `loopvarcapture` linter introduced
in #82324. Most of the improvements are related to the linter being more aware
of explicit synchronization the developer has added that makes references to
loop variables in goroutines safe (examples: `sync.WaitGroup`, channels, etc).

Previously, the `loopvarcapture` linter would flag any references to
loop variables found in closures passed to `go` or `defer`
statements. That happened even when the engineer intentionally
referenced the loop variable because extra synchronization would make
sure that a new iteration of the loop would not begin until the Go
routines were finished (by using wait groups, channels, or other
mechanisms). This led to safe code being reported, which can be
frustrating and add noise.

This PR adds the following changes to `loopvarcapture`:

* References synchronized using `sync.WaitGroup` are no longer flagged by the linter
(specifically, this happens if the Go routine calls `wg.Done()` *after* the reference
occurs, and there's a statement in the loop after `go` that calls `Wait()` on the same
wait group). The example below, for instance, is no longer invalid:

```go
for k, v := range coll {
    // ...
    var wg sync.WaitGroup
    // ...
    go func() {
        defer wg.Done()
        // ...
        someFunc(k, v)
        // ...
    }()
    // ...
    wg.Wait()
}
```

* Synchronization using channels is also supported. If the Go routine writes to
or closes a channel that is later read within the loop, the access is considered safe.

* Go-routine wrappers (such as `errgroup`, cockroach's `ctxgroup`, etc) generally
provide a `Wait()` function that blocks until all the goroutines created finish. The linter
is now able to understand these kinds of synchronization as well.

* Referencing a loop variable in the closure passed to `t.Run()` is safe by default (see next
item in this list). Even though the capture happens "by reference", the `Run()` function
will execute the closure immediately and will block until it returns. This means that references
to loop variables in that closure are safe. The semantics of `t.Run()` are now part of
the linter (since this is a very common case).

* Accessing loop variables in `t.Run()` is **not** safe if the test runs in parallel with other tests
(i.e., if there's a call to `t.Parallel()`). In such cases, referencing a loop variable in `t.Run()`is not
safe. The linter now finds invalid references of this kind, and #86488 was found because of that.

* Other invalid uses of loop variables that are now detected by the linter:

```go
func (s *S) Fn() {
    // ...
}

for _, n := range items {
    go fn(&n) // taking the address of a loop variable and passing it to a goroutine

    list := []S{/* ... */}
    for _, s := range list {
        go s.Fn() // will not call `Fn()` on every item in `list`
    }
}
```

Epic: None.

Release note: None.