### PR TITLE
roachtest: fix unintended exit when --cockroach-short is passed

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -210,8 +210,10 @@ func initBinariesAndLibraries() {
 	if cockroachShort != "" {
 		// defValue doesn't matter since cockroachShort is a non-empty string.
 		cockroachShort, err = findBinary(cockroachShort, "" /* defValue */)
-		fmt.Fprintf(os.Stderr, "%+v\n", err)
-		os.Exit(1)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	workload, err = findBinary(workload, "workload")


### PR DESCRIPTION
Fixes a regression introduced by
https://github.com/cockroachdb/cockroach/pull/86625.

Release justification: fix roachtest nightly (on master)
Release note: None