### PR TITLE
bazci: enable --flaky_test_attempts=3 for Unit tests on release branches

### DIFF
--- a/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests/unit_tests_impl.sh
@@ -3,6 +3,14 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
+
+EXTRA_PARAMS=""
+
+if tc_release_branch; then
+  # enable up to 2 retries (3 attempts, worst-case) per test executable to report flakes but only on release branches (i.e., not staging)
+  EXTRA_PARAMS=" --flaky_test_attempts=3" 
+fi
+
 $(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- test --config=cinolint --config=simplestamp -c fastbuild \
-		                  //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests \
-                                   --profile=/artifacts/profile.gz
+                                  //pkg:small_tests //pkg:medium_tests //pkg:large_tests //pkg:enormous_tests \
+                                   --profile=/artifacts/profile.gz $EXTRA_PARAMS


### PR DESCRIPTION
When a test fails, --flaky_test_attempts=3 will cause up to two retry
attempts by executing the corresponding test binary (shard).
If a test passes on either attempt, it is reported 'FLAKY' in the
test result summary. In addition, each attempt yields an (XML) log
under 'test_attempts' subdirectory. The attempts are now copied
into the artifactsDir.

Note, while the test result summary may say the test is 'FLAKY', it's
reported as 'PASS' as per main test.xml. Thus, a 'FLAKY' test will
not fail the CI; i.e., a test succeeding after up to two
retries is assumed to have _passed_ whereas three consecutive
failures result in a failed test. Consequently, CI now has a higher
probability of passing than before this change. However, the two additional
attempts per test binary (shard) could slow down the build. Hence, initially
the plan is to enable only on release branches and not staging (i.e., bors).

This change supports [1]. In a follow-up PR, a test reporter could be
augmented to parse attempt logs thereby obtaining a set of FLAKY tests
which should be skipped on subsequent builds.

[1] https://github.com/cockroachdb/cockroach/pull/81293

Release justification: CI improvement
Release note: None
Epic: None