### PR TITLE
backupccl: prevent full cluster restore in mixed version states

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
@@ -1,0 +1,49 @@
+new-server name=s1 beforeVersion=Start22_2
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foo VALUES (1, 'x'),(2,'y');
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/full_cluster_backup/';
+----
+
+# This is a server where the cluster version is behind the binary version. Such
+# a condition only occurs when the user has upgraded the node to a new major
+# version but has not yet finalized the upgrade.
+new-server name=s2 beforeVersion=Start22_2 share-io-dir=s1
+----
+
+exec-sql expect-error-regex=pq: cluster restore not supported during major version upgrade: restore started at cluster version 22.1 but binary version is.*
+RESTORE FROM LATEST IN 'nodelocal://1/full_cluster_backup/'
+----
+regex matches error
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+----
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/full_cluster_backup/' WITH new_db_name='d2';
+----
+
+query-sql
+SELECT * FROM d2.foo
+----
+1 x
+2 y
+
+exec-sql
+RESTORE TABLE foo FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
+----
+
+query-sql
+SELECT * FROM d.foo
+----
+1 x
+2 y


### PR DESCRIPTION
This checks that the cluster version matches the binary version during
planning and job resumption. Full cluster restores require careful
manipulation of system tables and the system's schema. This check is a
safety net to protect against unforseen classes of errors that could
occur if an upgrade was to overlap with these changes.

Release justification: Low risk change to prevent future failure
cases.

Release Note (ops change): Full cluster restores now fail if an
upgrade may be in progress.