### PR TITLE
ttl: remove unused const expiredRowsPerRange

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_test.go
@@ -420,7 +420,6 @@ func TestRowLevelTTLJobMultipleNodes(t *testing.T) {
 				tableName,
 			)
 			const rowsPerRange = 10
-			const expiredRowsPerRange = rowsPerRange / 2
 			splitPoints := make([]serverutils.SplitPoint, len(splitAts))
 			for i, splitAt := range splitAts {
 				newLeaseHolderIdx := (leaseHolderIdx + 1 + i) % numNodes


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/86838

Release justification: Linter fix.
Release note: None