### PR TITLE
roachprod{,-stress}: let roachprod-stress use roachprod library

### DIFF
--- a/pkg/cmd/roachprod-stress/BUILD.bazel
+++ b/pkg/cmd/roachprod-stress/BUILD.bazel
@@ -7,6 +7,9 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod-stress",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/roachprod",
+        "//pkg/roachprod/logger",
+        "//pkg/roachprod/ssh",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -505,7 +505,20 @@ The "status" command outputs the binary and PID for the specified nodes:
 `,
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) error {
-		return roachprod.Status(context.Background(), roachprodLibraryLogger, args[0], tag)
+		statuses, err := roachprod.Status(context.Background(), roachprodLibraryLogger, args[0], tag)
+		if err != nil {
+			return err
+		}
+		for _, status := range statuses {
+			if status.Err != nil {
+				roachprodLibraryLogger.Printf("  %2d: %s %s\n", status.NodeID, status.Err.Error())
+			} else if !status.Running {
+				roachprodLibraryLogger.Printf("  %2d: not running\n", status.NodeID)
+			} else {
+				roachprodLibraryLogger.Printf("  %2d: %s %s\n", status.NodeID, status.Version, status.Pid)
+			}
+		}
+		return nil
 	}),
 }
 

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -460,13 +460,15 @@ func IP(
 }
 
 // Status retrieves the status of nodes in a cluster.
-func Status(ctx context.Context, l *logger.Logger, clusterName, processTag string) error {
+func Status(
+	ctx context.Context, l *logger.Logger, clusterName, processTag string,
+) ([]install.NodeStatus, error) {
 	if err := LoadClusters(); err != nil {
-		return err
+		return nil, err
 	}
 	c, err := newCluster(l, clusterName, install.TagOption(processTag))
 	if err != nil {
-		return err
+		return nil, err
 	}
 	return c.Status(ctx, l)
 }


### PR DESCRIPTION
This patch migrates roachprod-stress from using the roachprod
binary to using the roachprod library.

Release justification: Non-production code changes
Release note: None