### PR TITLE
ui/cluster-ui: link session txn fingerprint ids to details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.module.scss
@@ -82,7 +82,8 @@
   max-height: 300px;
   overflow-y: scroll;
 
-  div {
+  .link-txn-fingerprint-id {
+    display: block;
     margin-bottom: 8px;
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsConnected.tsx
@@ -19,10 +19,12 @@ import {
 } from "src/store/sessions";
 import { actions as terminateQueryActions } from "src/store/terminateQuery";
 import { actions as nodesActions } from "src/store/nodes";
+import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as nodesLivenessActions } from "src/store/liveness";
 
 import { nodeDisplayNameByIDSelector } from "src/store/nodes";
 import { selectIsTenant } from "../store/uiConfig";
+import { TimeScale } from "src/timeScaleDropdown";
 
 export const SessionDetailsPageConnected = withRouter(
   connect(
@@ -39,6 +41,11 @@ export const SessionDetailsPageConnected = withRouter(
       cancelQuery: terminateQueryActions.terminateQuery,
       refreshNodes: nodesActions.refresh,
       refreshNodesLiveness: nodesLivenessActions.refresh,
+      setTimeScale: (ts: TimeScale) =>
+        localStorageActions.update({
+          key: "timeScale/SQLActivity",
+          value: ts,
+        }),
       onTerminateSessionClick: () =>
         analyticsActions.track({
           name: "Session Actions Clicked",

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetailsPage.fixture.ts
@@ -44,7 +44,7 @@ const sessionDetailsPropsBase: SessionDetailsProps = {
     isExact: true,
     params: { [sessionAttr]: "blah" },
   },
-
+  setTimeScale: () => {},
   refreshSessions: () => {},
   cancelSession: (req: CancelSessionRequestMessage) => {},
   cancelQuery: (req: CancelQueryRequestMessage) => {},

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/utils.ts
@@ -167,3 +167,27 @@ export const timeScaleToString = (ts: TimeScale): string => {
 
   return `${dateStart} ${timeStart} to ${dateEnd} ${timeEnd} (UTC)`;
 };
+
+/**
+ * Create a fixed TimeScale object from a date range.
+ * @param range date range containing start and end as moment objects
+ * @param options A map of time scale options, the computed timescale
+ * will have its properties match the time scale in this list for which
+ * it is the closest match.
+ * @returns new TimeScale object
+ */
+export const createTimeScaleFromDateRange = (
+  range: { start: moment.Moment; end: moment.Moment },
+  options = defaultTimeScaleOptions,
+): TimeScale => {
+  const { start, end } = range;
+  const seconds = end.diff(start, "seconds");
+  const timeScale: TimeScale = {
+    ...findClosestTimeScale(options, seconds),
+    windowSize: moment.duration(end.diff(start)),
+    fixedWindowEnd: end,
+    key: "Custom",
+  };
+
+  return timeScale;
+};

--- a/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/statements/statementsActions.ts
@@ -108,6 +108,8 @@ export function createOpenDiagnosticsModalAction(
         Combined Stats Actions
 ****************************************/
 
+// Setting the timescale using this action type has some additional
+// side effects, see statementSagas.ts for the saga function:
 export const SET_GLOBAL_TIME_SCALE =
   "cockroachui/statements/SET_GLOBAL_TIME_SCALE";
 

--- a/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/sessions/sessionDetails.tsx
@@ -29,6 +29,7 @@ import {
   terminateQueryAction,
   terminateSessionAction,
 } from "src/redux/sessions/sessionsSagas";
+import { setTimeScale } from "src/redux/timeScale";
 
 type SessionsState = Pick<AdminUIState, "cachedData", "sessions">;
 
@@ -63,6 +64,7 @@ const SessionDetailsPageConnected = withRouter(
       cancelQuery: terminateQueryAction,
       refreshNodes: refreshNodes,
       refreshNodesLiveness: refreshLiveness,
+      setTimeScale,
     },
   )(SessionDetails),
 );


### PR DESCRIPTION
This commit links the each txn fingerprint id from the list of cached
txn fingerprints in the session details page to the txn fingerprint's
details page. The global date range is also changed to the session's
start and end time on click in order to fetch and render the
transaction details.

Release justification: low risk update to existing functionality
Release note (ui change): in the sessions details page, users
can click on a txn fingerprint id from the list of cached
txn fingerprints to go to that transaction's details page. The
app will also change the selected date range to that of the session's
start and end time on click.


https://www.loom.com/share/0de478ccdae446bb8a09934d995ecbd1