### PR TITLE
kvserver: cancel consistency checks more reliably

### DIFF
--- a/pkg/kv/kvserver/api.proto
+++ b/pkg/kv/kvserver/api.proto
@@ -36,15 +36,18 @@ message CollectChecksumRequest {
   bytes checksum_id = 3 [(gogoproto.nullable) = false,
       (gogoproto.customname) = "ChecksumID",
       (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"];
-  bytes checksum = 4;
+  reserved 4;
+  // If true then the response must include the snapshot of the data from which
+  // the checksum is computed.
+  bool with_snapshot = 5;
 }
 
 message CollectChecksumResponse {
   // The checksum is the sha512 hash of the requested computation. It is empty
   // if the computation failed.
   bytes checksum = 1;
-  // snapshot is set if the roachpb.ComputeChecksumRequest had snapshot = true
-  // and the response checksum is different from the request checksum.
+  // snapshot is set if the with_snapshot in CollectChecksumRequest is true. For
+  // example, it can be set by the caller when it has detected an inconsistency.
   //
   // TODO(tschottdorf): with larger ranges, this is no longer tenable.
   // See https://github.com/cockroachdb/cockroach/issues/21128.

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -66,8 +66,9 @@ const consistencyCheckRateMinWait = 100 * time.Millisecond
 // replication factor of 7 could run 7 concurrent checks on every node.
 //
 // Note that checksum calculations below Raft are not tied to the caller's
-// context (especially on followers), and will continue to run even after the
-// caller has given up on them, which may cause them to build up.
+// context, and may continue to run even after the caller has given up on them,
+// which may cause them to build up. Although we do best effort to cancel the
+// running task on the receiving end when the incoming request is aborted.
 //
 // CHECK_STATS checks do not count towards this limit, as they are cheap and the
 // DistSender will parallelize them across all ranges (notably when calling
@@ -76,8 +77,8 @@ const consistencyCheckAsyncConcurrency = 7
 
 // consistencyCheckAsyncTimeout is a below-Raft timeout for asynchronous
 // consistency check calculations. These are not tied to the caller's context,
-// and thus will continue to run even after the caller has given up on them, so
-// we give them an upper timeout to prevent them from running forever.
+// and thus may continue to run even if the caller has given up on them, so we
+// give them an upper timeout to prevent them from running forever.
 const consistencyCheckAsyncTimeout = time.Hour
 
 var testingAggressiveConsistencyChecks = envutil.EnvOrDefaultBool("COCKROACH_CONSISTENCY_AGGRESSIVE", false)

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -552,7 +552,7 @@ type Replica struct {
 		lastUpdateTimes lastUpdateTimesMap
 
 		// Computed checksum at a snapshot UUID.
-		checksums map[uuid.UUID]replicaChecksum
+		checksums map[uuid.UUID]*replicaChecksum
 
 		// proposalQuota is the quota pool maintained by the lease holder where
 		// incoming writes acquire quota from a fixed quota pool before going

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -745,7 +745,6 @@ func (*Replica) sha512(
 }
 
 func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.ComputeChecksum) {
-	stopper := r.store.Stopper()
 	now := timeutil.Now()
 	r.mu.Lock()
 	var notify chan struct{}
@@ -798,7 +797,7 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.Co
 	//
 	// Don't use the proposal's context for this, as it likely to be canceled very
 	// soon.
-	const taskName = "storage.Replica: computing checksum"
+	const taskName = "kvserver.Replica: computing checksum"
 	sem := r.store.consistencySem
 	if cc.Mode == roachpb.ChecksumMode_CHECK_STATS {
 		// Stats-only checks are cheap, and the DistSender parallelizes these across
@@ -806,11 +805,15 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.Co
 		// they don't count towards the semaphore limit.
 		sem = nil
 	}
-	if err := stopper.RunAsyncTaskEx(r.AnnotateCtx(context.Background()), stop.TaskOpts{
+	stopper := r.store.Stopper()
+	taskCtx, taskCancel := stopper.WithCancelOnQuiesce(r.AnnotateCtx(context.Background()))
+	if err := stopper.RunAsyncTaskEx(taskCtx, stop.TaskOpts{
 		TaskName:   taskName,
 		Sem:        sem,
 		WaitForSem: false,
 	}, func(ctx context.Context) {
+		defer taskCancel()
+
 		if err := contextutil.RunWithTimeout(ctx, taskName, consistencyCheckAsyncTimeout,
 			func(ctx context.Context) error {
 				defer snap.Close()
@@ -875,7 +878,8 @@ A file preventing this node from restarting was placed at:
 		}
 
 	}); err != nil {
-		defer snap.Close()
+		taskCancel()
+		snap.Close()
 		log.Errorf(ctx, "could not run async checksum computation (ID = %s): %v", cc.ChecksumID, err)
 		// Set checksum to nil.
 		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -521,9 +521,6 @@ func (r *Replica) checksumWait(
 ) (bool, error) {
 	// Wait
 	select {
-	case <-r.store.Stopper().ShouldQuiesce():
-		return false,
-			errors.Errorf("store quiescing while waiting for compute checksum (ID = %s)", id)
 	case <-ctx.Done():
 		return false,
 			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -439,10 +439,10 @@ func (r *Replica) gcOldChecksumEntriesLocked(now time.Time) {
 	}
 }
 
-// getChecksum waits for the result of ComputeChecksum and returns it.
-// It returns false if there is no checksum being computed for the id,
-// or it has already been GCed.
-func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (replicaChecksum, error) {
+// getChecksum waits for the result of ComputeChecksum and returns it. Returns
+// an error if there is no checksum being computed for the ID, it has already
+// been GC-ed, or an error happened during the computation.
+func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (CollectChecksumResponse, error) {
 	now := timeutil.Now()
 	r.mu.Lock()
 	r.gcOldChecksumEntriesLocked(now)
@@ -462,14 +462,14 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (replicaChecksu
 	// Wait for the checksum to compute or at least to start.
 	computed, err := r.checksumInitialWait(ctx, id, c.notify)
 	if err != nil {
-		return replicaChecksum{}, err
+		return CollectChecksumResponse{}, err
 	}
 	// If the checksum started, but has not completed commit
 	// to waiting the full deadline.
 	if !computed {
 		_, err = r.checksumWait(ctx, id, c.notify, nil)
 		if err != nil {
-			return replicaChecksum{}, err
+			return CollectChecksumResponse{}, err
 		}
 	}
 
@@ -483,9 +483,9 @@ func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (replicaChecksu
 	// The latter case can occur when there's a version mismatch or, more generally,
 	// when the (async) checksum computation fails.
 	if !ok || c.Checksum == nil {
-		return replicaChecksum{}, errors.Errorf("no checksum found (ID = %s)", id)
+		return CollectChecksumResponse{}, errors.Errorf("no checksum found (ID = %s)", id)
 	}
-	return c, nil
+	return c.CollectChecksumResponse, nil
 }
 
 // Waits for the checksum to be available or for the checksum to start computing.

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -744,7 +744,9 @@ func (*Replica) sha512(
 	return &result, nil
 }
 
-func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.ComputeChecksum) {
+func (r *Replica) computeChecksumPostApply(
+	ctx context.Context, cc kvserverpb.ComputeChecksum,
+) error {
 	now := timeutil.Now()
 	r.mu.Lock()
 	var notify chan struct{}
@@ -766,11 +768,9 @@ func (r *Replica) computeChecksumPostApply(ctx context.Context, cc kvserverpb.Co
 	desc := *r.mu.state.Desc
 	r.mu.Unlock()
 
-	if cc.Version != batcheval.ReplicaChecksumVersion {
+	if req, have := cc.Version, uint32(batcheval.ReplicaChecksumVersion); req != have {
 		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
-		log.Infof(ctx, "incompatible ComputeChecksum versions (requested: %d, have: %d)",
-			cc.Version, batcheval.ReplicaChecksumVersion)
-		return
+		return errors.Errorf("incompatible versions (requested: %d, have: %d)", req, have)
 	}
 
 	// Caller is holding raftMu, so an engine snapshot is automatically
@@ -880,8 +880,8 @@ A file preventing this node from restarting was placed at:
 	}); err != nil {
 		taskCancel()
 		snap.Close()
-		log.Errorf(ctx, "could not run async checksum computation (ID = %s): %v", cc.ChecksumID, err)
-		// Set checksum to nil.
 		r.computeChecksumDone(ctx, cc.ChecksumID, nil, nil)
+		return err
 	}
+	return nil
 }

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -69,15 +69,16 @@ var fatalOnStatsMismatch = envutil.EnvOrDefaultBool("COCKROACH_ENFORCE_CONSISTEN
 
 // replicaChecksum contains progress on a replica checksum computation.
 type replicaChecksum struct {
-	CollectChecksumResponse
-	// started is true if the checksum computation has started.
-	started bool
-	// If gcTimestamp is nonzero, GC this checksum after gcTimestamp. gcTimestamp
-	// is zero if and only if the checksum computation is in progress.
+	// started is closed when the checksum computation has started.
+	started chan struct{}
+	// result passes a single checksum computation result from the task.
+	// INVARIANT: result is written to or closed only if started is closed.
+	result chan CollectChecksumResponse
+	// A non-zero gcTimestamp means this tracker is "inactive", i.e. either the
+	// computation task completed/failed, or the checksum collection request
+	// returned. A tracker is deleted from the state when both participants have
+	// learnt about it, or gcTimestamp passes, whichever happens first.
 	gcTimestamp time.Time
-	// This channel is closed after the checksum is computed, and is used
-	// as a notification.
-	notify chan struct{}
 }
 
 // CheckConsistency runs a consistency check on the range. It first applies a
@@ -439,116 +440,103 @@ func (r *Replica) gcOldChecksumEntriesLocked(now time.Time) {
 	}
 }
 
+// getReplicaChecksum returns replicaChecksum tracker for the given ID.
+func (r *Replica) getReplicaChecksum(id uuid.UUID, now time.Time) *replicaChecksum {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.gcOldChecksumEntriesLocked(now)
+	c := r.mu.checksums[id]
+	if c == nil {
+		c = &replicaChecksum{
+			started: make(chan struct{}),
+			result:  make(chan CollectChecksumResponse, 1), // allow an async send
+		}
+		r.mu.checksums[id] = c
+	}
+	return c
+}
+
+// gcReplicaChecksum schedules GC to remove the given replicaChecksum from the
+// state after replicaChecksumGCInterval passes from now, or removes immediately
+// if it is no longer active.
+//
+// Each user of replicaChecksum (at most two during its lifetime: sender and
+// receiver; in any order) must call this method exactly once when they finish
+// working on this tracker.
+//
+// The guarantee: both parties see the same tracker iff neither of them arrives
+// at it (by calling getReplicaChecksum) later than GC timeout past the moment
+// when the other left it (by calling gcReplicaChecksum).
+func (r *Replica) gcReplicaChecksum(id uuid.UUID, rc *replicaChecksum) {
+	// TODO(pavelkalinnikov): Avoid locking, use atomics.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	// If the tracker is inactive (GC is already scheduled) then the counterparty
+	// has abandoned this tracker, and will not come back to it. Remove it then.
+	if !rc.gcTimestamp.IsZero() {
+		delete(r.mu.checksums, id)
+	} else { // otherwise give the counterparty some time to see this tracker
+		rc.gcTimestamp = timeutil.Now().Add(replicaChecksumGCInterval)
+	}
+}
+
 // getChecksum waits for the result of ComputeChecksum and returns it. Returns
 // an error if there is no checksum being computed for the ID, it has already
 // been GC-ed, or an error happened during the computation.
 func (r *Replica) getChecksum(ctx context.Context, id uuid.UUID) (CollectChecksumResponse, error) {
 	now := timeutil.Now()
-	r.mu.Lock()
-	r.gcOldChecksumEntriesLocked(now)
-	c := r.mu.checksums[id]
-	if c == nil {
-		c = &replicaChecksum{notify: make(chan struct{})}
-		// TODO(tbg): we need to unconditionally set a gcTimestamp or this
-		// request can simply get stuck forever or cancel anyway and leak an
-		// entry in r.mu.checksums.
-		if d, dOk := ctx.Deadline(); dOk {
-			c.gcTimestamp = d
-		}
-		r.mu.checksums[id] = c
-	}
-	r.mu.Unlock()
+	c := r.getReplicaChecksum(id, now)
+	defer r.gcReplicaChecksum(id, c)
 
-	// Wait for the checksum to compute or at least to start.
-	computed, err := r.checksumInitialWait(ctx, id, c.notify)
-	if err != nil {
-		return CollectChecksumResponse{}, err
-	}
-	// If the checksum started, but has not completed commit
-	// to waiting the full deadline.
-	if !computed {
-		if _, err = r.checksumWait(ctx, id, c.notify, nil); err != nil {
-			return CollectChecksumResponse{}, err
-		}
-	}
-
-	if log.V(1) {
-		log.Infof(ctx, "waited for compute checksum for %s", timeutil.Since(now))
-	}
-
-	// If the checksum could not be computed, error out. This can occur when the
-	// async checksum computation task fails, e.g. if there is a version mismatch.
-	//
-	// Note: there is only one writer to replicaChecksum.CollectChecksumResponse,
-	// and we have synchronized with it above, so we don't have to lock r.mu here.
-	if c.Checksum == nil {
-		return CollectChecksumResponse{}, errors.Errorf("no checksum found (ID = %s)", id)
-	}
-	return c.CollectChecksumResponse, nil
-}
-
-// Waits for the checksum to be available or for the checksum to start computing.
-// If we waited for 10% of the deadline and it has not started, then it's
-// unlikely to start because this replica is most likely being restored from
-// snapshots.
-func (r *Replica) checksumInitialWait(
-	ctx context.Context, id uuid.UUID, notify chan struct{},
-) (bool, error) {
-	d, dOk := ctx.Deadline()
-	// The max wait time should be 5 seconds, so we dont end up waiting for
-	// minutes for a huge range.
-	maxInitialWait := 5 * time.Second
-	var initialWait <-chan time.Time
-	if dOk {
-		duration := time.Duration(timeutil.Until(d).Nanoseconds() / 10)
-		if duration > maxInitialWait {
-			duration = maxInitialWait
-		}
-		initialWait = time.After(duration)
-	} else {
-		initialWait = time.After(maxInitialWait)
-	}
-	return r.checksumWait(ctx, id, notify, initialWait)
-}
-
-// checksumWait waits for the checksum to be available or for the computation
-// to start  within the initialWait time. The bool return flag is used to
-// indicate if a checksum is available (true) or if the initial wait has expired
-// and the caller should wait more, since the checksum computation started.
-func (r *Replica) checksumWait(
-	ctx context.Context, id uuid.UUID, notify chan struct{}, initialWait <-chan time.Time,
-) (bool, error) {
-	// Wait
+	// Wait for the checksum computation to start.
 	select {
 	case <-ctx.Done():
-		return false,
+		return CollectChecksumResponse{},
 			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)
-	case <-initialWait:
-		{
-			r.mu.Lock()
-			started := r.mu.checksums[id].started
-			r.mu.Unlock()
-			if !started {
-				return false,
-					errors.Errorf("checksum computation did not start in time for (ID = %s)", id)
-			}
-			return false, nil
+	case <-time.After(r.checksumInitialWait(ctx)):
+		return CollectChecksumResponse{},
+			errors.Errorf("checksum computation did not start in time for (ID = %s)", id)
+	case <-c.started:
+		// Happy case, the computation has started.
+	}
+
+	// Wait for the computation result.
+	select {
+	case <-ctx.Done():
+		return CollectChecksumResponse{},
+			errors.Wrapf(ctx.Err(), "while waiting for compute checksum (ID = %s)", id)
+	case c, ok := <-c.result:
+		if log.V(1) {
+			log.Infof(ctx, "waited for compute checksum for %s", timeutil.Since(now))
 		}
-	case <-notify:
-		return true, nil
+		if !ok || c.Checksum == nil {
+			return CollectChecksumResponse{}, errors.Errorf("no checksum found (ID = %s)", id)
+		}
+		return c, nil
 	}
 }
 
-// computeChecksumDone adds the computed checksum, sets a deadline for GCing the
-// checksum, and sends out a notification.
-func (r *Replica) computeChecksumDone(
-	c *replicaChecksum, result *replicaHash, snapshot *roachpb.RaftSnapshotData,
-) {
-	// TODO(pavelkalinnikov): Communicate through the replicaChecksum directly,
-	// without using r.mu. E.g. send the CollectChecksumResponse through c.notify.
-	r.mu.Lock()
-	defer r.mu.Unlock()
+// checksumInitialWait returns the amount of time to wait until the checksum
+// computation has started. It is set to min of 5s and 10% of the remaining time
+// in the passed-in context (if it has a deadline).
+//
+// If it takes longer, chances are that the replica is being restored from
+// snapshots, or otherwise too busy to handle this request soon.
+func (*Replica) checksumInitialWait(ctx context.Context) time.Duration {
+	wait := 5 * time.Second
+	if d, ok := ctx.Deadline(); ok {
+		if dur := time.Duration(timeutil.Until(d).Nanoseconds() / 10); dur < wait {
+			wait = dur
+		}
+	}
+	return wait
+}
 
+// computeChecksumDone sends the checksum computation result to the receiver.
+func (*Replica) computeChecksumDone(
+	rc *replicaChecksum, result *replicaHash, snapshot *roachpb.RaftSnapshotData,
+) {
+	c := CollectChecksumResponse{Snapshot: snapshot}
 	if result != nil {
 		c.Checksum = result.SHA512[:]
 		delta := result.PersistedMS
@@ -556,9 +544,12 @@ func (r *Replica) computeChecksumDone(
 		c.Delta = enginepb.MVCCStatsDelta(delta)
 		c.Persisted = result.PersistedMS
 	}
-	c.gcTimestamp = timeutil.Now().Add(replicaChecksumGCInterval)
-	c.Snapshot = snapshot
-	close(c.notify) // notify the receiver that the computation is done
+
+	// Sending succeeds because the channel is buffered, and there is at most one
+	// computeChecksumDone per replicaChecksum. In case of a bug, another writer
+	// closes the channel, so this send panics instead of deadlocking. By design.
+	rc.result <- c
+	close(rc.result)
 }
 
 type replicaHash struct {
@@ -739,28 +730,22 @@ func (*Replica) sha512(
 func (r *Replica) computeChecksumPostApply(
 	ctx context.Context, cc kvserverpb.ComputeChecksum,
 ) error {
-	now := timeutil.Now()
-
-	r.mu.Lock()
-	c := r.mu.checksums[cc.ChecksumID]
-	// If there is no record of this ID, make a new one.
-	if c == nil {
-		c = &replicaChecksum{notify: make(chan struct{})}
-		r.mu.checksums[cc.ChecksumID] = c
-	}
-	if c.started {
-		log.Fatalf(ctx, "attempted to apply ComputeChecksum command with duplicated checksum ID %s",
-			cc.ChecksumID)
-	}
-	c.started = true
-	r.gcOldChecksumEntriesLocked(now)
-	desc := *r.mu.state.Desc
-	r.mu.Unlock()
+	// Note: all exit paths must call gcReplicaChecksum.
+	c := r.getReplicaChecksum(cc.ChecksumID, timeutil.Now())
+	// The close panics if there was another attempt to start computation with
+	// this ID, but it does not happen since post-apply triggers are invoked at
+	// most once per Raft log entry per process, and the ChecksumID is unique.
+	close(c.started)
 
 	if req, have := cc.Version, uint32(batcheval.ReplicaChecksumVersion); req != have {
 		r.computeChecksumDone(c, nil, nil)
+		r.gcReplicaChecksum(cc.ChecksumID, c)
 		return errors.Errorf("incompatible versions (requested: %d, have: %d)", req, have)
 	}
+
+	// Capture the current range descriptor, as it may change by the time the
+	// async task below runs.
+	desc := *r.Desc()
 
 	// Caller is holding raftMu, so an engine snapshot is automatically
 	// Raft-consistent (i.e. not in the middle of an AddSSTable).
@@ -816,6 +801,7 @@ func (r *Replica) computeChecksumPostApply(
 					result = nil
 				}
 				r.computeChecksumDone(c, result, snapshot)
+				r.gcReplicaChecksum(cc.ChecksumID, c)
 				return err
 			},
 		); err != nil {
@@ -870,6 +856,7 @@ A file preventing this node from restarting was placed at:
 		taskCancel()
 		snap.Close()
 		r.computeChecksumDone(c, nil, nil)
+		r.gcReplicaChecksum(cc.ChecksumID, c)
 		return err
 	}
 	return nil

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -53,12 +53,14 @@ func TestReplicaChecksumVersion(t *testing.T) {
 		} else {
 			cc.Version = 1
 		}
-		tc.repl.computeChecksumPostApply(ctx, cc)
+		taskErr := tc.repl.computeChecksumPostApply(ctx, cc)
 		rc, err := tc.repl.getChecksum(ctx, cc.ChecksumID)
 		if !matchingVersion {
+			require.ErrorContains(t, taskErr, "incompatible versions")
 			require.ErrorContains(t, err, "no checksum found")
 			require.Nil(t, rc.Checksum)
 		} else {
+			require.NoError(t, taskErr)
 			require.NoError(t, err)
 			require.NotNil(t, rc.Checksum)
 		}

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -58,7 +58,7 @@ func TestReplicaChecksumVersion(t *testing.T) {
 		rc, err := tc.repl.getChecksum(ctx, cc.ChecksumID)
 		if !matchingVersion {
 			require.ErrorContains(t, taskErr, "incompatible versions")
-			require.ErrorContains(t, err, "no checksum found")
+			require.ErrorContains(t, err, "checksum task failed to start")
 			require.Nil(t, rc.Checksum)
 		} else {
 			require.NoError(t, taskErr)
@@ -79,26 +79,44 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
 
-	// Simple condition, the checksum is notified, but not computed.
+	requireChecksumTaskNotStarted := func(id uuid.UUID) {
+		require.ErrorContains(t,
+			tc.repl.computeChecksumPostApply(context.Background(), kvserverpb.ComputeChecksum{
+				ChecksumID: id,
+				Mode:       roachpb.ChecksumMode_CHECK_FULL,
+				Version:    batcheval.ReplicaChecksumVersion,
+			}), "checksum collection request gave up")
+	}
+
+	// Checksum computation failed to start.
 	id := uuid.FastMakeV4()
-	c := tc.repl.getReplicaChecksum(id, timeutil.Now())
+	c, _ := tc.repl.getReplicaChecksum(id, timeutil.Now())
+	close(c.started)
+	rc, err := tc.repl.getChecksum(ctx, id)
+	require.ErrorContains(t, err, "checksum task failed to start")
+	require.Nil(t, rc.Checksum)
+
+	// Checksum computation started, but failed.
+	id = uuid.FastMakeV4()
+	c, _ = tc.repl.getReplicaChecksum(id, timeutil.Now())
+	c.started <- func() {}
 	close(c.started)
 	close(c.result)
-	rc, err := tc.repl.getChecksum(ctx, id)
+	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "no checksum found")
 	require.Nil(t, rc.Checksum)
 
-	// Next condition, the initial wait expires and checksum is not started,
-	// this will take 10ms.
+	// The initial wait for the task start expires. This will take 10ms.
 	id = uuid.FastMakeV4()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "checksum computation did not start")
 	require.Nil(t, rc.Checksum)
+	requireChecksumTaskNotStarted(id)
 
-	// Next condition, initial wait expired and we found the started flag,
-	// so next step is for context deadline.
+	// The computation has started, but the request context timed out.
 	id = uuid.FastMakeV4()
-	c = tc.repl.getReplicaChecksum(id, timeutil.Now())
+	c, _ = tc.repl.getReplicaChecksum(id, timeutil.Now())
+	c.started <- func() {}
 	close(c.started)
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
@@ -109,6 +127,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Nil(t, rc.Checksum)
+	requireChecksumTaskNotStarted(id)
 }
 
 // TestReplicaChecksumSHA512 checks that a given dataset produces the expected

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/stretchr/testify/require"
 )
@@ -78,14 +79,11 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
 
-	id := uuid.FastMakeV4()
-	notify := make(chan struct{})
-	close(notify)
-
 	// Simple condition, the checksum is notified, but not computed.
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = &replicaChecksum{notify: notify}
-	tc.repl.mu.Unlock()
+	id := uuid.FastMakeV4()
+	c := tc.repl.getReplicaChecksum(id, timeutil.Now())
+	close(c.started)
+	close(c.result)
 	rc, err := tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "no checksum found")
 	require.Nil(t, rc.Checksum)
@@ -93,9 +91,6 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// Next condition, the initial wait expires and checksum is not started,
 	// this will take 10ms.
 	id = uuid.FastMakeV4()
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = &replicaChecksum{notify: make(chan struct{})}
-	tc.repl.mu.Unlock()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "checksum computation did not start")
 	require.Nil(t, rc.Checksum)
@@ -103,9 +98,14 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// Next condition, initial wait expired and we found the started flag,
 	// so next step is for context deadline.
 	id = uuid.FastMakeV4()
-	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = &replicaChecksum{notify: make(chan struct{}), started: true}
-	tc.repl.mu.Unlock()
+	c = tc.repl.getReplicaChecksum(id, timeutil.Now())
+	close(c.started)
+	rc, err = tc.repl.getChecksum(ctx, id)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, rc.Checksum)
+
+	// Context is canceled during the initial waiting.
+	id = uuid.FastMakeV4()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 	require.Nil(t, rc.Checksum)

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -113,17 +113,6 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 		t.Fatal(err)
 	}
 	require.Nil(t, rc.Checksum)
-
-	// Need to reset the context, since we deadlined it above.
-	ctx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-	// Next condition, node should quiesce.
-	tc.repl.store.Stopper().Quiesce(ctx)
-	rc, err = tc.repl.getChecksum(ctx, uuid.FastMakeV4())
-	if !testutils.IsError(err, "store quiescing") {
-		t.Fatal(err)
-	}
-	require.Nil(t, rc.Checksum)
 }
 
 // TestReplicaChecksumSHA512 checks that a given dataset produces the expected

--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -84,7 +84,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 
 	// Simple condition, the checksum is notified, but not computed.
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: notify}
+	tc.repl.mu.checksums[id] = &replicaChecksum{notify: notify}
 	tc.repl.mu.Unlock()
 	rc, err := tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "no checksum found")
@@ -94,7 +94,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// this will take 10ms.
 	id = uuid.FastMakeV4()
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{})}
+	tc.repl.mu.checksums[id] = &replicaChecksum{notify: make(chan struct{})}
 	tc.repl.mu.Unlock()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorContains(t, err, "checksum computation did not start")
@@ -104,7 +104,7 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 	// so next step is for context deadline.
 	id = uuid.FastMakeV4()
 	tc.repl.mu.Lock()
-	tc.repl.mu.checksums[id] = replicaChecksum{notify: make(chan struct{}), started: true}
+	tc.repl.mu.checksums[id] = &replicaChecksum{notify: make(chan struct{}), started: true}
 	tc.repl.mu.Unlock()
 	rc, err = tc.repl.getChecksum(ctx, id)
 	require.ErrorIs(t, err, context.DeadlineExceeded)

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -100,7 +100,7 @@ func newUnloadedReplica(
 		return kvserverbase.SplitByLoadMergeDelay.Get(&store.cfg.Settings.SV)
 	})
 	r.mu.proposals = map[kvserverbase.CmdIDKey]*ProposalData{}
-	r.mu.checksums = map[uuid.UUID]replicaChecksum{}
+	r.mu.checksums = map[uuid.UUID]*replicaChecksum{}
 	r.mu.proposalBuf.Init((*replicaProposer)(r), tracker.NewLockfreeTracker(), r.Clock(), r.ClusterSettings())
 	r.mu.proposalBuf.testing.allowLeaseProposalWhenNotLeader = store.cfg.TestingKnobs.AllowLeaseRequestProposalsWhenNotLeader
 	r.mu.proposalBuf.testing.allowLeaseTransfersWhenTargetMayNeedSnapshot = store.cfg.TestingKnobs.AllowLeaseTransfersWhenTargetMayNeedSnapshot

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -56,6 +56,8 @@ func (is Server) CollectChecksum(
 	resp := &CollectChecksumResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
+			ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
+			defer cancel()
 			r, err := s.GetReplica(req.RangeID)
 			if err != nil {
 				return err

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -11,7 +11,6 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
 	"time"
 
@@ -19,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/redact"
 )
 
 // Server implements PerReplicaServer.
@@ -53,7 +51,7 @@ func (is Server) execStoreCommand(
 func (is Server) CollectChecksum(
 	ctx context.Context, req *CollectChecksumRequest,
 ) (*CollectChecksumResponse, error) {
-	resp := &CollectChecksumResponse{}
+	var resp *CollectChecksumResponse
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
 			ctx, cancel := s.stopper.WithCancelOnQuiesce(ctx)
@@ -66,17 +64,7 @@ func (is Server) CollectChecksum(
 			if err != nil {
 				return err
 			}
-			if !bytes.Equal(req.Checksum, ccr.Checksum) {
-				// If this check is false, then this request is the replica carrying out
-				// the consistency check. The message is spurious, but we want to leave the
-				// snapshot (if present) intact.
-				if len(req.Checksum) > 0 {
-					log.Errorf(ctx, "consistency check failed on range r%d: expected checksum %x, got %x",
-						req.RangeID, redact.Safe(req.Checksum), redact.Safe(ccr.Checksum))
-					// Leave resp.Snapshot alone so that the caller will receive what's
-					// in it (if anything).
-				}
-			} else {
+			if !req.WithSnapshot {
 				ccr.Snapshot = nil
 			}
 			resp = &ccr

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -62,11 +62,10 @@ func (is Server) CollectChecksum(
 			if err != nil {
 				return err
 			}
-			c, err := r.getChecksum(ctx, req.ChecksumID)
+			ccr, err := r.getChecksum(ctx, req.ChecksumID)
 			if err != nil {
 				return err
 			}
-			ccr := c.CollectChecksumResponse
 			if !bytes.Equal(req.Checksum, ccr.Checksum) {
 				// If this check is false, then this request is the replica carrying out
 				// the consistency check. The message is spurious, but we want to leave the


### PR DESCRIPTION
This PR increases chance of propagating cancelation signal to replicas to
prevent them from running abandoned consistency check tasks. Specifically:

- The computation is aborted if the collection request is canceled.
- The computation is not started if the collection request gave up recently.
- The initiator runs all requests in parallel to reduce asynchrony, and to be
  able to cancel all the requests explicitly, instead of skipping some of them.

---
### Background

Consistency checks are initiated by `ComputeChecksum` command in the Raft log,
and run until completion under a background context. The result is collected by
the initiator via the `CollectChecksum` long poll. The task is synchronized with
the collection handler via the map of `replicaChecksum` structs.

Currently, the replica initiating the consistency check sends a collection
request to itself first, and only then to other replicas in parallel. This
results in substantial asynchrony on the receiving replica, between the request
handler and the computation task. The current solution to that is keeping the
checksum computation results in memory for `replicaChecksumGCInterval` to return
them to late arriving requests. However, there is **no symmetry** here: if the
computation starts late instead, it doesn't learn about a previously failed request.

The reason why the initiator blocks on its local checksum first is that it
computes the "master checksum", which is then added to all other requests.
However, this field is only used by the receiving end to log an inconsistency
error. The actual killing of this replica happens on the second phase of the
protocol, after the initiating replica commits another Raft message with the
`Terminate` field populated. So, there is **no strong reason to keep this blocking
behaviour**.

When the `CollectChecksum` handler exits due to a canceled context (for example,
the request timed out, or the remote caller crashed), the background task
continues to run. If it was not running, it may start in the future. In both
cases, the consistency checks pool (which has a limited size and processing
rate) spends resources on running dangling checks, and rejects useful ones.

If the initiating replica fails to compute its local checksum, it does not send
requests (or any indication to cancel) to other replicas. This is problematic
because the checksum tasks will be run on all replicas, which opens the
possibility for accumulating many such dangling checks.

---

Part of #77432

Release justification: performance and stability improvement

Release note(bug fix): A consistency check is now skipped/stopped when its
remote initiator gives up on it. Previously such checks would still be
attempted to run, and, due to the limited size of the worker pool, prevent the
useful checks from running. In addition, consistency check requests are now
sent in parallel, and cancelation signal propagates more reliably.