### PR TITLE
release-21.2: colexec: mark some errors as Expected

### DIFF
--- a/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/hash_avg_agg.eg.go
@@ -161,7 +161,7 @@ func (a *avgInt16HashAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -285,7 +285,7 @@ func (a *avgInt32HashAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -409,7 +409,7 @@ func (a *avgInt64HashAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -527,7 +527,7 @@ func (a *avgDecimalHashAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/ordered_avg_agg.eg.go
@@ -120,7 +120,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -162,7 +162,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -206,7 +206,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -246,7 +246,7 @@ func (a *avgInt16OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -297,7 +297,7 @@ func (a *avgInt16OrderedAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -381,7 +381,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -423,7 +423,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -467,7 +467,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -507,7 +507,7 @@ func (a *avgInt32OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -558,7 +558,7 @@ func (a *avgInt32OrderedAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -642,7 +642,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -684,7 +684,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -728,7 +728,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -768,7 +768,7 @@ func (a *avgInt64OrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -819,7 +819,7 @@ func (a *avgInt64OrderedAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -899,7 +899,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -940,7 +940,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -983,7 +983,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -1022,7 +1022,7 @@ func (a *avgDecimalOrderedAgg) Compute(
 
 								a.col[a.curIdx].SetInt64(a.curCount)
 								if _, err := tree.DecimalCtx.Quo(&a.col[a.curIdx], &a.curSum, &a.col[a.curIdx]); err != nil {
-									colexecerror.InternalError(err)
+									colexecerror.ExpectedError(err)
 								}
 							}
 							a.curIdx++
@@ -1072,7 +1072,7 @@ func (a *avgDecimalOrderedAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
+++ b/pkg/sql/colexec/colexecagg/window_avg_agg.eg.go
@@ -161,7 +161,7 @@ func (a *avgInt16WindowAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -344,7 +344,7 @@ func (a *avgInt32WindowAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -527,7 +527,7 @@ func (a *avgInt64WindowAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }
@@ -704,7 +704,7 @@ func (a *avgDecimalWindowAgg) Flush(outputIdx int) {
 
 		a.col[outputIdx].SetInt64(a.curCount)
 		if _, err := tree.DecimalCtx.Quo(&a.col[outputIdx], &a.curSum, &a.col[outputIdx]); err != nil {
-			colexecerror.InternalError(err)
+			colexecerror.ExpectedError(err)
 		}
 	}
 }

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -176,7 +176,7 @@ func (b *SpillingBuffer) AppendTuples(
 	if b.diskQueue == nil {
 		if b.fdSemaphore != nil {
 			if err = b.fdSemaphore.Acquire(ctx, numSpillingBufferFDs); err != nil {
-				colexecerror.InternalError(err)
+				colexecerror.ExpectedError(err)
 			}
 		}
 		if b.diskQueue, err = colcontainer.NewRewindableDiskQueue(

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -434,7 +434,7 @@ func (q *SpillingQueue) maybeSpillToDisk(ctx context.Context) error {
 	// one for the read file.
 	if q.fdSemaphore != nil {
 		if err = q.fdSemaphore.Acquire(ctx, q.numFDsOpenAtAnyGivenTime()); err != nil {
-			return err
+			colexecerror.ExpectedError(err)
 		}
 	}
 	log.VEvent(ctx, 1, "spilled to disk")

--- a/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/avg_agg_gen.go
@@ -64,7 +64,7 @@ func (a avgTmplInfo) AssignDivInt64(targetElem, leftElem, rightElem, _, _, _ str
 		return fmt.Sprintf(`
 			%s.SetInt64(%s)
 			if _, err := tree.DecimalCtx.Quo(&%s, &%s, &%s); err != nil {
-				colexecerror.InternalError(err)
+				colexecerror.ExpectedError(err)
 			}`,
 			targetElem, rightElem, targetElem, leftElem, targetElem,
 		)

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -359,7 +359,7 @@ func (s *externalSorter) Next() coldata.Batch {
 				if !s.testingKnobs.delegateFDAcquisitions && s.fdState.fdSemaphore != nil {
 					toAcquire := s.maxNumberPartitions
 					if err := s.fdState.fdSemaphore.Acquire(s.Ctx, toAcquire); err != nil {
-						colexecerror.InternalError(err)
+						colexecerror.ExpectedError(err)
 					}
 					s.fdState.acquiredFDs = toAcquire
 				}

--- a/pkg/sql/colexec/hash_based_partitioner.go
+++ b/pkg/sql/colexec/hash_based_partitioner.go
@@ -439,7 +439,7 @@ StateChanged:
 			if !op.testingKnobs.delegateFDAcquisitions && op.fdState.acquiredFDs == 0 {
 				toAcquire := op.maxNumberActivePartitions
 				if err := op.fdState.fdSemaphore.Acquire(op.Ctx, toAcquire); err != nil {
-					colexecerror.InternalError(err)
+					colexecerror.ExpectedError(err)
 				}
 				op.fdState.acquiredFDs = toAcquire
 			}


### PR DESCRIPTION
Backport 1/1 commits from #86698.

/cc @cockroachdb/release

---

This commit fixes a couple of oversights where we mistakenly propagated
the errors as "internal" (meaning they would get an assertion failure
annotation and a sentry report):
- an error returned when `Acquire`-ing file descriptors
- an error encountered when performing a decimal division for avg
aggregates.

Fixes: #83059.

Release justification: bug fix.

Release note: None
