### PR TITLE
custom build pr

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -456,15 +456,39 @@ func (c *copyMachine) readCSVData(ctx context.Context, final bool) (brk bool, er
 				return false, err
 			}
 		}
-		// At this point, we know fullLine ends in '\n'. Keep track of the total
-		// number of QUOTE chars in fullLine -- if it is even, then it means that
-		// the quotes are balanced and '\n' is not in a quoted field.
-		// Currently, the QUOTE char and ESCAPE char are both always equal to '"'
-		// and are not configurable. As per the COPY spec, any appearance of the
-		// QUOTE or ESCAPE characters in an actual value must be preceded by an
-		// ESCAPE character. This means that an escaped '"' also results in an even
-		// number of '"' characters.
-		quoteCharsSeen += bytes.Count(line, []byte{'"'})
+
+		// Now we need to calculate if we are still quoted.
+		if c.csvEscape == 0 {
+			// CSV escape is not specified and hence defaults to '"'.¥
+			// At this point, we know fullLine ends in '\n'. Keep track of the total
+			// number of QUOTE chars in fullLine -- if it is even, then it means that
+			// the quotes are balanced and '\n' is not in a quoted field.
+			// Currently, the QUOTE char and ESCAPE char are both always equal to '"'
+			// and are not configurable. As per the COPY spec, any appearance of the
+			// QUOTE or ESCAPE characters in an actual value must be preceded by an
+			// ESCAPE character. This means that an escaped '"' also results in an even
+			// number of '"' characters.
+			// This branch is kept in the interests of "backporting safely" - this
+			// was the old code. Users who use COPY ... ESCAPE will be the only
+			// ones hitting the new code below.
+			quoteCharsSeen += bytes.Count(line, []byte{'"'})
+		} else {
+			// Otherwise, we have to do a more involved count of quotes and
+			// ignore any escaped quotes for counting.
+			isEscaped := false
+			for _, ch := range line {
+				if isEscaped {
+					isEscaped = false
+					continue
+				}
+				if ch == '"' {
+					quoteCharsSeen++
+				}
+				if rune(ch) == c.csvEscape {
+					isEscaped = true
+				}
+			}
+		}
 		if quoteCharsSeen%2 == 0 {
 			break
 		}

--- a/pkg/sql/pgwire/testdata/pgtest/copy
+++ b/pkg/sql/pgwire/testdata/pgtest/copy
@@ -422,7 +422,8 @@ send
 Query {"String": "DELETE FROM t"}
 Query {"String": "COPY t FROM STDIN CSV ESCAPE 'x'"}
 CopyData {"Data": "1,\"x\"\"\n"}
-CopyData {"Data": "1,\"xxx\",xx\"\n"}
+CopyData {"Data": "2,\"xxx\",\"\n"}
+CopyData {"Data": "3,\"xxx\",xx\"\n"}
 CopyData {"Data": "\\.\n"}
 CopyDone
 Query {"String": "SELECT * FROM t ORDER BY i"}
@@ -436,11 +437,12 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"DELETE 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
-{"Type":"CommandComplete","CommandTag":"COPY 2"}
+{"Type":"CommandComplete","CommandTag":"COPY 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"DataRow","Values":[{"text":"1"},{"text":"\""}]}
-{"Type":"DataRow","Values":[{"text":"1"},{"text":"x\",x"}]}
-{"Type":"CommandComplete","CommandTag":"SELECT 2"}
+{"Type":"DataRow","Values":[{"text":"2"},{"text":"x\","}]}
+{"Type":"DataRow","Values":[{"text":"3"},{"text":"x\",x"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
 send
@@ -471,7 +473,7 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-{"Type":"CommandComplete","CommandTag":"DELETE 2"}
+{"Type":"CommandComplete","CommandTag":"DELETE 3"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"CopyInResponse","ColumnFormatCodes":[0,0]}
 {"Type":"CommandComplete","CommandTag":"COPY 3"}


### PR DESCRIPTION
Release justification: critical bug fix to existing functionality

Release note (bug fix): Previously, escaping a double quote (`"`) with
`COPY` in `CSV` mode could ignore all subsequent lines in the same COPY
if an `ESCAPE` clause were specified. This is now resolved.