### PR TITLE
batcheval: fix incorrect StartTime in ExportResponse

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_export.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export.go
@@ -137,7 +137,10 @@ func evalExport(
 	// BACKUP to correctly note the supported time bounds for RESTORE AS OF SYSTEM
 	// TIME.
 	if args.MVCCFilter == roachpb.MVCCFilter_All {
-		reply.StartTime = cArgs.EvalCtx.GetGCThreshold()
+		reply.StartTime = args.StartTime
+		if args.StartTime.IsEmpty() {
+			reply.StartTime = cArgs.EvalCtx.GetGCThreshold()
+		}
 	}
 
 	var exportAllRevisions bool


### PR DESCRIPTION
Previously, ExportResponse for a revision history backup
was always setting the `StartTime` in the response to the
GCThreshold of the span being exported. This is correct for
a full backup where revision history stretches only as far back
as the GCThreshold, but is incorrect for incremental backups
where the StartTime should stretch as far back as the StartTime
of the ExportRequest.

Thankfully, this StartTime in ExportResponse is only used for
validating that the restore AOST is greater than the StartTime
of the full backup i.e. this field is inconsequential for incrementals.
Nonetheless, we should send back an accurate response.

Release note: None

Release justification: low risk bug fix