### PR TITLE
release-22.1: colmem: improve memory-limiting behavior of the accounting helpers

### DIFF
--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -145,7 +145,7 @@ func NewCaseOp(
 ) colexecop.Operator {
 	// We internally use three selection vectors, scratch.order, origSel, and
 	// prevSel.
-	allocator.AdjustMemoryUsage(3 * colmem.SizeOfBatchSizeSelVector)
+	allocator.AdjustMemoryUsage(3 * colmem.SelVectorSize(coldata.BatchSize()))
 	return &caseOp{
 		allocator: allocator,
 		buffer:    buffer.(*bufferOp),

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -107,6 +107,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 	}
 	c.output, _ = c.unlimitedAllocator.ResetMaybeReallocate(
 		c.outputTypes, c.output, willEmit, c.maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 	if willEmit > c.output.Capacity() {
 		willEmit = c.output.Capacity()

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -40,7 +40,7 @@ func NewCrossJoiner(
 	rightTypes []*types.T,
 	diskAcc *mon.BoundAccount,
 ) colexecop.Operator {
-	return &crossJoiner{
+	c := &crossJoiner{
 		crossJoinerBase: newCrossJoinerBase(
 			unlimitedAllocator,
 			joinType,
@@ -51,21 +51,20 @@ func NewCrossJoiner(
 			fdSemaphore,
 			diskAcc,
 		),
-		joinHelper:            newJoinHelper(left, right),
-		unlimitedAllocator:    unlimitedAllocator,
-		outputTypes:           joinType.MakeOutputTypes(leftTypes, rightTypes),
-		maxOutputBatchMemSize: memoryLimit,
+		joinHelper:  newJoinHelper(left, right),
+		outputTypes: joinType.MakeOutputTypes(leftTypes, rightTypes),
 	}
+	c.helper.Init(unlimitedAllocator, memoryLimit)
+	return c
 }
 
 type crossJoiner struct {
 	*crossJoinerBase
 	*joinHelper
 
-	unlimitedAllocator    *colmem.Allocator
-	rightInputConsumed    bool
-	outputTypes           []*types.T
-	maxOutputBatchMemSize int64
+	helper             colmem.AccountingHelper
+	rightInputConsumed bool
+	outputTypes        []*types.T
 	// isLeftAllNulls and isRightAllNulls indicate whether the output vectors
 	// corresponding to the left and right inputs, respectively, should consist
 	// only of NULL values. This is the case when we have right or left,
@@ -105,10 +104,7 @@ func (c *crossJoiner) Next() coldata.Batch {
 		c.done = true
 		return coldata.ZeroBatch
 	}
-	c.output, _ = c.unlimitedAllocator.ResetMaybeReallocate(
-		c.outputTypes, c.output, willEmit, c.maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
-	)
+	c.output, _ = c.helper.ResetMaybeReallocate(c.outputTypes, c.output, willEmit)
 	if willEmit > c.output.Capacity() {
 		willEmit = c.output.Capacity()
 	}

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -12,7 +12,6 @@ package colexecjoin
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -733,10 +732,8 @@ func (hj *hashJoiner) resetOutput(nResults int) {
 	// 4. when the hashJoiner is used by the external hash joiner as the main
 	// strategy, the hash-based partitioner is responsible for making sure that
 	// partitions fit within memory limit.
-	const maxOutputBatchMemSize = math.MaxInt64
-	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(
-		hj.outputTypes, hj.output, nResults, maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
+	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocateNoMemLimit(
+		hj.outputTypes, hj.output, nResults,
 	)
 }
 

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -736,6 +736,7 @@ func (hj *hashJoiner) resetOutput(nResults int) {
 	const maxOutputBatchMemSize = math.MaxInt64
 	hj.output, _ = hj.outputUnlimitedAllocator.ResetMaybeReallocate(
 		hj.outputTypes, hj.output, nResults, maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 }
 

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -532,6 +532,7 @@ func newMergeJoinBase(
 		},
 		diskAcc: diskAcc,
 	}
+	base.helper.Init(unlimitedAllocator, memoryLimit)
 	base.left.distincterInput = &colexecop.FeedOperator{}
 	base.left.distincter, base.left.distinctOutput = colexecbase.OrderedDistinctColsToOperators(
 		base.left.distincterInput, lEqCols, leftTypes, false, /* nullsAreDistinct */
@@ -549,6 +550,7 @@ type mergeJoinBase struct {
 	colexecop.CloserHelper
 
 	unlimitedAllocator *colmem.Allocator
+	helper             colmem.AccountingHelper
 	memoryLimit        int64
 	diskQueueCfg       colcontainer.DiskQueueCfg
 	fdSemaphore        semaphore.Semaphore

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14102,6 +14102,7 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_exceptall.eg.go
@@ -14100,10 +14100,7 @@ func (o *mergeJoinExceptAllOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinExceptAllOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15268,10 +15268,7 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_fullouter.eg.go
@@ -15270,6 +15270,7 @@ func (o *mergeJoinFullOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinFullOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10780,10 +10780,7 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 }
 
 func (o *mergeJoinInnerOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_inner.eg.go
@@ -10782,6 +10782,7 @@ func (o *mergeJoinInnerOp) buildFromBufferedGroup() (bufferedGroupComplete bool)
 func (o *mergeJoinInnerOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11490,10 +11490,7 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 }
 
 func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_intersectall.eg.go
@@ -11492,6 +11492,7 @@ func (o *mergeJoinIntersectAllOp) buildFromBufferedGroup() (bufferedGroupComplet
 func (o *mergeJoinIntersectAllOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13012,6 +13012,7 @@ func (o *mergeJoinLeftAntiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftanti.eg.go
@@ -13010,10 +13010,7 @@ func (o *mergeJoinLeftAntiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 }
 
 func (o *mergeJoinLeftAntiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13036,10 +13036,7 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftouter.eg.go
@@ -13038,6 +13038,7 @@ func (o *mergeJoinLeftOuterOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinLeftOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10734,10 +10734,7 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 }
 
 func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_leftsemi.eg.go
@@ -10736,6 +10736,7 @@ func (o *mergeJoinLeftSemiOp) buildFromBufferedGroup() (bufferedGroupComplete bo
 func (o *mergeJoinLeftSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -12962,10 +12962,7 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightanti.eg.go
@@ -12964,6 +12964,7 @@ func (o *mergeJoinRightAntiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinRightAntiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13012,10 +13012,7 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 }
 
 func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightouter.eg.go
@@ -13014,6 +13014,7 @@ func (o *mergeJoinRightOuterOp) buildFromBufferedGroup() (bufferedGroupComplete 
 func (o *mergeJoinRightOuterOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10693,10 +10693,7 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 }
 
 func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_rightsemi.eg.go
@@ -10695,6 +10695,7 @@ func (o *mergeJoinRightSemiOp) buildFromBufferedGroup() (bufferedGroupComplete b
 func (o *mergeJoinRightSemiOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1309,6 +1309,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
 	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
 		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_tmpl.go
@@ -1307,10 +1307,7 @@ func _SOURCE_FINISHED_SWITCH(_JOIN_TYPE joinTypeInfo) { // */}}
 // */}}
 
 func (o *mergeJoin_JOIN_TYPE_STRINGOp) Next() coldata.Batch {
-	o.output, _ = o.unlimitedAllocator.ResetMaybeReallocate(
-		o.outputTypes, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
-	)
+	o.output, _ = o.helper.ResetMaybeReallocate(o.outputTypes, o.output, 0 /* tuplesToBeSet */)
 	o.outputCapacity = o.output.Capacity()
 	o.bufferedGroup.helper.output = o.output
 	o.builderState.outCount = 0

--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -11,8 +11,6 @@
 package colexecutils
 
 import (
-	"math"
-
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecop"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
@@ -59,10 +57,8 @@ func (p *deselectorOp) Next() coldata.Batch {
 	// deselectorOp should *not* limit the capacities of the returned batches,
 	// so we don't use a memory limit here. It is up to the wrapped operator to
 	// limit the size of batches based on the memory footprint.
-	const maxBatchMemSize = math.MaxInt64
-	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocate(
-		p.inputTypes, p.output, batch.Length(), maxBatchMemSize,
-		true, /* desiredCapacitySufficient */
+	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocateNoMemLimit(
+		p.inputTypes, p.output, batch.Length(),
 	)
 	sel := batch.Selection()
 	p.unlimitedAllocator.PerformOperation(p.output.ColVecs(), func() {

--- a/pkg/sql/colexec/colexecutils/deselector.go
+++ b/pkg/sql/colexec/colexecutils/deselector.go
@@ -62,6 +62,7 @@ func (p *deselectorOp) Next() coldata.Batch {
 	const maxBatchMemSize = math.MaxInt64
 	p.output, _ = p.unlimitedAllocator.ResetMaybeReallocate(
 		p.inputTypes, p.output, batch.Length(), maxBatchMemSize,
+		true, /* desiredCapacitySufficient */
 	)
 	sel := batch.Selection()
 	p.unlimitedAllocator.PerformOperation(p.output.ColVecs(), func() {

--- a/pkg/sql/colexec/colexecutils/spilling_queue.go
+++ b/pkg/sql/colexec/colexecutils/spilling_queue.go
@@ -193,6 +193,7 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 			const maxBatchMemSize = math.MaxInt64
 			q.diskQueueDeselectionScratch, _ = q.unlimitedAllocator.ResetMaybeReallocate(
 				q.typs, q.diskQueueDeselectionScratch, n, maxBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			q.unlimitedAllocator.PerformOperation(q.diskQueueDeselectionScratch.ColVecs(), func() {
 				for i := range q.typs {
@@ -295,6 +296,7 @@ func (q *SpillingQueue) Enqueue(ctx context.Context, batch coldata.Batch) {
 		// attention to the memory registered with the unlimited allocator, and
 		// we will stop adding tuples into this batch and spill when needed.
 		math.MaxInt64, /* maxBatchMemSize */
+		true,          /* desiredCapacitySufficient */
 	)
 	q.unlimitedAllocator.PerformOperation(newBatch.ColVecs(), func() {
 		for i := range q.typs {

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -12,7 +12,6 @@ package colexecwindow
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colcontainer"
@@ -248,10 +247,8 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			sel := batch.Selection()
 			// We don't limit the batches based on the memory footprint because
 			// we assume that the input is producing reasonably sized batches.
-			const maxBatchMemSize = math.MaxInt64
-			b.currentBatch, _ = b.allocator.ResetMaybeReallocate(
-				b.outputTypes, b.currentBatch, batch.Length(), maxBatchMemSize,
-				true, /* desiredCapacitySufficient */
+			b.currentBatch, _ = b.allocator.ResetMaybeReallocateNoMemLimit(
+				b.outputTypes, b.currentBatch, batch.Length(),
 			)
 			b.allocator.PerformOperation(b.currentBatch.ColVecs(), func() {
 				for colIdx, vec := range batch.ColVecs() {

--- a/pkg/sql/colexec/colexecwindow/buffered_window.go
+++ b/pkg/sql/colexec/colexecwindow/buffered_window.go
@@ -251,6 +251,7 @@ func (b *bufferedWindowOp) Next() coldata.Batch {
 			const maxBatchMemSize = math.MaxInt64
 			b.currentBatch, _ = b.allocator.ResetMaybeReallocate(
 				b.outputTypes, b.currentBatch, batch.Length(), maxBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			b.allocator.PerformOperation(b.currentBatch.ColVecs(), func() {
 				for colIdx, vec := range batch.ColVecs() {

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -197,7 +197,8 @@ func (c *Columnarizer) Next() coldata.Batch {
 	switch c.mode {
 	case columnarizerBufferingMode:
 		c.batch, reallocated = c.allocator.ResetMaybeReallocate(
-			c.typs, c.batch, 1 /* minDesiredCapacity */, c.maxBatchMemSize,
+			c.typs, c.batch, 1, /* minDesiredCapacity */
+			c.maxBatchMemSize, false, /* desiredCapacitySufficient */
 		)
 	case columnarizerStreamingMode:
 		// Note that we're not using ResetMaybeReallocate because we will

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -54,14 +54,16 @@ type Columnarizer struct {
 	execinfra.ProcessorBaseNoHelper
 	colexecop.NonExplainable
 
-	mode      columnarizerMode
+	mode columnarizerMode
+	// helper is used in the columnarizerBufferingMode mode.
+	helper colmem.AccountingHelper
+	// allocator is used directly only in the columnarizerStreamingMode mode.
 	allocator *colmem.Allocator
 	input     execinfra.RowSource
 	da        tree.DatumAlloc
 
 	buffered        rowenc.EncDatumRows
 	batch           coldata.Batch
-	maxBatchMemSize int64
 	accumulatedMeta []execinfrapb.ProducerMetadata
 	typs            []*types.T
 
@@ -110,10 +112,12 @@ func newColumnarizer(
 		colexecerror.InternalError(errors.AssertionFailedf("unexpected columnarizerMode %d", mode))
 	}
 	c := &Columnarizer{
-		allocator:       allocator,
-		input:           input,
-		maxBatchMemSize: execinfra.GetWorkMemLimit(flowCtx),
-		mode:            mode,
+		allocator: allocator,
+		input:     input,
+		mode:      mode,
+	}
+	if mode == columnarizerBufferingMode {
+		c.helper.Init(allocator, execinfra.GetWorkMemLimit(flowCtx))
 	}
 	c.ProcessorBaseNoHelper.Init(
 		nil, /* self */
@@ -196,9 +200,8 @@ func (c *Columnarizer) Next() coldata.Batch {
 	var reallocated bool
 	switch c.mode {
 	case columnarizerBufferingMode:
-		c.batch, reallocated = c.allocator.ResetMaybeReallocate(
-			c.typs, c.batch, 1, /* minDesiredCapacity */
-			c.maxBatchMemSize, false, /* desiredCapacitySufficient */
+		c.batch, reallocated = c.helper.ResetMaybeReallocate(
+			c.typs, c.batch, 0, /* tuplesToBeSet */
 		)
 	case columnarizerStreamingMode:
 		// Note that we're not using ResetMaybeReallocate because we will
@@ -213,14 +216,23 @@ func (c *Columnarizer) Next() coldata.Batch {
 	if reallocated {
 		oldRows := c.buffered
 		newRows := make(rowenc.EncDatumRows, c.batch.Capacity())
-		_ = newRows[len(oldRows)]
-		for i := 0; i < len(oldRows); i++ {
-			//gcassert:bce
-			newRows[i] = oldRows[i]
-		}
-		for i := len(oldRows); i < len(newRows); i++ {
-			//gcassert:bce
-			newRows[i] = make(rowenc.EncDatumRow, len(c.typs))
+		copy(newRows, oldRows)
+		if len(oldRows) < len(newRows) {
+			_ = newRows[len(oldRows)]
+			for i := len(oldRows); i < len(newRows); i++ {
+				//gcassert:bce
+				newRows[i] = make(rowenc.EncDatumRow, len(c.typs))
+			}
+		} else if len(newRows) < len(oldRows) {
+			_ = oldRows[len(newRows)]
+			// Lose the reference to the old rows that aren't copied into the
+			// new slice - we need to do this since the capacity of the batch
+			// might have shrunk, and the rows at the end of the slice might
+			// never get overwritten.
+			for i := len(newRows); i < len(oldRows); i++ {
+				//gcassert:bce
+				oldRows[i] = nil
+			}
 		}
 		c.buffered = newRows
 	}

--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -839,5 +839,5 @@ func (o *inputPartitioningOperator) close() {
 	// allocate a new windowed batch if necessary (which might be the case for
 	// the fallback strategy of the users of the hash-based partitioner).
 	o.windowedBatch = nil
-	o.allocator.ReleaseMemory(colmem.SizeOfBatchSizeSelVector)
+	o.allocator.ReleaseMemory(colmem.SelVectorSize(coldata.BatchSize()))
 }

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -454,26 +454,21 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				if l := op.bufferingState.pendingBatch.Length(); l > 0 {
@@ -602,26 +597,21 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				op.state = hashAggregatorDone

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -457,6 +457,7 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&
@@ -604,6 +605,7 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -457,7 +457,7 @@ func getNext_true(op *hashAggregator) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
@@ -600,7 +600,7 @@ func getNext_false(op *hashAggregator) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {

--- a/pkg/sql/colexec/hash_aggregator.go
+++ b/pkg/sql/colexec/hash_aggregator.go
@@ -140,12 +140,7 @@ type hashAggregator struct {
 	// populating the output.
 	curOutputBucketIdx int
 
-	maxOutputBatchMemSize int64
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when, after setting a row, we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
-	output      coldata.Batch
+	output coldata.Batch
 
 	aggFnsAlloc *colexecagg.AggregateFuncsAlloc
 	hashAlloc   aggBucketAlloc
@@ -210,19 +205,18 @@ func NewHashAggregator(
 		colexecerror.InternalError(err)
 	}
 	hashAgg := &hashAggregator{
-		OneInputNode:          colexecop.NewOneInputNode(args.Input),
-		hashTableAllocator:    args.Allocator,
-		spec:                  args.Spec,
-		state:                 hashAggregatorBuffering,
-		inputTypes:            args.InputTypes,
-		outputTypes:           args.OutputTypes,
-		inputArgsConverter:    inputArgsConverter,
-		toClose:               toClose,
-		maxOutputBatchMemSize: maxOutputBatchMemSize,
-		aggFnsAlloc:           aggFnsAlloc,
-		hashAlloc:             aggBucketAlloc{allocator: args.Allocator},
+		OneInputNode:       colexecop.NewOneInputNode(args.Input),
+		hashTableAllocator: args.Allocator,
+		spec:               args.Spec,
+		state:              hashAggregatorBuffering,
+		inputTypes:         args.InputTypes,
+		outputTypes:        args.OutputTypes,
+		inputArgsConverter: inputArgsConverter,
+		toClose:            toClose,
+		aggFnsAlloc:        aggFnsAlloc,
+		hashAlloc:          aggBucketAlloc{allocator: args.Allocator},
 	}
-	hashAgg.accountingHelper.Init(outputUnlimitedAllocator, args.OutputTypes)
+	hashAgg.accountingHelper.Init(outputUnlimitedAllocator, maxOutputBatchMemSize, args.OutputTypes)
 	hashAgg.bufferingState.tuples = colexecutils.NewAppendOnlyBufferedBatch(args.Allocator, args.InputTypes, nil /* colsToStore */)
 	hashAgg.datumAlloc.AllocSize = hashAggregatorAllocSize
 	hashAgg.aggHelper = newAggregatorHelper(args, &hashAgg.datumAlloc, true /* isHashAgg */, hashAggregatorMaxBuffered)

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -343,6 +343,7 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 			// len(op.buckets) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
 				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
 			for curOutputIdx < op.output.Capacity() &&

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -343,7 +343,7 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
 			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx,
 			)
 			curOutputIdx := 0
 			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -340,26 +340,21 @@ func getNext(op *hashAggregator, partialOrder bool) coldata.Batch {
 		case hashAggregatorOutputting:
 			// Note that ResetMaybeReallocate truncates the requested capacity
 			// at coldata.BatchSize(), so we can just try asking for
-			// len(op.buckets) capacity.
+			// len(op.buckets)-op.curOutputBucketIdx (the number of remaining
+			// output tuples) capacity.
 			op.output, _ = op.accountingHelper.ResetMaybeReallocate(
-				op.outputTypes, op.output, len(op.buckets), op.maxOutputBatchMemSize,
-				true, /* desiredCapacitySufficient */
+				op.outputTypes, op.output, len(op.buckets)-op.curOutputBucketIdx, true, /* desiredCapacitySufficient */
 			)
 			curOutputIdx := 0
-			for curOutputIdx < op.output.Capacity() &&
-				op.curOutputBucketIdx < len(op.buckets) &&
-				(op.maxCapacity == 0 || curOutputIdx < op.maxCapacity) {
+			for batchDone := false; op.curOutputBucketIdx < len(op.buckets) && !batchDone; {
 				bucket := op.buckets[op.curOutputBucketIdx]
 				for fnIdx, fn := range bucket.fns {
 					fn.SetOutput(op.output.ColVec(fnIdx))
 					fn.Flush(curOutputIdx)
 				}
-				op.accountingHelper.AccountForSet(curOutputIdx)
+				batchDone = op.accountingHelper.AccountForSet(curOutputIdx)
 				curOutputIdx++
 				op.curOutputBucketIdx++
-				if op.maxCapacity == 0 && op.accountingHelper.Allocator.Used() >= op.maxOutputBatchMemSize {
-					op.maxCapacity = curOutputIdx
-				}
 			}
 			if op.curOutputBucketIdx >= len(op.buckets) {
 				if partialOrder {

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -12,7 +12,6 @@ package colexec
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/sql/colconv"
@@ -268,15 +267,15 @@ func (a *orderedAggregator) Next() coldata.Batch {
 		case orderedAggregatorReallocating:
 			// The ordered aggregator *cannot* limit the capacities of its
 			// internal batches because it works under the assumption that any
-			// input batch can be handled in a single pass, so we don't use a
-			// memory limit here. It is up to the input to limit the size of
-			// batches based on the memory footprint.
-			const maxBatchMemSize = math.MaxInt64
+			// input batch can be handled in a single pass, so we use
+			// ResetMaybeReallocateNoMemLimit. It is up to the input to limit
+			// the size of batches based on the memory footprint.
+			//
 			// Twice the batchSize is allocated to avoid having to check for
 			// overflow when outputting.
 			newMinCapacity := 2 * a.lastReadBatch.Length()
 			if newMinCapacity > coldata.BatchSize() {
-				// ResetMaybeReallocate truncates the capacity to
+				// ResetMaybeReallocateNoMemLimit truncates the capacity to
 				// coldata.BatchSize(), but we actually want a batch with larger
 				// capacity, so we choose to instantiate the batch with fixed
 				// maximal capacity that can be needed by the aggregator.
@@ -284,17 +283,15 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				newMinCapacity = 2 * coldata.BatchSize()
 				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, newMinCapacity)
 			} else {
-				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(
+				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocateNoMemLimit(
 					a.outputTypes, a.scratch.Batch, newMinCapacity,
-					maxBatchMemSize, true, /* desiredCapacitySufficient */
 				)
 			}
 			// We will never copy more than coldata.BatchSize() into the
 			// temporary buffer, so a half of the scratch's capacity will always
 			// be sufficient.
-			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocate(
+			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocateNoMemLimit(
 				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2,
-				maxBatchMemSize, true, /* desiredCapacitySufficient */
 			)
 			for fnIdx, fn := range a.bucket.fns {
 				fn.SetOutput(a.scratch.ColVec(fnIdx))

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -285,14 +285,16 @@ func (a *orderedAggregator) Next() coldata.Batch {
 				a.scratch.Batch = a.allocator.NewMemBatchWithFixedCapacity(a.outputTypes, newMinCapacity)
 			} else {
 				a.scratch.Batch, _ = a.allocator.ResetMaybeReallocate(
-					a.outputTypes, a.scratch.Batch, newMinCapacity, maxBatchMemSize,
+					a.outputTypes, a.scratch.Batch, newMinCapacity,
+					maxBatchMemSize, true, /* desiredCapacitySufficient */
 				)
 			}
 			// We will never copy more than coldata.BatchSize() into the
 			// temporary buffer, so a half of the scratch's capacity will always
 			// be sufficient.
 			a.scratch.tempBuffer, _ = a.allocator.ResetMaybeReallocate(
-				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2, maxBatchMemSize,
+				a.outputTypes, a.scratch.tempBuffer, newMinCapacity/2,
+				maxBatchMemSize, true, /* desiredCapacitySufficient */
 			)
 			for fnIdx, fn := range a.bucket.fns {
 				fn.SetOutput(a.scratch.ColVec(fnIdx))

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -36,7 +36,6 @@ type OrderedSynchronizer struct {
 	span *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
-	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -57,10 +56,6 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when, after setting a row, we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
 	output      coldata.Batch
 	outVecs     coldata.TypedVecs
 }
@@ -90,13 +85,12 @@ func NewOrderedSynchronizer(
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
-		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
-	os.accountingHelper.Init(allocator, typs)
+	os.accountingHelper.Init(allocator, memoryLimit, typs)
 	return os
 }
 
@@ -116,7 +110,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+	for batchDone := false; !batchDone; {
 		if o.advanceMinBatch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
@@ -256,11 +250,8 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 		o.advanceMinBatch = true
 
 		// Account for the memory of the row we have just set.
-		o.accountingHelper.AccountForSet(outputIdx)
+		batchDone = o.accountingHelper.AccountForSet(outputIdx)
 		outputIdx++
-		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
-			o.maxCapacity = outputIdx
-		}
 	}
 
 	o.output.SetLength(outputIdx)
@@ -270,8 +261,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
+		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -271,6 +271,7 @@ func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -261,7 +261,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
+		o.typs, o.output, 0, /* tuplesToBeSet */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -215,6 +215,7 @@ func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
 		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -59,7 +59,6 @@ type OrderedSynchronizer struct {
 	span *tracing.Span
 
 	accountingHelper      colmem.SetAccountingHelper
-	memoryLimit           int64
 	inputs                []colexecargs.OpWithMetaInfo
 	ordering              colinfo.ColumnOrdering
 	typs                  []*types.T
@@ -80,10 +79,6 @@ type OrderedSynchronizer struct {
 	heap []int
 	// comparators stores one comparator per ordering column.
 	comparators []vecComparator
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when, after setting a row, we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
 	output      coldata.Batch
 	outVecs     coldata.TypedVecs
 }
@@ -113,13 +108,12 @@ func NewOrderedSynchronizer(
 	ordering colinfo.ColumnOrdering,
 ) *OrderedSynchronizer {
 	os := &OrderedSynchronizer{
-		memoryLimit:           memoryLimit,
 		inputs:                inputs,
 		ordering:              ordering,
 		typs:                  typs,
 		canonicalTypeFamilies: typeconv.ToCanonicalTypeFamilies(typs),
 	}
-	os.accountingHelper.Init(allocator, typs)
+	os.accountingHelper.Init(allocator, memoryLimit, typs)
 	return os
 }
 
@@ -139,7 +133,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 	}
 	o.resetOutput()
 	outputIdx := 0
-	for outputIdx < o.output.Capacity() && (o.maxCapacity == 0 || outputIdx < o.maxCapacity) {
+	for batchDone := false; !batchDone; {
 		if o.advanceMinBatch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
@@ -200,11 +194,8 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 		o.advanceMinBatch = true
 
 		// Account for the memory of the row we have just set.
-		o.accountingHelper.AccountForSet(outputIdx)
+		batchDone = o.accountingHelper.AccountForSet(outputIdx)
 		outputIdx++
-		if o.maxCapacity == 0 && o.accountingHelper.Allocator.Used() >= o.memoryLimit {
-			o.maxCapacity = outputIdx
-		}
 	}
 
 	o.output.SetLength(outputIdx)
@@ -214,8 +205,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, o.memoryLimit,
-		false, /* desiredCapacitySufficient */
+		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/ordered_synchronizer_tmpl.go
+++ b/pkg/sql/colexec/ordered_synchronizer_tmpl.go
@@ -205,7 +205,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 func (o *OrderedSynchronizer) resetOutput() {
 	var reallocated bool
 	o.output, reallocated = o.accountingHelper.ResetMaybeReallocate(
-		o.typs, o.output, 1 /* minDesiredCapacity */, false, /* desiredCapacitySufficient */
+		o.typs, o.output, 0, /* tuplesToBeSet */
 	)
 	if reallocated {
 		o.outVecs.SetBatch(o.output)

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -287,7 +287,10 @@ func (p *sortOp) Next() coldata.Batch {
 				p.state = sortDone
 				continue
 			}
-			p.output, _ = p.allocator.ResetMaybeReallocate(p.inputTypes, p.output, toEmit, p.maxOutputBatchMemSize)
+			p.output, _ = p.allocator.ResetMaybeReallocate(
+				p.inputTypes, p.output, toEmit, p.maxOutputBatchMemSize,
+				true, /* desiredCapacitySufficient */
+			)
 			if toEmit > p.output.Capacity() {
 				toEmit = p.output.Capacity()
 			}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -47,15 +47,15 @@ func NewTopKSorter(
 		colexecerror.InternalError(errors.AssertionFailedf("invalid matchLen %v", matchLen))
 	}
 	base := &topKSorter{
-		allocator:             allocator,
-		OneInputNode:          colexecop.NewOneInputNode(input),
-		inputTypes:            inputTypes,
-		orderingCols:          orderingCols,
-		k:                     k,
-		hasPartialOrder:       matchLen > 0,
-		matchLen:              matchLen,
-		maxOutputBatchMemSize: maxOutputBatchMemSize,
+		allocator:       allocator,
+		OneInputNode:    colexecop.NewOneInputNode(input),
+		inputTypes:      inputTypes,
+		orderingCols:    orderingCols,
+		k:               k,
+		hasPartialOrder: matchLen > 0,
+		matchLen:        matchLen,
 	}
+	base.helper.Init(allocator, maxOutputBatchMemSize)
 	if base.hasPartialOrder {
 		base.heaper = &topKPartialOrderHeaper{base}
 		partialOrderCols := make([]uint32, matchLen)
@@ -94,6 +94,7 @@ type topKSorter struct {
 	colexecop.OneInputNode
 	colexecop.InitHelper
 	allocator       *colmem.Allocator
+	helper          colmem.AccountingHelper
 	orderingCols    []execinfrapb.Ordering_Column
 	inputTypes      []*types.T
 	k               uint64
@@ -116,9 +117,8 @@ type topKSorter struct {
 	// sel is a selection vector which specifies an ordering on topK.
 	sel []int
 	// emitted is the count of rows which have been emitted so far.
-	emitted               int
-	output                coldata.Batch
-	maxOutputBatchMemSize int64
+	emitted int
+	output  coldata.Batch
 
 	exportedFromTopK  int
 	exportedFromBatch int
@@ -200,10 +200,7 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(
-		t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize,
-		true, /* desiredCapacitySufficient */
-	)
+	t.output, _ = t.helper.ResetMaybeReallocate(t.inputTypes, t.output, toEmit)
 	if toEmit > t.output.Capacity() {
 		toEmit = t.output.Capacity()
 	}

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -200,7 +200,10 @@ func (t *topKSorter) emit() coldata.Batch {
 		// We're done.
 		return coldata.ZeroBatch
 	}
-	t.output, _ = t.allocator.ResetMaybeReallocate(t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize)
+	t.output, _ = t.allocator.ResetMaybeReallocate(
+		t.inputTypes, t.output, toEmit, t.maxOutputBatchMemSize,
+		true, /* desiredCapacitySufficient */
+	)
 	if toEmit > t.output.Capacity() {
 		toEmit = t.output.Capacity()
 	}

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -287,21 +287,12 @@ type cFetcher struct {
 	// kvFetcherMemAcc is a memory account that will be used by the underlying
 	// KV fetcher.
 	kvFetcherMemAcc *mon.BoundAccount
-
-	// maxCapacity if non-zero indicates the target capacity of the output
-	// batch. It is set when at the row finalization we realize that the output
-	// batch has exceeded the memory limit.
-	maxCapacity int
 }
 
 func (cf *cFetcher) resetBatch() {
 	var reallocated bool
 	var minDesiredCapacity int
-	if cf.maxCapacity > 0 {
-		// If we have already exceeded the memory limit for the output batch, we
-		// will only be using the same batch from now on.
-		minDesiredCapacity = cf.maxCapacity
-	} else if cf.machine.limitHint > 0 && (cf.estimatedRowCount == 0 || uint64(cf.machine.limitHint) < cf.estimatedRowCount) {
+	if cf.machine.limitHint > 0 && (cf.estimatedRowCount == 0 || uint64(cf.machine.limitHint) < cf.estimatedRowCount) {
 		// If we have a limit hint, and either
 		//   1) we don't have an estimate, or
 		//   2) we have a soft limit,
@@ -323,8 +314,7 @@ func (cf *cFetcher) resetBatch() {
 		}
 	}
 	cf.machine.batch, reallocated = cf.accountingHelper.ResetMaybeReallocate(
-		cf.table.typs, cf.machine.batch, minDesiredCapacity, cf.memoryLimit,
-		false, /* desiredCapacitySufficient */
+		cf.table.typs, cf.machine.batch, minDesiredCapacity, false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		cf.machine.colvecs.SetBatch(cf.machine.batch)
@@ -479,7 +469,7 @@ func (cf *cFetcher) Init(
 	}
 
 	cf.table = table
-	cf.accountingHelper.Init(allocator, cf.table.typs)
+	cf.accountingHelper.Init(allocator, cf.memoryLimit, cf.table.typs)
 
 	return nil
 }
@@ -916,23 +906,14 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			// column is requested) yet, but it is ok for the purposes of the
 			// memory accounting - oids are fixed length values and, thus, have
 			// already been accounted for when the batch was allocated.
-			cf.accountingHelper.AccountForSet(cf.machine.rowIdx)
+			emitBatch := cf.accountingHelper.AccountForSet(cf.machine.rowIdx)
 			cf.machine.rowIdx++
 			cf.shiftState()
 
-			var emitBatch bool
-			if cf.maxCapacity == 0 && cf.accountingHelper.Allocator.Used() >= cf.memoryLimit {
-				cf.maxCapacity = cf.machine.rowIdx
-			}
-			if cf.machine.rowIdx >= cf.machine.batch.Capacity() ||
-				(cf.maxCapacity > 0 && cf.machine.rowIdx >= cf.maxCapacity) ||
-				(cf.machine.limitHint > 0 && cf.machine.rowIdx >= cf.machine.limitHint) {
-				// We either
-				//   1. have no more room in our batch, so output it immediately
-				// or
-				//   2. we made it to our limit hint, so output our batch early
-				//      to make sure that we don't bother filling in extra data
-				//      if we don't need to.
+			if cf.machine.limitHint > 0 && cf.machine.rowIdx >= cf.machine.limitHint {
+				// If we made it to our limit hint, so output our batch early to
+				// make sure that we don't bother filling in extra data if we
+				// don't need to.
 				emitBatch = true
 				// Update the limit hint to track the expected remaining rows to
 				// be fetched.

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -324,6 +324,7 @@ func (cf *cFetcher) resetBatch() {
 	}
 	cf.machine.batch, reallocated = cf.accountingHelper.ResetMaybeReallocate(
 		cf.table.typs, cf.machine.batch, minDesiredCapacity, cf.memoryLimit,
+		false, /* desiredCapacitySufficient */
 	)
 	if reallocated {
 		cf.machine.colvecs.SetBatch(cf.machine.batch)

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -291,14 +291,14 @@ type cFetcher struct {
 
 func (cf *cFetcher) resetBatch() {
 	var reallocated bool
-	var minDesiredCapacity int
+	var tuplesToBeSet int
 	if cf.machine.limitHint > 0 && (cf.estimatedRowCount == 0 || uint64(cf.machine.limitHint) < cf.estimatedRowCount) {
 		// If we have a limit hint, and either
 		//   1) we don't have an estimate, or
 		//   2) we have a soft limit,
 		// use the hint to size the batch. Note that if it exceeds
 		// coldata.BatchSize, ResetMaybeReallocate will chop it down.
-		minDesiredCapacity = cf.machine.limitHint
+		tuplesToBeSet = cf.machine.limitHint
 	} else {
 		// Otherwise, use the estimate. Note that if the estimate is not
 		// present, it'll be 0 and ResetMaybeReallocate will allocate the
@@ -308,13 +308,13 @@ func (cf *cFetcher) resetBatch() {
 		// into an int. We have to be careful: if we just cast it directly, a
 		// giant estimate will wrap around and become negative.
 		if cf.estimatedRowCount > uint64(coldata.BatchSize()) {
-			minDesiredCapacity = coldata.BatchSize()
+			tuplesToBeSet = coldata.BatchSize()
 		} else {
-			minDesiredCapacity = int(cf.estimatedRowCount)
+			tuplesToBeSet = int(cf.estimatedRowCount)
 		}
 	}
 	cf.machine.batch, reallocated = cf.accountingHelper.ResetMaybeReallocate(
-		cf.table.typs, cf.machine.batch, minDesiredCapacity, false, /* desiredCapacitySufficient */
+		cf.table.typs, cf.machine.batch, tuplesToBeSet,
 	)
 	if reallocated {
 		cf.machine.colvecs.SetBatch(cf.machine.batch)
@@ -911,7 +911,7 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 			cf.shiftState()
 
 			if cf.machine.limitHint > 0 && cf.machine.rowIdx >= cf.machine.limitHint {
-				// If we made it to our limit hint, so output our batch early to
+				// We made it to our limit hint, so output our batch early to
 				// make sure that we don't bother filling in extra data if we
 				// don't need to.
 				emitBatch = true

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -409,7 +409,10 @@ func (i *Inbox) Next() coldata.Batch {
 		}
 		// We rely on the outboxes to produce reasonably sized batches.
 		const maxBatchMemSize = math.MaxInt64
-		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(i.typs, i.scratch.b, batchLength, maxBatchMemSize)
+		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(
+			i.typs, i.scratch.b, batchLength, maxBatchMemSize,
+			true, /* desiredCapacitySufficient */
+		)
 		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {
 			if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {
 				colexecerror.InternalError(err)

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -13,7 +13,6 @@ package colrpc
 import (
 	"context"
 	"io"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -408,10 +407,8 @@ func (i *Inbox) Next() coldata.Batch {
 			colexecerror.InternalError(err)
 		}
 		// We rely on the outboxes to produce reasonably sized batches.
-		const maxBatchMemSize = math.MaxInt64
-		i.scratch.b, _ = i.allocator.ResetMaybeReallocate(
-			i.typs, i.scratch.b, batchLength, maxBatchMemSize,
-			true, /* desiredCapacitySufficient */
+		i.scratch.b, _ = i.allocator.ResetMaybeReallocateNoMemLimit(
+			i.typs, i.scratch.b, batchLength,
 		)
 		i.allocator.PerformOperation(i.scratch.b.ColVecs(), func() {
 			if err := i.converter.ArrowToBatch(i.scratch.data, batchLength, i.scratch.b); err != nil {

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
     srcs = [
         "adjust_memory_usage_test.go",
         "allocator_test.go",
+        "reset_maybe_reallocate_test.go",
     ],
     embed = [":colmem"],
     deps = [

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -43,7 +43,9 @@ type Allocator struct {
 	factory      coldata.ColumnFactory
 }
 
-func selVectorSize(capacity int) int64 {
+// SelVectorSize returns the memory usage of the selection vector of the given
+// capacity.
+func SelVectorSize(capacity int) int64 {
 	return int64(capacity) * memsize.Int
 }
 
@@ -82,7 +84,7 @@ func GetBatchMemSize(b coldata.Batch) int64 {
 	// below.
 	usesSel := b.Selection() != nil
 	b.SetSelection(true)
-	memUsage := selVectorSize(cap(b.Selection())) + getVecsMemoryFootprint(b.ColVecs())
+	memUsage := SelVectorSize(cap(b.Selection())) + getVecsMemoryFootprint(b.ColVecs())
 	b.SetSelection(usesSel)
 	return memUsage
 }
@@ -100,7 +102,7 @@ func GetProportionalBatchMemSize(b coldata.Batch, length int64) int64 {
 	b.SetSelection(usesSel)
 	proportionalBatchMemSize := int64(0)
 	if selCapacity > 0 {
-		proportionalBatchMemSize = selVectorSize(selCapacity) * length / int64(selCapacity)
+		proportionalBatchMemSize = SelVectorSize(selCapacity) * length / int64(selCapacity)
 	}
 	for _, vec := range b.ColVecs() {
 		switch vec.CanonicalTypeFamily() {
@@ -155,7 +157,7 @@ func NewLimitedAllocator(
 // Note: consider whether you want the dynamic batch size behavior (in which
 // case you should be using ResetMaybeReallocate).
 func (a *Allocator) NewMemBatchWithFixedCapacity(typs []*types.T, capacity int) coldata.Batch {
-	estimatedMemoryUsage := selVectorSize(capacity) + EstimateBatchSizeBytes(typs, capacity)
+	estimatedMemoryUsage := SelVectorSize(capacity) + EstimateBatchSizeBytes(typs, capacity)
 	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		colexecerror.InternalError(err)
 	}
@@ -173,7 +175,7 @@ func (a *Allocator) NewMemBatchWithMaxCapacity(typs []*types.T) coldata.Batch {
 // allocates memory for the selection vector but does *not* allocate any memory
 // for the column vectors - those will have to be added separately.
 func (a *Allocator) NewMemBatchNoCols(typs []*types.T, capacity int) coldata.Batch {
-	estimatedMemoryUsage := selVectorSize(capacity)
+	estimatedMemoryUsage := SelVectorSize(capacity)
 	if err := a.acc.Grow(a.ctx, estimatedMemoryUsage); err != nil {
 		colexecerror.InternalError(err)
 	}
@@ -197,18 +199,25 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 // capacity of old batch is at least minDesiredCapacity, then the old batch is
 // reused.
 //
+// oldBatchReachedMemSize is true IFF we calculated the memory footprint of the
+// non-nil old batch and it reached maxBatchMemSize. The calculation only occurs
+// if desiredCapacitySufficient is false or the old batch has the capacity less
+// that minDesiredCapacity. If oldBatchReachedMemSize is true, then the old
+// batch is reused (the converse is not necessarily true).
+//
 // NOTE: if the reallocation occurs, then the memory under the old batch is
 // released, so it is expected that the caller will lose the references to the
 // old batch.
 // Note: the method assumes that minDesiredCapacity is at least 0 and will clamp
 // minDesiredCapacity to be between 1 and coldata.BatchSize() inclusive.
+// TODO(yuzefovich): unexport this method.
 func (a *Allocator) ResetMaybeReallocate(
 	typs []*types.T,
 	oldBatch coldata.Batch,
 	minDesiredCapacity int,
 	maxBatchMemSize int64,
 	desiredCapacitySufficient bool,
-) (newBatch coldata.Batch, reallocated bool) {
+) (newBatch coldata.Batch, reallocated bool, oldBatchReachedMemSize bool) {
 	if minDesiredCapacity < 0 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid minDesiredCapacity %d", minDesiredCapacity))
 	} else if minDesiredCapacity == 0 {
@@ -233,7 +242,8 @@ func (a *Allocator) ResetMaybeReallocate(
 			// Check if the old batch already reached the maximum memory size,
 			// and use it if so.
 			oldBatchMemSize = GetBatchMemSize(oldBatch)
-			useOldBatch = oldBatchMemSize >= maxBatchMemSize
+			oldBatchReachedMemSize = oldBatchMemSize >= maxBatchMemSize
+			useOldBatch = oldBatchReachedMemSize
 		}
 		if useOldBatch {
 			reallocated = false
@@ -251,7 +261,7 @@ func (a *Allocator) ResetMaybeReallocate(
 			newBatch = a.NewMemBatchWithFixedCapacity(typs, newCapacity)
 		}
 	}
-	return newBatch, reallocated
+	return newBatch, reallocated, oldBatchReachedMemSize
 }
 
 // ResetMaybeReallocateNoMemLimit is the same as ResetMaybeReallocate when
@@ -263,7 +273,8 @@ func (a *Allocator) ResetMaybeReallocate(
 func (a *Allocator) ResetMaybeReallocateNoMemLimit(
 	typs []*types.T, oldBatch coldata.Batch, requiredCapacity int,
 ) (newBatch coldata.Batch, reallocated bool) {
-	return a.ResetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
+	newBatch, reallocated, _ = a.ResetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
+	return newBatch, reallocated
 }
 
 // NewMemColumn returns a new coldata.Vec of the desired capacity.
@@ -479,10 +490,6 @@ func sizeOfDecimals(decimals coldata.Decimals, startIdx int) int64 {
 	return size
 }
 
-// SizeOfBatchSizeSelVector is the size (in bytes) of a selection vector of
-// coldata.BatchSize() length.
-var SizeOfBatchSizeSelVector = int64(coldata.BatchSize()) * memsize.Int
-
 // EstimateBatchSizeBytes returns an estimated amount of bytes needed to
 // store a batch in memory that has column types vecTypes.
 // WARNING: This only is correct for fixed width types, and returns an
@@ -569,6 +576,133 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 	return size
 }
 
+// AccountingHelper is a helper that provides a reasonable heuristic for
+// reallocating batches with ResetMaybeReallocate() function.
+//
+// The heuristic is as follows:
+// - the first time a batch exceeds the memory limit, its capacity is memorized,
+//   and from now on that capacity will determine the upper bound on the
+//   capacities of the batches allocated through the helper;
+// - if at any point in time a batch exceeds the memory limit by at least a
+//   factor of two, then that batch is discarded, and the capacity will never
+//   exceed half of the capacity of the discarded batch;
+// - if the memory limit is not reached, then the behavior of the dynamic growth
+//   of the capacity provided by Allocator.ResetMaybeReallocate is still
+//   applicable (i.e. the capacities will grow exponentially until
+//   coldata.BatchSize()).
+//
+// NOTE: it works under the assumption that only a single coldata.Batch is being
+// used.
+type AccountingHelper struct {
+	allocator *Allocator
+	// memoryLimit determines the maximum memory footprint of the batch.
+	memoryLimit int64
+	// maxCapacity if non-zero indicates the target capacity of the batch. It is
+	// set once the batch exceeds the memory limit. It will be reduced even
+	// further if the batch significantly exceeds the memory limit.
+	// TODO(yuzefovich): consider growing the maxCapacity after the number of
+	// "successes" (a batch of maxCapacity not reaching the memory limit)
+	// reaches some threshold.
+	maxCapacity int
+}
+
+// discardBatch returns true if the batch with the given memory footprint has
+// exceeded the limit by too much and should be discarded.
+func (h *AccountingHelper) discardBatch(batchMemSize int64) bool {
+	// We use the division instead of multiplication to avoid issues with the
+	// overflow.
+	return batchMemSize/2 >= h.memoryLimit
+}
+
+// Init initializes the helper. The allocator can be shared with other
+// components.
+func (h *AccountingHelper) Init(allocator *Allocator, memoryLimit int64) {
+	h.allocator = allocator
+	if memoryLimit == 1 {
+		// The memory limit of 1 most likely indicates that we are in a "force
+		// disk spilling" scenario, but the helper should ignore that, so we
+		// override it to the default value of the distsql_workmem variable.
+		memoryLimit = 64 << 20 /* 64 MiB */
+	}
+	h.memoryLimit = memoryLimit
+}
+
+// ResetMaybeReallocate returns a batch that is guaranteed to be in a "reset"
+// state (meaning it is ready to be used) and to have the capacity of at least
+// 1.
+//
+// The method will grow the allocated capacity of the batch exponentially
+// (possibly incurring a reallocation), until the batch reaches
+// coldata.BatchSize() in capacity or the target memory limit (specified in
+// Init()) in the memory footprint. If the limit is exceeded by at least a
+// factor of two, then the old batch is discarded, and the new batch will be
+// allocated of at most half of the capacity (the capacity will never increase
+// from that point).
+//
+// - tuplesToBeSet, if positive, indicates the total number of tuples that are
+// yet to be set, use 0 if unknown.
+//
+// NOTE: if the reallocation occurs, then the memory under the old batch is
+// released, so it is expected that the caller will lose the references to the
+// old batch.
+func (h *AccountingHelper) ResetMaybeReallocate(
+	typs []*types.T, oldBatch coldata.Batch, tuplesToBeSet int,
+) (newBatch coldata.Batch, reallocated bool) {
+	if oldBatch != nil {
+		// First, do a quick check whether the allocator as a whole has exceeded
+		// the limit by too much. (The allocator here is allowed to be shared
+		// with other components, thus, we cannot ask it directly for the batch
+		// mem size, yet the allocator can provide a useful upper bound.)
+		if batchMemSizeUpperBound := h.allocator.Used(); h.discardBatch(batchMemSizeUpperBound) {
+			// Now check whether the precise footprint of the batch is too much.
+			if batchMemSize := GetBatchMemSize(oldBatch); h.discardBatch(batchMemSize) {
+				// The old batch has exceeded the memory limit by too much, so
+				// we release it and will allocate a new one that is at most
+				// half of the capacity.
+				newMaxCapacity := (oldBatch.Capacity() + 1) / 2 // round up
+				if h.maxCapacity == 0 || newMaxCapacity < h.maxCapacity {
+					h.maxCapacity = newMaxCapacity
+				}
+				h.allocator.ReleaseMemory(batchMemSize)
+				oldBatch = nil
+			}
+		}
+	}
+	// Protect from the misuse.
+	if tuplesToBeSet < 0 {
+		tuplesToBeSet = 0
+	}
+	// By default, assume that the number of tuples to be set is sufficient and
+	// ask for it. If that number is unknown, we'll rely on the
+	// Allocator.ResetMaybeReallocate method to provide the dynamically-growing
+	// batches.
+	minDesiredCapacity := tuplesToBeSet
+	desiredCapacitySufficient := tuplesToBeSet > 0
+	if h.maxCapacity > 0 && (h.maxCapacity < tuplesToBeSet || tuplesToBeSet == 0) {
+		// If we have already exceeded the max capacity, and
+		// - that capacity is lower then the number of tuples to be set, or
+		// - the number of tuples to be set is unknown,
+		// then we'll use that max capacity and tell the allocator to not try
+		// allocating larger batch.
+		minDesiredCapacity = h.maxCapacity
+		desiredCapacitySufficient = true
+	}
+	var oldBatchReachedMemSize bool
+	newBatch, reallocated, oldBatchReachedMemSize = h.allocator.ResetMaybeReallocate(
+		typs, oldBatch, minDesiredCapacity, h.memoryLimit, desiredCapacitySufficient,
+	)
+	if oldBatchReachedMemSize && h.maxCapacity == 0 {
+		// The old batch has just reached the memory size for the first time, so
+		// we memorize the maximum capacity. Note that this is not strictly
+		// necessary to do (since Allocator.ResetMaybeReallocate would never
+		// allocate a new batch from now on), but it makes things more clear and
+		// allows us to avoid computing the memory size of the batch on each
+		// call.
+		h.maxCapacity = oldBatch.Capacity()
+	}
+	return newBatch, reallocated
+}
+
 // SetAccountingHelper is a utility struct that should be used by callers that
 // only perform "set" operations on the coldata.Batch (i.e. neither copies nor
 // appends). It encapsulates the logic for performing the memory accounting for
@@ -576,16 +710,11 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 // NOTE: it works under the assumption that only a single coldata.Batch is being
 // used.
 type SetAccountingHelper struct {
-	allocator *Allocator
+	helper AccountingHelper
 
 	// curCapacity is the capacity of the last batch returned by
 	// ResetMaybeReallocate.
 	curCapacity int
-	// maxCapacity if non-zero indicates the target capacity of the batch. It is
-	// set once the batch exceeds the memory limit.
-	maxCapacity int
-	// memoryLimit determines the maximum memory footprint of the batch.
-	memoryLimit int64
 
 	// allFixedLength indicates that we're working with the type schema of only
 	// fixed-length elements.
@@ -629,8 +758,7 @@ type SetAccountingHelper struct {
 // Init initializes the helper. The allocator must **not** be shared with any
 // other component.
 func (h *SetAccountingHelper) Init(allocator *Allocator, memoryLimit int64, typs []*types.T) {
-	h.allocator = allocator
-	h.memoryLimit = memoryLimit
+	h.helper.Init(allocator, memoryLimit)
 
 	for vecIdx, typ := range typs {
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
@@ -658,14 +786,14 @@ func (h *SetAccountingHelper) getBytesLikeTotalSize() int64 {
 }
 
 // ResetMaybeReallocate is a light wrapper on top of
-// Allocator.ResetMaybeReallocate (and thus has the same contract) with an
-// additional logic for memory tracking purposes.
+// AccountingHelper.ResetMaybeReallocate (and thus has the same contract) with
+// an additional logic for memory tracking purposes.
+// - tuplesToBeSet, if positive, indicates the total number of tuples that are
+// yet to be set, use 0 if unknown.
 func (h *SetAccountingHelper) ResetMaybeReallocate(
-	typs []*types.T, oldBatch coldata.Batch, minCapacity int, desiredCapacitySufficient bool,
+	typs []*types.T, oldBatch coldata.Batch, tuplesToBeSet int,
 ) (newBatch coldata.Batch, reallocated bool) {
-	newBatch, reallocated = h.allocator.ResetMaybeReallocate(
-		typs, oldBatch, minCapacity, h.memoryLimit, desiredCapacitySufficient,
-	)
+	newBatch, reallocated = h.helper.ResetMaybeReallocate(typs, oldBatch, tuplesToBeSet)
 	h.curCapacity = newBatch.Capacity()
 	if reallocated && !h.allFixedLength {
 		// Allocator.ResetMaybeReallocate has released the precise memory
@@ -731,7 +859,7 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 
 	if len(h.bytesLikeVectors) > 0 {
 		newBytesLikeTotalSize := h.getBytesLikeTotalSize()
-		h.allocator.adjustMemoryUsageAfterAllocation(newBytesLikeTotalSize - h.prevBytesLikeTotalSize)
+		h.helper.allocator.adjustMemoryUsageAfterAllocation(newBytesLikeTotalSize - h.prevBytesLikeTotalSize)
 		h.prevBytesLikeTotalSize = newBytesLikeTotalSize
 	}
 
@@ -741,7 +869,7 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 			d := decimalVec.Get(rowIdx)
 			newDecimalSizes += int64(d.Size())
 		}
-		h.allocator.adjustMemoryUsageAfterAllocation(newDecimalSizes - h.decimalSizes[rowIdx])
+		h.helper.allocator.adjustMemoryUsageAfterAllocation(newDecimalSizes - h.decimalSizes[rowIdx])
 		h.decimalSizes[rowIdx] = newDecimalSizes
 	}
 
@@ -753,17 +881,23 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 			// was already included in EstimateBatchSizeBytes.
 			newVarLengthDatumSize += int64(datumSize)
 		}
-		h.allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize)
+		h.helper.allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize)
 	}
 
-	if h.maxCapacity == 0 && h.allocator.Used() >= h.memoryLimit {
-		// This is the first time we exceeded the memory limit, so we memorize
-		// the capacity.
-		h.maxCapacity = rowIdx + 1
+	// The allocator is not shared with any other components, so we can just use
+	// it directly to get the memory footprint of the batch.
+	batchMemSize := h.helper.allocator.Used()
+	if (h.helper.maxCapacity == 0 && batchMemSize >= h.helper.memoryLimit) || h.helper.discardBatch(batchMemSize) {
+		// This is either
+		// - the first time we exceeded the memory limit, or
+		// - the batch has just significantly exceeded the memory limit, so
+		// we update the memorized capacity. If it's the latter, then on the
+		// following call to ResetMaybeReallocate, the batch will be discarded.
+		h.helper.maxCapacity = rowIdx + 1
 	}
-	if h.maxCapacity > 0 && h.maxCapacity == rowIdx+1 {
-		// The batch is also done if we've exceeded the memory limit, and we've
-		// just set the last row according to the memorized capacity.
+	if h.helper.maxCapacity > 0 && h.helper.maxCapacity == rowIdx+1 {
+		// The batch is done if we've exceeded the memory limit, and we've just
+		// set the last row according to the memorized capacity.
 		batchDone = true
 	}
 	return batchDone
@@ -772,7 +906,7 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 // TestingUpdateMemoryLimit sets the new memory limit. It should only be used in
 // tests.
 func (h *SetAccountingHelper) TestingUpdateMemoryLimit(memoryLimit int64) {
-	h.memoryLimit = memoryLimit
+	h.helper.memoryLimit = memoryLimit
 }
 
 // Release releases all of the resources so that they can be garbage collected.

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -254,6 +254,18 @@ func (a *Allocator) ResetMaybeReallocate(
 	return newBatch, reallocated
 }
 
+// ResetMaybeReallocateNoMemLimit is the same as ResetMaybeReallocate when
+// MaxInt64 is used as the maxBatchMemSize argument and the desired capacity is
+// sufficient. This should be used by the callers that know exactly the capacity
+// they need and have no control over that number. It is guaranteed that the
+// returned batch has the capacity of at least requiredCapacity (clamped to
+// [1, coldata.BatchSize()] range).
+func (a *Allocator) ResetMaybeReallocateNoMemLimit(
+	typs []*types.T, oldBatch coldata.Batch, requiredCapacity int,
+) (newBatch coldata.Batch, reallocated bool) {
+	return a.ResetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
+}
+
 // NewMemColumn returns a new coldata.Vec of the desired capacity.
 // NOTE: consider whether you should be using MaybeAppendColumn,
 // NewMemBatchWith*, or ResetMaybeReallocate methods.

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -187,7 +187,7 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 	a.ReleaseMemory(batch.ResetInternalBatch())
 }
 
-// ResetMaybeReallocate returns a batch that is guaranteed to be in a "reset"
+// resetMaybeReallocate returns a batch that is guaranteed to be in a "reset"
 // state (meaning it is ready to be used) and to have the capacity of at least
 // 1. minDesiredCapacity is a hint about the capacity of the returned batch
 // (subject to the memory limit).
@@ -210,8 +210,7 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 // old batch.
 // Note: the method assumes that minDesiredCapacity is at least 0 and will clamp
 // minDesiredCapacity to be between 1 and coldata.BatchSize() inclusive.
-// TODO(yuzefovich): unexport this method.
-func (a *Allocator) ResetMaybeReallocate(
+func (a *Allocator) resetMaybeReallocate(
 	typs []*types.T,
 	oldBatch coldata.Batch,
 	minDesiredCapacity int,
@@ -264,7 +263,7 @@ func (a *Allocator) ResetMaybeReallocate(
 	return newBatch, reallocated, oldBatchReachedMemSize
 }
 
-// ResetMaybeReallocateNoMemLimit is the same as ResetMaybeReallocate when
+// ResetMaybeReallocateNoMemLimit is the same as resetMaybeReallocate when
 // MaxInt64 is used as the maxBatchMemSize argument and the desired capacity is
 // sufficient. This should be used by the callers that know exactly the capacity
 // they need and have no control over that number. It is guaranteed that the
@@ -273,7 +272,7 @@ func (a *Allocator) ResetMaybeReallocate(
 func (a *Allocator) ResetMaybeReallocateNoMemLimit(
 	typs []*types.T, oldBatch coldata.Batch, requiredCapacity int,
 ) (newBatch coldata.Batch, reallocated bool) {
-	newBatch, reallocated, _ = a.ResetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
+	newBatch, reallocated, _ = a.resetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
 	return newBatch, reallocated
 }
 
@@ -587,7 +586,7 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 //   factor of two, then that batch is discarded, and the capacity will never
 //   exceed half of the capacity of the discarded batch;
 // - if the memory limit is not reached, then the behavior of the dynamic growth
-//   of the capacity provided by Allocator.ResetMaybeReallocate is still
+//   of the capacity provided by Allocator.resetMaybeReallocate is still
 //   applicable (i.e. the capacities will grow exponentially until
 //   coldata.BatchSize()).
 //
@@ -674,7 +673,7 @@ func (h *AccountingHelper) ResetMaybeReallocate(
 	}
 	// By default, assume that the number of tuples to be set is sufficient and
 	// ask for it. If that number is unknown, we'll rely on the
-	// Allocator.ResetMaybeReallocate method to provide the dynamically-growing
+	// Allocator.resetMaybeReallocate method to provide the dynamically-growing
 	// batches.
 	minDesiredCapacity := tuplesToBeSet
 	desiredCapacitySufficient := tuplesToBeSet > 0
@@ -688,13 +687,13 @@ func (h *AccountingHelper) ResetMaybeReallocate(
 		desiredCapacitySufficient = true
 	}
 	var oldBatchReachedMemSize bool
-	newBatch, reallocated, oldBatchReachedMemSize = h.allocator.ResetMaybeReallocate(
+	newBatch, reallocated, oldBatchReachedMemSize = h.allocator.resetMaybeReallocate(
 		typs, oldBatch, minDesiredCapacity, h.memoryLimit, desiredCapacitySufficient,
 	)
 	if oldBatchReachedMemSize && h.maxCapacity == 0 {
 		// The old batch has just reached the memory size for the first time, so
 		// we memorize the maximum capacity. Note that this is not strictly
-		// necessary to do (since Allocator.ResetMaybeReallocate would never
+		// necessary to do (since Allocator.resetMaybeReallocate would never
 		// allocate a new batch from now on), but it makes things more clear and
 		// allows us to avoid computing the memory size of the batch on each
 		// call.
@@ -796,7 +795,7 @@ func (h *SetAccountingHelper) ResetMaybeReallocate(
 	newBatch, reallocated = h.helper.ResetMaybeReallocate(typs, oldBatch, tuplesToBeSet)
 	h.curCapacity = newBatch.Capacity()
 	if reallocated && !h.allFixedLength {
-		// Allocator.ResetMaybeReallocate has released the precise memory
+		// Allocator.resetMaybeReallocate has released the precise memory
 		// footprint of the old batch and has accounted for the estimated
 		// footprint of the new batch. This means that we need to update our
 		// internal memory tracking state to those estimates.

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -576,7 +576,16 @@ func GetFixedSizeTypeSize(t *types.T) (size int64) {
 // NOTE: it works under the assumption that only a single coldata.Batch is being
 // used.
 type SetAccountingHelper struct {
-	Allocator *Allocator
+	allocator *Allocator
+
+	// curCapacity is the capacity of the last batch returned by
+	// ResetMaybeReallocate.
+	curCapacity int
+	// maxCapacity if non-zero indicates the target capacity of the batch. It is
+	// set once the batch exceeds the memory limit.
+	maxCapacity int
+	// memoryLimit determines the maximum memory footprint of the batch.
+	memoryLimit int64
 
 	// allFixedLength indicates that we're working with the type schema of only
 	// fixed-length elements.
@@ -617,9 +626,11 @@ type SetAccountingHelper struct {
 	varLenDatumVecs []coldata.DatumVec
 }
 
-// Init initializes the helper.
-func (h *SetAccountingHelper) Init(allocator *Allocator, typs []*types.T) {
-	h.Allocator = allocator
+// Init initializes the helper. The allocator must **not** be shared with any
+// other component.
+func (h *SetAccountingHelper) Init(allocator *Allocator, memoryLimit int64, typs []*types.T) {
+	h.allocator = allocator
+	h.memoryLimit = memoryLimit
 
 	for vecIdx, typ := range typs {
 		switch typeconv.TypeFamilyToCanonicalTypeFamily(typ.Family()) {
@@ -650,15 +661,12 @@ func (h *SetAccountingHelper) getBytesLikeTotalSize() int64 {
 // Allocator.ResetMaybeReallocate (and thus has the same contract) with an
 // additional logic for memory tracking purposes.
 func (h *SetAccountingHelper) ResetMaybeReallocate(
-	typs []*types.T,
-	oldBatch coldata.Batch,
-	minCapacity int,
-	maxBatchMemSize int64,
-	desiredCapacitySufficient bool,
+	typs []*types.T, oldBatch coldata.Batch, minCapacity int, desiredCapacitySufficient bool,
 ) (newBatch coldata.Batch, reallocated bool) {
-	newBatch, reallocated = h.Allocator.ResetMaybeReallocate(
-		typs, oldBatch, minCapacity, maxBatchMemSize, desiredCapacitySufficient,
+	newBatch, reallocated = h.allocator.ResetMaybeReallocate(
+		typs, oldBatch, minCapacity, h.memoryLimit, desiredCapacitySufficient,
 	)
+	h.curCapacity = newBatch.Capacity()
 	if reallocated && !h.allFixedLength {
 		// Allocator.ResetMaybeReallocate has released the precise memory
 		// footprint of the old batch and has accounted for the estimated
@@ -708,17 +716,22 @@ func (h *SetAccountingHelper) ResetMaybeReallocate(
 
 // AccountForSet updates the Allocator according to the new variable length
 // values in the row rowIdx in the batch that was returned by the last call to
-// ResetMaybeReallocate.
-func (h *SetAccountingHelper) AccountForSet(rowIdx int) {
+// ResetMaybeReallocate. It returns a boolean indicating whether the batch is
+// done (i.e. no more rows should be set on it before it is reset).
+func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
+	// The batch is done if we've just set the last row that the batch has the
+	// capacity for.
+	batchDone = h.curCapacity == rowIdx+1
 	if h.allFixedLength {
 		// All vectors are of fixed-length and are already correctly accounted
-		// for.
-		return
+		// for. We also utilize the whole capacity since setting extra rows
+		// incurs no additional memory usage.
+		return batchDone
 	}
 
 	if len(h.bytesLikeVectors) > 0 {
 		newBytesLikeTotalSize := h.getBytesLikeTotalSize()
-		h.Allocator.adjustMemoryUsageAfterAllocation(newBytesLikeTotalSize - h.prevBytesLikeTotalSize)
+		h.allocator.adjustMemoryUsageAfterAllocation(newBytesLikeTotalSize - h.prevBytesLikeTotalSize)
 		h.prevBytesLikeTotalSize = newBytesLikeTotalSize
 	}
 
@@ -728,7 +741,7 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) {
 			d := decimalVec.Get(rowIdx)
 			newDecimalSizes += int64(d.Size())
 		}
-		h.Allocator.adjustMemoryUsageAfterAllocation(newDecimalSizes - h.decimalSizes[rowIdx])
+		h.allocator.adjustMemoryUsageAfterAllocation(newDecimalSizes - h.decimalSizes[rowIdx])
 		h.decimalSizes[rowIdx] = newDecimalSizes
 	}
 
@@ -740,8 +753,26 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) {
 			// was already included in EstimateBatchSizeBytes.
 			newVarLengthDatumSize += int64(datumSize)
 		}
-		h.Allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize)
+		h.allocator.adjustMemoryUsageAfterAllocation(newVarLengthDatumSize)
 	}
+
+	if h.maxCapacity == 0 && h.allocator.Used() >= h.memoryLimit {
+		// This is the first time we exceeded the memory limit, so we memorize
+		// the capacity.
+		h.maxCapacity = rowIdx + 1
+	}
+	if h.maxCapacity > 0 && h.maxCapacity == rowIdx+1 {
+		// The batch is also done if we've exceeded the memory limit, and we've
+		// just set the last row according to the memorized capacity.
+		batchDone = true
+	}
+	return batchDone
+}
+
+// TestingUpdateMemoryLimit sets the new memory limit. It should only be used in
+// tests.
+func (h *SetAccountingHelper) TestingUpdateMemoryLimit(memoryLimit int64) {
+	h.memoryLimit = memoryLimit
 }
 
 // Release releases all of the resources so that they can be garbage collected.

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -192,7 +192,10 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 //
 // The method will grow the allocated capacity of the batch exponentially
 // (possibly incurring a reallocation), until the batch reaches
-// coldata.BatchSize() in capacity or maxBatchMemSize in the memory footprint.
+// coldata.BatchSize() in capacity or maxBatchMemSize in the memory footprint if
+// desiredCapacitySufficient is false. When that parameter is true and the
+// capacity of old batch is at least minDesiredCapacity, then the old batch is
+// reused.
 //
 // NOTE: if the reallocation occurs, then the memory under the old batch is
 // released, so it is expected that the caller will lose the references to the
@@ -200,7 +203,11 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 // Note: the method assumes that minDesiredCapacity is at least 0 and will clamp
 // minDesiredCapacity to be between 1 and coldata.BatchSize() inclusive.
 func (a *Allocator) ResetMaybeReallocate(
-	typs []*types.T, oldBatch coldata.Batch, minDesiredCapacity int, maxBatchMemSize int64,
+	typs []*types.T,
+	oldBatch coldata.Batch,
+	minDesiredCapacity int,
+	maxBatchMemSize int64,
+	desiredCapacitySufficient bool,
 ) (newBatch coldata.Batch, reallocated bool) {
 	if minDesiredCapacity < 0 {
 		colexecerror.InternalError(errors.AssertionFailedf("invalid minDesiredCapacity %d", minDesiredCapacity))
@@ -215,6 +222,11 @@ func (a *Allocator) ResetMaybeReallocate(
 	} else {
 		// If old batch is already of the largest capacity, we will reuse it.
 		useOldBatch := oldBatch.Capacity() == coldata.BatchSize()
+		// If the old batch already satisfies the desired capacity which is
+		// sufficient, we will reuse it too.
+		if desiredCapacitySufficient && oldBatch.Capacity() >= minDesiredCapacity {
+			useOldBatch = true
+		}
 		// Avoid calculating the memory footprint if possible.
 		var oldBatchMemSize int64
 		if !useOldBatch {
@@ -626,10 +638,14 @@ func (h *SetAccountingHelper) getBytesLikeTotalSize() int64 {
 // Allocator.ResetMaybeReallocate (and thus has the same contract) with an
 // additional logic for memory tracking purposes.
 func (h *SetAccountingHelper) ResetMaybeReallocate(
-	typs []*types.T, oldBatch coldata.Batch, minCapacity int, maxBatchMemSize int64,
+	typs []*types.T,
+	oldBatch coldata.Batch,
+	minCapacity int,
+	maxBatchMemSize int64,
+	desiredCapacitySufficient bool,
 ) (newBatch coldata.Batch, reallocated bool) {
 	newBatch, reallocated = h.Allocator.ResetMaybeReallocate(
-		typs, oldBatch, minCapacity, maxBatchMemSize,
+		typs, oldBatch, minCapacity, maxBatchMemSize, desiredCapacitySufficient,
 	)
 	if reallocated && !h.allFixedLength {
 		// Allocator.ResetMaybeReallocate has released the precise memory

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -287,7 +287,7 @@ func TestSetAccountingHelper(t *testing.T) {
 	}
 
 	var helper colmem.SetAccountingHelper
-	helper.Init(testAllocator, typs)
+	helper.Init(testAllocator, math.MaxInt64, typs)
 
 	numIterations := rng.Intn(10) + 1
 	numRows := rng.Intn(coldata.BatchSize()) + 1
@@ -305,7 +305,8 @@ func TestSetAccountingHelper(t *testing.T) {
 			// new batch with larger capacity might be allocated.
 			maxBatchMemSize = largeMemSize
 		}
-		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, maxBatchMemSize, false /* desiredCapacitySufficient */)
+		helper.TestingUpdateMemoryLimit(maxBatchMemSize)
+		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, false /* desiredCapacitySufficient */)
 
 		for rowIdx := 0; rowIdx < batch.Capacity(); rowIdx++ {
 			for vecIdx, typ := range typs {
@@ -321,7 +322,10 @@ func TestSetAccountingHelper(t *testing.T) {
 					coldata.SetValueAt(batch.ColVec(vecIdx), converter(datum), rowIdx)
 				}
 			}
-			helper.AccountForSet(rowIdx)
+			// The purpose of this test is ensuring that memory accounting is
+			// up-to-date, so we ignore the recommendation of the helper whether
+			// the batch is done.
+			_ = helper.AccountForSet(rowIdx)
 		}
 
 		// At this point, we have set all rows in the batch and performed the

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -118,13 +118,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 		typs := []*types.T{types.Bytes}
 
 		// Allocate a new batch and modify it.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		b.SetSelection(true)
 		b.Selection()[0] = 1
 		b.ColVec(0).Bytes().Set(1, []byte("foo"))
 
 		oldBatch := b
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64)
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		// We should have used the same batch, and now it should be in a "reset"
 		// state.
 		require.Equal(t, oldBatch, b)
@@ -151,15 +151,21 @@ func TestResetMaybeReallocate(t *testing.T) {
 		// Allocate a new batch attempting to use the batch with too small of a
 		// capacity - new batch should **not** be allocated because the memory
 		// limit is already exceeded.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize)
+		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
 		oldBatch := b
 
+		// Reset the batch asking for the same small desired capacity when it is
+		// sufficient - the same batch should be returned.
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
+		require.Equal(t, smallBatch, b)
+		require.Equal(t, minDesiredCapacity/2, b.Capacity())
+
 		// Reset the batch and confirm that a new batch is allocated because we
 		// have given larger memory limit.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize)
+		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 		require.NotEqual(t, oldBatch, b)
 		require.Equal(t, minDesiredCapacity, b.Capacity())
 
@@ -170,7 +176,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 			// ResetMaybeReallocate truncates the capacity at
 			// coldata.BatchSize(), so we run this part of the test only when
 			// doubled capacity will not be truncated.
-			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize)
+			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 			require.NotEqual(t, oldBatch, b)
 			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
 		}
@@ -299,7 +305,7 @@ func TestSetAccountingHelper(t *testing.T) {
 			// new batch with larger capacity might be allocated.
 			maxBatchMemSize = largeMemSize
 		}
-		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, maxBatchMemSize)
+		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, maxBatchMemSize, false /* desiredCapacitySufficient */)
 
 		for rowIdx := 0; rowIdx < batch.Capacity(); rowIdx++ {
 			for vecIdx, typ := range typs {

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -93,94 +92,6 @@ func TestMaybeAppendColumn(t *testing.T) {
 		require.Equal(t, 1, b.Width())
 		require.Equal(t, coldata.BatchSize(), b.ColVec(colIdx).Length())
 		_ = b.ColVec(colIdx).Int64()[0]
-	})
-}
-
-func TestResetMaybeReallocate(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
-	t.Run("ResettingBehavior", func(t *testing.T) {
-		if coldata.BatchSize() == 1 {
-			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
-		}
-
-		var b coldata.Batch
-		typs := []*types.T{types.Bytes}
-
-		// Allocate a new batch and modify it.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
-		b.SetSelection(true)
-		b.Selection()[0] = 1
-		b.ColVec(0).Bytes().Set(1, []byte("foo"))
-
-		oldBatch := b
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
-		// We should have used the same batch, and now it should be in a "reset"
-		// state.
-		require.Equal(t, oldBatch, b)
-		require.Nil(t, b.Selection())
-		// We should be able to set in the Bytes vector using an arbitrary
-		// position since the vector should have been reset.
-		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
-	})
-
-	t.Run("LimitingByMemSize", func(t *testing.T) {
-		if coldata.BatchSize() == 1 {
-			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
-		}
-
-		var b coldata.Batch
-		typs := []*types.T{types.Int}
-		const minDesiredCapacity = 2
-		const smallMemSize = 0
-		const largeMemSize = math.MaxInt64
-
-		// Allocate a batch with smaller capacity.
-		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minDesiredCapacity/2)
-
-		// Allocate a new batch attempting to use the batch with too small of a
-		// capacity - new batch should **not** be allocated because the memory
-		// limit is already exceeded.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
-		require.Equal(t, smallBatch, b)
-		require.Equal(t, minDesiredCapacity/2, b.Capacity())
-
-		oldBatch := b
-
-		// Reset the batch asking for the same small desired capacity when it is
-		// sufficient - the same batch should be returned.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
-		require.Equal(t, smallBatch, b)
-		require.Equal(t, minDesiredCapacity/2, b.Capacity())
-
-		// Reset the batch and confirm that a new batch is allocated because we
-		// have given larger memory limit.
-		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
-		require.NotEqual(t, oldBatch, b)
-		require.Equal(t, minDesiredCapacity, b.Capacity())
-
-		if coldata.BatchSize() >= minDesiredCapacity*2 {
-			// Now reset the batch with large memory limit - we should get a new
-			// batch with the double capacity.
-			//
-			// ResetMaybeReallocate truncates the capacity at
-			// coldata.BatchSize(), so we run this part of the test only when
-			// doubled capacity will not be truncated.
-			b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
-			require.NotEqual(t, oldBatch, b)
-			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
-		}
 	})
 }
 

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -118,13 +119,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 		typs := []*types.T{types.Bytes}
 
 		// Allocate a new batch and modify it.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		b.SetSelection(true)
 		b.Selection()[0] = 1
 		b.ColVec(0).Bytes().Set(1, []byte("foo"))
 
 		oldBatch := b
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
 		// We should have used the same batch, and now it should be in a "reset"
 		// state.
 		require.Equal(t, oldBatch, b)
@@ -151,7 +152,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 		// Allocate a new batch attempting to use the batch with too small of a
 		// capacity - new batch should **not** be allocated because the memory
 		// limit is already exceeded.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
@@ -159,13 +160,13 @@ func TestResetMaybeReallocate(t *testing.T) {
 
 		// Reset the batch asking for the same small desired capacity when it is
 		// sufficient - the same batch should be returned.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
 		require.Equal(t, smallBatch, b)
 		require.Equal(t, minDesiredCapacity/2, b.Capacity())
 
 		// Reset the batch and confirm that a new batch is allocated because we
 		// have given larger memory limit.
-		b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+		b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 		require.NotEqual(t, oldBatch, b)
 		require.Equal(t, minDesiredCapacity, b.Capacity())
 
@@ -176,7 +177,7 @@ func TestResetMaybeReallocate(t *testing.T) {
 			// ResetMaybeReallocate truncates the capacity at
 			// coldata.BatchSize(), so we run this part of the test only when
 			// doubled capacity will not be truncated.
-			b, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+			b, _, _ = testAllocator.ResetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
 			require.NotEqual(t, oldBatch, b)
 			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
 		}
@@ -265,6 +266,208 @@ func TestPerformAppend(t *testing.T) {
 	}
 }
 
+// TestAccountingHelper verifies that the colmem.AccountingHelper makes
+// reasonable decisions about when to allocate new batches.
+func TestAccountingHelper(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Set the batch size to a fixed small value to make the tests both
+	// predictable and concise.
+	oldBatchSize := coldata.BatchSize()
+	require.NoError(t, coldata.SetBatchSizeForTests(7))
+	defer func() {
+		require.NoError(t, coldata.SetBatchSizeForTests(oldBatchSize))
+	}()
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	// Use increment of 1 so that no allocations are "reserved".
+	testMemMonitor := mon.NewMonitor(
+		"test-mem",
+		mon.MemoryResource,
+		nil,           /* curCount */
+		nil,           /* maxHist */
+		1,             /* increment */
+		math.MaxInt64, /* noteworthy */
+		st,
+	)
+	testMemMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	// Allocate a scratch bytes value that exceeds the target size in all
+	// scenarios.
+	v := make([]byte, 10000)
+	typs := []*types.T{types.Bytes}
+
+	// overhead returns the overhead of the batch with a single coldata.Bytes
+	// vector.
+	overhead := func(batchCapacity int) int64 {
+		return colmem.SelVectorSize(batchCapacity) +
+			coldata.FlatBytesOverhead +
+			int64(batchCapacity)*coldata.ElementSize
+	}
+
+	// iteration describes a single iteration of using the AccountingHelper.
+	type iteration struct {
+		// expectedCapacity specifies the expected capacity of the batch after
+		// ResetMaybeReallocate call of the current iteration.
+		expectedCapacity int
+		// expectedReallocated specifies whether the batch is expected to be
+		// reallocated during the ResetMaybeReallocate call of the current
+		// iteration.
+		expectedReallocated bool
+		// bytesValueSize determines the footprint of the bytes values that are
+		// set during the current iteration. Note that this only affects the
+		// call to ResetMaybeReallocate of the **next** iteration.
+		bytesValueSize int64
+	}
+	type testCase struct {
+		memoryLimit int64
+		// totalTuples, if positive, indicates the number of tuples that are
+		// expected to be set throughout this test case.
+		totalTuples int
+		iterations  []iteration
+	}
+	errorMessage := func(tc testCase, i iteration) string {
+		return fmt.Sprintf(
+			"tc: limit=%d, tuples=%d, iterations=%d i: cap=%d, realloc=%t, size=%d",
+			tc.memoryLimit, tc.totalTuples, len(tc.iterations), i.expectedCapacity,
+			i.expectedReallocated, i.bytesValueSize,
+		)
+	}
+
+	for _, tc := range []testCase{
+		// Verify the dynamic behavior of the helper. We start out without any
+		// knowledge on the number of tuples and with an unlimited budget, so
+		// we expect the capacity to grow until it reaches the maximum batch
+		// size.
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				{7, true, 700},
+				{7, false, 700},
+				{7, false, 700},
+			},
+		},
+		// A couple of tests for when the total number of tuples is known in
+		// advance.
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 4,
+			iterations: []iteration{
+				{4, true, 400},
+			},
+		},
+		{
+			memoryLimit: math.MaxInt64,
+			totalTuples: 13,
+			iterations: []iteration{
+				{7, true, 700},
+				{7, false, 600},
+			},
+		},
+		// A test case when the memory limit is exceeded on the third iteration
+		// at which point the batch no longer grows but is reused.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				{4, false, 400},
+				{4, false, 400},
+			},
+		},
+		// A test case with values of different sizes with the memory limit
+		// being exceeded even after the batch has shrunk.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 0,
+			iterations: []iteration{
+				{1, true, 100},
+				{2, true, 200},
+				{4, true, 400},
+				// The limit has just been exceeded, but not by too much, so we
+				// reuse the same batch.
+				{4, false, 1400},
+				// Now the limit has been exceeded by too much - a new batch of
+				// smaller capacity must be allocated.
+				{2, true, 200},
+				{2, false, 200},
+				{2, false, 1200},
+				// Now the limit has been exceeded by too much again - a new
+				// batch of smaller capacity must be allocated.
+				{1, true, 400},
+				// The limit has been exceeded but not by too much, so the batch
+				// is reused.
+				{1, false, 1100},
+				// Now the limit has been exceeded by too much again - a new
+				// batch is allocated, but we cannot reduce the capacity since
+				// we're at the minimum already.
+				{1, true, 100},
+			},
+		},
+		// A test case with values of different sizes with the memory limit
+		// being exceeded even after the batch has shrunk when the total number
+		// of tuples is known.
+		{
+			memoryLimit: 300 + overhead(3),
+			totalTuples: 17,
+			iterations: []iteration{
+				{7, true, 700},
+				// The limit has been exceeded by too much - a new batch of
+				// smaller capacity must be allocated.
+				{4, true, 400},
+				// The limit has just been exceeded, but not by too much, so we
+				// reuse the same batch.
+				{4, false, 1400},
+				// Now the limit has been exceeded by too much again - a new
+				// batch of smaller capacity must be allocated.
+				{2, true, 100},
+			},
+		},
+	} {
+		// Prime the allocator for reuse.
+		testAllocator.ReleaseMemory(testAllocator.Used())
+		var helper colmem.AccountingHelper
+		helper.Init(testAllocator, tc.memoryLimit)
+		tuplesToBeSet := tc.totalTuples
+		var batch coldata.Batch
+		var reallocated bool
+		for _, iteration := range tc.iterations {
+			batch, reallocated = helper.ResetMaybeReallocate(typs, batch, tuplesToBeSet)
+			require.Equal(t, iteration.expectedCapacity, batch.Capacity(), errorMessage(tc, iteration))
+			require.Equal(t, iteration.expectedReallocated, reallocated, errorMessage(tc, iteration))
+			testAllocator.PerformOperation(batch.ColVecs(), func() {
+				batch.ColVec(0).Bytes().Set(0, v[:iteration.bytesValueSize])
+				batch.SetLength(batch.Capacity())
+			})
+			// Since Bytes.Set appends to a byte slice, we don't know the exact
+			// capacity that is allocated for the buffer, meaning that the
+			// actual footprint can be greater than our target. That's ok since
+			// we're still properly accounting for it.
+			require.GreaterOrEqual(t, testAllocator.Used(), overhead(batch.Capacity())+iteration.bytesValueSize, errorMessage(tc, iteration))
+			if tuplesToBeSet > 0 {
+				tuplesToBeSet -= batch.Capacity()
+			}
+		}
+	}
+}
+
+// TestSetAccountingHelper verifies that the colmem.SetAccountingHelper
+// precisely tracks the memory footprint of the batch across AccountForSet()
+// calls.
 func TestSetAccountingHelper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -306,7 +509,7 @@ func TestSetAccountingHelper(t *testing.T) {
 			maxBatchMemSize = largeMemSize
 		}
 		helper.TestingUpdateMemoryLimit(maxBatchMemSize)
-		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows, false /* desiredCapacitySufficient */)
+		batch, _ = helper.ResetMaybeReallocate(typs, batch, numRows)
 
 		for rowIdx := 0; rowIdx < batch.Capacity(); rowIdx++ {
 			for vecIdx, typ := range typs {

--- a/pkg/sql/colmem/reset_maybe_reallocate_test.go
+++ b/pkg/sql/colmem/reset_maybe_reallocate_test.go
@@ -1,0 +1,116 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package colmem
+
+import (
+	"context"
+	"math"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/col/coldata"
+	"github.com/cockroachdb/cockroach/pkg/col/coldataext"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResetMaybeReallocate(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
+	defer testMemMonitor.Stop(ctx)
+	memAcc := testMemMonitor.MakeBoundAccount()
+	defer memAcc.Close(ctx)
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := NewAllocator(ctx, &memAcc, testColumnFactory)
+
+	t.Run("ResettingBehavior", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Bytes}
+
+		// Allocate a new batch and modify it.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		b.SetSelection(true)
+		b.Selection()[0] = 1
+		b.ColVec(0).Bytes().Set(1, []byte("foo"))
+
+		oldBatch := b
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, coldata.BatchSize(), math.MaxInt64, false /* desiredCapacitySufficient */)
+		// We should have used the same batch, and now it should be in a "reset"
+		// state.
+		require.Equal(t, oldBatch, b)
+		require.Nil(t, b.Selection())
+		// We should be able to set in the Bytes vector using an arbitrary
+		// position since the vector should have been reset.
+		require.NotPanics(t, func() { b.ColVec(0).Bytes().Set(0, []byte("bar")) })
+	})
+
+	t.Run("LimitingByMemSize", func(t *testing.T) {
+		if coldata.BatchSize() == 1 {
+			skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 2")
+		}
+
+		var b coldata.Batch
+		typs := []*types.T{types.Int}
+		const minDesiredCapacity = 2
+		const smallMemSize = 0
+		const largeMemSize = math.MaxInt64
+
+		// Allocate a batch with smaller capacity.
+		smallBatch := testAllocator.NewMemBatchWithFixedCapacity(typs, minDesiredCapacity/2)
+
+		// Allocate a new batch attempting to use the batch with too small of a
+		// capacity - new batch should **not** be allocated because the memory
+		// limit is already exceeded.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, smallBatch, minDesiredCapacity, smallMemSize, false /* desiredCapacitySufficient */)
+		require.Equal(t, smallBatch, b)
+		require.Equal(t, minDesiredCapacity/2, b.Capacity())
+
+		oldBatch := b
+
+		// Reset the batch asking for the same small desired capacity when it is
+		// sufficient - the same batch should be returned.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity/2, smallMemSize, true /* desiredCapacitySufficient */)
+		require.Equal(t, smallBatch, b)
+		require.Equal(t, minDesiredCapacity/2, b.Capacity())
+
+		// Reset the batch and confirm that a new batch is allocated because we
+		// have given larger memory limit.
+		b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+		require.NotEqual(t, oldBatch, b)
+		require.Equal(t, minDesiredCapacity, b.Capacity())
+
+		if coldata.BatchSize() >= minDesiredCapacity*2 {
+			// Now reset the batch with large memory limit - we should get a new
+			// batch with the double capacity.
+			//
+			// resetMaybeReallocate truncates the capacity at
+			// coldata.BatchSize(), so we run this part of the test only when
+			// doubled capacity will not be truncated.
+			b, _, _ = testAllocator.resetMaybeReallocate(typs, b, minDesiredCapacity, largeMemSize, false /* desiredCapacitySufficient */)
+			require.NotEqual(t, oldBatch, b)
+			require.Equal(t, 2*minDesiredCapacity, b.Capacity())
+		}
+	})
+}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "colmem: improve the behavior of ResetMaybeReallocate" (#81535)
  * 4/4 commits from "colmem: improve memory-limiting behavior of the accounting helpers" (#85440)

Please see individual PRs for details.

Release justification: bug fix.

/cc @cockroachdb/release
