### PR TITLE
ui: properly construct timescale object from session storage

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/timeScale.ts
@@ -66,7 +66,14 @@ export class TimeScaleState {
   constructor() {
     let timeScale: TimeScale;
     try {
-      timeScale = getValueFromSessionStorage(TIME_SCALE_SESSION_STORAGE_KEY);
+      const val = getValueFromSessionStorage(TIME_SCALE_SESSION_STORAGE_KEY);
+      timeScale = {
+        key: val.key,
+        windowSize: val.windowSize && moment.duration(val.windowSize),
+        windowValid: val.windowValid && moment.duration(val.windowValid),
+        sampleSize: val.sampleSize && moment.duration(val.sampleSize),
+        fixedWindowEnd: val.fixedWindowEnd && moment(val.fixedWindowEnd),
+      };
     } catch {
       console.warn(
         `Couldn't retrieve or parse TimeScale options from SessionStorage`,


### PR DESCRIPTION
Previously, when we restore the global timescale object from session
storage, we did not properly construct non primitive type fields. This
commit properly constructs the TimeScale object from session storage,
reconstructing the moment.duration and moment objects that are expected
in certain fields.

Release justification: bug fix
Release note (bug fix): timescale object is properly constructed
from session storage, preventing  bugs and crashes in pages that use
the time scale object when reloading the page