### PR TITLE
roachpb: reduce size of BatchRequest struct below 256 bytes

### DIFF
--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -2428,9 +2428,6 @@ message Header {
   // supported requests from max_span_request_keys apply to the target_bytes
   // option as well.
   int64 target_bytes = 15;
-  // If true, allow returning an empty result when the first result exceeds a
-  // limit (e.g. TargetBytes). Only supported by Get, Scan, and ReverseScan.
-  bool allow_empty = 23;
   // If positive, Scan and ReverseScan requests with limits (MaxSpanRequestKeys
   // or TargetBytes) will not return results with partial SQL rows at the end
   // (recall that SQL rows can span multiple keys). Such partial rows will be
@@ -2444,6 +2441,9 @@ message Header {
   //
   // Added in 22.1, callers must check the ScanWholeRows version gate first.
   int32 whole_rows_of_size = 26;
+  // If true, allow returning an empty result when the first result exceeds a
+  // limit (e.g. TargetBytes). Only supported by Get, Scan, and ReverseScan.
+  bool allow_empty = 23;
   // If true, DistSender returns partial non-empty results when encountering a
   // range boundary, with an appropriate resume span and reason
   // RESUME_RANGE_BOUNDARY. This will disable parallelism of DistSender
@@ -2472,18 +2472,6 @@ message Header {
   // EndTxnRequest. Currently set conservatively: a request might be
   // composed of distinct spans yet have this field set to false.
   bool distinct_spans = 9;
-  // client_range_info represents the kvclient's knowledge about the state of
-  // the range (i.e. of the range descriptor and lease). The kvserver checks
-  // whether the client's info is up to date and, if it isn't, it will return a
-  // RangeInfo with up-to-date information. Typically this entire field is set
-  // by the client's DistSender, however it will preserve the value of the field 
-  // `ExplicitlyRequested` so that requests passed to DistSender can request 
-  // `RangeInfos` if desired.
-  ClientRangeInfo client_range_info = 17 [(gogoproto.nullable) = false];
-  // gateway_node_id is the ID of the gateway node where the request originated.
-  // For requests from tenants, this is set to the NodeID of the KV node handling
-  // the BatchRequest.
-  int32 gateway_node_id = 11 [(gogoproto.customname) = "GatewayNodeID", (gogoproto.casttype) = "NodeID"];
   // If set, the request will return to the client before proposing the
   // request into Raft. All consensus processing will be performed
   // asynchronously. Because consensus may fail, this means that the
@@ -2501,6 +2489,18 @@ message Header {
   // current batch. When set, it allows the server to handle pushes and write
   // too old conditions locally.
   bool can_forward_read_timestamp = 16;
+  // gateway_node_id is the ID of the gateway node where the request originated.
+  // For requests from tenants, this is set to the NodeID of the KV node handling
+  // the BatchRequest.
+  int32 gateway_node_id = 11 [(gogoproto.customname) = "GatewayNodeID", (gogoproto.casttype) = "NodeID"];
+  // client_range_info represents the kvclient's knowledge about the state of
+  // the range (i.e. of the range descriptor and lease). The kvserver checks
+  // whether the client's info is up to date and, if it isn't, it will return a
+  // RangeInfo with up-to-date information. Typically this entire field is set
+  // by the client's DistSender, however it will preserve the value of the field
+  // `ExplicitlyRequested` so that requests passed to DistSender can request
+  // `RangeInfos` if desired.
+  ClientRangeInfo client_range_info = 17 [(gogoproto.nullable) = false];
   // bounded_staleness is set when a read-only batch is performing a bounded
   // staleness read and wants its timestamp to be chosen dynamically, based
   // on a resolved timestamp from its target replica(s).
@@ -2512,7 +2512,7 @@ message Header {
   // Requests with a non-zero timestamp are not allowed to set this field.
   BoundedStalenessHeader bounded_staleness = 22;
 
-  util.tracing.tracingpb.TraceInfo trace_info = 25 [(gogoproto.nullable) = false];
+  util.tracing.tracingpb.TraceInfo trace_info = 25;
 
   reserved 7, 10, 12, 14, 20;
 }

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -13,6 +13,7 @@ package roachpb
 import (
 	"reflect"
 	"testing"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -405,4 +406,12 @@ func TestFlagCombinations(t *testing.T) {
 			}
 		}
 	}
+}
+
+// TestBatchRequestSize asserts that the size of BatchRequest remains below 256
+// bytes. In #86541, we found that once the size reaches or exceeds this size,
+// end-to-end benchmarks observe a large (~10%) performance regression.
+func TestBatchRequestSize(t *testing.T) {
+	size := int(unsafe.Sizeof(BatchRequest{}))
+	require.Less(t, size, 256)
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1156,7 +1156,7 @@ func setupSpanForIncomingRPC(
 		var remoteParent tracing.SpanMeta
 		if !ba.TraceInfo.Empty() {
 			ctx, newSpan = tr.StartSpanCtx(ctx, grpcinterceptor.BatchMethodName,
-				tracing.WithRemoteParentFromTraceInfo(&ba.TraceInfo),
+				tracing.WithRemoteParentFromTraceInfo(ba.TraceInfo),
 				tracing.WithServerSpanKind)
 		} else {
 			// For backwards compatibility with 21.2, if tracing info was passed as

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -607,7 +607,7 @@ func (ds *ServerImpl) setupSpanForIncomingRPC(
 
 	if !req.TraceInfo.Empty() {
 		return tr.StartSpanCtx(ctx, grpcinterceptor.SetupFlowMethodName,
-			tracing.WithRemoteParentFromTraceInfo(&req.TraceInfo),
+			tracing.WithRemoteParentFromTraceInfo(req.TraceInfo),
 			tracing.WithServerSpanKind)
 	}
 	// For backwards compatibility with 21.2, if tracing info was passed as

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -29,7 +29,7 @@ import "util/tracing/tracingpb/tracing.proto";
 message SetupFlowRequest {
   reserved 1, 2;
 
-  optional util.tracing.tracingpb.TraceInfo trace_info = 11 [(gogoproto.nullable) = false];
+  optional util.tracing.tracingpb.TraceInfo trace_info = 11;
 
   // LeafTxnInputState is the input parameter for the *client.Txn needed for
   // executing the flow.

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -875,9 +875,9 @@ func (sm SpanMeta) String() string {
 	return s.String()
 }
 
-// ToProto converts a SpanMeta to the TraceInfo proto.
-func (sm SpanMeta) ToProto() tracingpb.TraceInfo {
-	ti := tracingpb.TraceInfo{
+// ToProto converts a SpanMeta to the *TraceInfo proto.
+func (sm SpanMeta) ToProto() *tracingpb.TraceInfo {
+	ti := &tracingpb.TraceInfo{
 		TraceID:       sm.traceID,
 		ParentSpanID:  sm.spanID,
 		RecordingMode: sm.recordingType.ToProto(),

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -553,7 +553,7 @@ func TestSpanRecordingFinished(t *testing.T) {
 
 	tr2 := NewTracer()
 	childTraceInfo := child.Meta().ToProto()
-	remoteChildChild := tr2.StartSpan("root.child.remotechild", WithRemoteParentFromTraceInfo(&childTraceInfo))
+	remoteChildChild := tr2.StartSpan("root.child.remotechild", WithRemoteParentFromTraceInfo(childTraceInfo))
 	child.ImportRemoteRecording(remoteChildChild.GetRecording(tracingpb.RecordingVerbose))
 	remoteChildChild.Finish()
 

--- a/pkg/util/tracing/tracingpb/tracing.go
+++ b/pkg/util/tracing/tracingpb/tracing.go
@@ -12,5 +12,5 @@ package tracingpb
 
 // Empty returns true if t does not have any tracing info in it.
 func (t *TraceInfo) Empty() bool {
-	return t.TraceID == 0
+	return t == nil || t.TraceID == 0
 }


### PR DESCRIPTION
Resolves #86541.

This commit reduces the size of `BatchRequest` from 264 bytes to 232 bytes. It
does so by packing fields and making the `TraceInfo` field nullable. In doing
so, it resolves a sizable performance regression caused by c7c154a.

It's not entirely clear why we see the performance cliff once the size of this
struct reaches or exceeds 256 bytes, but the cliff is very visible in macro
benchmarks (less so in micro benchmarks). A theory floated in #86541 is that is
has to do with heap allocated `BatchRequest`s falling into a different malloc
small object size class. That seems plausible, but I don't know if that explains
the regression when the struct is exactly 256.

Another theory is that it is related to passing such a large struct by value to
functions throughout the sender stack. Are function arguments above a certain
size treated differently than those below a certain size? Or perhaps this was
causing additional stack growth that changed the number of times that goroutine
stacks needed to grow and the locations in which they grew. I'm not sure, but I
do have a [WIP branch](https://github.com/cockroachdb/cockroach/pull/86958) that finally switches to passing BatchRequest by reference
which shows an additional performance win.

### Macro benchmarks
```
name                           old ops/s    new ops/s    delta
kv95/enc=false/nodes=3/cpu=32    109k ±10%    120k ± 4%   +9.85%  (p=0.000 n=10+10)

name                           old avg(ms)  new avg(ms)  delta
kv95/enc=false/nodes=3/cpu=32    1.79 ±12%    1.60 ± 0%  -10.61%  (p=0.000 n=10+7)

name                           old p99(ms)  new p99(ms)  delta
kv95/enc=false/nodes=3/cpu=32    8.53 ±17%    7.79 ± 4%   -8.68%  (p=0.004 n=10+10)
```

### Micro benchmarks
```
name                        old time/op    new time/op    delta
KV/Insert/Native/rows=1-10    41.5µs ± 2%    41.4µs ± 2%    ~     (p=0.393 n=10+10)
KV/Insert/SQL/rows=1-10        123µs ± 1%     123µs ± 1%    ~     (p=0.356 n=9+10)
KV/Update/Native/rows=1-10    66.2µs ± 1%    65.9µs ± 1%    ~     (p=0.165 n=10+10)
KV/Update/SQL/rows=1-10        169µs ± 2%     168µs ± 1%    ~     (p=0.123 n=10+10)
KV/Delete/SQL/rows=1-10        136µs ± 1%     137µs ± 2%    ~     (p=0.661 n=10+9)
KV/Scan/Native/rows=1-10      17.0µs ± 2%    17.0µs ± 2%    ~     (p=0.404 n=10+10)
KV/Scan/SQL/rows=1-10         92.1µs ± 1%    92.1µs ± 1%    ~     (p=1.000 n=10+10)
KV/Delete/Native/rows=1-10    41.1µs ± 1%    41.6µs ± 1%  +1.22%  (p=0.002 n=10+10)

name                        old alloc/op   new alloc/op   delta
KV/Scan/Native/rows=1-10      7.67kB ± 0%    7.57kB ± 0%  -1.30%  (p=0.000 n=9+10)
KV/Insert/Native/rows=1-10    15.9kB ± 0%    15.7kB ± 0%  -1.09%  (p=0.000 n=10+10)
KV/Update/Native/rows=1-10    22.5kB ± 0%    22.2kB ± 0%  -1.08%  (p=0.000 n=10+10)
KV/Delete/Native/rows=1-10    15.6kB ± 0%    15.5kB ± 0%  -0.52%  (p=0.000 n=9+10)
KV/Update/SQL/rows=1-10       51.8kB ± 1%    51.6kB ± 0%  -0.44%  (p=0.003 n=10+10)
KV/Scan/SQL/rows=1-10         24.4kB ± 0%    24.3kB ± 0%  -0.44%  (p=0.000 n=10+10)
KV/Delete/SQL/rows=1-10       51.8kB ± 0%    51.5kB ± 0%  -0.42%  (p=0.000 n=10+8)
KV/Insert/SQL/rows=1-10       44.9kB ± 0%    44.8kB ± 0%  -0.26%  (p=0.001 n=9+10)

name                        old allocs/op  new allocs/op  delta
KV/Insert/Native/rows=1-10       128 ± 0%       128 ± 0%    ~     (all equal)
KV/Insert/SQL/rows=1-10          359 ± 0%       359 ± 0%    ~     (p=1.111 n=9+10)
KV/Update/Native/rows=1-10       182 ± 0%       182 ± 0%    ~     (p=0.173 n=10+9)
KV/Update/SQL/rows=1-10          521 ± 0%       521 ± 0%    ~     (p=0.137 n=8+10)
KV/Delete/Native/rows=1-10       127 ± 0%       127 ± 0%    ~     (all equal)
KV/Delete/SQL/rows=1-10          386 ± 0%       386 ± 0%    ~     (p=0.065 n=9+10)
KV/Scan/Native/rows=1-10        55.0 ± 0%      55.0 ± 0%    ~     (all equal)
KV/Scan/SQL/rows=1-10            281 ± 0%       281 ± 0%    ~     (all equal)
```

Release justification: Resolves performance regression.