### PR TITLE
kvserver: add Raft transport queue byte size metric

### DIFF
--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"net"
 	"runtime/pprof"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -155,9 +156,18 @@ type RaftTransport struct {
 	stopper *stop.Stopper
 	metrics *RaftTransportMetrics
 
-	queues   [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*chan *RaftMessageRequest
+	queues   [rpc.NumConnectionClasses]syncutil.IntMap // map[roachpb.NodeID]*raftSendQueue
 	dialer   *nodedialer.Dialer
 	handlers syncutil.IntMap // map[roachpb.StoreID]*RaftMessageHandler
+}
+
+// raftSendQueue is a queue of outgoing RaftMessageRequest messages.
+type raftSendQueue struct {
+	reqs chan *kvserverpb.RaftMessageRequest
+	// The number of bytes in flight. Must be updated *atomically* on sending and
+	// receiving from the reqs channel.
+	// TODO(pavelkalinnikov): replace by atomic.Int64 when CRDB uses Go 1.19.
+	bytes int64
 }
 
 // NewDummyRaftTransport returns a dummy raft transport for use in tests which
@@ -198,17 +208,28 @@ func (t *RaftTransport) Metrics() *RaftTransportMetrics {
 	return t.metrics
 }
 
-func (t *RaftTransport) queuedMessageCount() int64 {
-	var n int64
-	addLength := func(k int64, v unsafe.Pointer) bool {
-		ch := *(*chan *kvserverpb.RaftMessageRequest)(v)
-		n += int64(len(ch))
-		return true
-	}
+// visitQueues calls the visit callback on each outgoing messages sub-queue.
+func (t *RaftTransport) visitQueues(visit func(*raftSendQueue)) {
 	for class := range t.queues {
-		t.queues[class].Range(addLength)
+		t.queues[class].Range(func(k int64, v unsafe.Pointer) bool {
+			visit((*raftSendQueue)(v))
+			return true
+		})
 	}
-	return n
+}
+
+// queueMessageCount returns the total number of outgoing messages in the queue.
+func (t *RaftTransport) queueMessageCount() int64 {
+	var count int64
+	t.visitQueues(func(q *raftSendQueue) { count += int64(len(q.reqs)) })
+	return count
+}
+
+// queueByteSize returns the total bytes size of outgoing messages in the queue.
+func (t *RaftTransport) queueByteSize() int64 {
+	var size int64
+	t.visitQueues(func(q *raftSendQueue) { size += atomic.LoadInt64(&q.bytes) })
+	return size
 }
 
 func (t *RaftTransport) getHandler(storeID roachpb.StoreID) (RaftMessageHandler, bool) {
@@ -374,7 +395,7 @@ func (t *RaftTransport) Stop(storeID roachpb.StoreID) {
 // lost and a new instance of processQueue will be started by the next message
 // to be sent.
 func (t *RaftTransport) processQueue(
-	ch chan *kvserverpb.RaftMessageRequest, stream MultiRaft_RaftMessageBatchClient,
+	q *raftSendQueue, stream MultiRaft_RaftMessageBatchClient,
 ) error {
 	errCh := make(chan error, 1)
 
@@ -418,15 +439,19 @@ func (t *RaftTransport) processQueue(
 			return nil
 		case err := <-errCh:
 			return err
-		case req := <-ch:
-			budget := targetRaftOutgoingBatchSize.Get(&t.st.SV) - int64(req.Size())
+		case req := <-q.reqs:
+			size := int64(req.Size())
+			atomic.AddInt64(&q.bytes, -size)
+			budget := targetRaftOutgoingBatchSize.Get(&t.st.SV) - size
 			batch.Requests = append(batch.Requests, *req)
 			releaseRaftMessageRequest(req)
 			// Pull off as many queued requests as possible, within reason.
 			for budget > 0 {
 				select {
-				case req = <-ch:
-					budget -= int64(req.Size())
+				case req = <-q.reqs:
+					size := int64(req.Size())
+					atomic.AddInt64(&q.bytes, -size)
+					budget -= size
 					batch.Requests = append(batch.Requests, *req)
 					releaseRaftMessageRequest(req)
 				default:
@@ -454,14 +479,14 @@ func (t *RaftTransport) processQueue(
 // indicating whether the queue already exists (true) or was created (false).
 func (t *RaftTransport) getQueue(
 	nodeID roachpb.NodeID, class rpc.ConnectionClass,
-) (chan *kvserverpb.RaftMessageRequest, bool) {
+) (*raftSendQueue, bool) {
 	queuesMap := &t.queues[class]
 	value, ok := queuesMap.Load(int64(nodeID))
 	if !ok {
-		ch := make(chan *kvserverpb.RaftMessageRequest, raftSendBufferSize)
-		value, ok = queuesMap.LoadOrStore(int64(nodeID), unsafe.Pointer(&ch))
+		q := raftSendQueue{reqs: make(chan *kvserverpb.RaftMessageRequest, raftSendBufferSize)}
+		value, ok = queuesMap.LoadOrStore(int64(nodeID), unsafe.Pointer(&q))
 	}
-	return *(*chan *kvserverpb.RaftMessageRequest)(value), ok
+	return (*raftSendQueue)(value), ok
 }
 
 // SendAsync sends a message to the recipient specified in the request. It
@@ -492,7 +517,7 @@ func (t *RaftTransport) SendAsync(
 		return false
 	}
 
-	ch, existingQueue := t.getQueue(toNodeID, class)
+	q, existingQueue := t.getQueue(toNodeID, class)
 	if !existingQueue {
 		// Note that startProcessNewQueue is in charge of deleting the queue.
 		ctx := t.AnnotateCtx(context.Background())
@@ -501,8 +526,12 @@ func (t *RaftTransport) SendAsync(
 		}
 	}
 
+	// Note: computing the size of the request *before* sending it to the queue,
+	// because the receiver takes ownership of, and can modify it.
+	size := int64(req.Size())
 	select {
-	case ch <- req:
+	case q.reqs <- req:
+		atomic.AddInt64(&q.bytes, size)
 		return true
 	default:
 		if logRaftSendQueueFullEvery.ShouldLog() {
@@ -525,7 +554,7 @@ func (t *RaftTransport) SendAsync(
 func (t *RaftTransport) startProcessNewQueue(
 	ctx context.Context, toNodeID roachpb.NodeID, class rpc.ConnectionClass,
 ) (started bool) {
-	cleanup := func(ch chan *kvserverpb.RaftMessageRequest) {
+	cleanup := func(q *raftSendQueue) {
 		// Account for the remainder of `ch` which was never sent.
 		// NB: we deleted the queue above, so within a short amount
 		// of time nobody should be writing into the channel any
@@ -534,7 +563,8 @@ func (t *RaftTransport) startProcessNewQueue(
 		// way the code is written).
 		for {
 			select {
-			case <-ch:
+			case req := <-q.reqs:
+				atomic.AddInt64(&q.bytes, -int64(req.Size()))
 				t.metrics.MessagesDropped.Inc(1)
 			default:
 				return
@@ -542,11 +572,11 @@ func (t *RaftTransport) startProcessNewQueue(
 		}
 	}
 	worker := func(ctx context.Context) {
-		ch, existingQueue := t.getQueue(toNodeID, class)
+		q, existingQueue := t.getQueue(toNodeID, class)
 		if !existingQueue {
 			log.Fatalf(ctx, "queue for n%d does not exist", toNodeID)
 		}
-		defer cleanup(ch)
+		defer cleanup(q)
 		defer t.queues[class].Delete(int64(toNodeID))
 		// NB: we dial without a breaker here because the caller has already
 		// checked the breaker. Checking it again can cause livelock, see:
@@ -567,7 +597,7 @@ func (t *RaftTransport) startProcessNewQueue(
 			return
 		}
 
-		if err := t.processQueue(ch, stream); err != nil {
+		if err := t.processQueue(q, stream); err != nil {
 			log.Warningf(ctx, "while processing outgoing Raft queue to node %d: %s:", toNodeID, err)
 		}
 	}

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -501,6 +501,7 @@ func (t *RaftTransport) SendAsync(
 	defer func() {
 		if !sent {
 			t.metrics.MessagesDropped.Inc(1)
+			releaseRaftMessageRequest(req)
 		}
 	}()
 
@@ -537,7 +538,6 @@ func (t *RaftTransport) SendAsync(
 		if logRaftSendQueueFullEvery.ShouldLog() {
 			log.Warningf(t.AnnotateCtx(context.Background()), "raft send queue to n%d is full", toNodeID)
 		}
-		releaseRaftMessageRequest(req)
 		return false
 	}
 }
@@ -566,6 +566,7 @@ func (t *RaftTransport) startProcessNewQueue(
 			case req := <-q.reqs:
 				atomic.AddInt64(&q.bytes, -int64(req.Size()))
 				t.metrics.MessagesDropped.Inc(1)
+				releaseRaftMessageRequest(req)
 			default:
 				return
 			}

--- a/pkg/kv/kvserver/raft_transport_metrics.go
+++ b/pkg/kv/kvserver/raft_transport_metrics.go
@@ -14,7 +14,8 @@ import "github.com/cockroachdb/cockroach/pkg/util/metric"
 
 // RaftTransportMetrics is the set of metrics for a given RaftTransport.
 type RaftTransportMetrics struct {
-	SendQueueSize *metric.Gauge
+	SendQueueSize  *metric.Gauge
+	SendQueueBytes *metric.Gauge
 
 	MessagesDropped *metric.Counter
 	MessagesSent    *metric.Counter
@@ -32,10 +33,23 @@ func (t *RaftTransport) initMetrics() {
 
 The queue is composed of multiple bounded channels associated with different
 peers. The overall size of tens of thousands could indicate issues streaming
-messages to at least one peer.`,
+messages to at least one peer. Use this metric in conjunction with
+send-queue-bytes.`,
 			Measurement: "Messages",
 			Unit:        metric.Unit_COUNT,
-		}, t.queuedMessageCount),
+		}, t.queueMessageCount),
+
+		SendQueueBytes: metric.NewFunctionalGauge(metric.Metadata{
+			Name: "raft.transport.send-queue-bytes",
+			Help: `The total byte size of pending outgoing messages in the queue.
+
+The queue is composed of multiple bounded channels associated with different
+peers. A size higher than the average baseline could indicate issues streaming
+messages to at least one peer. Use this metric together with send-queue-size, to
+have a fuller picture.`,
+			Measurement: "Bytes",
+			Unit:        metric.Unit_BYTES,
+		}, t.queueByteSize),
 
 		MessagesDropped: metric.NewCounter(metric.Metadata{
 			Name:        "raft.transport.sends-dropped",

--- a/pkg/kv/kvserver/raft_transport_unit_test.go
+++ b/pkg/kv/kvserver/raft_transport_unit_test.go
@@ -90,8 +90,7 @@ func TestRaftTransportStartNewQueue(t *testing.T) {
 		}
 	}()
 
-	_, existingQueue := tp.getQueue(1, rpc.SystemClass)
-	if existingQueue {
+	if _, existingQueue := tp.getQueue(1, rpc.SystemClass); existingQueue {
 		t.Fatal("queue already exists")
 	}
 	timeout := time.Duration(rand.Int63n(int64(5 * time.Millisecond)))

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1911,6 +1911,10 @@ var charts = []sectionDescription{
 				Metrics: []string{"raft.transport.send-queue-size"},
 			},
 			{
+				Title:   "Send Queue Byte Size",
+				Metrics: []string{"raft.transport.send-queue-bytes"},
+			},
+			{
 				Title:   "Raft Message Sends Dropped",
 				Metrics: []string{"raft.transport.sends-dropped"},
 			},


### PR DESCRIPTION
The new metric measures the total size in bytes of the outgoing Raft messages
queue in `RaftTransport`. In the future it could be used for rate-limiting.

Experiment running a local cluster with added 10ms delay on queue receiving end:
<img width="996" alt="Screenshot 2022-08-30 at 14 12 55" src="https://user-images.githubusercontent.com/3757441/187446097-9c8bb933-7918-4922-a4f9-55fb9cd74e6d.png">

Fixes #86371

Release justification: helps investigating customer issues
Release note: None