### PR TITLE
descs: rewrite Collection backend

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "temporary_descriptors.go",
         "txn.go",
         "type.go",
+        "uncommitted_descriptors.go",
         "validate.go",
         "virtual_descriptors.go",
     ],
@@ -114,6 +115,7 @@ go_test(
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/parser",
         "//pkg/sql/privilege",
+        "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
@@ -132,7 +134,6 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
@@ -95,8 +96,9 @@ func (tc *Collection) getDescriptorsByID(
 		}
 	}()
 
-	log.VEventf(ctx, 2, "looking up descriptors for ids %d", ids)
+	log.VEventf(ctx, 2, "looking up descriptors for ids %v", ids)
 	descs = make([]catalog.Descriptor, len(ids))
+	vls := make([]catalog.ValidationLevel, len(ids))
 	{
 		// Look up the descriptors in all layers except the KV layer on a
 		// best-effort basis.
@@ -106,9 +108,10 @@ func (tc *Collection) getDescriptorsByID(
 			tc:    tc,
 			flags: flags,
 		}
-		for _, fn := range []func(id descpb.ID) (catalog.Descriptor, error){
+		for _, fn := range []func(id descpb.ID) (catalog.Descriptor, catalog.ValidationLevel, error){
 			q.lookupVirtual,
 			q.lookupSynthetic,
+			q.lookupUncommitted,
 			q.lookupCached,
 			q.lookupLeased,
 		} {
@@ -116,82 +119,44 @@ func (tc *Collection) getDescriptorsByID(
 				if descs[i] != nil {
 					continue
 				}
-				desc, err := fn(id)
+				desc, vl, err := fn(id)
 				if err != nil {
 					return nil, err
 				}
+				if desc == nil {
+					continue
+				}
 				descs[i] = desc
+				vls[i] = vl
 			}
 		}
 	}
 
-	remainingIDs := make([]descpb.ID, 0, len(ids))
-	indexes := make([]int, 0, len(ids))
+	// Read any missing descriptors from the store and add them to the slice.
+	var readIDs catalog.DescriptorIDSet
 	for i, id := range ids {
-		if descs[i] != nil {
-			continue
+		if descs[i] == nil {
+			readIDs.Add(id)
 		}
-		remainingIDs = append(remainingIDs, id)
-		indexes = append(indexes, i)
 	}
-	if len(remainingIDs) == 0 {
-		// No KV lookup necessary, return early.
-		return descs, nil
+	if !readIDs.Empty() {
+		if err = tc.stored.EnsureFromStorageByIDs(ctx, txn, readIDs, catalog.Any); err != nil {
+			return nil, err
+		}
+		for i, id := range ids {
+			if descs[i] == nil {
+				descs[i] = tc.stored.GetCachedByID(id)
+				vls[i] = tc.stored.GetValidationLevelByID(id)
+			}
+		}
 	}
-	kvDescs, err := tc.withReadFromStore(ctx, flags.RequireMutable, func() ([]catalog.Descriptor, error) {
-		ret := make([]catalog.Descriptor, len(remainingIDs))
-		// Try to re-use any unvalidated descriptors we may have.
-		kvIDs := make([]descpb.ID, 0, len(remainingIDs))
-		kvIndexes := make([]int, 0, len(remainingIDs))
-		for i, id := range remainingIDs {
-			if imm, status := tc.stored.getCachedByID(id); imm != nil && status == notValidatedYet {
-				err := tc.Validate(ctx, txn, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, imm)
-				if err != nil {
-					return nil, err
-				}
-				ret[i] = imm
-				continue
-			}
-			kvIDs = append(kvIDs, id)
-			kvIndexes = append(kvIndexes, i)
-		}
-		// Read all others from the store.
-		if len(kvIDs) > 0 {
-			vd := tc.newValidationDereferencer(txn)
-			kvDescs, err := tc.stored.getByIDs(ctx, tc.version, txn, vd, kvIDs)
-			if err != nil {
-				return nil, err
-			}
-			for k, imm := range kvDescs {
-				ret[kvIndexes[k]] = imm
-			}
-		}
-		return ret, nil
-	})
-	if err != nil {
+
+	// At this point, all descriptors are in the slice, finalize and hydrate them.
+	if err := tc.finalizeDescriptors(ctx, txn, flags, descs, vls); err != nil {
 		return nil, err
 	}
-	for j, desc := range kvDescs {
-		// Callers expect the descriptors to come back hydrated.
-		// In practice, array types here are not hydrated, and that's a bummer.
-		// Nobody presently is upset about it, but it's not a good thing.
-		// Ideally we'd have a clearer contract regarding hydration and the values
-		// stored in the various maps inside the collection. One might want to
-		// store only hydrated values in the various maps. This turns out to be
-		// somewhat tricky because we'd need to make sure to properly re-hydrate
-		// all the relevant descriptors when a type descriptor change. Leased
-		// descriptors are at least as tricky, plus, there we have a cache that
-		// works relatively well.
-		//
-		// TODO(ajwerner): Sort out the hydration mess; define clearly what is
-		// hydrated where and test the API boundary accordingly.
-		if hydratable, ok := desc.(catalog.HydratableDescriptor); ok {
-			desc, err = tc.hydrateTypesInDescWithOptions(ctx, txn, hydratable, flags.IncludeOffline, flags.AvoidLeased)
-			if err != nil {
-				return nil, err
-			}
-		}
-		descs[indexes[j]] = desc
+	if err := tc.hydrateDescriptors(ctx, txn, flags, descs); err != nil {
+		return nil, err
 	}
 	return descs, nil
 }
@@ -206,74 +171,66 @@ type byIDLookupContext struct {
 	flags tree.CommonLookupFlags
 }
 
-func (q *byIDLookupContext) lookupVirtual(id descpb.ID) (catalog.Descriptor, error) {
-	return q.tc.virtual.getByID(q.ctx, id, q.flags.RequireMutable)
+func (q *byIDLookupContext) lookupVirtual(
+	id descpb.ID,
+) (catalog.Descriptor, catalog.ValidationLevel, error) {
+	desc, err := q.tc.virtual.getByID(q.ctx, id, q.flags.RequireMutable)
+	return desc, validate.Write, err
 }
 
-func (q *byIDLookupContext) lookupSynthetic(id descpb.ID) (catalog.Descriptor, error) {
+func (q *byIDLookupContext) lookupSynthetic(
+	id descpb.ID,
+) (catalog.Descriptor, catalog.ValidationLevel, error) {
 	if q.flags.AvoidSynthetic {
-		return nil, nil
+		return nil, catalog.NoValidation, nil
 	}
 	_, sd := q.tc.synthetic.getByID(id)
 	if sd == nil {
-		return nil, nil
+		return nil, catalog.NoValidation, nil
 	}
 	if q.flags.RequireMutable {
-		return nil, newMutableSyntheticDescriptorAssertionError(sd.GetID())
+		return nil, catalog.NoValidation, newMutableSyntheticDescriptorAssertionError(sd.GetID())
 	}
-	return sd, nil
+	return sd, validate.Write, nil
 }
 
-func (q *byIDLookupContext) lookupCached(id descpb.ID) (_ catalog.Descriptor, err error) {
-	sd, status := q.tc.stored.getCachedByID(id)
-	if sd == nil {
-		return nil, nil
+func (q *byIDLookupContext) lookupCached(
+	id descpb.ID,
+) (catalog.Descriptor, catalog.ValidationLevel, error) {
+	if desc := q.tc.stored.GetCachedByID(id); desc != nil {
+		return desc, q.tc.stored.GetValidationLevelByID(id), nil
 	}
-	if status == notValidatedYet {
-		err := q.tc.Validate(q.ctx, q.txn, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, sd)
-		if err != nil {
-			return nil, err
-		}
-		err = q.tc.stored.upgradeToValidated(sd.GetID())
-		if err != nil {
-			return nil, err
-		}
-	}
-	log.VEventf(q.ctx, 2, "found cached descriptor %d", id)
-	if q.flags.RequireMutable {
-		sd, err = q.tc.stored.checkOut(id)
-		if err != nil {
-			return nil, err
-		}
-	}
-	// Hydrate any types in the descriptor if necessary, for uncommitted
-	// descriptors we are going to include offline and get non-cached view.
-	if desc, ok := sd.(catalog.HydratableDescriptor); ok {
-		sd, err = q.tc.hydrateTypesInDescWithOptions(q.ctx, q.txn, desc, true, true)
-		if err != nil {
-			return nil, err
-		}
-	}
-	return sd, nil
+	return nil, catalog.NoValidation, nil
 }
 
-func (q *byIDLookupContext) lookupLeased(id descpb.ID) (catalog.Descriptor, error) {
+func (q *byIDLookupContext) lookupUncommitted(
+	id descpb.ID,
+) (catalog.Descriptor, catalog.ValidationLevel, error) {
+	if desc := q.tc.uncommitted.GetUncommittedByID(id); desc != nil {
+		return desc, validate.MutableRead, nil
+	}
+	return nil, catalog.NoValidation, nil
+}
+
+func (q *byIDLookupContext) lookupLeased(
+	id descpb.ID,
+) (catalog.Descriptor, catalog.ValidationLevel, error) {
 	if q.flags.AvoidLeased || q.flags.RequireMutable || lease.TestingTableLeasesAreDisabled() {
-		return nil, nil
+		return nil, catalog.NoValidation, nil
 	}
 	// If we have already read all of the descriptors, use it as a negative
 	// cache to short-circuit a lookup we know will be doomed to fail.
 	//
 	// TODO(ajwerner): More generally leverage this set of kv descriptors on
 	// the resolution path.
-	if q.tc.stored.idDefinitelyDoesNotExist(id) {
-		return nil, catalog.ErrDescriptorNotFound
+	if q.tc.stored.IsIDKnownToNotExist(id) {
+		return nil, catalog.NoValidation, catalog.ErrDescriptorNotFound
 	}
 	desc, shouldReadFromStore, err := q.tc.leased.getByID(q.ctx, q.tc.deadlineHolder(q.txn), id)
 	if err != nil || shouldReadFromStore {
-		return nil, err
+		return nil, catalog.NoValidation, err
 	}
-	return desc, nil
+	return desc, validate.ImmutableRead, nil
 }
 
 // filterDescriptorsStates is a helper function for getDescriptorsByID.
@@ -333,83 +290,132 @@ func (tc *Collection) getByName(
 		return true, sd, nil
 	}
 
-	{
-		ud := tc.stored.getCachedByName(parentID, parentSchemaID, name)
-		if ud != nil {
-			log.VEventf(ctx, 2, "found cached descriptor %d", ud.GetID())
-			if mutable {
-				ud, err = tc.stored.checkOut(ud.GetID())
-				if err != nil {
-					return false, nil, err
-				}
-			}
-			return true, ud, nil
+	desc = tc.uncommitted.GetUncommittedByName(parentID, parentSchemaID, name)
+
+	// Look up descriptor in store cache.
+	if desc == nil {
+		if cd := tc.stored.GetCachedByName(parentID, parentSchemaID, name); cd != nil {
+			desc = cd
+			log.VEventf(ctx, 2, "found cached descriptor %d", desc.GetID())
 		}
 	}
 
-	if !avoidLeased && !mutable && !lease.TestingTableLeasesAreDisabled() {
-		var shouldReadFromStore bool
-		desc, shouldReadFromStore, err = tc.leased.getByName(ctx, tc.deadlineHolder(txn), parentID, parentSchemaID, name)
+	// Look up leased descriptor.
+	if desc == nil && !avoidLeased && !mutable && !lease.TestingTableLeasesAreDisabled() {
+		leasedDesc, shouldReadFromStore, err := tc.leased.getByName(ctx, tc.deadlineHolder(txn), parentID, parentSchemaID, name)
 		if err != nil {
 			return false, nil, err
 		}
 		if !shouldReadFromStore {
-			return desc != nil, desc, nil
+			return leasedDesc != nil, leasedDesc, nil
 		}
 	}
 
-	var descs []catalog.Descriptor
-	descs, err = tc.withReadFromStore(ctx, mutable, func() ([]catalog.Descriptor, error) {
-		// Try to re-use an unvalidated descriptor if there is one.
-		if imm := tc.stored.getUnvalidatedByName(parentID, parentSchemaID, name); imm != nil {
-			return []catalog.Descriptor{imm},
-				tc.Validate(ctx, txn, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, imm)
+	// Look up descriptor in storage.
+	if desc == nil {
+		desc, err = tc.stored.GetByName(ctx, txn, parentID, parentSchemaID, name)
+		if err != nil || desc == nil {
+			return false, nil, err
 		}
-		// If not possible, read it from the store.
-		uncommittedParent, _ := tc.stored.getCachedByID(parentID)
-		uncommittedDB, _ := catalog.AsDatabaseDescriptor(uncommittedParent)
-		version := tc.settings.Version.ActiveVersion(ctx)
-		vd := tc.newValidationDereferencer(txn)
-		imm, err := tc.stored.getByName(ctx, version, txn, vd, uncommittedDB, parentID, parentSchemaID, name)
-		if err != nil {
-			return nil, err
-		}
-		return []catalog.Descriptor{imm}, nil
-	})
-	if err != nil {
-		return false, nil, err
 	}
-	return descs[0] != nil, descs[0], err
+
+	// At this point the descriptor exists.
+	// Finalize it and return it.
+	{
+		ret := []catalog.Descriptor{desc}
+		flags := tree.CommonLookupFlags{RequireMutable: mutable}
+		if err = tc.finalizeDescriptors(ctx, txn, flags, ret, nil /* validationLevels */); err != nil {
+			return false, nil, err
+		}
+		desc = ret[0]
+		return desc != nil, desc, err
+	}
 }
 
-// withReadFromStore updates the state of the Collection, especially its
-// stored descriptors layer, after reading a descriptor from the storage
-// layer. The logic is the same regardless of whether the descriptor was read
-// by name or by ID.
-func (tc *Collection) withReadFromStore(
-	ctx context.Context, requireMutable bool, readFn func() ([]catalog.Descriptor, error),
-) (descs []catalog.Descriptor, _ error) {
-	descs, err := readFn()
-	if err != nil {
-		return nil, err
-	}
-	for i, desc := range descs {
-		if desc == nil {
-			continue
-		}
-		desc, err = tc.stored.add(ctx, desc.NewBuilder().BuildExistingMutable(), notCheckedOutYet)
-		if err != nil {
-			return nil, err
-		}
-		if requireMutable {
-			desc, err = tc.stored.checkOut(desc.GetID())
-			if err != nil {
-				return nil, err
+// finalizeDescriptors ensures that descriptors are properly validated and in
+// the correct layers before being returned.
+// Known validation levels can be provided via validationLevels, otherwise when
+// nil a safe default is generated instead.
+func (tc *Collection) finalizeDescriptors(
+	ctx context.Context,
+	txn *kv.Txn,
+	flags tree.CommonLookupFlags,
+	descs []catalog.Descriptor,
+	validationLevels []catalog.ValidationLevel,
+) error {
+	if validationLevels == nil {
+		validationLevels = make([]catalog.ValidationLevel, len(descs))
+		for i, desc := range descs {
+			if tc.uncommitted.GetUncommittedByID(desc.GetID()) != nil {
+				validationLevels[i] = validate.MutableRead
+			} else {
+				validationLevels[i] = tc.stored.GetValidationLevelByID(desc.GetID())
 			}
 		}
-		descs[i] = desc
 	}
-	return descs, nil
+	// Ensure that all descriptors are sufficiently validated.
+	requiredLevel := validate.MutableRead
+	if !flags.RequireMutable && !flags.AvoidLeased {
+		requiredLevel = validate.ImmutableRead
+	}
+	var toValidate []catalog.Descriptor
+	for i, vl := range validationLevels {
+		if vl < requiredLevel {
+			toValidate = append(toValidate, descs[i])
+		}
+	}
+	if len(toValidate) > 0 {
+		if err := tc.Validate(ctx, txn, catalog.ValidationReadTelemetry, requiredLevel, toValidate...); err != nil {
+			return err
+		}
+		for _, desc := range toValidate {
+			tc.stored.UpdateValidationLevel(desc, requiredLevel)
+		}
+	}
+	// Add the descriptors to the uncommitted layer if we want them to be mutable.
+	if !flags.RequireMutable {
+		return nil
+	}
+	for i, desc := range descs {
+		mut, err := tc.uncommitted.EnsureMutable(ctx, desc)
+		if err != nil {
+			return err
+		}
+		descs[i] = mut
+	}
+	return nil
+}
+
+// hydrateDescriptors ensures that the descriptors in the slice are hydrated.
+//
+// Callers expect the descriptors to come back hydrated.
+// In practice, array types here are not hydrated, and that's a bummer.
+// Nobody presently is upset about it, but it's not a good thing.
+// Ideally we'd have a clearer contract regarding hydration and the values
+// stored in the various maps inside the collection. One might want to
+// store only hydrated values in the various maps. This turns out to be
+// somewhat tricky because we'd need to make sure to properly re-hydrate
+// all the relevant descriptors when a type descriptor change. Leased
+// descriptors are at least as tricky, plus, there we have a cache that
+// works relatively well.
+//
+// TODO(ajwerner): Sort out the hydration mess; define clearly what is
+// hydrated where and test the API boundary accordingly.
+func (tc *Collection) hydrateDescriptors(
+	ctx context.Context, txn *kv.Txn, flags tree.CommonLookupFlags, descs []catalog.Descriptor,
+) error {
+	for i, desc := range descs {
+		hd, isHydratable := desc.(catalog.HydratableDescriptor)
+		if !isHydratable {
+			continue
+		}
+		var err error
+		descs[i], err = tc.hydrateTypesInDescWithOptions(ctx, txn, hd, flags.IncludeOffline, flags.AvoidLeased)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (tc *Collection) deadlineHolder(txn *kv.Txn) deadlineHolder {
@@ -463,7 +469,7 @@ func getSchemaByName(
 		if isDone, sc := tc.temporary.getSchemaByName(ctx, db.GetID(), name); sc != nil || isDone {
 			return sc != nil, sc, nil
 		}
-		scID, err := tc.stored.lookupName(ctx, txn, nil /* maybeDB */, db.GetID(), keys.RootNamespaceID, name)
+		scID, err := tc.stored.LookupName(ctx, txn, nil /* maybeDB */, db.GetID(), keys.RootNamespaceID, name)
 		if err != nil || scID == descpb.InvalidID {
 			return false, nil, err
 		}

--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -259,7 +259,7 @@ func hydrateCatalog(ctx context.Context, cat nstree.Catalog) error {
 
 func (tc *Collection) canUseHydratedDescriptorCache(id descpb.ID) bool {
 	return tc.hydrated != nil &&
-		tc.stored.descs.GetByID(id) == nil &&
+		tc.stored.GetCachedByID(id) == nil &&
 		tc.synthetic.descs.GetByID(id) == nil
 }
 

--- a/pkg/sql/catalog/descs/stored_descriptors.go
+++ b/pkg/sql/catalog/descs/stored_descriptors.go
@@ -13,141 +13,37 @@ package descs
 import (
 	"context"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/catkv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
-	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 )
 
-// storedDescriptorStatus is the status of a stored descriptor.
-type storedDescriptorStatus int
-
-const (
-	// notValidatedYet designates descriptors which have been read from
-	// storage but have not been validated yet. Until they're validated they
-	// cannot be used for anything else than validating other descriptors.
-	notValidatedYet storedDescriptorStatus = iota
-
-	// notCheckedOutYet designates descriptors which have been properly read from
-	// storage and have been validated but have never been checked out yet. This
-	// means that the mutable and immutable descriptor protos are known to be the
-	// exact same.
-	notCheckedOutYet
-
-	// checkedOutAtLeastOnce designates descriptors which have been checked out at
-	// least once. Newly-created descriptors are considered to have been checked
-	// out as well.
-	checkedOutAtLeastOnce
-)
-
-// storedDescriptor is a descriptor that has been cached after being read
-// and/or being modified in the current transaction.
-type storedDescriptor struct {
-
-	// immutable holds the descriptor as it was when this struct was initialized,
-	// either after being read from storage or after being checked in.
-	immutable catalog.Descriptor
-
-	// mutable is initialized as a mutable copy of immutable when the descriptor
-	// is read from storage.
-	// This value might be nil in some rare cases where we completely bypass
-	// storage for performance reasons because the descriptor is guaranteed to
-	// never change. Such is the case of the system database descriptor for
-	// instance.
-	// This value should not make its way outside the storedDescriptors
-	// other than via checkOut.
-	mutable catalog.MutableDescriptor
-
-	// storedDescriptorStatus describes the status of the mutable and
-	// immutable descriptors
-	storedDescriptorStatus
-}
-
-// GetName implements the catalog.NameEntry interface.
-func (u *storedDescriptor) GetName() string {
-	return u.immutable.GetName()
-}
-
-// GetParentID implements the catalog.NameEntry interface.
-func (u *storedDescriptor) GetParentID() descpb.ID {
-	return u.immutable.GetParentID()
-}
-
-// GetParentSchemaID implements the catalog.NameEntry interface.
-func (u storedDescriptor) GetParentSchemaID() descpb.ID {
-	return u.immutable.GetParentSchemaID()
-}
-
-// GetID implements the catalog.NameEntry interface.
-func (u storedDescriptor) GetID() descpb.ID {
-	return u.immutable.GetID()
-}
-
-// checkOut is how the mutable descriptor should be accessed.
-func (u *storedDescriptor) checkOut() catalog.MutableDescriptor {
-	if u.mutable == nil {
-		// This special case is allowed for certain system descriptors which
-		// for performance reasons are never actually read from storage, instead
-		// we use a copy of the descriptor hard-coded in the system schema used for
-		// bootstrapping a cluster.
-		//
-		// This implies that these descriptors never undergo any changes and
-		// therefore checking out a mutable descriptor is pointless for the most
-		// part. This may nonetheless legitimately happen during migrations
-		// which change all descriptors somehow, so we need to support this.
-		return u.immutable.NewBuilder().BuildExistingMutable()
-	}
-	u.storedDescriptorStatus = checkedOutAtLeastOnce
-	return u.mutable
-}
-
-var _ catalog.NameEntry = (*storedDescriptor)(nil)
-
-// storedDescriptors is the data structure holding all
-// storedDescriptor objects for a Collection.
-//
-// Immutable descriptors can be freely looked up.
-// Mutable descriptors can be:
-// 1. added into it,
-// 2. checked out of it,
-// 3. checked back in to it.
-//
-// An error will be triggered by:
-// - checking out a mutable descriptor that hasn't yet been added,
-// - checking in a descriptor that has been added but not yet checked out,
-// - any checked-out-but-not-checked-in mutable descriptors at commit time.
-//
+// storedDescriptors is the data structure caching the descriptors in storage
+// for a Collection. The descriptors are such as they were at the beginning of
+// the transaction. Validation is performed lazily.
 type storedDescriptors struct {
+	// codec used for reading from storage.
 	codec keys.SQLCodec
 
-	// A mirror of the descriptors in storage. These descriptors are either (1)
-	// already stored and were read from KV, or (2) have been modified by the
-	// uncommitted transaction affiliated with this Collection and should be
-	// written to KV upon commit.
-	// Source (1) serves as a cache. Source (2) allows a transaction to see its
-	// own modifications while bypassing the descriptor lease mechanism. The
-	// lease mechanism will have its own transaction to read the descriptor and
-	// will hang waiting for the uncommitted changes to the descriptor if this
-	// transaction is PRIORITY HIGH. These descriptors are local to this
-	// Collection and their state is thus not visible to other transactions.
-	descs nstree.Map
+	// cache mirrors the descriptors in storage.
+	// This map does not store descriptors by name.
+	cache nstree.Map
 
-	// addedSystemDatabase is used to mark whether the optimization to add the
-	// system database to the set of stored descriptors has occurred.
-	addedSystemDatabase bool
+	// nameIndex is a subset of cache which allows lookups by name.
+	nameIndex nstree.Map
+
+	// validationLevels persists the levels to which each descriptor in cache
+	// has already been validated.
+	validationLevels map[descpb.ID]catalog.ValidationLevel
 
 	// systemNamespace is a cache of system table namespace entries. We assume
 	// these are immutable for the life of the process.
@@ -174,340 +70,167 @@ type storedDescriptors struct {
 func makeStoredDescriptors(
 	codec keys.SQLCodec, systemNamespace *systemDatabaseNamespaceCache, monitor *mon.BytesMonitor,
 ) storedDescriptors {
-	return storedDescriptors{
+	sd := storedDescriptors{
 		codec:           codec,
 		systemNamespace: systemNamespace,
 		memAcc:          monitor.MakeBoundAccount(),
 	}
+	return sd
 }
 
-func (sd *storedDescriptors) reset(ctx context.Context) {
-	sd.descs.Clear()
-	sd.addedSystemDatabase = false
-	sd.hasAllDescriptors = false
-	sd.hasAllDatabaseDescriptors = false
-	sd.allSchemasForDatabase = nil
+// Reset zeroes the object for re-use in a new transaction.
+func (sd *storedDescriptors) Reset(ctx context.Context) {
+	sd.cache.Clear()
+	sd.nameIndex.Clear()
 	sd.memAcc.Clear(ctx)
+	old := *sd
+	*sd = storedDescriptors{
+		codec:           old.codec,
+		cache:           old.cache,
+		nameIndex:       old.nameIndex,
+		systemNamespace: old.systemNamespace,
+		memAcc:          old.memAcc,
+	}
 }
 
-// add adds a descriptor to the set of stored descriptors and returns
-// an immutable copy of that descriptor.
-func (sd *storedDescriptors) add(
-	ctx context.Context, mut catalog.MutableDescriptor, status storedDescriptorStatus,
-) (catalog.Descriptor, error) {
-	uNew, err := makeStoredDescriptor(mut, status)
-	if err != nil {
-		return nil, err
+// Ensure adds a descriptor to the storedDescriptors layer.
+// This should not cause any information loss.
+func (sd *storedDescriptors) Ensure(ctx context.Context, desc catalog.Descriptor) error {
+	if _, isMutable := desc.(catalog.MutableDescriptor); isMutable {
+		return errors.AssertionFailedf("attempted to add mutable descriptor to storedDescriptors")
 	}
-	if prev, ok := sd.descs.GetByID(mut.GetID()).(*storedDescriptor); ok {
-		if prev.mutable.OriginalVersion() != mut.OriginalVersion() {
-			return nil, errors.AssertionFailedf(
-				"cannot add a version of descriptor with a different original version" +
-					" than it was previously added with")
-		}
-	} else {
-		if err := sd.memAcc.Grow(ctx, mut.ByteSize()); err != nil {
-			err = errors.Wrap(err, "Memory usage exceeds limit for storedDescriptors.descs")
-			return nil, err
+	if sd.UpdateValidationLevel(desc, catalog.NoValidation) {
+		if err := sd.memAcc.Grow(ctx, desc.ByteSize()); err != nil {
+			return err
 		}
 	}
-	sd.descs.Upsert(uNew, mut.SkipNamespace())
-	return uNew.immutable, err
+	sd.cache.Upsert(desc, true /* skipNameMap */)
+	sd.nameIndex.Upsert(desc, desc.Dropped() || desc.SkipNamespace())
+	return nil
 }
 
-// checkOut checks out a stored mutable descriptor for use in the
-// transaction. This descriptor should later be checked in again.
-func (sd *storedDescriptors) checkOut(id descpb.ID) (_ catalog.MutableDescriptor, err error) {
-	defer func() {
-		err = errors.NewAssertionErrorWithWrappedErrf(
-			err, "cannot check out stored descriptor with ID %d", id,
-		)
-	}()
+// GetCachedByID looks up a descriptor by ID.
+// The system database descriptor is given special treatment to speed up lookups
+// and validations by avoiding an unnecessary round-trip to storage, as this
+// descriptor is known to never change.
+func (sd *storedDescriptors) GetCachedByID(id descpb.ID) catalog.Descriptor {
+	if e := sd.cache.GetByID(id); e != nil {
+		return e.(catalog.Descriptor)
+	}
 	if id == keys.SystemDatabaseID {
-		sd.maybeAddSystemDatabase()
+		sd.UpdateValidationLevel(systemschema.SystemDB, validate.Write)
+		sd.cache.Upsert(systemschema.SystemDB, true /* skipNameMap */)
+		sd.nameIndex.Upsert(systemschema.SystemDB, systemschema.SystemDB.SkipNamespace())
+		return systemschema.SystemDB
 	}
-	entry := sd.descs.GetByID(id)
-	if entry == nil {
-		return nil, errors.New("descriptor hasn't been added yet")
-	}
-	u := entry.(*storedDescriptor)
-	if u.storedDescriptorStatus == notValidatedYet {
-		return nil, errors.New("descriptor hasn't been validated yet")
-	}
-	return u.checkOut(), nil
+	return nil
 }
 
-// checkIn checks in a stored mutable descriptor that was previously
-// checked out.
-func (sd *storedDescriptors) checkIn(mut catalog.MutableDescriptor) error {
-	uNew, err := makeStoredDescriptor(mut, checkedOutAtLeastOnce)
+// GetCachedByName is the by-name equivalent of GetCachedByID.
+// Since name collisions can occur in the presence of dropped descriptors, this
+// will return the descriptor which has been added last, which should be the one
+// which isn't dropped and actually owns the name.
+func (sd *storedDescriptors) GetCachedByName(
+	dbID descpb.ID, schemaID descpb.ID, name string,
+) catalog.Descriptor {
+	if e := sd.nameIndex.GetByName(dbID, schemaID, name); e != nil {
+		return e.(catalog.Descriptor)
+	}
+	if dbID == 0 && schemaID == 0 && name == catconstants.SystemDatabaseName {
+		return sd.GetCachedByID(keys.SystemDatabaseID)
+	}
+	return nil
+}
+
+// EnsureAllDescriptors ensures that all stored descriptors are cached.
+func (sd *storedDescriptors) EnsureAllDescriptors(ctx context.Context, txn *kv.Txn) error {
+	if sd.hasAllDescriptors {
+		return nil
+	}
+	c, err := catkv.GetCatalogUnvalidated(ctx, sd.codec, txn)
 	if err != nil {
 		return err
 	}
-	if prev := sd.descs.GetByID(mut.GetID()); prev != nil {
-		return errors.AssertionFailedf("cannot check in a descriptor that has not been previously checked out")
+	if err = c.ForEachDescriptorEntry(func(desc catalog.Descriptor) error {
+		return sd.Ensure(ctx, desc)
+	}); err != nil {
+		return err
 	}
-	sd.descs.Upsert(uNew, mut.SkipNamespace())
-	return err
-}
-
-// upgradeToValidated upgrades a stored descriptor that was previously
-// unvalidated to not checked out yet.
-func (sd *storedDescriptors) upgradeToValidated(id descpb.ID) (err error) {
-	defer func() {
-		err = errors.NewAssertionErrorWithWrappedErrf(
-			err, "cannot upgrade stored descriptor with ID %d", id,
-		)
-	}()
-	entry := sd.descs.GetByID(id)
-	if entry == nil {
-		return errors.New("descriptor has not been cached")
-	}
-	storedDesc := entry.(*storedDescriptor)
-	if storedDesc.storedDescriptorStatus == checkedOutAtLeastOnce {
-		return errors.New("descriptor has already been checked out")
-	}
-	storedDesc.storedDescriptorStatus = notCheckedOutYet
+	sd.hasAllDescriptors = true
 	return nil
 }
 
-func makeStoredDescriptor(
-	desc catalog.MutableDescriptor, status storedDescriptorStatus,
-) (*storedDescriptor, error) {
-	version := desc.GetVersion()
-	origVersion := desc.OriginalVersion()
-	if version != origVersion && version != origVersion+1 {
-		return nil, errors.AssertionFailedf(
-			"descriptor %d version %d not compatible with cluster version %d",
-			desc.GetID(), version, origVersion)
+// EnsureAllDatabaseDescriptors ensures that all stored database descriptors
+// are in the cache.
+func (sd *storedDescriptors) EnsureAllDatabaseDescriptors(ctx context.Context, txn *kv.Txn) error {
+	if sd.hasAllDescriptors || sd.hasAllDatabaseDescriptors {
+		return nil
 	}
-
-	mutable, err := maybeRefreshCachedFieldsOnTypeDescriptor(desc)
+	c, err := catkv.GetAllDatabaseDescriptorIDs(ctx, txn, sd.codec)
 	if err != nil {
-		return nil, err
+		return err
 	}
-
-	return &storedDescriptor{
-		mutable:                mutable,
-		immutable:              mutable.ImmutableCopy(),
-		storedDescriptorStatus: status,
-	}, nil
-}
-
-// maybeRefreshCachedFieldsOnTypeDescriptor refreshes the cached fields on a
-// Mutable if the given descriptor is a type descriptor and works as a pass
-// through for all other descriptors. Mutable type descriptors are refreshed to
-// reconstruct enumMetadata. This ensures that tables hydration following a
-// type descriptor update (in the same txn) happens using the modified fields.
-func maybeRefreshCachedFieldsOnTypeDescriptor(
-	desc catalog.MutableDescriptor,
-) (catalog.MutableDescriptor, error) {
-	typeDesc, ok := desc.(catalog.TypeDescriptor)
-	if ok {
-		return typedesc.UpdateCachedFieldsOnModifiedMutable(typeDesc)
-	}
-	return desc, nil
-}
-
-// getCachedByID looks up a cached descriptor by ID.
-func (sd *storedDescriptors) getCachedByID(
-	id descpb.ID,
-) (catalog.Descriptor, storedDescriptorStatus) {
-	if id == keys.SystemDatabaseID {
-		sd.maybeAddSystemDatabase()
-	}
-	entry := sd.descs.GetByID(id)
-	if entry == nil {
-		return nil, notValidatedYet
-	}
-	u := entry.(*storedDescriptor)
-	return u.immutable, u.storedDescriptorStatus
-}
-
-// getCachedByName looks up a cached descriptor by name.
-func (sd *storedDescriptors) getCachedByName(
-	dbID descpb.ID, schemaID descpb.ID, name string,
-) catalog.Descriptor {
-	if dbID == 0 && schemaID == 0 && name == systemschema.SystemDatabaseName {
-		sd.maybeAddSystemDatabase()
-	}
-	// Walk latest to earliest so that a DROP followed by a CREATE with the same
-	// name will result in the CREATE being seen.
-	if got := sd.descs.GetByName(dbID, schemaID, name); got != nil {
-		u := got.(*storedDescriptor)
-		if u.storedDescriptorStatus == notValidatedYet {
-			return nil
+	var readIDs catalog.DescriptorIDSet
+	_ = c.ForEachNamespaceEntry(func(e catalog.NameEntry) error {
+		if id := e.GetID(); sd.GetCachedByID(id) == nil {
+			readIDs.Add(id)
 		}
-		return u.immutable
+		return nil
+	})
+	if err = sd.EnsureFromStorageByIDs(ctx, txn, readIDs, catalog.Database); err != nil {
+		return err
 	}
+	sd.hasAllDatabaseDescriptors = true
 	return nil
 }
 
-// getUnvalidatedByName looks up an unvalidated descriptor by name.
-func (sd *storedDescriptors) getUnvalidatedByName(
-	dbID descpb.ID, schemaID descpb.ID, name string,
-) catalog.Descriptor {
-	if dbID == 0 && schemaID == 0 && name == systemschema.SystemDatabaseName {
-		sd.maybeAddSystemDatabase()
-	}
-	entry := sd.descs.GetByName(dbID, schemaID, name)
-	if entry == nil {
-		return nil
-	}
-	u := entry.(*storedDescriptor)
-	if u.storedDescriptorStatus != notValidatedYet {
-		return nil
-	}
-	return u.immutable
-}
-
-// getAllDescriptors looks up all descriptors. The first call must go to KV.
-// Subsequent calls can retrieve descriptors from the cache.
-func (sd *storedDescriptors) getAllDescriptors(
-	ctx context.Context, txn *kv.Txn, version clusterversion.ClusterVersion,
-) (nstree.Catalog, error) {
-	if !sd.hasAllDescriptors {
-		c, err := catkv.GetCatalogUnvalidated(ctx, sd.codec, txn)
-		if err != nil {
-			return nstree.Catalog{}, err
-		}
-		descs := c.OrderedDescriptors()
-		ve := c.Validate(ctx, version, catalog.ValidationReadTelemetry, catalog.ValidationLevelCrossReferences, descs...)
-		if err := ve.CombinedError(); err != nil {
-			return nstree.Catalog{}, err
-		}
-		if err := c.ForEachDescriptorEntry(func(desc catalog.Descriptor) error {
-			if sd.descs.GetByID(desc.GetID()) == nil {
-				// Cache this descriptor.
-				mut := desc.NewBuilder().BuildExistingMutable()
-				_, err := sd.add(ctx, mut, notCheckedOutYet)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
-			return nstree.Catalog{}, err
-		}
-		sd.hasAllDescriptors = true
-		sd.hasAllDatabaseDescriptors = true
-	}
-	// TODO(jchan): There's a lot of wasted effort here in reconstructing a
-	// catalog and hydrating every descriptor. We could do better by caching the
-	// catalog and invalidating it upon descriptor check-out.
-	cat := nstree.MutableCatalog{}
-	if err := sd.descs.IterateByID(func(entry catalog.NameEntry) error {
-		var desc catalog.Descriptor
-		sDesc := entry.(*storedDescriptor)
-		if sDesc.storedDescriptorStatus == checkedOutAtLeastOnce {
-			desc = sDesc.mutable.ImmutableCopy()
-		} else {
-			desc = sDesc.immutable
-		}
-		cat.UpsertDescriptorEntry(desc)
-		return nil
-	}); err != nil {
-		return nstree.Catalog{}, err
-	}
-	// There could be tables with user defined types that need hydrating.
-	if err := hydrateCatalog(ctx, cat.Catalog); err != nil {
-		// If we ran into an error hydrating the types, that means that we
-		// have some sort of corrupted descriptor state. Rather than disable
-		// uses of getAllDescriptors, just log the error.
-		log.Errorf(ctx, "%s", err.Error())
-	}
-	return cat.Catalog, nil
-}
-
-// getAllDatabaseDescriptors looks up all database descriptors. The first call
-// must go to KV, except if getAllDescriptors has been called. Subsequent calls
-// can retrieve descriptors from the cache.
-func (sd *storedDescriptors) getAllDatabaseDescriptors(
-	ctx context.Context,
-	version clusterversion.ClusterVersion,
-	txn *kv.Txn,
-	vd validate.ValidationDereferencer,
-) ([]catalog.DatabaseDescriptor, error) {
-	if !sd.hasAllDescriptors && !sd.hasAllDatabaseDescriptors {
-		c, err := catkv.GetAllDatabaseDescriptorIDs(ctx, txn, sd.codec)
-		if err != nil {
-			return nil, err
-		}
-		dbDescs, err := catkv.MustGetDescriptorsByID(ctx, version, sd.codec, txn, vd, c.OrderedDescriptorIDs(), catalog.Database)
-		if err != nil {
-			return nil, err
-		}
-		for _, desc := range dbDescs {
-			if sd.descs.GetByID(desc.GetID()) == nil {
-				mut := desc.NewBuilder().BuildExistingMutable()
-				_, err := sd.add(ctx, mut, notCheckedOutYet)
-				if err != nil {
-					return nil, err
-				}
-			}
-		}
-		sd.hasAllDatabaseDescriptors = true
-	}
-	var allDatabaseDescriptors []catalog.DatabaseDescriptor
-	if err := sd.descs.IterateDatabasesByName(func(entry catalog.NameEntry) error {
-		sDesc := entry.(*storedDescriptor)
-		var dbDesc catalog.DatabaseDescriptor
-		if sDesc.storedDescriptorStatus == checkedOutAtLeastOnce {
-			dbDesc = sDesc.mutable.ImmutableCopy().(catalog.DatabaseDescriptor)
-		} else {
-			dbDesc = sDesc.immutable.(catalog.DatabaseDescriptor)
-		}
-		allDatabaseDescriptors = append(allDatabaseDescriptors, dbDesc)
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	return allDatabaseDescriptors, nil
-}
-
-func (sd *storedDescriptors) getSchemasForDatabase(
+func (sd *storedDescriptors) ensureAllSchemaIDsAndNamesForDatabase(
 	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
-) (map[descpb.ID]string, error) {
+) error {
 	if sd.allSchemasForDatabase == nil {
 		sd.allSchemasForDatabase = make(map[descpb.ID]map[descpb.ID]string)
 	}
-	if _, ok := sd.allSchemasForDatabase[db.GetID()]; !ok {
-		var err error
-		allSchemas, err := resolver.GetForDatabase(ctx, txn, sd.codec, db)
-		if err != nil {
-			return nil, err
-		}
-		sd.allSchemasForDatabase[db.GetID()] = make(map[descpb.ID]string)
-		for id, entry := range allSchemas {
-			sd.allSchemasForDatabase[db.GetID()][id] = entry.Name
-		}
-		return sd.allSchemasForDatabase[db.GetID()], nil
-	}
-	schemasForDatabase := sd.allSchemasForDatabase[db.GetID()]
-	if err := sd.descs.IterateSchemasForDatabaseByName(db.GetID(), func(entry catalog.NameEntry) error {
-		sDesc := entry.(*storedDescriptor)
-		var schemaDesc catalog.Descriptor
-		if sDesc.storedDescriptorStatus == checkedOutAtLeastOnce {
-			schemaDesc = sDesc.mutable.ImmutableCopy()
-		} else {
-			schemaDesc = sDesc.immutable
-		}
-		schemasForDatabase[schemaDesc.GetID()] = schemaDesc.GetName()
+	if _, ok := sd.allSchemasForDatabase[db.GetID()]; ok {
 		return nil
-	}); err != nil {
-		return nil, err
 	}
-	return schemasForDatabase, nil
+	schemasNamespaceEntries, err := resolver.GetForDatabase(ctx, txn, sd.codec, db)
+	if err != nil {
+		return err
+	}
+	m := make(map[descpb.ID]string, len(schemasNamespaceEntries))
+	for id, entry := range schemasNamespaceEntries {
+		m[id] = entry.Name
+	}
+	sd.allSchemasForDatabase[db.GetID()] = m
+	return nil
 }
 
-func (sd *storedDescriptors) idDefinitelyDoesNotExist(id descpb.ID) bool {
+// GetSchemaIDsAndNamesForDatabase generates a new map containing the ID -> name
+// mappings for all schemas in the given database.
+func (sd *storedDescriptors) GetSchemaIDsAndNamesForDatabase(
+	ctx context.Context, txn *kv.Txn, db catalog.DatabaseDescriptor,
+) (map[descpb.ID]string, error) {
+	if err := sd.ensureAllSchemaIDsAndNamesForDatabase(ctx, txn, db); err != nil {
+		return nil, err
+	}
+	src := sd.allSchemasForDatabase[db.GetID()]
+	ret := make(map[descpb.ID]string, len(src))
+	for id, name := range src {
+		ret[id] = name
+	}
+	return ret, nil
+}
+
+// IsIDKnownToNotExist returns false iff there definitely is no descriptor
+// in storage with that ID.
+func (sd *storedDescriptors) IsIDKnownToNotExist(id descpb.ID) bool {
 	if !sd.hasAllDescriptors {
 		return false
 	}
-	return sd.descs.GetByID(id) == nil
+	return sd.GetCachedByID(id) == nil
 }
 
-// lookupName is used when reading a descriptor from the storage layer by name.
+// LookupName is used when reading a descriptor from the storage layer by name.
 // Descriptors are physically keyed by ID, so we need to resolve their ID by
 // querying the system.namespace table first, which is what this method does.
 // We can avoid having to do this in some special cases:
@@ -516,7 +239,7 @@ func (sd *storedDescriptors) idDefinitelyDoesNotExist(id descpb.ID) bool {
 // - When we're looking up a schema for which we already have the descriptor
 //   of the parent database. The schema ID can be looked up in it.
 //
-func (sd *storedDescriptors) lookupName(
+func (sd *storedDescriptors) LookupName(
 	ctx context.Context,
 	txn *kv.Txn,
 	maybeDB catalog.DatabaseDescriptor,
@@ -527,7 +250,7 @@ func (sd *storedDescriptors) lookupName(
 	// Handle special cases which might avoid a namespace table query.
 	switch parentID {
 	case descpb.InvalidID:
-		if name == systemschema.SystemDatabaseName {
+		if name == catconstants.SystemDatabaseName {
 			// Special case: looking up the system database.
 			// The system database's descriptor ID is hard-coded.
 			return keys.SystemDatabaseID, nil
@@ -567,7 +290,7 @@ func (sd *storedDescriptors) lookupName(
 	)
 }
 
-// getByName reads a descriptor from the storage layer by name.
+// GetByName reads a descriptor from the storage layer by name.
 //
 // This is a three-step process:
 // 1. resolve the descriptor's ID using the name information,
@@ -575,29 +298,30 @@ func (sd *storedDescriptors) lookupName(
 // 3. check that the name in the descriptor is the one we expect; meaning that
 //    there is no RENAME underway for instance.
 //
-func (sd *storedDescriptors) getByName(
-	ctx context.Context,
-	version clusterversion.ClusterVersion,
-	txn *kv.Txn,
-	vd validate.ValidationDereferencer,
-	maybeDB catalog.DatabaseDescriptor,
-	parentID descpb.ID,
-	parentSchemaID descpb.ID,
-	name string,
+func (sd *storedDescriptors) GetByName(
+	ctx context.Context, txn *kv.Txn, parentID descpb.ID, parentSchemaID descpb.ID, name string,
 ) (catalog.Descriptor, error) {
-	descID, err := sd.lookupName(ctx, txn, maybeDB, parentID, parentSchemaID, name)
-	if err != nil || descID == descpb.InvalidID {
+	var maybeDB catalog.DatabaseDescriptor
+	if parent := sd.GetCachedByID(parentID); parent != nil {
+		maybeDB, _ = catalog.AsDatabaseDescriptor(parent)
+	}
+	id, err := sd.LookupName(ctx, txn, maybeDB, parentID, parentSchemaID, name)
+	if err != nil || id == descpb.InvalidID {
 		return nil, err
 	}
-	descs, err := sd.getByIDs(ctx, version, txn, vd, []descpb.ID{descID})
-	if err != nil {
-		if errors.Is(err, catalog.ErrDescriptorNotFound) {
-			// Having done the namespace lookup, the descriptor must exist.
-			return nil, errors.WithAssertionFailure(err)
+	desc := sd.GetCachedByID(id)
+	if desc == nil {
+		err = sd.EnsureFromStorageByIDs(ctx, txn, catalog.MakeDescriptorIDSet(id), catalog.Any)
+		if err != nil {
+			if errors.Is(err, catalog.ErrDescriptorNotFound) {
+				// Having done the namespace lookup, the descriptor must exist.
+				return nil, errors.WithAssertionFailure(err)
+			}
+			return nil, err
 		}
-		return nil, err
+		desc = sd.GetCachedByID(id)
 	}
-	if descs[0].GetName() != name {
+	if desc.GetName() != name {
 		// Immediately after a RENAME an old name still points to the descriptor
 		// during the drain phase for the name. Do not return a descriptor during
 		// draining.
@@ -608,125 +332,88 @@ func (sd *storedDescriptors) getByName(
 		// uncommitted namespace operations.
 		return nil, nil
 	}
-	return descs[0], nil
+	return desc, nil
 }
 
-// getByIDs actually reads a batch of descriptors from the storage layer.
-func (sd *storedDescriptors) getByIDs(
+// EnsureFromStorageByIDs actually reads a batch of descriptors from storage
+// and adds them to the cache. It assumes (without checking) that they are not
+// already present in the cache.
+func (sd *storedDescriptors) EnsureFromStorageByIDs(
 	ctx context.Context,
-	version clusterversion.ClusterVersion,
 	txn *kv.Txn,
-	vd validate.ValidationDereferencer,
-	ids []descpb.ID,
-) ([]catalog.Descriptor, error) {
-	ret := make([]catalog.Descriptor, len(ids))
-	kvIDs := make([]descpb.ID, 0, len(ids))
-	indexes := make([]int, 0, len(ids))
-	for i, id := range ids {
-		if id == keys.SystemDatabaseID {
-			// Special handling for the system database descriptor.
-			//
-			// This is done for performance reasons, to save ourselves an unnecessary
-			// round trip to storage which otherwise quickly compounds.
-			//
-			// The system database descriptor should never actually be mutated, which is
-			// why we return the same hard-coded descriptor every time. It's assumed
-			// that callers of this method will check the privileges on the descriptor
-			// (like any other database) and return an error.
-			ret[i] = dbdesc.NewBuilder(systemschema.SystemDB.DatabaseDesc()).BuildExistingMutable()
-		} else {
-			kvIDs = append(kvIDs, id)
-			indexes = append(indexes, i)
-		}
-	}
-	if len(kvIDs) == 0 {
-		return ret, nil
-	}
-	kvDescs, err := catkv.MustGetDescriptorsByID(ctx, version, sd.codec, txn, vd, kvIDs, catalog.Any)
-	if err != nil {
-		return nil, err
-	}
-	for j, desc := range kvDescs {
-		ret[indexes[j]] = desc
-	}
-	return ret, nil
-}
-
-func (sd *storedDescriptors) iterateNewVersionByID(
-	fn func(originalVersion lease.IDVersion) error,
+	ids catalog.DescriptorIDSet,
+	descriptorType catalog.DescriptorType,
 ) error {
-	return sd.descs.IterateByID(func(entry catalog.NameEntry) error {
-		u := entry.(*storedDescriptor)
-		if u.storedDescriptorStatus == notValidatedYet {
-			return nil
-		}
-		mut := u.mutable
-		if mut == nil || mut.IsNew() || !mut.IsUncommittedVersion() {
-			return nil
-		}
-		return fn(lease.NewIDVersionPrev(mut.OriginalName(), mut.OriginalID(), mut.OriginalVersion()))
-	})
-}
-
-func (sd *storedDescriptors) iterateUncommittedByID(fn func(imm catalog.Descriptor) error) error {
-	return sd.descs.IterateByID(func(entry catalog.NameEntry) error {
-		u := entry.(*storedDescriptor)
-		if u.storedDescriptorStatus != checkedOutAtLeastOnce || !u.immutable.IsUncommittedVersion() {
-			return nil
-		}
-		return fn(u.immutable)
-	})
-}
-
-func (sd *storedDescriptors) getUncommittedTables() (tables []catalog.TableDescriptor) {
-	_ = sd.iterateUncommittedByID(func(desc catalog.Descriptor) error {
-		if table, ok := desc.(catalog.TableDescriptor); ok {
-			tables = append(tables, table)
-		}
+	if ids.Empty() {
 		return nil
-	})
-	return tables
-}
-
-func (sd *storedDescriptors) getUncommittedDescriptorsForValidation() (descs []catalog.Descriptor) {
-	_ = sd.iterateUncommittedByID(func(desc catalog.Descriptor) error {
-		descs = append(descs, desc)
-		return nil
-	})
-	return descs
-}
-
-func (sd *storedDescriptors) hasUncommittedTables() (has bool) {
-	_ = sd.iterateUncommittedByID(func(desc catalog.Descriptor) error {
-		if _, has = desc.(catalog.TableDescriptor); has {
-			return iterutil.StopIteration()
-		}
-		return nil
-	})
-	return has
-}
-
-func (sd *storedDescriptors) hasUncommittedTypes() (has bool) {
-	_ = sd.iterateUncommittedByID(func(desc catalog.Descriptor) error {
-		if _, has = desc.(catalog.TypeDescriptor); has {
-			return iterutil.StopIteration()
-		}
-		return nil
-	})
-	return has
-}
-
-var systemStoredDatabase = &storedDescriptor{
-	immutable: dbdesc.NewBuilder(systemschema.SystemDB.DatabaseDesc()).BuildImmutableDatabase(),
-	// Note that the mutable field is left as nil. We'll generate a new
-	// value lazily when this is needed, which ought to be exceedingly rare.
-	mutable:                nil,
-	storedDescriptorStatus: notCheckedOutYet,
-}
-
-func (sd *storedDescriptors) maybeAddSystemDatabase() {
-	if !sd.addedSystemDatabase {
-		sd.addedSystemDatabase = true
-		sd.descs.Upsert(systemStoredDatabase, false /* skipNameMap */)
 	}
+	descs, err := catkv.MustGetDescriptorsByIDUnvalidated(
+		ctx, sd.codec, txn, ids.Ordered(), descriptorType,
+	)
+	if err != nil {
+		return err
+	}
+	for _, desc := range descs {
+		if err = sd.Ensure(ctx, desc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// IterateCachedByID applies fn to all known descriptors in the cache in
+// increasing sequence of IDs.
+func (sd *storedDescriptors) IterateCachedByID(fn func(desc catalog.Descriptor) error) error {
+	return sd.cache.IterateByID(func(entry catalog.NameEntry) error {
+		return fn(entry.(catalog.Descriptor))
+	})
+}
+
+// IterateDatabasesByName applies fn to all known database descriptors in the
+// cache in increasing sequence of names.
+func (sd *storedDescriptors) IterateDatabasesByName(
+	fn func(desc catalog.DatabaseDescriptor) error,
+) error {
+	return sd.nameIndex.IterateDatabasesByName(func(entry catalog.NameEntry) error {
+		db, err := catalog.AsDatabaseDescriptor(entry.(catalog.Descriptor))
+		if err != nil {
+			return err
+		}
+		return fn(db)
+	})
+}
+
+// GetValidationLevelByID returns the known level of validation for a cached
+// descriptor.
+func (sd *storedDescriptors) GetValidationLevelByID(id descpb.ID) catalog.ValidationLevel {
+	if vl, ok := sd.validationLevels[id]; ok {
+		return vl
+	}
+	if id == keys.SystemDatabaseID {
+		return validate.Write
+	}
+	return catalog.NoValidation
+}
+
+// UpdateValidationLevel increases the known level of validation for a cached
+// descriptor, if the new level is higher than the previous. In that case it
+// returns true.
+func (sd *storedDescriptors) UpdateValidationLevel(
+	desc catalog.Descriptor, newLevel catalog.ValidationLevel,
+) (wasUpdated bool) {
+	if sd.validationLevels == nil {
+		sd.validationLevels = make(map[descpb.ID]catalog.ValidationLevel)
+	}
+	if vl, ok := sd.validationLevels[desc.GetID()]; !ok || vl < newLevel {
+		sd.validationLevels[desc.GetID()] = newLevel
+		return true
+	}
+	return false
+}
+
+// RemoveUncommitted removes a newly-uncommitted descriptor from the name
+// index. If this isn't done this layer won't be properly shadowed by the
+// uncommitted layer.
+func (sd *storedDescriptors) RemoveUncommitted(desc catalog.Descriptor) {
+	sd.nameIndex.Remove(desc.GetID())
 }

--- a/pkg/sql/catalog/descs/system_table.go
+++ b/pkg/sql/catalog/descs/system_table.go
@@ -46,7 +46,7 @@ func (r *systemTableIDResolver) LookupSystemTableID(
 	if err := r.collectionFactory.Txn(ctx, r.db, func(
 		ctx context.Context, txn *kv.Txn, descriptors *Collection,
 	) (err error) {
-		id, err = descriptors.stored.lookupName(
+		id, err = descriptors.stored.LookupName(
 			ctx, txn, nil, /* maybeDatabase */
 			keys.SystemDatabaseID, keys.PublicSchemaID, tableName,
 		)

--- a/pkg/sql/catalog/descs/table.go
+++ b/pkg/sql/catalog/descs/table.go
@@ -80,19 +80,23 @@ func (tc *Collection) GetLeasedImmutableTableByID(
 
 // GetUncommittedMutableTableByID returns an uncommitted mutable table by its
 // ID.
-func (tc *Collection) GetUncommittedMutableTableByID(id descpb.ID) (*tabledesc.Mutable, error) {
-	if imm, status := tc.stored.getCachedByID(id); imm == nil || status == notValidatedYet {
-		return nil, nil
+func (tc *Collection) GetUncommittedMutableTableByID(
+	id descpb.ID,
+) (catalog.TableDescriptor, *tabledesc.Mutable, error) {
+	original, mut := tc.uncommitted.GetUncommittedMutableByID(id)
+	if mut == nil {
+		return nil, nil, nil
 	}
-	mut, err := tc.stored.checkOut(id)
-	if err != nil {
-		return nil, err
+	if _, err := catalog.AsTableDescriptor(mut); err != nil {
+		return nil, nil, err
 	}
-	if table, ok := mut.(*tabledesc.Mutable); ok {
-		return table, nil
+	if original == nil {
+		return nil, mut.(*tabledesc.Mutable), nil
 	}
-	// Check non-table descriptors back in.
-	return nil, tc.stored.checkIn(mut)
+	if _, err := catalog.AsTableDescriptor(original); err != nil {
+		return nil, nil, err
+	}
+	return original.(catalog.TableDescriptor), mut.(*tabledesc.Mutable), nil
 }
 
 // GetMutableTableByID returns a mutable table descriptor with

--- a/pkg/sql/catalog/descs/txn.go
+++ b/pkg/sql/catalog/descs/txn.go
@@ -292,14 +292,9 @@ func CheckSpanCountLimit(
 	if !descsCol.codec().ForSystemTenant() {
 		var totalSpanCountDelta int
 		for _, ut := range descsCol.GetUncommittedTables() {
-			uncommittedMutTable, err := descsCol.GetUncommittedMutableTableByID(ut.GetID())
+			originalTableDesc, uncommittedMutTable, err := descsCol.GetUncommittedMutableTableByID(ut.GetID())
 			if err != nil {
 				return err
-			}
-
-			var originalTableDesc catalog.TableDescriptor
-			if originalDesc := uncommittedMutTable.OriginalDescriptor(); originalDesc != nil {
-				originalTableDesc = originalDesc.(catalog.TableDescriptor)
 			}
 			delta, err := spanconfig.Delta(ctx, splitter, originalTableDesc, uncommittedMutTable)
 			if err != nil {

--- a/pkg/sql/catalog/descs/uncommitted_descriptors.go
+++ b/pkg/sql/catalog/descs/uncommitted_descriptors.go
@@ -1,0 +1,186 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package descs
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// uncommittedDescriptors is the data structure holding all uncommitted
+// descriptors for a Collection.
+// This allows a transaction to see its own modifications while bypassing the
+// descriptor lease mechanism. The lease mechanism will have its own transaction
+// to read the descriptor and will hang waiting for the uncommitted changes to
+// the descriptor if this transaction is PRIORITY HIGH. These descriptors are
+// local to this Collection and their state is thus not visible to other
+// transactions.
+type uncommittedDescriptors struct {
+
+	// These maps store the descriptors which have undergone mutations in the
+	// current transaction:
+	// - original stores the original state of such descriptors in storage, unless
+	//   they are new.
+	// - uncommitted stores the uncommitted state of such descriptors, that is to
+	//   say the state they were in when the AddUncommittedDescriptor method was
+	//   called, which is done (among other things) when the mutated descriptor
+	//   is persisted to storage via WriteDescToBatch. These descriptors are
+	//   immutable and this map serves as the reference when querying this layer.
+	// - mutable stores the mutable descriptors associated with the uncommitted
+	//   descriptors in this collection. These are always the same in-memory
+	//   objects for each ID for the duration of the transaction.
+	original, uncommitted, mutable nstree.Map
+
+	// memAcc is the actual account of an injected, upstream monitor
+	// to track memory usage of uncommittedDescriptors.
+	memAcc mon.BoundAccount
+}
+
+func makeUncommittedDescriptors(monitor *mon.BytesMonitor) uncommittedDescriptors {
+	return uncommittedDescriptors{
+		memAcc: monitor.MakeBoundAccount(),
+	}
+}
+
+// Reset zeroes the object for re-use in a new transaction.
+func (ud *uncommittedDescriptors) Reset(ctx context.Context) {
+	ud.original.Clear()
+	ud.uncommitted.Clear()
+	ud.mutable.Clear()
+	ud.memAcc.Clear(ctx)
+	old := *ud
+	*ud = uncommittedDescriptors{
+		original:    old.original,
+		uncommitted: old.uncommitted,
+		mutable:     old.mutable,
+		memAcc:      old.memAcc,
+	}
+}
+
+// GetUncommittedByID returns the uncommitted descriptor for this ID, if it
+// exists.
+func (ud *uncommittedDescriptors) GetUncommittedByID(id descpb.ID) catalog.Descriptor {
+	if e := ud.uncommitted.GetByID(id); e != nil {
+		return e.(catalog.Descriptor)
+	}
+	return nil
+}
+
+// GetUncommittedMutableByID returns the original descriptor as well as the
+// uncommitted mutable descriptor for this ID if they exist.
+func (ud *uncommittedDescriptors) GetUncommittedMutableByID(
+	id descpb.ID,
+) (original catalog.Descriptor, mutable catalog.MutableDescriptor) {
+	if ud.uncommitted.GetByID(id) == nil {
+		return nil, nil
+	}
+	if me := ud.mutable.GetByID(id); me != nil {
+		mutable = me.(catalog.MutableDescriptor)
+	}
+	if oe := ud.original.GetByID(id); oe != nil {
+		original = oe.(catalog.Descriptor)
+	}
+	return original, mutable
+}
+
+// GetUncommittedByName returns the uncommitted descriptor for this name key, if
+// it exists.
+func (ud *uncommittedDescriptors) GetUncommittedByName(
+	parentID, parentSchemaID descpb.ID, name string,
+) catalog.Descriptor {
+	if e := ud.uncommitted.GetByName(parentID, parentSchemaID, name); e != nil {
+		return e.(catalog.Descriptor)
+	}
+	return nil
+}
+
+// IterateNewVersionByID applies fn to each lease.IDVersion from the original
+// descriptor, if it exists, for each uncommitted descriptor, in ascending
+// sequence of IDs.
+func (ud *uncommittedDescriptors) IterateNewVersionByID(
+	fn func(originalVersion lease.IDVersion) error,
+) error {
+	return ud.uncommitted.IterateByID(func(entry catalog.NameEntry) error {
+		if o := ud.original.GetByID(entry.GetID()); o != nil {
+			return fn(lease.NewIDVersionPrev(o.GetName(), o.GetID(), o.(catalog.Descriptor).GetVersion()))
+		}
+		return nil
+	})
+}
+
+// IterateUncommittedByID applies fn to the uncommitted descriptors in ascending
+// sequence of IDs.
+func (ud *uncommittedDescriptors) IterateUncommittedByID(
+	fn func(desc catalog.Descriptor) error,
+) error {
+	return ud.uncommitted.IterateByID(func(entry catalog.NameEntry) error {
+		return fn(entry.(catalog.Descriptor))
+	})
+}
+
+// EnsureMutable is called when mutable descriptors are queried by the
+// collection. This is a prerequisite to accepting any subsequent
+// AddUncommittedDescriptor calls for any of these descriptors.
+// Calling this does not change the results of any queries on this layer.
+func (ud *uncommittedDescriptors) EnsureMutable(
+	ctx context.Context, original catalog.Descriptor,
+) (catalog.MutableDescriptor, error) {
+	if e := ud.mutable.GetByID(original.GetID()); e != nil {
+		return e.(catalog.MutableDescriptor), nil
+	}
+	mut := original.NewBuilder().BuildExistingMutable()
+	if original.GetID() == keys.SystemDatabaseID {
+		return mut, nil
+	}
+	if err := ud.memAcc.Grow(ctx, mut.ByteSize()); err != nil {
+		return nil, errors.Wrap(err, "Memory usage exceeds limit for uncommittedDescriptors")
+	}
+	ud.original.Upsert(original, true /* skipNameMap */)
+	ud.mutable.Upsert(mut, true /* skipNameMap */)
+	return mut, nil
+}
+
+// Upsert adds an uncommitted descriptor to this layer.
+// This is called by AddUncommittedDescriptors.
+func (ud *uncommittedDescriptors) Upsert(
+	ctx context.Context, original catalog.Descriptor, mut catalog.MutableDescriptor,
+) (err error) {
+	// Refresh the cached fields on mutable type descriptors.
+	if typ, ok := mut.(*typedesc.Mutable); ok {
+		mut, err = typedesc.UpdateCachedFieldsOnModifiedMutable(typ)
+		if err != nil {
+			return err
+		}
+	}
+	// Add the descriptors to the uncommitted descriptors layer.
+	imm := mut.ImmutableCopy()
+	newBytes := imm.ByteSize()
+	if mut.IsNew() {
+		newBytes += mut.ByteSize()
+	}
+	if err = ud.memAcc.Grow(ctx, newBytes); err != nil {
+		return errors.Wrap(err, "Memory usage exceeds limit for uncommittedDescriptors")
+	}
+	ud.mutable.Upsert(mut, true /* skipNameMap */)
+	ud.uncommitted.Upsert(imm, imm.SkipNamespace())
+	if original != nil {
+		ud.original.Upsert(original, true /* skipNameMap */)
+	}
+	return nil
+}

--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -22,6 +22,19 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+const (
+	// ImmutableRead is the default validation level when reading an immutable
+	// descriptor.
+	ImmutableRead = catalog.ValidationLevelCrossReferences
+
+	// MutableRead is the default validation level when reading a mutable
+	// descriptor.
+	MutableRead = catalog.ValidationLevelCrossReferences
+
+	// Write is the default validation level when writing a descriptor.
+	Write = catalog.ValidationLevelAllPreTxnCommit
+)
+
 // Self is a convenience function for Validate called at the
 // ValidationLevelSelfOnly level and combining the resulting errors.
 func Self(version clusterversion.ClusterVersion, descriptors ...catalog.Descriptor) error {
@@ -406,7 +419,7 @@ func collectDescriptorsForValidation(
 		referencedBy: catalog.MakeDescriptorIDSet(),
 	}
 	for _, desc := range descriptors {
-		if desc == nil {
+		if desc == nil || desc.Dropped() {
 			continue
 		}
 		if err := cs.addDirectReferences(desc); err != nil {

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1022,15 +1022,6 @@ func (desc *Mutable) ClusterVersion() descpb.TableDescriptor {
 	return desc.original.TableDescriptor
 }
 
-// OriginalDescriptor returns the original state of the descriptor prior to
-// the mutations.
-func (desc *Mutable) OriginalDescriptor() catalog.Descriptor {
-	if desc.original != nil {
-		return desc.original
-	}
-	return nil
-}
-
 // FamilyHeuristicTargetBytes is the target total byte size of columns that the
 // current heuristic will assign to a family.
 const FamilyHeuristicTargetBytes = 256

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -26,7 +26,7 @@ const (
 	// NoValidation means don't perform any validation checks at all.
 	NoValidation ValidationLevel = 0
 	// ValidationLevelSelfOnly means only validate internal descriptor consistency.
-	ValidationLevelSelfOnly = 1<<(iota+1) - 1
+	ValidationLevelSelfOnly ValidationLevel = 1<<(iota+1) - 1
 	// ValidationLevelCrossReferences means do the above and also check
 	// cross-references.
 	ValidationLevelCrossReferences

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -403,7 +403,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			}
 			var foundExternalReference bool
 			for id := range refs {
-				if t, err := params.p.Descriptors().GetUncommittedMutableTableByID(id); err != nil {
+				if _, t, err := params.p.Descriptors().GetUncommittedMutableTableByID(id); err != nil {
 					return err
 				} else if t == nil || !t.IsNew() {
 					foundExternalReference = true

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -108,7 +108,7 @@ func (n *createViewNode) startExec(params runParams) error {
 	backRefMutables := make(map[descpb.ID]*tabledesc.Mutable, len(n.planDeps))
 	hasTempBackref := false
 	for id, updated := range n.planDeps {
-		backRefMutable, err := params.p.Descriptors().GetUncommittedMutableTableByID(id)
+		_, backRefMutable, err := params.p.Descriptors().GetUncommittedMutableTableByID(id)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/sem/tree/name_resolution.go
+++ b/pkg/sql/sem/tree/name_resolution.go
@@ -169,7 +169,7 @@ type CommonLookupFlags struct {
 	IncludeOffline bool
 	// IncludeOffline specifies if dropped descriptors should be visible.
 	IncludeDropped bool
-	// AvoidSynthetic specifies if the any synthetic descriptors will be ignored.
+	// AvoidSynthetic specifies if the synthetic descriptors will be ignored.
 	AvoidSynthetic bool
 }
 

--- a/pkg/upgrade/upgrades/role_options_migration_test.go
+++ b/pkg/upgrade/upgrades/role_options_migration_test.go
@@ -66,8 +66,7 @@ func runTestRoleOptionsMigration(t *testing.T, numUsers int) {
 	s := tc.Server(0)
 
 	// Inject the old copy of the descriptor.
-	upgrades.InjectLegacyTable(ctx, t, s, systemschema.UsersTable,
-		getDeprecatedSystemRoleOptionsTable)
+	upgrades.InjectLegacyTable(ctx, t, s, systemschema.RoleOptionsTable, getDeprecatedSystemRoleOptionsTable)
 
 	tdb.Exec(t, "CREATE USER testuser")
 	tdb.Exec(t, `ALTER ROLE testuser CREATEROLE NOLOGIN VALID UNTIL "2021-01-01" CONTROLJOB`)


### PR DESCRIPTION
This rewrite was motivated by the upcoming need to validate descriptors
up to different levels depending on why they were being read.

This requires tracking the validation level in a more granular fashion
in the Collection's caches. This in turn required dissociating the
uncommitted descriptors from the stored descriptors again, to allow the
stored descriptors cache to more closely mirror what's physically being
stored in the system.descriptor table.

Validation is now performed lazily and all descriptor queries now share
a common structure, be it by-ID lookups, by-name lookups, or full table
scans: cache lookups, reads, validation and hydration all happen in the
same sequence.

Despite significant rewriting of the inner workings of the descriptors
collection, this commit should not functionally change anything.

Informs #85263.

Release justification: low-risk, high-benefit change.
Release note: None