### PR TITLE
release-21.2: sql: fix array decoding in COPY

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -732,7 +732,11 @@ func (c *copyMachine) readTextTuple(ctx context.Context, line []byte) error {
 			exprs[i] = tree.DNull
 			continue
 		}
-		switch t := c.resultColumns[i].Typ; t.Family() {
+		decodeTyp := c.resultColumns[i].Typ
+		for decodeTyp.Family() == types.ArrayFamily {
+			decodeTyp = decodeTyp.ArrayContents()
+		}
+		switch decodeTyp.Family() {
 		case types.BytesFamily,
 			types.DateFamily,
 			types.IntervalFamily,

--- a/pkg/sql/sem/tree/parse_array_test.go
+++ b/pkg/sql/sem/tree/parse_array_test.go
@@ -75,6 +75,11 @@ lo}`, types.String, Datums{NewDString(`hel`), NewDString(`lo`)}},
 
 		{`{日本語}`, types.String, Datums{NewDString(`日本語`)}},
 
+		// byte(133) and byte(160) are treated as whitespace to ignore by unicode,
+		// but Postgres handles them as normal characters.
+		{string([]byte{'{', 133, '}'}), types.String, Datums{NewDString("\x85")}},
+		{string([]byte{'{', 160, '}'}), types.String, Datums{NewDString("\xa0")}},
+
 		// This can generate some strings with invalid UTF-8, but this isn't a
 		// problem, since the input would have had to be invalid UTF-8 for that to
 		// occur.


### PR DESCRIPTION
Backport 1/1 commits from #86712.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/82792

Release note (bug fix): Fixed a bug that caused some special characters
to be misread if they were being ready by COPY ... FROM into a
TEXT[] column.

Release justification: bug fix to existing functionality.
