### PR TITLE
release-22.1: sql: add nil guard when formatting placeholders

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -815,7 +815,7 @@ func formatWithPlaceholders(ast tree.Statement, evalCtx *tree.EvalContext) strin
 			fmtFlags,
 			tree.FmtPlaceholderFormat(func(ctx *tree.FmtCtx, placeholder *tree.Placeholder) {
 				d, err := placeholder.Eval(evalCtx)
-				if err != nil {
+				if err != nil || d == nil {
 					// Fall back to the default behavior if something goes wrong.
 					ctx.Printf("$%d", placeholder.Idx+1)
 					return


### PR DESCRIPTION
Backport 1/1 commits from #86607.

/cc @cockroachdb/release

---

Fixes https://github.com/cockroachdb/cockroach/issues/85363

Release note (bug fix): Fixed a crash that could happen when formatting
queries that have placeholder BitArray arguments.

Release justification: Fix a panic.
