### PR TITLE
release-22.1: ui: use plan gist instead of plan id

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -74,7 +74,8 @@ function renderExplainPlan(
   backToPlanTable: () => void,
 ): React.ReactElement {
   const explainPlan =
-    plan.explain_plan === "" ? "unavailable" : plan.explain_plan;
+    `Plan Gist: ${plan.stats.plan_gists[0]} \n\n` +
+    (plan.explain_plan === "" ? "unavailable" : plan.explain_plan);
   return (
     <div>
       <Helmet title="Plan Details" />

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -25,13 +25,13 @@ export type PlanHashStats = cockroach.server.serverpb.StatementDetailsResponse.I
 export class PlansSortedTable extends SortedTable<PlanHashStats> {}
 
 const planDetailsColumnLabels = {
-  planID: "Plan ID",
   lastExecTime: "Last Execution Time",
   avgExecTime: "Average Execution Time",
   execCount: "Execution Count",
   avgRowsRead: "Average Rows Read",
   fullScan: "Full Scan",
   distSQL: "Distributed",
+  planGist: "Plan Gist",
   vectorized: "Vectorized",
 };
 export type PlanDetailsTableColumnKeys = keyof typeof planDetailsColumnLabels;
@@ -41,14 +41,14 @@ type PlanDetailsTableTitleType = {
 };
 
 export const planDetailsTableTitles: PlanDetailsTableTitleType = {
-  planID: () => {
+  planGist: () => {
     return (
       <Tooltip
         style="tableTitle"
         placement="bottom"
-        content={"The ID of the Plan."}
+        content={"The Gist of the Explain Plan."}
       >
-        {planDetailsColumnLabels.planID}
+        {planDetailsColumnLabels.planGist}
       </Tooltip>
     );
   },
@@ -138,12 +138,18 @@ export function makeExplainPlanColumns(
   const count = (v: number) => v.toFixed(1);
   return [
     {
-      name: "planID",
-      title: planDetailsTableTitles.planID(),
+      name: "planGist",
+      title: planDetailsTableTitles.planGist(),
       cell: (item: PlanHashStats) => (
-        <a onClick={() => handleDetails(item)}>{longToInt(item.plan_hash)}</a>
+        <Tooltip placement="bottom" content={item.stats.plan_gists[0]}>
+          <a onClick={() => handleDetails(item)}>
+            {item.stats.plan_gists[0].length > 25
+              ? item.stats.plan_gists[0].slice(0, 22).concat("...")
+              : item.stats.plan_gists[0]}
+          </a>
+        </Tooltip>
       ),
-      sort: (item: PlanHashStats) => longToInt(item.plan_hash),
+      sort: (item: PlanHashStats) => item.stats.plan_gists[0],
       alwaysShow: true,
     },
     {


### PR DESCRIPTION
Backport 1/1 commits from #86653.

/cc @cockroachdb/release

---

Previously, we were using plan id on the table
listing plans, but that was hard to link back to stats.
This commit changes to use gist instead.
It also adds the plan gist on the display of the actual
plan.

Fixes #85272
<img width="1600" alt="Screen Shot 2022-08-23 at 8 27 29 AM" src="https://user-images.githubusercontent.com/1017486/186157925-dad1e120-a1f6-4f08-a150-ce18076c625a.png">
<img width="338" alt="Screen Shot 2022-08-23 at 8 27 35 AM" src="https://user-images.githubusercontent.com/1017486/186157939-f4753ee5-2d16-481d-94ce-daf3e7c076c1.png">
<img width="718" alt="Screen Shot 2022-08-23 at 8 27 44 AM" src="https://user-images.githubusercontent.com/1017486/186157949-fe37f1b8-900c-4091-9c6f-453387d78fad.png">



Release justification: low risk, high benefit change
Release note (ui change): Use plan gist instead of
plan ID on plans table inside the Explain Plan tab of Statement
Details. Also add the plan gist as the first line on the actual
Explain Plan display.
