### PR TITLE
kv: pass BatchRequest by reference, not value

### DIFF
--- a/pkg/ccl/backupccl/backup_intents_test.go
+++ b/pkg/ccl/backupccl/backup_intents_test.go
@@ -43,7 +43,7 @@ func TestCleanupIntentsDuringBackupPerformanceRegression(t *testing.T) {
 
 	// Interceptor catches requests that cleanup transactions of size 1000 which are
 	// test data transactions. All other transaction commits pass though.
-	interceptor := func(ctx context.Context, req roachpb.BatchRequest) *roachpb.Error {
+	interceptor := func(ctx context.Context, req *roachpb.BatchRequest) *roachpb.Error {
 		endTxn := req.Requests[0].GetEndTxn()
 		if endTxn != nil && !endTxn.Commit && len(endTxn.LockSpans) == perTransactionRowCount {
 			// If this is a rollback of one the test's SQL transactions, allow the

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6170,7 +6170,7 @@ func TestRestoreErrorPropagates(t *testing.T) {
 	jobsTableKey := keys.SystemSQLCodec.TablePrefix(uint32(systemschema.JobsTable.GetID()))
 	var shouldFail, failures int64
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			// Intercept Put and ConditionalPut requests to the jobs table
 			// and, if shouldFail is positive, increment failures and return an
 			// injected error.
@@ -6298,7 +6298,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 			r.EndKey.Equal(r.Key.PrefixEnd())
 	}
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 			for _, ru := range request.Requests {
 				if exportRequest, ok := ru.GetInner().(*roachpb.ExportRequest); ok &&
 					!isLeasingExportRequest(exportRequest) {
@@ -6316,7 +6316,7 @@ func TestPaginatedBackupTenant(t *testing.T) {
 			}
 			return nil
 		},
-		TestingResponseFilter: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+		TestingResponseFilter: func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 			for i, ru := range br.Responses {
 				if exportRequest, ok := ba.Requests[i].GetInner().(*roachpb.ExportRequest); ok &&
 					!isLeasingExportRequest(exportRequest) {
@@ -7156,7 +7156,7 @@ func TestClientDisconnect(t *testing.T) {
 					blockBackupOrRestore(ctx)
 				}}},
 				Store: &kvserver.StoreTestingKnobs{
-					TestingResponseFilter: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+					TestingResponseFilter: func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 						for _, ru := range br.Responses {
 							switch ru.GetInner().(type) {
 							case *roachpb.ExportResponse:

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4830,7 +4830,7 @@ func TestChangefeedProtectedTimestamps(t *testing.T) {
 			}
 		}
 		requestFilter = kvserverbase.ReplicaRequestFilter(func(
-			ctx context.Context, ba roachpb.BatchRequest,
+			ctx context.Context, ba *roachpb.BatchRequest,
 		) *roachpb.Error {
 			if ba.Txn == nil || ba.Txn.Name != "changefeed backfill" {
 				return nil

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -134,7 +134,7 @@ func canSendToFollower(
 	st *cluster.Settings,
 	clock *hlc.Clock,
 	ctPolicy roachpb.RangeClosedTimestampPolicy,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 ) bool {
 	return kvserver.BatchCanBeEvaluatedOnFollower(ba) &&
 		closedTimestampLikelySufficient(st, clock, ctPolicy, ba.RequiredFrontier()) &&

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads_test.go
@@ -108,17 +108,17 @@ func TestCanSendToFollower(t *testing.T) {
 		txn.GlobalUncertaintyLimit = ts
 		return txn
 	}
-	batch := func(txn *roachpb.Transaction, req roachpb.Request) roachpb.BatchRequest {
-		var ba roachpb.BatchRequest
+	batch := func(txn *roachpb.Transaction, req roachpb.Request) *roachpb.BatchRequest {
+		ba := &roachpb.BatchRequest{}
 		ba.Txn = txn
 		ba.Add(req)
 		return ba
 	}
-	withBatchTimestamp := func(ba roachpb.BatchRequest, ts hlc.Timestamp) roachpb.BatchRequest {
+	withBatchTimestamp := func(ba *roachpb.BatchRequest, ts hlc.Timestamp) *roachpb.BatchRequest {
 		ba.Timestamp = ts
 		return ba
 	}
-	withServerSideBatchTimestamp := func(ba roachpb.BatchRequest, ts hlc.Timestamp) roachpb.BatchRequest {
+	withServerSideBatchTimestamp := func(ba *roachpb.BatchRequest, ts hlc.Timestamp) *roachpb.BatchRequest {
 		ba = withBatchTimestamp(ba, ts)
 		ba.TimestampFromServerClock = (*hlc.ClockTimestamp)(&ts)
 		return ba
@@ -126,7 +126,7 @@ func TestCanSendToFollower(t *testing.T) {
 
 	testCases := []struct {
 		name                  string
-		ba                    roachpb.BatchRequest
+		ba                    *roachpb.BatchRequest
 		ctPolicy              roachpb.RangeClosedTimestampPolicy
 		disabledEnterprise    bool
 		disabledFollowerReads bool
@@ -441,11 +441,13 @@ func TestCanSendToFollower(t *testing.T) {
 		},
 		{
 			name:               "non-enterprise",
+			ba:                 withBatchTimestamp(batch(nil, &roachpb.GetRequest{}), stale),
 			disabledEnterprise: true,
 			exp:                false,
 		},
 		{
 			name:                  "follower reads disabled",
+			ba:                    withBatchTimestamp(batch(nil, &roachpb.GetRequest{}), stale),
 			disabledFollowerReads: true,
 			exp:                   false,
 		},

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_test.go
@@ -151,7 +151,7 @@ func TestStreamIngestionJobWithRandomClient(t *testing.T) {
 		},
 	}
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			for _, req := range ba.Requests {
 				switch r := req.GetInner().(type) {
 				case *roachpb.RevertRangeRequest:

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -264,7 +264,7 @@ func TestUnavailableZip(t *testing.T) {
 	close(closedCh)
 	unavailableCh.Store(closedCh)
 	knobs := &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, _ *roachpb.BatchRequest) *roachpb.Error {
 			select {
 			case <-unavailableCh.Load().(chan struct{}):
 			case <-ctx.Done():

--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -526,8 +526,8 @@ func (b *batch) rangeID() roachpb.RangeID {
 	return b.reqs[0].rangeID
 }
 
-func (b *batch) batchRequest(cfg *Config) roachpb.BatchRequest {
-	req := roachpb.BatchRequest{
+func (b *batch) batchRequest(cfg *Config) *roachpb.BatchRequest {
+	req := &roachpb.BatchRequest{
 		// Preallocate the Requests slice.
 		Requests: make([]roachpb.RequestUnion, 0, len(b.reqs)),
 	}

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2728,7 +2728,7 @@ func TestStartableJobTxnRetry(t *testing.T) {
 	haveInjectedRetry := false
 	params := base.TestServerArgs{}
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, r roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, r *roachpb.BatchRequest) *roachpb.Error {
 			if r.Txn == nil || r.Txn.Name != txnName {
 				return nil
 			}

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -753,7 +753,7 @@ func (b *SSTBatcher) addSSTable(
 					req.SSTTimestampToRequestTimestamp = batchTS
 				}
 
-				ba := roachpb.BatchRequest{
+				ba := &roachpb.BatchRequest{
 					Header: roachpb.Header{Timestamp: batchTS, ClientRangeInfo: roachpb.ClientRangeInfo{ExplicitlyRequested: true}},
 					AdmissionHeader: roachpb.AdmissionHeader{
 						Priority:                 int32(admissionpb.BulkNormalPri),

--- a/pkg/kv/client_test.go
+++ b/pkg/kv/client_test.go
@@ -762,7 +762,7 @@ func TestReadConsistencyTypes(t *testing.T) {
 			// Mock out DistSender's sender function to check the read consistency for
 			// outgoing BatchRequests and return an empty reply.
 			factory := kv.NonTransactionalFactoryFunc(
-				func(_ context.Context, ba roachpb.BatchRequest,
+				func(_ context.Context, ba *roachpb.BatchRequest,
 				) (*roachpb.BatchResponse, *roachpb.Error) {
 					if ba.ReadConsistency != rc {
 						return nil, roachpb.NewErrorf("BatchRequest has unexpected ReadConsistency %s", ba.ReadConsistency)
@@ -908,7 +908,7 @@ func TestNodeIDAndObservedTimestamps(t *testing.T) {
 	// Mock out sender function to check that created transactions
 	// have the observed timestamp set for the configured node ID.
 	factory := kv.MakeMockTxnSenderFactory(
-		func(_ context.Context, _ *roachpb.Transaction, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		func(_ context.Context, _ *roachpb.Transaction, ba *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			return ba.CreateReply(), nil
 		})
 
@@ -1086,7 +1086,7 @@ func TestRollbackWithCanceledContextInsidious(t *testing.T) {
 	key := roachpb.Key("a")
 	ctx, cancel := context.WithCancel(context.Background())
 	var rollbacks int
-	storeKnobs.TestingRequestFilter = func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	storeKnobs.TestingRequestFilter = func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if !ba.IsSingleEndTxnRequest() {
 			return nil
 		}

--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -214,7 +214,7 @@ var _ Sender = &CrossRangeTxnWrapperSender{}
 
 // Send implements the Sender interface.
 func (s *CrossRangeTxnWrapperSender) Send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	if ba.Txn != nil {
 		log.Fatalf(ctx, "CrossRangeTxnWrapperSender can't handle transactional requests")
@@ -824,7 +824,7 @@ func sendAndFill(ctx context.Context, send SenderFunc, b *Batch) error {
 	// fails. But send() also returns its own errors, so there's some dancing
 	// here to do because we want to run fillResults() so that the individual
 	// result gets initialized with an error from the corresponding call.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Requests = b.reqs
 	ba.Header = b.Header
 	ba.AdmissionHeader = b.AdmissionHeader
@@ -965,14 +965,14 @@ func runTxn(ctx context.Context, txn *Txn, retryable func(context.Context, *Txn)
 // send runs the specified calls synchronously in a single batch and returns
 // any errors. Returns (nil, nil) for an empty batch.
 func (db *DB) send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	return db.sendUsingSender(ctx, ba, db.NonTransactionalSender())
 }
 
 // sendUsingSender uses the specified sender to send the batch request.
 func (db *DB) sendUsingSender(
-	ctx context.Context, ba roachpb.BatchRequest, sender Sender,
+	ctx context.Context, ba *roachpb.BatchRequest, sender Sender,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	if len(ba.Requests) == 0 {
 		return nil, nil

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -182,7 +182,7 @@ var CanSendToFollower = func(
 	_ *cluster.Settings,
 	_ *hlc.Clock,
 	_ roachpb.RangeClosedTimestampPolicy,
-	_ roachpb.BatchRequest,
+	_ *roachpb.BatchRequest,
 ) bool {
 	return false
 }
@@ -774,14 +774,11 @@ func unsetCanForwardReadTimestampFlag(ba *roachpb.BatchRequest) {
 // When the request spans ranges, it is split by range and a partial
 // subset of the batch request is sent to affected ranges in parallel.
 func (ds *DistSender) Send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
-	ds.incrementBatchCounters(&ba)
+	ds.incrementBatchCounters(ba)
 
-	// TODO(nvanbenschoten): This causes ba to escape to the heap. Either
-	// commit to passing BatchRequests by reference or return an updated
-	// value from this method instead.
-	if pErr := ds.initAndVerifyBatch(ctx, &ba); pErr != nil {
+	if pErr := ds.initAndVerifyBatch(ctx, ba); pErr != nil {
 		return nil, pErr
 	}
 
@@ -801,7 +798,7 @@ func (ds *DistSender) Send(
 	if ba.Txn != nil && ba.Txn.Epoch > 0 && !require1PC {
 		splitET = true
 	}
-	parts := splitBatchAndCheckForRefreshSpans(&ba, splitET)
+	parts := splitBatchAndCheckForRefreshSpans(ba, splitET)
 	if len(parts) > 1 && (ba.MaxSpanRequestKeys != 0 || ba.TargetBytes != 0) {
 		// We already verified above that the batch contains only scan requests of the same type.
 		// Such a batch should never need splitting.
@@ -811,10 +808,13 @@ func (ds *DistSender) Send(
 	var singleRplChunk [1]*roachpb.BatchResponse
 	rplChunks := singleRplChunk[:0:1]
 
+	onePart := len(parts) == 1
 	errIdxOffset := 0
 	for len(parts) > 0 {
-		part := parts[0]
-		ba.Requests = part
+		if !onePart {
+			ba = ba.ShallowCopy()
+			ba.Requests = parts[0]
+		}
 		// The minimal key range encompassing all requests contained within.
 		// Local addressing has already been resolved.
 		// TODO(tschottdorf): consider rudimentary validation of the batch here
@@ -850,7 +850,8 @@ func (ds *DistSender) Send(
 			} else if require1PC {
 				log.Fatalf(ctx, "required 1PC transaction cannot be split: %s", ba)
 			}
-			parts = splitBatchAndCheckForRefreshSpans(&ba, true /* split ET */)
+			parts = splitBatchAndCheckForRefreshSpans(ba, true /* split ET */)
+			onePart = false
 			// Restart transaction of the last chunk as multiple parts with
 			// EndTxn in the last part.
 			continue
@@ -866,9 +867,11 @@ func (ds *DistSender) Send(
 
 		// Propagate transaction from last reply to next request. The final
 		// update is taken and put into the response's main header.
-		ba.UpdateTxn(rpl.Txn)
 		rplChunks = append(rplChunks, rpl)
 		parts = parts[1:]
+		if len(parts) > 0 {
+			ba.UpdateTxn(rpl.Txn)
+		}
 	}
 
 	var reply *roachpb.BatchResponse
@@ -926,7 +929,7 @@ type response struct {
 // method is never invoked recursively, but it is exposed to maintain symmetry
 // with divideAndSendBatchToRanges.
 func (ds *DistSender) divideAndSendParallelCommit(
-	ctx context.Context, ba roachpb.BatchRequest, rs roachpb.RSpan, isReverse bool, batchIdx int,
+	ctx context.Context, ba *roachpb.BatchRequest, rs roachpb.RSpan, isReverse bool, batchIdx int,
 ) (br *roachpb.BatchResponse, pErr *roachpb.Error) {
 	// Search backwards, looking for the first pre-commit QueryIntent.
 	swapIdx := -1
@@ -962,7 +965,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	// Create a new pre-commit QueryIntent-only batch and issue it
 	// in a non-limited async task. This batch may need to be split
 	// over multiple ranges, so call into divideAndSendBatchToRanges.
-	qiBa := ba
+	qiBa := ba.ShallowCopy()
 	qiBa.Requests = swappedReqs[swapIdx+1:]
 	qiRS, err := keys.Range(qiBa.Requests)
 	if err != nil {
@@ -971,7 +974,6 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	qiIsReverse := false // QueryIntentRequests do not carry the isReverse flag
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
-	qiBaCopy := qiBa // avoids escape to heap
 
 	runTask := ds.rpcContext.Stopper.RunAsyncTask
 	if ds.disableParallelBatches {
@@ -1007,6 +1009,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	// Adjust the original batch request to ignore the pre-commit
 	// QueryIntent requests. Make sure to determine the request's
 	// new key span.
+	ba = ba.ShallowCopy()
 	ba.Requests = swappedReqs[:swapIdx+1]
 	rs, err = keys.Range(ba.Requests)
 	if err != nil {
@@ -1050,7 +1053,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 		}
 		// Populate the pre-commit QueryIntent batch response. If we made it
 		// here then we know we can ignore intent missing errors.
-		qiReply.reply = qiBaCopy.CreateReply()
+		qiReply.reply = qiBa.CreateReply()
 		for _, ru := range qiReply.reply.Responses {
 			ru.GetQueryIntent().FoundIntent = true
 		}
@@ -1091,7 +1094,7 @@ func (ds *DistSender) divideAndSendParallelCommit(
 func (ds *DistSender) detectIntentMissingDueToIntentResolution(
 	ctx context.Context, txn *roachpb.Transaction,
 ) (bool, error) {
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Timestamp = ds.clock.Now()
 	ba.Add(&roachpb.QueryTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
@@ -1187,7 +1190,7 @@ func mergeErrors(pErr1, pErr2 *roachpb.Error) *roachpb.Error {
 // this method is invoked recursively.
 func (ds *DistSender) divideAndSendBatchToRanges(
 	ctx context.Context,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	rs roachpb.RSpan,
 	isReverse bool,
 	withCommit bool,
@@ -1257,7 +1260,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 		}
 	}
 	// Make sure the CanForwardReadTimestamp flag is set to false, if necessary.
-	unsetCanForwardReadTimestampFlag(&ba)
+	unsetCanForwardReadTimestampFlag(ba)
 
 	// Make an empty slice of responses which will be populated with responses
 	// as they come in via Combine().
@@ -1371,7 +1374,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 			responseCh <- response{pErr: roachpb.NewError(err)}
 			return
 		}
-		curRangeBatch := ba
+		curRangeBatch := ba.ShallowCopy()
 		var positions []int
 		curRangeBatch.Requests, positions, seekKey, err = truncationHelper.Truncate(curRangeRS)
 		if len(positions) == 0 && err == nil {
@@ -1481,7 +1484,7 @@ func (ds *DistSender) divideAndSendBatchToRanges(
 // sent.
 func (ds *DistSender) sendPartialBatchAsync(
 	ctx context.Context,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	rs roachpb.RSpan,
 	isReverse bool,
 	withCommit bool,
@@ -1513,7 +1516,7 @@ func (ds *DistSender) sendPartialBatchAsync(
 
 func slowRangeRPCWarningStr(
 	s *redact.StringBuilder,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	dur time.Duration,
 	attempts int64,
 	desc *roachpb.RangeDescriptor,
@@ -1554,7 +1557,7 @@ func slowRangeRPCReturnWarningStr(s *redact.StringBuilder, dur time.Duration, at
 // the ranges in the span and resend to each.
 func (ds *DistSender) sendPartialBatch(
 	ctx context.Context,
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	rs roachpb.RSpan,
 	isReverse bool,
 	withCommit bool,
@@ -1759,7 +1762,7 @@ func (ds *DistSender) deduceRetryEarlyExitError(ctx context.Context) error {
 // nextKey is the first key that was not processed. This will be used when
 // filling up the ResumeSpan's.
 func fillSkippedResponses(
-	ba roachpb.BatchRequest,
+	ba *roachpb.BatchRequest,
 	br *roachpb.BatchResponse,
 	nextKey roachpb.RKey,
 	resumeReason roachpb.ResumeReason,
@@ -1929,7 +1932,7 @@ func noMoreReplicasErr(ambiguousErr, lastAttemptErr error) error {
 // that do not definitively rule out the possibility that the batch could have
 // succeeded are transformed into AmbiguousResultErrors.
 func (ds *DistSender) sendToReplicas(
-	ctx context.Context, ba roachpb.BatchRequest, routing rangecache.EvictionToken, withCommit bool,
+	ctx context.Context, ba *roachpb.BatchRequest, routing rangecache.EvictionToken, withCommit bool,
 ) (*roachpb.BatchResponse, error) {
 	desc := routing.Desc()
 	ba.RangeID = desc.RangeID
@@ -2177,7 +2180,7 @@ func (ds *DistSender) sendToReplicas(
 
 				if ds.kvInterceptor != nil {
 					numReplicas := len(desc.Replicas().Descriptors())
-					reqInfo := tenantcostmodel.MakeRequestInfo(&ba, numReplicas)
+					reqInfo := tenantcostmodel.MakeRequestInfo(ba, numReplicas)
 					respInfo := tenantcostmodel.MakeResponseInfo(br, !reqInfo.IsWrite())
 					if err := ds.kvInterceptor.OnResponseWait(ctx, reqInfo, respInfo); err != nil {
 						return nil, err

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -109,7 +109,7 @@ func (c *countConnectionsTransport) IsExhausted() bool {
 }
 
 func (c *countConnectionsTransport) SendNext(
-	ctx context.Context, request roachpb.BatchRequest,
+	ctx context.Context, request *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	return c.wrapped.SendNext(ctx, request)
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_server_test.go
@@ -1230,7 +1230,7 @@ func TestMultiRangeScanDeleteRange(t *testing.T) {
 	txn := kv.NewTxnFromProto(ctx, db, s.NodeID(), now, kv.RootTxn, &txnProto)
 
 	scan := roachpb.NewScan(writes[0], writes[len(writes)-1].Next(), false)
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: &txnProto}
 	ba.Add(scan)
 	br, pErr := txn.Send(ctx, ba)
@@ -1379,7 +1379,7 @@ func TestMultiRangeScanWithPagination(t *testing.T) {
 								numPages++
 
 								// Build the batch.
-								var ba roachpb.BatchRequest
+								ba := &roachpb.BatchRequest{}
 								for _, span := range operations {
 									var req roachpb.Request
 									switch {
@@ -1921,7 +1921,7 @@ func TestAsyncAbortPoisons(t *testing.T) {
 	var storeKnobs kvserver.StoreTestingKnobs
 	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 	commitCh := make(chan error, 1)
-	storeKnobs.TestingRequestFilter = func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	storeKnobs.TestingRequestFilter = func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		for _, req := range ba.Requests {
 			switch r := req.GetInner().(type) {
 			case *roachpb.EndTxnRequest:
@@ -3105,7 +3105,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				// directly. This should be picked up by the transaction's
 				// QueryIntent when chaining on to the pipelined write to
 				// key "a".
-				var ba roachpb.BatchRequest
+				ba := &roachpb.BatchRequest{}
 				ba.Add(&roachpb.ResolveIntentRequest{
 					RequestHeader: roachpb.RequestHeader{
 						Key: roachpb.Key("a"),
@@ -3131,7 +3131,7 @@ func TestTxnCoordSenderRetries(t *testing.T) {
 				// Simulate a failed intent write by resolving the intent
 				// directly. This should be picked up by the transaction's
 				// pre-commit QueryIntent for the pipelined write to key "a".
-				var ba roachpb.BatchRequest
+				ba := &roachpb.BatchRequest{}
 				ba.Add(&roachpb.ResolveIntentRequest{
 					RequestHeader: roachpb.RequestHeader{
 						Key: roachpb.Key("a"),
@@ -3518,7 +3518,7 @@ func BenchmarkReturnOnRangeBoundary(b *testing.B) {
 	ctx := context.Background()
 	scanCtx := context.WithValue(ctx, scanKey{}, "scan")
 
-	reqFilter := func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+	reqFilter := func(ctx context.Context, _ *roachpb.BatchRequest) *roachpb.Error {
 		if ctx.Value(scanKey{}) != nil && Latency > 0 {
 			time.Sleep(Latency)
 		}

--- a/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
+++ b/pkg/kv/kvclient/kvcoord/local_test_cluster_util.go
@@ -36,7 +36,7 @@ type localTestClusterTransport struct {
 }
 
 func (l *localTestClusterTransport) SendNext(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	if l.latency > 0 {
 		time.Sleep(l.latency)

--- a/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error.go
+++ b/pkg/kv/kvclient/kvcoord/lock_spans_over_budget_error.go
@@ -31,7 +31,7 @@ type lockSpansOverBudgetError struct {
 }
 
 func newLockSpansOverBudgetError(
-	lockSpansBytes, limitBytes int64, ba roachpb.BatchRequest,
+	lockSpansBytes, limitBytes int64, ba *roachpb.BatchRequest,
 ) lockSpansOverBudgetError {
 	return lockSpansOverBudgetError{
 		lockSpansBytes: lockSpansBytes,

--- a/pkg/kv/kvclient/kvcoord/mocks_generated_test.go
+++ b/pkg/kv/kvclient/kvcoord/mocks_generated_test.go
@@ -106,7 +106,7 @@ func (mr *MockTransportMockRecorder) Release() *gomock.Call {
 }
 
 // SendNext mocks base method.
-func (m *MockTransport) SendNext(arg0 context.Context, arg1 roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+func (m *MockTransport) SendNext(arg0 context.Context, arg1 *roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendNext", arg0, arg1)
 	ret0, _ := ret[0].(*roachpb.BatchResponse)

--- a/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
+++ b/pkg/kv/kvclient/kvcoord/replayed_commit_test.go
@@ -34,11 +34,11 @@ import (
 
 type interceptingTransport struct {
 	kvcoord.Transport
-	intercept func(context.Context, roachpb.BatchRequest, *roachpb.BatchResponse, error) (*roachpb.BatchResponse, error)
+	intercept func(context.Context, *roachpb.BatchRequest, *roachpb.BatchResponse, error) (*roachpb.BatchResponse, error)
 }
 
 func (f *interceptingTransport) SendNext(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	br, err := f.Transport.SendNext(ctx, ba)
 	return f.intercept(ctx, ba, br, err)
@@ -75,7 +75,7 @@ func TestCommitSanityCheckAssertionFiresOnUndetectedAmbiguousCommit(t *testing.T
 			}
 			return &interceptingTransport{
 				Transport: tf,
-				intercept: func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse, err error) (*roachpb.BatchResponse, error) {
+				intercept: func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse, err error) (*roachpb.BatchResponse, error) {
 					if err != nil || ba.Txn == nil || br.Txn == nil ||
 						ba.Txn.Status != roachpb.PENDING || br.Txn.Status != roachpb.COMMITTED ||
 						!keys.ScratchRangeMin.Equal(br.Txn.Key) {

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -158,7 +158,7 @@ func (f *firstNErrorTransport) IsExhausted() bool {
 func (f *firstNErrorTransport) Release() {}
 
 func (f *firstNErrorTransport) SendNext(
-	_ context.Context, _ roachpb.BatchRequest,
+	_ context.Context, _ *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error) {
 	var err error
 	if f.numSent < f.numErrors {
@@ -378,5 +378,5 @@ func sendBatch(
 	routing, err := ds.getRoutingInfo(ctx, desc.StartKey, rangecache.EvictionToken{}, false /* useReverseScan */)
 	require.NoError(t, err)
 
-	return ds.sendToReplicas(ctx, roachpb.BatchRequest{}, routing, false /* withCommit */)
+	return ds.sendToReplicas(ctx, &roachpb.BatchRequest{}, routing, false /* withCommit */)
 }

--- a/pkg/kv/kvclient/kvcoord/transport_test.go
+++ b/pkg/kv/kvclient/kvcoord/transport_test.go
@@ -128,7 +128,7 @@ func TestSpanImport(t *testing.T) {
 
 	server.tr = tracing.SpanFromContext(recCtx).Tracer()
 
-	br, err := gt.sendBatch(recCtx, roachpb.NodeID(1), &server, roachpb.BatchRequest{})
+	br, err := gt.sendBatch(recCtx, roachpb.NodeID(1), &server, &roachpb.BatchRequest{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -182,10 +182,10 @@ func (h *txnHeartbeater) init(
 
 // SendLocked is part of the txnInterceptor interface.
 func (h *txnHeartbeater) SendLocked(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	etArg, hasET := ba.GetArg(roachpb.EndTxn)
-	firstLockingIndex, pErr := firstLockingIndex(&ba)
+	firstLockingIndex, pErr := firstLockingIndex(ba)
 	if pErr != nil {
 		return nil, pErr
 	}
@@ -431,7 +431,7 @@ func (h *txnHeartbeater) heartbeatLocked(ctx context.Context) bool {
 	if txn.Key == nil {
 		log.Fatalf(ctx, "attempting to heartbeat txn without anchor key: %v", txn)
 	}
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Txn = txn
 	ba.Add(&roachpb.HeartbeatTxnRequest{
 		RequestHeader: roachpb.RequestHeader{
@@ -514,7 +514,7 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 
 	// Construct a batch with an EndTxn request.
 	txn := h.mu.txn.Clone()
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	ba.Add(&roachpb.EndTxnRequest{
 		Commit: false,

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
@@ -37,7 +37,7 @@ type txnMetricRecorder struct {
 
 // SendLocked is part of the txnInterceptor interface.
 func (m *txnMetricRecorder) SendLocked(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	if m.txnStartNanos == 0 {
 		m.txnStartNanos = timeutil.Now().UnixNano()

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_client_test.go
@@ -88,7 +88,7 @@ func TestTxnPipelinerCondenseLockSpans(t *testing.T) {
 	// Check end transaction locks, which should be condensed and split
 	// at range boundaries.
 	expLocks := []roachpb.Span{aToBClosed, cToEClosed, fTog1}
-	sendFn := func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+	sendFn := func(_ context.Context, ba *roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 		resp := ba.CreateReply()
 		resp.Txn = ba.Txn
 		if req, ok := ba.GetArg(roachpb.EndTxn); ok {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
@@ -79,7 +79,7 @@ type txnSeqNumAllocator struct {
 
 // SendLocked is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) SendLocked(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	for _, ru := range ba.Requests {
 		req := ru.GetInner()

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -138,7 +138,7 @@ type txnSpanRefresher struct {
 
 // SendLocked implements the lockedSender interface.
 func (sr *txnSpanRefresher) SendLocked(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Set the batch's CanForwardReadTimestamp flag.
 	ba.CanForwardReadTimestamp = sr.canForwardReadTimestampWithoutRefresh(ba.Txn)
@@ -214,7 +214,7 @@ func (sr *txnSpanRefresher) maybeCondenseRefreshSpans(
 // catches serializable errors and attempts to avoid them by refreshing the txn
 // at a larger timestamp.
 func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
-	ctx context.Context, ba roachpb.BatchRequest, maxRefreshAttempts int,
+	ctx context.Context, ba *roachpb.BatchRequest, maxRefreshAttempts int,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	if ba.Txn.WriteTooOld {
 		// The WriteTooOld flag is not supposed to be set on requests. It's only set
@@ -269,7 +269,7 @@ func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
 			log.VEventf(ctx, 2, "not checking error for refresh; refresh attempts exhausted")
 		}
 	}
-	if err := sr.forwardRefreshTimestampOnResponse(&ba, br, pErr); err != nil {
+	if err := sr.forwardRefreshTimestampOnResponse(ba, br, pErr); err != nil {
 		return nil, roachpb.NewError(err)
 	}
 	return br, pErr
@@ -280,7 +280,7 @@ func (sr *txnSpanRefresher) sendLockedWithRefreshAttempts(
 // txn timestamp, it recurses into sendLockedWithRefreshAttempts and retries the
 // batch. If the refresh fails, the input pErr is returned.
 func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
-	ctx context.Context, ba roachpb.BatchRequest, pErr *roachpb.Error, maxRefreshAttempts int,
+	ctx context.Context, ba *roachpb.BatchRequest, pErr *roachpb.Error, maxRefreshAttempts int,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	txn := pErr.GetTxn()
 	if txn == nil || !sr.canForwardReadTimestamp(txn) {
@@ -308,6 +308,7 @@ func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
 	// We've refreshed all of the read spans successfully and bumped
 	// ba.Txn's timestamps. Attempt the request again.
 	log.Eventf(ctx, "refresh succeeded; retrying original request")
+	ba = ba.ShallowCopy()
 	ba.UpdateTxn(refreshToTxn)
 	sr.refreshAutoRetries.Inc(1)
 
@@ -342,7 +343,7 @@ func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
 // only the EndTxn request. It then issues the two partial batches in order,
 // stitching their results back together at the end.
 func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// NOTE: call back into SendLocked with each partial batch, not into
 	// sendLockedWithRefreshAttempts. This ensures that we properly set
@@ -351,7 +352,7 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 
 	// Issue a batch up to but not including the EndTxn request.
 	etIdx := len(ba.Requests) - 1
-	baPrefix := ba
+	baPrefix := ba.ShallowCopy()
 	baPrefix.Requests = ba.Requests[:etIdx]
 	brPrefix, pErr := sr.SendLocked(ctx, baPrefix)
 	if pErr != nil {
@@ -359,7 +360,7 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 	}
 
 	// Issue a batch containing only the EndTxn request.
-	baSuffix := ba
+	baSuffix := ba.ShallowCopy()
 	baSuffix.Requests = ba.Requests[etIdx:]
 	baSuffix.UpdateTxn(brPrefix.Txn)
 	brSuffix, pErr := sr.SendLocked(ctx, baSuffix)
@@ -384,8 +385,8 @@ func (sr *txnSpanRefresher) splitEndTxnAndRetrySend(
 // If the force flag is true, the refresh will be attempted even if a refresh
 // is not inevitable.
 func (sr *txnSpanRefresher) maybeRefreshPreemptivelyLocked(
-	ctx context.Context, ba roachpb.BatchRequest, force bool,
-) (roachpb.BatchRequest, *roachpb.Error) {
+	ctx context.Context, ba *roachpb.BatchRequest, force bool,
+) (*roachpb.BatchRequest, *roachpb.Error) {
 	// If we know that the transaction will need a refresh at some point because
 	// its write timestamp has diverged from its read timestamp, consider doing
 	// so preemptively. We perform a preemptive refresh if either a) doing so
@@ -445,7 +446,7 @@ func (sr *txnSpanRefresher) maybeRefreshPreemptivelyLocked(
 	// If the transaction cannot change its read timestamp, no refresh is
 	// possible.
 	if !sr.canForwardReadTimestamp(ba.Txn) {
-		return ba, newRetryErrorOnFailedPreemptiveRefresh(ba.Txn, nil)
+		return nil, newRetryErrorOnFailedPreemptiveRefresh(ba.Txn, nil)
 	}
 
 	refreshFrom := ba.Txn.ReadTimestamp
@@ -457,10 +458,11 @@ func (sr *txnSpanRefresher) maybeRefreshPreemptivelyLocked(
 	// Try refreshing the txn spans at a timestamp that will allow us to commit.
 	if refreshErr := sr.tryRefreshTxnSpans(ctx, refreshFrom, refreshToTxn); refreshErr != nil {
 		log.Eventf(ctx, "preemptive refresh failed; propagating retry error")
-		return roachpb.BatchRequest{}, newRetryErrorOnFailedPreemptiveRefresh(ba.Txn, refreshErr)
+		return nil, newRetryErrorOnFailedPreemptiveRefresh(ba.Txn, refreshErr)
 	}
 
 	log.Eventf(ctx, "preemptive refresh succeeded")
+	ba = ba.ShallowCopy()
 	ba.UpdateTxn(refreshToTxn)
 	return ba, nil
 }
@@ -517,7 +519,7 @@ func (sr *txnSpanRefresher) tryRefreshTxnSpans(
 
 	// Refresh all spans (merge first).
 	// TODO(nvanbenschoten): actually merge spans.
-	refreshSpanBa := roachpb.BatchRequest{}
+	refreshSpanBa := &roachpb.BatchRequest{}
 	refreshSpanBa.Txn = refreshToTxn
 	addRefreshes := func(refreshes *condensableSpanSet) {
 		// We're going to check writes between the previous refreshed timestamp, if
@@ -564,7 +566,7 @@ func (sr *txnSpanRefresher) tryRefreshTxnSpans(
 // appendRefreshSpans appends refresh spans from the supplied batch request,
 // qualified by the batch response where appropriate.
 func (sr *txnSpanRefresher) appendRefreshSpans(
-	ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse,
+	ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse,
 ) error {
 	expLogEnabled := log.ExpensiveLogEnabled(ctx, 3)
 	return ba.RefreshSpanIterate(br, func(span roachpb.Span) {

--- a/pkg/kv/kvclient/kvcoord/txn_lock_gatekeeper.go
+++ b/pkg/kv/kvclient/kvcoord/txn_lock_gatekeeper.go
@@ -30,7 +30,7 @@ type lockedSender interface {
 	// WARNING: because the lock is released when calling this method and
 	// re-acquired before it returned, callers cannot rely on a single mutual
 	// exclusion zone mainted across the call.
-	SendLocked(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
+	SendLocked(context.Context, *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
 }
 
 // txnLockGatekeeper is a lockedSender that sits at the bottom of the
@@ -54,7 +54,7 @@ type txnLockGatekeeper struct {
 
 // SendLocked implements the lockedSender interface.
 func (gs *txnLockGatekeeper) SendLocked(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// If so configured, protect against concurrent use of the txn. Concurrent
 	// requests don't work generally because of races between clients sending

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -205,7 +205,7 @@ func TestPriorityRatchetOnAbortOrPush(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			// Reject transaction heartbeats, which can make the test flaky when they
 			// detect an aborted transaction before the Get operation does. See #68584
 			// for an explanation.
@@ -634,7 +634,7 @@ func TestTxnCommitTimestampAdvancedByRefresh(t *testing.T) {
 	var refreshTS hlc.Timestamp
 	errKey := roachpb.Key("inject_err")
 	s := createTestDBWithKnobs(t, &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			if g, ok := ba.GetArg(roachpb.Get); ok && g.(*roachpb.GetRequest).Key.Equal(errKey) {
 				if injected {
 					return nil

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1141,7 +1141,7 @@ func (w *workerCoordinator) performRequestAsync(
 		},
 		func(ctx context.Context) {
 			defer w.asyncRequestCleanup(false /* budgetMuAlreadyLocked */)
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.Header.WaitPolicy = w.lockWaitPolicy
 			ba.Header.TargetBytes = targetBytes
 			ba.Header.AllowEmpty = !headOfLine

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/cache_test.go
@@ -66,7 +66,7 @@ func TestCache(t *testing.T) {
 	readRowsAt := func(t *testing.T, ts hlc.Timestamp) []roachpb.KeyValue {
 		txn := kvDB.NewTxn(ctx, "test")
 		require.NoError(t, txn.SetFixedTimestamp(ctx, ts))
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(&roachpb.ScanRequest{
 			RequestHeader: roachpb.RequestHeader{
 				Key:    scratch,

--- a/pkg/kv/kvprober/kvprober_integration_test.go
+++ b/pkg/kv/kvprober/kvprober_integration_test.go
@@ -87,7 +87,7 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 	t.Run("a single range is unavailable for all KV ops", func(t *testing.T) {
 		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(i context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(i context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 					for _, ru := range ba.Requests {
 						key := ru.GetInner().Header().Key
 						if bytes.HasPrefix(key, keys.TimeseriesPrefix) {
@@ -129,7 +129,7 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(i context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(i context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 					if !dbIsAvailable.Get() {
 						for _, ru := range ba.Requests {
 							if ru.GetGet() != nil {
@@ -174,7 +174,7 @@ func TestProberDoesReadsAndWrites(t *testing.T) {
 
 		s, _, p, cleanup := initTestProber(t, base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(i context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(i context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 					if !dbIsAvailable.Get() {
 						for _, ru := range ba.Requests {
 							if ru.GetPut() != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -1632,7 +1632,7 @@ func TestAddSSTableIntentResolution(t *testing.T) {
 		pointKV("b", 1, "2"),
 		pointKV("c", 1, "3"),
 	})
-	ba := roachpb.BatchRequest{
+	ba := &roachpb.BatchRequest{
 		Header: roachpb.Header{UserPriority: roachpb.MaxUserPriority},
 	}
 	ba.Add(&roachpb.AddSSTableRequest{
@@ -1676,7 +1676,7 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsTSCache(t *testing.T) {
 		MVCCStats:                      storageutils.SSTStats(t, sst, 0),
 		SSTTimestampToRequestTimestamp: hlc.Timestamp{WallTime: 1},
 	}
-	ba := roachpb.BatchRequest{
+	ba := &roachpb.BatchRequest{
 		Header: roachpb.Header{Timestamp: txnTS.Prev()},
 	}
 	ba.Add(sstReq)
@@ -1691,7 +1691,7 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsTSCache(t *testing.T) {
 
 	// Adding the SST again and reading results in the new value, because the
 	// tscache pushed the SST forward.
-	ba = roachpb.BatchRequest{
+	ba = &roachpb.BatchRequest{
 		Header: roachpb.Header{Timestamp: txnTS.Prev()},
 	}
 	ba.Add(sstReq)
@@ -1736,7 +1736,7 @@ func TestAddSSTableSSTTimestampToRequestTimestampRespectsClosedTS(t *testing.T) 
 		MVCCStats:                      storageutils.SSTStats(t, sst, 0),
 		SSTTimestampToRequestTimestamp: hlc.Timestamp{WallTime: 1},
 	}
-	ba := roachpb.BatchRequest{
+	ba := &roachpb.BatchRequest{
 		Header: roachpb.Header{Timestamp: reqTS},
 	}
 	ba.Add(sstReq)

--- a/pkg/kv/kvserver/batcheval/cmd_is_span_empty_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_is_span_empty_test.go
@@ -33,7 +33,7 @@ func TestIsSpanEmpty(t *testing.T) {
 		ServerArgs: base.TestServerArgs{
 			Knobs: base.TestingKnobs{
 				Store: &kvserver.StoreTestingKnobs{
-					TestingRequestFilter: func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+					TestingRequestFilter: func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 						if _, exists := request.GetArg(roachpb.IsSpanEmpty); exists {
 							atomic.AddInt64(&sentIsSpanEmptyRequests, 1)
 						}

--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -631,7 +631,7 @@ func TestStoreLeaseTransferTimestampCacheRead(t *testing.T) {
 
 		// Read the key at readTS.
 		// NB: don't use SendWrapped because we want access to br.Timestamp.
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = readTS
 		ba.Add(getArgs(key))
 		br, pErr := tc.Servers[0].DistSender().Send(ctx, ba)
@@ -649,7 +649,7 @@ func TestStoreLeaseTransferTimestampCacheRead(t *testing.T) {
 		// Attempt to write under the read on the new leaseholder. The batch
 		// should get forwarded to a timestamp after the read.
 		// NB: don't use SendWrapped because we want access to br.Timestamp.
-		ba = roachpb.BatchRequest{}
+		ba = &roachpb.BatchRequest{}
 		ba.Timestamp = readTS
 		ba.Add(incrementArgs(key, 1))
 		br, pErr = tc.Servers[0].DistSender().Send(ctx, ba)
@@ -1336,7 +1336,7 @@ func TestAcquireLeaseTimeout(t *testing.T) {
 	// return the context error.
 	var blockRangeID int32
 
-	maybeBlockLeaseRequest := func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	maybeBlockLeaseRequest := func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if ba.IsSingleRequestLeaseRequest() && int32(ba.RangeID) == atomic.LoadInt32(&blockRangeID) {
 			t.Logf("blocked lease request for r%d", ba.RangeID)
 			<-ctx.Done()

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -204,7 +204,7 @@ func TestStoreResolveMetrics(t *testing.T) {
 	const resolveAbortCount = int64(800)
 	const resolvePoisonCount = int64(2400)
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	{
 		repl := store.LookupReplica(keys.MustAddr(span.Key))
 		var err error

--- a/pkg/kv/kvserver/client_replica_backpressure_test.go
+++ b/pkg/kv/kvserver/client_replica_backpressure_test.go
@@ -71,7 +71,7 @@ func TestBackpressureNotAppliedWhenReducingRangeSize(t *testing.T) {
 			ServerArgs: base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
-						TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+						TestingRequestFilter: func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 							if ba.Header.Txn != nil && ba.Header.Txn.Name == "split" && !allowSplits.Load().(bool) {
 								rangesBlocked.Store(ba.Header.RangeID, true)
 								defer rangesBlocked.Delete(ba.Header.RangeID)

--- a/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/client_replica_circuit_breaker_test.go
@@ -888,7 +888,7 @@ func (cbt *circuitBreakerTest) SendCtxTS(
 		rec := finishAndGet()
 		cbt.t.Logf("%s", rec)
 	}()
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	repl := cbt.repls[idx]
 	ba.RangeID = repl.Desc().RangeID
 	ba.Timestamp = ts
@@ -929,7 +929,7 @@ func (cbt *circuitBreakerTest) sendViaDistSender(
 	ds *kvcoord.DistSender, req roachpb.Request,
 ) error {
 	cbt.t.Helper()
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(req)
 	ctx, cancel := context.WithTimeout(context.Background(), testutils.DefaultSucceedsSoonDuration)
 	defer cancel()

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -1226,7 +1226,7 @@ func TestStoreRangeSplitBackpressureWrites(t *testing.T) {
 			zoneConfig.RangeMaxBytes = proto.Int64(maxBytes)
 
 			testingRequestFilter :=
-				func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 					for _, req := range ba.Requests {
 						if cPut, ok := req.GetInner().(*roachpb.ConditionalPutRequest); ok {
 							if cPut.Key.Equal(keys.RangeDescriptorKey(splitKey)) {
@@ -1793,7 +1793,7 @@ func TestStoreSplitOnRemovedReplica(t *testing.T) {
 	inFilter := make(chan struct{}, 1)
 	beginBlockingSplit := make(chan struct{})
 	finishBlockingSplit := make(chan struct{})
-	filter := func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	filter := func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		// Block replica 1's attempt to perform the AdminSplit. We detect the
 		// split's range descriptor update and block until the rest of the test
 		// is ready. We then return a ConditionFailedError, simulating a
@@ -2483,7 +2483,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 				// This simulates txn deadlock or a max priority txn aborting a
 				// normal or min priority txn.
 				if force {
-					ba := roachpb.BatchRequest{}
+					ba := &roachpb.BatchRequest{}
 					ba.Timestamp = store.Clock().Now()
 					ba.RangeID = lhs.RangeID
 					ba.Add(&roachpb.PushTxnRequest{
@@ -3022,7 +3022,7 @@ func TestStoreSplitRangeLookupRace(t *testing.T) {
 	blockedRangeLookups := int32(0)
 	rangeLookupIsBlocked := make(chan struct{}, 1)
 	unblockRangeLookups := make(chan struct{})
-	respFilter := func(ctx context.Context, ba roachpb.BatchRequest, _ *roachpb.BatchResponse) *roachpb.Error {
+	respFilter := func(ctx context.Context, ba *roachpb.BatchRequest, _ *roachpb.BatchResponse) *roachpb.Error {
 		select {
 		case <-blockRangeLookups:
 			if kv.TestingIsRangeLookup(ba) &&
@@ -3555,7 +3555,7 @@ func TestStoreRangeSplitAndMergeWithGlobalReads(t *testing.T) {
 	// necessary, see maybeCommitWaitBeforeCommitTrigger.
 	var clock atomic.Value
 	var splitsWithSyntheticTS, mergesWithSyntheticTS int64
-	respFilter := func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+	respFilter := func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 		if req, ok := ba.GetArg(roachpb.EndTxn); ok {
 			endTxn := req.(*roachpb.EndTxnRequest)
 			if br.Txn.Status == roachpb.COMMITTED && br.Txn.WriteTimestamp.Synthetic {

--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -102,7 +102,7 @@ func TestClosedTimestampCanServe(t *testing.T) {
 		// We just served a follower read. As a sanity check, make sure that we can't write at
 		// that same timestamp.
 		{
-			var baWrite roachpb.BatchRequest
+			baWrite := &roachpb.BatchRequest{}
 			r := &roachpb.DeleteRequest{}
 			r.Key = desc.StartKey.AsRawKey()
 			txn := roachpb.MakeTransaction("testwrite", r.Key, roachpb.NormalUserPriority, ts, 100, int32(tc.Server(0).SQLInstanceID()))
@@ -546,7 +546,7 @@ func TestClosedTimestampCantServeForNonTransactionalReadRequest(t *testing.T) {
 	})
 
 	// Create a "nontransactional" read-only batch.
-	var baQueryTxn roachpb.BatchRequest
+	baQueryTxn := &roachpb.BatchRequest{}
 	baQueryTxn.Header.RangeID = desc.RangeID
 	r := &roachpb.QueryTxnRequest{}
 	r.Key = desc.StartKey.AsRawKey()
@@ -812,7 +812,7 @@ SET CLUSTER SETTING kv.closed_timestamp.follower_reads_enabled = true;
 				require.NoError(t, err)
 				writeTime := rhsLeaseStart.Prev()
 				require.True(t, mergedLeaseholder.GetCurrentClosedTimestamp(ctx).Less(writeTime))
-				var baWrite roachpb.BatchRequest
+				baWrite := &roachpb.BatchRequest{}
 				baWrite.Header.RangeID = leftDesc.RangeID
 				baWrite.Header.Timestamp = writeTime
 				put := &roachpb.PutRequest{}
@@ -935,7 +935,7 @@ func (filter *mergeFilter) resetBlocker() (*mergeBlocker, bool) {
 // Communication with actors interested in blocked merges is done through
 // BlockNextMerge().
 func (filter *mergeFilter) SuspendMergeTrigger(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) *roachpb.Error {
 	for _, req := range ba.Requests {
 		if et := req.GetEndTxn(); et != nil && et.Commit &&
@@ -1064,7 +1064,7 @@ func getTargetStore(
 }
 
 func verifyNotLeaseHolderErrors(
-	t *testing.T, ba roachpb.BatchRequest, repls []*kvserver.Replica, expectedNLEs int,
+	t *testing.T, ba *roachpb.BatchRequest, repls []*kvserver.Replica, expectedNLEs int,
 ) {
 	t.Helper()
 	notLeaseholderErrs, err := countNotLeaseHolderErrors(ba, repls)
@@ -1076,7 +1076,7 @@ func verifyNotLeaseHolderErrors(
 	}
 }
 
-func countNotLeaseHolderErrors(ba roachpb.BatchRequest, repls []*kvserver.Replica) (int64, error) {
+func countNotLeaseHolderErrors(ba *roachpb.BatchRequest, repls []*kvserver.Replica) (int64, error) {
 	g, ctx := errgroup.WithContext(context.Background())
 	var notLeaseholderErrs int64
 	for i := range repls {
@@ -1303,7 +1303,7 @@ func expectRows(expectedRows int) respFunc {
 func verifyCanReadFromAllRepls(
 	ctx context.Context,
 	t *testing.T,
-	baRead roachpb.BatchRequest,
+	baRead *roachpb.BatchRequest,
 	repls []*kvserver.Replica,
 	f respFunc,
 ) error {
@@ -1331,10 +1331,10 @@ func verifyCanReadFromAllRepls(
 	return g.Wait()
 }
 
-func makeTxnReadBatchForDesc(desc roachpb.RangeDescriptor, ts hlc.Timestamp) roachpb.BatchRequest {
+func makeTxnReadBatchForDesc(desc roachpb.RangeDescriptor, ts hlc.Timestamp) *roachpb.BatchRequest {
 	txn := roachpb.MakeTransaction("txn", nil, 0, ts, 0, 0)
 
-	var baRead roachpb.BatchRequest
+	baRead := &roachpb.BatchRequest{}
 	baRead.Header.RangeID = desc.RangeID
 	baRead.Header.Timestamp = ts
 	baRead.Header.Txn = &txn

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -169,7 +169,7 @@ func TestCheckConsistencyReplay(t *testing.T) {
 
 	// Arrange to trigger a retry when a ComputeChecksum request arrives.
 	testKnobs.TestingResponseFilter = func(
-		ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse,
+		ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse,
 	) *roachpb.Error {
 		state.Lock()
 		defer state.Unlock()

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -409,7 +409,7 @@ func MakeSSTable(
 }
 
 func ProposeAddSSTable(ctx context.Context, key, val string, ts hlc.Timestamp, store *Store) error {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.RangeID = store.LookupReplica(roachpb.RKey(key)).RangeID
 
 	var addReq roachpb.AddSSTableRequest

--- a/pkg/kv/kvserver/intent_resolver_integration_test.go
+++ b/pkg/kv/kvserver/intent_resolver_integration_test.go
@@ -48,7 +48,7 @@ func beginTransaction(
 		return txn
 	}
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	put := putArgs(key, []byte("value"))
 	ba.Add(&put)
@@ -240,7 +240,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			return readyC
 		}
 
-		requestFilter := func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		requestFilter := func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			// If we receive a heartbeat from a txn in abortHeartbeats,
 			// close the aborted channel and return an error response.
 			if _, ok := ba.GetArg(roachpb.HeartbeatTxn); ok && ba.Txn != nil {
@@ -271,7 +271,7 @@ func TestReliableIntentCleanup(t *testing.T) {
 			return nil
 		}
 
-		responseFilter := func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+		responseFilter := func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 			// If we receive a Put request from a txn in blockPuts, signal
 			// the caller that the Put is ready to block by passing it an
 			// unblock channel, and wait for it to close.

--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -88,11 +88,11 @@ func (f *FilterArgs) InRaftCmd() bool {
 // ReplicaRequestFilter can be used in testing to influence the error returned
 // from a request before it is evaluated. Return nil to continue with regular
 // processing or non-nil to terminate processing with the returned error.
-type ReplicaRequestFilter func(context.Context, roachpb.BatchRequest) *roachpb.Error
+type ReplicaRequestFilter func(context.Context, *roachpb.BatchRequest) *roachpb.Error
 
 // ReplicaConcurrencyRetryFilter can be used to examine a concurrency retry
 // error before it is handled and its batch is re-evaluated.
-type ReplicaConcurrencyRetryFilter func(context.Context, roachpb.BatchRequest, *roachpb.Error)
+type ReplicaConcurrencyRetryFilter func(context.Context, *roachpb.BatchRequest, *roachpb.Error)
 
 // ReplicaCommandFilter may be used in tests through the StoreTestingKnobs to
 // intercept the handling of commands and artificially generate errors. Return
@@ -111,7 +111,7 @@ type ReplicaApplyFilter func(args ApplyFilterArgs) (int, *roachpb.Error)
 // ReplicaResponseFilter is used in unittests to modify the outbound
 // response returned to a waiting client after a replica command has
 // been processed. This filter is invoked only by the command proposer.
-type ReplicaResponseFilter func(context.Context, roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
+type ReplicaResponseFilter func(context.Context, *roachpb.BatchRequest, *roachpb.BatchResponse) *roachpb.Error
 
 // ReplicaRangefeedFilter is used in unit tests to modify the request, inject
 // responses, or return errors from rangefeeds.

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -186,7 +186,7 @@ func (mq *mergeQueue) requestRangeStats(
 	ctx context.Context, key roachpb.Key,
 ) (desc *roachpb.RangeDescriptor, stats enginepb.MVCCStats, qps float64, qpsOK bool, err error) {
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&roachpb.RangeStatsRequest{
 		RequestHeader: roachpb.RequestHeader{Key: key},
 	})

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -525,8 +525,7 @@ func (r *replicaGCer) send(ctx context.Context, req roachpb.GCRequest) error {
 	n := atomic.AddInt32(&r.count, 1)
 	log.Eventf(ctx, "sending batch %d (%d keys)", n, len(req.Keys))
 
-	var ba roachpb.BatchRequest
-
+	ba := &roachpb.BatchRequest{}
 	// Technically not needed since we're talking directly to the Replica.
 	ba.RangeID = r.repl.Desc().RangeID
 	ba.Timestamp = r.repl.Clock().Now()
@@ -567,7 +566,7 @@ func (r *replicaGCer) send(ctx context.Context, req roachpb.GCRequest) error {
 		}
 		ba.Replica.StoreID = r.storeID
 		var err error
-		admissionHandle, err = r.admissionController.AdmitKVWork(ctx, roachpb.SystemTenantID, &ba)
+		admissionHandle, err = r.admissionController.AdmitKVWork(ctx, roachpb.SystemTenantID, ba)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1380,7 +1380,7 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	fmtStr := fmt.Sprintf("%%0%dd", keySize)
 
 	// First write 2 * gcKeyVersionChunkBytes different keys (each with two versions).
-	ba1, ba2 := roachpb.BatchRequest{}, roachpb.BatchRequest{}
+	ba1, ba2 := &roachpb.BatchRequest{}, &roachpb.BatchRequest{}
 	for i := 0; i < 2*keyCount; i++ {
 		// Create keys which are
 		key := roachpb.Key(fmt.Sprintf(fmtStr, i))
@@ -1403,7 +1403,7 @@ func TestMVCCGCQueueChunkRequests(t *testing.T) {
 	key1 := roachpb.Key(fmt.Sprintf(fmtStr, 2*keyCount))
 	key2 := roachpb.Key(fmt.Sprintf(fmtStr, 2*keyCount+1))
 	for i := 0; i < 2*keyCount+1; i++ {
-		ba := roachpb.BatchRequest{}
+		ba := &roachpb.BatchRequest{}
 		// Only write keyCount+1 versions of key1.
 		if i < keyCount+1 {
 			pArgs1 := putArgs(key1, []byte(fmt.Sprintf("value%04d", i)))

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -867,7 +867,7 @@ func TestTruncateLogRecompute(t *testing.T) {
 		var v roachpb.Value
 		v.SetBytes(bytes.Repeat([]byte("x"), RaftLogQueueStaleSize*5))
 		put := roachpb.NewPut(key, v)
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(put)
 		ba.RangeID = repl.RangeID
 

--- a/pkg/kv/kvserver/replica_batch_updates.go
+++ b/pkg/kv/kvserver/replica_batch_updates.go
@@ -64,6 +64,7 @@ func maybeStripInFlightWrites(ba *roachpb.BatchRequest) (*roachpb.BatchRequest, 
 	et = &etAlloc.et
 	et.InFlightWrites = nil
 	et.LockSpans = et.LockSpans[:len(et.LockSpans):len(et.LockSpans)] // immutable
+	ba = ba.ShallowCopy()
 	ba.Requests = append([]roachpb.RequestUnion(nil), ba.Requests...)
 	ba.Requests[len(ba.Requests)-1].Value = &etAlloc.union
 

--- a/pkg/kv/kvserver/replica_batch_updates_test.go
+++ b/pkg/kv/kvserver/replica_batch_updates_test.go
@@ -92,10 +92,10 @@ func TestMaybeStripInFlightWrites(t *testing.T) {
 		},
 	}
 	for _, c := range testCases {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(c.reqs...)
 		t.Run(fmt.Sprint(ba), func(t *testing.T) {
-			resBa, err := maybeStripInFlightWrites(&ba)
+			resBa, err := maybeStripInFlightWrites(ba)
 			if c.expErr == "" {
 				if err != nil {
 					t.Errorf("expected no error, got %v", err)

--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -35,7 +35,7 @@ import (
 type replicaInCircuitBreaker interface {
 	Clock() *hlc.Clock
 	Desc() *roachpb.RangeDescriptor
-	Send(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
+	Send(context.Context, *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
 	slowReplicationThreshold(ba *roachpb.BatchRequest) (time.Duration, bool)
 	replicaUnavailableError(err error) error
 	poisonInflightLatches(err error)
@@ -213,13 +213,13 @@ func sendProbe(ctx context.Context, r replicaInCircuitBreaker) error {
 	if !desc.IsInitialized() {
 		return nil
 	}
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Timestamp = r.Clock().Now()
 	ba.RangeID = r.Desc().RangeID
 	probeReq := &roachpb.ProbeRequest{}
 	probeReq.Key = desc.StartKey.AsRawKey()
 	ba.Add(probeReq)
-	thresh, ok := r.slowReplicationThreshold(&ba)
+	thresh, ok := r.slowReplicationThreshold(ba)
 	if !ok {
 		// Breakers are disabled now.
 		return nil

--- a/pkg/kv/kvserver/replica_circuit_breaker_test.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker_test.go
@@ -36,8 +36,6 @@ func TestReplicaUnavailableError(t *testing.T) {
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 1, StoreID: 10, ReplicaID: 100})
 	repls.AddReplica(roachpb.ReplicaDescriptor{NodeID: 2, StoreID: 20, ReplicaID: 200})
 	desc := roachpb.NewRangeDescriptor(10, roachpb.RKey("a"), roachpb.RKey("z"), repls)
-	var ba roachpb.BatchRequest
-	ba.Add(&roachpb.RequestLeaseRequest{})
 	lm := liveness.IsLiveMap{
 		1: liveness.IsLiveMapEntry{IsLive: true},
 	}

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -973,7 +973,7 @@ func TestServerSideBoundedStalenessNegotiation(t *testing.T) {
 				tc.repl.mu.Unlock()
 
 				// Construct and issue the request.
-				var ba roachpb.BatchRequest
+				ba := &roachpb.BatchRequest{}
 				ba.RangeID = tc.rangeID
 				ba.BoundedStaleness = &roachpb.BoundedStalenessHeader{
 					MinTimestampBound:       test.minTSBound,
@@ -1077,7 +1077,8 @@ func TestServerSideBoundedStalenessNegotiationWithResumeSpan(t *testing.T) {
 	//  get:  [g]
 	//  get:  [h]
 	//
-	makeReq := func(maxKeys int) (ba roachpb.BatchRequest) {
+	makeReq := func(maxKeys int) *roachpb.BatchRequest {
+		ba := &roachpb.BatchRequest{}
 		ba.BoundedStaleness = &roachpb.BoundedStalenessHeader{
 			MinTimestampBound: makeTS(5),
 		}

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -112,7 +112,7 @@ func TestBumpSideTransportClosed(t *testing.T) {
 			exp:  false,
 			knobs: func() (*kvserver.StoreTestingKnobs, chan chan struct{}) {
 				mergeC := make(chan chan struct{})
-				testingResponseFilter := func(ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+				testingResponseFilter := func(ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 					if ba.IsSingleSubsumeRequest() {
 						unblockC := make(chan struct{})
 						mergeC <- unblockC
@@ -817,7 +817,7 @@ func TestNonBlockingReadsWithServerSideBoundedStalenessNegotiation(t *testing.T)
 			// to block on an intent. Send to a specific store instead of through
 			// a DistSender so that we'll hear an error (NotLeaseholderError) if
 			// the request would otherwise be redirected to the leaseholder.
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.RangeID = rangeID
 			ba.BoundedStaleness = &roachpb.BoundedStalenessHeader{
 				MinTimestampBound:       minTSBound,

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -36,7 +36,7 @@ var FollowerReadsEnabled = settings.RegisterBoolSetting(
 // BatchCanBeEvaluatedOnFollower determines if a batch consists exclusively of
 // requests that can be evaluated on a follower replica, given a sufficiently
 // advanced closed timestamp.
-func BatchCanBeEvaluatedOnFollower(ba roachpb.BatchRequest) bool {
+func BatchCanBeEvaluatedOnFollower(ba *roachpb.BatchRequest) bool {
 	// Explanation of conditions:
 	// 1. the batch cannot have or intend to receive a timestamp set from a
 	//    server-side clock. If a follower with a lagging clock sets its timestamp
@@ -63,7 +63,7 @@ func BatchCanBeEvaluatedOnFollower(ba roachpb.BatchRequest) bool {
 // must be transactional and composed exclusively of this kind of request to be
 // accepted as a follower read.
 func (r *Replica) canServeFollowerReadRLocked(ctx context.Context, ba *roachpb.BatchRequest) bool {
-	eligible := BatchCanBeEvaluatedOnFollower(*ba) && FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV)
+	eligible := BatchCanBeEvaluatedOnFollower(ba) && FollowerReadsEnabled.Get(&r.store.cfg.Settings.SV)
 	if !eligible {
 		// We couldn't do anything with the error, propagate it.
 		return false

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -750,7 +750,7 @@ func TestSplitRetriesOnFailedExitOfJointConfig(t *testing.T) {
 	var rangeIDAtomic int64
 	var rejectedCount int
 	const maxRejects = 3
-	reqFilter := func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	reqFilter := func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		rangeID := roachpb.RangeID(atomic.LoadInt64(&rangeIDAtomic))
 		if ba.RangeID == rangeID && ba.IsSingleTransferLeaseRequest() && rejectedCount < maxRejects {
 			rejectedCount++
@@ -1215,7 +1215,7 @@ func TestLearnerAndVoterOutgoingFollowerRead(t *testing.T) {
 	check := func() {
 		ts := tc.Server(0).Clock().Now()
 		txn := roachpb.MakeTransaction("txn", nil, 0, ts, 0, int32(tc.Server(0).SQLInstanceID()))
-		req := roachpb.BatchRequest{Header: roachpb.Header{
+		req := &roachpb.BatchRequest{Header: roachpb.Header{
 			RangeID:   scratchDesc.RangeID,
 			Timestamp: ts,
 			Txn:       &txn,

--- a/pkg/kv/kvserver/replica_probe_test.go
+++ b/pkg/kv/kvserver/replica_probe_test.go
@@ -125,7 +125,7 @@ func TestReplicaProbeRequest(t *testing.T) {
 	for _, srv := range tc.Servers {
 		repl, _, err := srv.Stores().GetReplicaForRangeID(ctx, desc.RangeID)
 		require.NoError(t, err)
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(probeReq)
 		ba.Timestamp = srv.Clock().Now()
 		_, pErr := repl.Send(ctx, ba)
@@ -143,7 +143,7 @@ func TestReplicaProbeRequest(t *testing.T) {
 	for _, srv := range tc.Servers {
 		repl, _, err := srv.Stores().GetReplicaForRangeID(ctx, desc.RangeID)
 		require.NoError(t, err)
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = srv.Clock().Now()
 		ba.Add(probeReq)
 		_, pErr := repl.Send(ctx, ba)

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -240,25 +240,25 @@ type proposalCreator struct {
 }
 
 func (pc proposalCreator) newPutProposal(ts hlc.Timestamp) *ProposalData {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&roachpb.PutRequest{})
 	ba.Timestamp = ts
 	return pc.newProposal(ba)
 }
 
 func (pc proposalCreator) newLeaseRequestProposal(lease roachpb.Lease) *ProposalData {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: lease, PrevLease: pc.lease.Lease})
 	return pc.newProposal(ba)
 }
 
 func (pc proposalCreator) newLeaseTransferProposal(lease roachpb.Lease) *ProposalData {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&roachpb.TransferLeaseRequest{Lease: lease, PrevLease: pc.lease.Lease})
 	return pc.newProposal(ba)
 }
 
-func (pc proposalCreator) newProposal(ba roachpb.BatchRequest) *ProposalData {
+func (pc proposalCreator) newProposal(ba *roachpb.BatchRequest) *ProposalData {
 	var lease *roachpb.Lease
 	var isLeaseRequest bool
 	switch v := ba.Requests[0].GetInner().(type) {
@@ -277,7 +277,7 @@ func (pc proposalCreator) newProposal(ba roachpb.BatchRequest) *ProposalData {
 				State:          &kvserverpb.ReplicaState{Lease: lease},
 			},
 		},
-		Request:     &ba,
+		Request:     ba,
 		leaseStatus: pc.lease,
 	}
 	p.encodedCommand = pc.encodeProposal(p)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -528,7 +528,7 @@ func (p *pendingLeaseRequest) requestLease(
 	// solution to the below issue:
 	//
 	// https://github.com/cockroachdb/cockroach/issues/37906
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Timestamp = p.repl.store.Clock().Now()
 	ba.RangeID = p.repl.RangeID
 	// NB:

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -445,7 +445,7 @@ func TestReplicaRangefeed(t *testing.T) {
 	}
 	gcReq.Key = startKey
 	gcReq.EndKey = firstStore.LookupReplica(startKey).Desc().EndKey.AsRawKey()
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.RangeID = rangeID
 	ba.Add(gcReq)
 	if _, pErr := firstStore.Send(ctx, ba); pErr != nil {
@@ -1194,7 +1194,7 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 				WallClock: manualClock,
 			},
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 					// Once reject is set, the test wants full control over the requests
 					// evaluating on the scratch range. On that range, we'll reject
 					// everything that's not triggered by the test because we want to only
@@ -1369,7 +1369,7 @@ func TestNewRangefeedForceLeaseRetry(t *testing.T) {
 				WallClock: manualClock,
 			},
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 
 					// Once reject is set, the test wants full control over the requests
 					// evaluating on the scratch range. On that range, we'll reject

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -122,8 +122,8 @@ func TestAddSSTQPSStat(t *testing.T) {
 		RequestHeader: roachpb.RequestHeader{Key: start},
 	}
 
-	addSSTBA := roachpb.BatchRequest{}
-	nonSSTBA := roachpb.BatchRequest{}
+	addSSTBA := &roachpb.BatchRequest{}
+	nonSSTBA := &roachpb.BatchRequest{}
 	addSSTBA.Add(sstReq)
 	nonSSTBA.Add(get)
 
@@ -134,7 +134,7 @@ func TestAddSSTQPSStat(t *testing.T) {
 	testCases := []struct {
 		addsstRequestFactor int
 		expectedQPS         float64
-		ba                  roachpb.BatchRequest
+		ba                  *roachpb.BatchRequest
 	}{
 		{0, 1, addSSTBA},
 		{100, 1, nonSSTBA},
@@ -184,9 +184,9 @@ func TestAddSSTQPSStat(t *testing.T) {
 }
 
 // genVariableRead returns a batch request containing, start-end sequential key reads.
-func genVariableRead(ctx context.Context, start, end roachpb.Key) roachpb.BatchRequest {
+func genVariableRead(ctx context.Context, start, end roachpb.Key) *roachpb.BatchRequest {
 	scan := roachpb.NewScan(start, end, false)
-	readBa := roachpb.BatchRequest{}
+	readBa := &roachpb.BatchRequest{}
 	readBa.Add(scan)
 	return readBa
 }
@@ -355,7 +355,7 @@ func TestReadLoadMetricAccounting(t *testing.T) {
 		MVCCStats:     storageutils.SSTStats(t, sst, 0),
 	}
 
-	addSSTBA := roachpb.BatchRequest{}
+	addSSTBA := &roachpb.BatchRequest{}
 	addSSTBA.Add(sstReq)
 
 	// Send an AddSSTRequest once to create the key range.
@@ -366,18 +366,18 @@ func TestReadLoadMetricAccounting(t *testing.T) {
 		RequestHeader: roachpb.RequestHeader{Key: start},
 	}
 
-	getReadBA := roachpb.BatchRequest{}
+	getReadBA := &roachpb.BatchRequest{}
 	getReadBA.Add(get)
 
 	scan := &roachpb.ScanRequest{
 		RequestHeader: roachpb.RequestHeader{Key: start, EndKey: end},
 	}
 
-	scanReadBA := roachpb.BatchRequest{}
+	scanReadBA := &roachpb.BatchRequest{}
 	scanReadBA.Add(scan)
 
 	testCases := []struct {
-		ba           roachpb.BatchRequest
+		ba           *roachpb.BatchRequest
 		expectedRQPS float64
 		expectedWPS  float64
 		expectedRPS  float64

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -615,7 +615,7 @@ func TestRaftSSTableSideloadingProposal(t *testing.T) {
 	}
 
 	{
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		get := getArgs(roachpb.Key(key))
 		ba.Add(&get)
 		ba.Header.RangeID = tc.repl.RangeID
@@ -712,7 +712,7 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	// Disable log truncation to make sure our proposal stays in the log.
 	tc.store.SetRaftLogQueueActive(false)
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.RangeID = tc.repl.RangeID
 
 	// Put a sideloaded proposal on the Range.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -222,7 +222,7 @@ func (tc *testContext) StartWithStoreConfigAndVersion(
 }
 
 func (tc *testContext) Sender() kv.Sender {
-	return kv.Wrap(tc.repl, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
+	return kv.Wrap(tc.repl, func(ba *roachpb.BatchRequest) *roachpb.BatchRequest {
 		if ba.RangeID == 0 {
 			ba.RangeID = 1
 		}
@@ -430,7 +430,7 @@ func TestIsOnePhaseCommit(t *testing.T) {
 			fmt.Sprintf("%d:isNonTxn:%t,canForwardTS:%t,isRestarted:%t,isWTO:%t,isTSOff:%t",
 				i, c.isNonTxn, c.canForwardTS, c.isRestarted, c.isWTO, c.isTSOff),
 			func(t *testing.T) {
-				ba := roachpb.BatchRequest{Requests: c.ru}
+				ba := &roachpb.BatchRequest{Requests: c.ru}
 				if !c.isNonTxn {
 					ba.Txn = newTransaction("txn", roachpb.Key("a"), 1, clock)
 					if c.canForwardTS {
@@ -455,9 +455,9 @@ func TestIsOnePhaseCommit(t *testing.T) {
 				// Emulate what a server actually does and bump the write timestamp when
 				// possible. This makes some batches with diverged read and write
 				// timestamps pass isOnePhaseCommit().
-				maybeBumpReadTimestampToWriteTimestamp(ctx, &ba, allSpansGuard())
+				maybeBumpReadTimestampToWriteTimestamp(ctx, ba, allSpansGuard())
 
-				if is1PC := isOnePhaseCommit(&ba); is1PC != c.exp1PC {
+				if is1PC := isOnePhaseCommit(ba); is1PC != c.exp1PC {
 					t.Errorf("expected 1pc=%t; got %t", c.exp1PC, is1PC)
 				}
 			})
@@ -497,7 +497,7 @@ func TestReplicaContains(t *testing.T) {
 
 func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	ctx := context.Background()
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Timestamp = r.store.Clock().Now()
 	st := r.CurrentLeaseStatus(ctx)
 	leaseReq := &roachpb.RequestLeaseRequest{
@@ -506,7 +506,7 @@ func sendLeaseRequest(r *Replica, l *roachpb.Lease) error {
 	}
 	ba.Add(leaseReq)
 	_, tok := r.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := r.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+	ch, _, _, _, pErr := r.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor this to a more conventional error-handling pattern.
@@ -863,7 +863,7 @@ func TestReplicaRangeMismatchRedirect(t *testing.T) {
 	}
 
 	gArgs := getArgs(roachpb.Key("b"))
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{
 		RangeID: 1,
 	}
@@ -1333,11 +1333,11 @@ func TestReplicaLeaseRejectUnknownRaftNodeID(t *testing.T) {
 		},
 	}
 	st := tc.repl.CurrentLeaseStatus(ctx)
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Timestamp = tc.repl.store.Clock().Now()
 	ba.Add(&roachpb.RequestLeaseRequest{Lease: *lease})
 	_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := tc.repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+	ch, _, _, _, pErr := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 	if pErr == nil {
 		// Next if the command was committed, wait for the range to apply it.
 		// TODO(bdarnell): refactor to a more conventional error-handling pattern.
@@ -2201,7 +2201,7 @@ func TestReplicaLatching(t *testing.T) {
 						defer close(blockingDone) // make sure teardown can happen
 
 						sendWithHeader := func(header roachpb.Header, args roachpb.Request) *roachpb.Error {
-							ba := roachpb.BatchRequest{}
+							ba := &roachpb.BatchRequest{}
 							ba.Header = header
 							ba.Add(args)
 
@@ -2426,7 +2426,7 @@ func TestReplicaLatchingSelfOverlap(t *testing.T) {
 	testutils.RunTrueAndFalse(t, "cmd1Read", func(t *testing.T, cmd1Read bool) {
 		testutils.RunTrueAndFalse(t, "cmd2Read", func(t *testing.T, cmd2Read bool) {
 			key := fmt.Sprintf("%v,%v", cmd1Read, cmd2Read)
-			ba := roachpb.BatchRequest{}
+			ba := &roachpb.BatchRequest{}
 			ba.Add(readOrWriteArgs(roachpb.Key(key), cmd1Read))
 			ba.Add(readOrWriteArgs(roachpb.Key(key), cmd2Read))
 
@@ -2508,11 +2508,11 @@ func TestReplicaLatchingTimestampNonInterference(t *testing.T) {
 			blockKey.Store(test.key)
 			errCh := make(chan *roachpb.Error, 2)
 
-			baR := roachpb.BatchRequest{}
+			baR := &roachpb.BatchRequest{}
 			baR.Timestamp = test.readerTS
 			gArgs := getArgs(test.key)
 			baR.Add(&gArgs)
-			baW := roachpb.BatchRequest{}
+			baW := &roachpb.BatchRequest{}
 			baW.Timestamp = test.writerTS
 			pArgs := putArgs(test.key, []byte("value"))
 			baW.Add(&pArgs)
@@ -2620,7 +2620,7 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	testutils.RunTrueAndFalse(t, "point-reads", func(t *testing.T, pointReads bool) {
-		var baRead roachpb.BatchRequest
+		baRead := &roachpb.BatchRequest{}
 		if pointReads {
 			gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
 			gArgs3, gArgs4 := getArgsString("c"), getArgsString("d")
@@ -2700,7 +2700,7 @@ func TestReplicaLatchingOptimisticEvaluationKeyLimit(t *testing.T) {
 				<-blockedCh
 				// Write is now blocked while holding latches.
 				blockWriter.Store(false)
-				baReadCopy := baRead
+				baReadCopy := baRead.ShallowCopy()
 				baReadCopy.MaxSpanRequestKeys = test.limit
 				go func() {
 					_, pErr := tc.Sender().Send(context.Background(), baReadCopy)
@@ -2748,7 +2748,7 @@ func TestReplicaLatchingOptimisticEvaluationSkipLocked(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	testutils.RunTrueAndFalse(t, "point-reads", func(t *testing.T, pointReads bool) {
 		testutils.RunTrueAndFalse(t, "locking-reads", func(t *testing.T, lockingReads bool) {
-			var baRead roachpb.BatchRequest
+			baRead := &roachpb.BatchRequest{}
 			baRead.WaitPolicy = lock.WaitPolicy_SkipLocked
 			if pointReads {
 				gArgs1, gArgs2 := getArgsString("a"), getArgsString("b")
@@ -2894,7 +2894,7 @@ func TestReplicaUseTSCache(t *testing.T) {
 
 		// Perform a conflicting write. Should get bumped.
 		pArgs := putArgs([]byte("a"), []byte("value"))
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(&pArgs)
 		ba.Timestamp = startTS
 
@@ -2936,7 +2936,7 @@ func TestReplicaTSCacheForwardsIntentTS(t *testing.T) {
 		gArgs := getArgs(keyGet)
 		drArgs := deleteRangeArgs(keyDeleteRange, keyDeleteRange.Next())
 		assignSeqNumsForReqs(txnNew, &gArgs, &drArgs)
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Header.Txn = txnNew
 		ba.Add(&gArgs, &drArgs)
 		if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
@@ -3183,7 +3183,7 @@ func TestReplicaNoTSCacheInconsistent(t *testing.T) {
 			}
 			pArgs := putArgs([]byte("a"), []byte("value"))
 
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.Header = roachpb.Header{Timestamp: hlc.Timestamp{WallTime: 0, Logical: 1}}
 			ba.Add(&pArgs)
 			br, pErr := tc.Sender().Send(context.Background(), ba)
@@ -3237,7 +3237,7 @@ func TestReplicaNoTSCacheUpdateOnFailure(t *testing.T) {
 		}
 
 		// Write the intent again -- should not have its timestamp upgraded!
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Header = roachpb.Header{Txn: txn}
 		ba.Add(&pArgs)
 		assignSeqNumsForReqs(txn, &pArgs)
@@ -3278,7 +3278,7 @@ func TestReplicaNoTSCacheIncrementWithinTxn(t *testing.T) {
 	}
 
 	// Now try a write and verify timestamp isn't incremented.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	pArgs := putArgs(key, []byte("value"))
 	ba.Add(&pArgs)
@@ -3306,7 +3306,7 @@ func TestReplicaNoTSCacheIncrementWithinTxn(t *testing.T) {
 	expTS := ts
 	expTS.Logical++
 
-	ba = roachpb.BatchRequest{}
+	ba = &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Timestamp: ts}
 	ba.Add(&pArgs)
 	assignSeqNumsForReqs(txn, &pArgs)
@@ -3414,7 +3414,7 @@ func TestReplicaTxnIdempotency(t *testing.T) {
 	tc.Start(ctx, t, stopper)
 
 	runWithTxn := func(txn *roachpb.Transaction, reqs ...roachpb.Request) error {
-		ba := roachpb.BatchRequest{}
+		ba := &roachpb.BatchRequest{}
 		ba.Header.Txn = txn
 		ba.Add(reqs...)
 		_, pErr := tc.Sender().Send(ctx, ba)
@@ -4068,7 +4068,7 @@ func TestEndTxnDeadline_1PC(t *testing.T) {
 	// Past deadline.
 	et.Deadline = txn.WriteTimestamp.Prev()
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = etH
 	ba.Add(&put, &et)
 	assignSeqNumsForReqs(txn, &put, &et)
@@ -4105,7 +4105,7 @@ func Test1PCTransactionWriteTimestamp(t *testing.T) {
 	}
 
 	// Now verify that the write triggers a retry.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = etH
 	ba.Add(&put, &et)
 	assignSeqNumsForReqs(txn, &put, &et)
@@ -4526,7 +4526,7 @@ func TestEndTxnRollbackAbortedTransaction(t *testing.T) {
 		}
 
 		// Check that the intent has not yet been resolved.
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		gArgs := getArgs(key)
 		ba.Add(&gArgs)
 		if err := ba.SetActiveTimestamp(tc.Clock()); err != nil {
@@ -4593,7 +4593,7 @@ func TestRPCRetryProtectionInTxn(t *testing.T) {
 		txn := newTransaction("test", key, 1, tc.Clock())
 
 		// Send a batch with put & end txn.
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.CanForwardReadTimestamp = noPriorReads
 		put := putArgs(key, []byte("value"))
 		et, _ := endTxnArgs(txn, true)
@@ -4645,7 +4645,7 @@ func TestErrorsDontCarryWriteTooOldFlag(t *testing.T) {
 
 	// Write a value outside of the txn to cause a WriteTooOldError later.
 	put := putArgs(keyA, []byte("val1"))
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&put)
 	_, pErr := tc.Sender().Send(ctx, ba)
 	require.Nil(t, pErr)
@@ -4690,7 +4690,7 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	txn := newTransaction("test", key, 1, tc.Clock())
 
 	// Send a put for keyA.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	put := putArgs(key, []byte("value"))
 	ba.Header = roachpb.Header{Txn: txn}
 	ba.Add(&put)
@@ -4704,7 +4704,7 @@ func TestBatchRetryCantCommitIntents(t *testing.T) {
 	}
 
 	// Send a put for keyB.
-	var ba2 roachpb.BatchRequest
+	ba2 := &roachpb.BatchRequest{}
 	putB := putArgs(keyB, []byte("value"))
 	putTxn := br.Txn.Clone()
 	ba2.Header = roachpb.Header{Txn: putTxn}
@@ -4860,7 +4860,7 @@ func setupResolutionTest(
 	}
 
 	{
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Header = h
 		ba.RangeID = newRepl.RangeID
 		if err := ba.SetActiveTimestamp(newRepl.store.Clock()); err != nil {
@@ -4912,7 +4912,7 @@ func TestEndTxnResolveOnlyLocalIntents(t *testing.T) {
 
 	// Check if the intent in the other range has not yet been resolved.
 	{
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Header.RangeID = newRepl.RangeID
 		gArgs := getArgs(splitKey)
 		ba.Add(&gArgs)
@@ -5062,7 +5062,7 @@ func TestEndTxnDirectGC_1PC(t *testing.T) {
 			et.LockSpans = []roachpb.Span{{Key: key}}
 			assignSeqNumsForReqs(txn, &put, &et)
 
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.Header = etH
 			ba.Add(&put, &et)
 			br, err := tc.Sender().Send(ctx, ba)
@@ -5138,7 +5138,7 @@ func TestReplicaTransactionRequires1PC(t *testing.T) {
 			key := roachpb.Key(fmt.Sprintf("%d", i))
 
 			// Create the 1PC batch.
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			txn := newTransaction("test", key, 1, tc.Clock())
 			put := putArgs(key, []byte("value"))
 			et, etH := endTxnArgs(txn, true)
@@ -5180,7 +5180,7 @@ func TestReplicaEndTxnWithRequire1PC(t *testing.T) {
 
 	key := roachpb.Key("a")
 	txn := newTransaction("test", key, 1, tc.Clock())
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	put := putArgs(key, []byte("value"))
 	ba.Add(&put)
@@ -5191,7 +5191,7 @@ func TestReplicaEndTxnWithRequire1PC(t *testing.T) {
 
 	et, etH := endTxnArgs(txn, true)
 	et.Require1PC = true
-	ba = roachpb.BatchRequest{}
+	ba = &roachpb.BatchRequest{}
 	ba.Header = etH
 	ba.Add(&et)
 	assignSeqNumsForReqs(txn, &et)
@@ -6006,7 +6006,7 @@ func TestPushTxnSerializableRestart(t *testing.T) {
 
 	// Try to end pushed transaction at restart timestamp, which is
 	// earlier than its now-pushed timestamp. Should fail.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&put)
 	ba.Add(&etArgs)
 	ba.Header.Txn = pushee
@@ -6140,7 +6140,7 @@ func TestQueryIntentRequest(t *testing.T) {
 			txnCopy := *txn
 			pArgs2 := putArgs(keyPrevent, []byte("value2"))
 			assignSeqNumsForReqs(&txnCopy, &pArgs2)
-			ba := roachpb.BatchRequest{}
+			ba := &roachpb.BatchRequest{}
 			ba.Header = roachpb.Header{Txn: &txnCopy}
 			ba.Add(&pArgs2)
 			br, pErr := tc.Sender().Send(context.Background(), ba)
@@ -6942,7 +6942,7 @@ func TestBatchErrorWithIndex(t *testing.T) {
 	defer stopper.Stop(ctx)
 	tc.Start(ctx, t, stopper)
 
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	// This one succeeds.
 	ba.Add(&roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{Key: roachpb.Key("k")},
@@ -7041,7 +7041,7 @@ func TestQuotaPoolReleasedOnFailedProposal(t *testing.T) {
 		t.Fatal(pErr)
 	}
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	pArg := putArgs(roachpb.Key("a"), make([]byte, 1<<10))
 	ba.Add(&pArg)
 	ctx = context.WithValue(ctx, magicKey{}, "foo")
@@ -7437,7 +7437,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			if cancelEarly {
 				cancel()
 			}
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.RangeID = 1
 			ba.Add(&roachpb.GetRequest{
 				RequestHeader: roachpb.RequestHeader{Key: key},
@@ -7445,7 +7445,7 @@ func TestReplicaCancelRaft(t *testing.T) {
 			if err := ba.SetActiveTimestamp(tc.Clock()); err != nil {
 				t.Fatal(err)
 			}
-			_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, &ba, (*Replica).executeWriteBatch)
+			_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch)
 			if cancelEarly {
 				if !testutils.IsPError(pErr, context.Canceled.Error()) {
 					t.Fatalf("expected canceled error; got %v", pErr)
@@ -7495,13 +7495,13 @@ func TestReplicaAbandonProposal(t *testing.T) {
 	}
 	tc.repl.mu.Unlock()
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.RangeID = 1
 	ba.Timestamp = tc.Clock().Now()
 	ba.Add(&roachpb.PutRequest{
 		RequestHeader: roachpb.RequestHeader{Key: []byte("acdfg")},
 	})
-	_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, &ba, (*Replica).executeWriteBatch)
+	_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(ctx, ba, (*Replica).executeWriteBatch)
 	if pErr == nil {
 		t.Fatal("expected failure, but found success")
 	}
@@ -7603,7 +7603,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 
 	pArg := putArgs(roachpb.Key("a"), []byte("asd"))
 	{
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(&pArg)
 		ba.Timestamp = tc.Clock().Now()
 		if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
@@ -7622,7 +7622,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 
 	log.Infof(ctx, "test begins")
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.RangeID = 1
 	ba.Timestamp = tc.Clock().Now()
 	const expInc = 123
@@ -7631,7 +7631,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 	{
 		_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(
 			context.WithValue(ctx, magicKey{}, "foo"),
-			&ba,
+			ba,
 			(*Replica).executeWriteBatch,
 		)
 		if pErr != nil {
@@ -7666,7 +7666,7 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 		})
 		_, _, pErr := tc.repl.executeBatchWithConcurrencyRetries(
 			context.WithValue(ctx, magicKey{}, "foo"),
-			&ba,
+			ba,
 			(*Replica).executeWriteBatch,
 		)
 		if pErr != nil {
@@ -7707,7 +7707,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 	var chs []chan proposalResult
 	const num = 10
 	for i := 0; i < num; i++ {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{
 			RequestHeader: roachpb.RequestHeader{
@@ -7716,7 +7716,7 @@ func TestReplicaCancelRaftCommandProgress(t *testing.T) {
 		})
 		st := repl.CurrentLeaseStatus(ctx)
 		_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-		ch, _, id, _, err := repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+		ch, _, id, _, err := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7778,7 +7778,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 	const num = 10
 	chs := make([]chan proposalResult, 0, num)
 	for i := 0; i < num; i++ {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{
 			RequestHeader: roachpb.RequestHeader{
@@ -7787,7 +7787,7 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 		})
 		_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
 		st := tc.repl.CurrentLeaseStatus(ctx)
-		ch, _, _, _, err := tc.repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+		ch, _, _, _, err := tc.repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -7897,11 +7897,11 @@ func TestReplicaRefreshPendingCommandsTicks(t *testing.T) {
 	for i := 0; i < 2*electionTicks; i++ {
 		// Add another pending command on each iteration.
 		id := fmt.Sprintf("%08d", i)
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = tc.Clock().Now()
 		ba.Add(&roachpb.PutRequest{RequestHeader: roachpb.RequestHeader{Key: roachpb.Key(id)}})
 		st := r.CurrentLeaseStatus(ctx)
-		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), &ba, allSpansGuard(), &st, uncertainty.Interval{})
+		cmd, pErr := r.requestToProposal(ctx, kvserverbase.CmdIDKey(id), ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -8018,14 +8018,14 @@ func TestReplicaRefreshMultiple(t *testing.T) {
 	// since the reproposals we're concerned with don't result in
 	// reevaluation it doesn't matter)
 	inc := incrementArgs(key, 1)
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(inc)
 	ba.Timestamp = tc.Clock().Now()
 
 	incCmdID = makeIDKey()
 	atomic.StoreInt32(&filterActive, 1)
 	st := repl.CurrentLeaseStatus(ctx)
-	proposal, pErr := repl.requestToProposal(ctx, incCmdID, &ba, allSpansGuard(), &st, uncertainty.Interval{})
+	proposal, pErr := repl.requestToProposal(ctx, incCmdID, ba, allSpansGuard(), &st, uncertainty.Interval{})
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -8176,7 +8176,7 @@ func TestReplicaReproposalWithNewLeaseIndexError(t *testing.T) {
 
 	// Perform a write that will first hit an illegal lease index error and
 	// will then hit the injected error when we attempt to repropose it.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	iArg := incrementArgs(key, 10)
 	ba.Add(iArg)
 	if _, pErr := tc.Sender().Send(magicCtx, ba); pErr == nil {
@@ -8216,7 +8216,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	key := roachpb.Key("a")
 	txn := newTransaction("test", key, 1, tc.Clock())
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	put := putArgs(key, []byte("value"))
 	assignSeqNumsForReqs(txn, &put)
@@ -8246,7 +8246,7 @@ func TestFailureToProcessCommandClearsLocalResult(t *testing.T) {
 	opCtx, getRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test-recording")
 	defer getRecAndFinish()
 
-	ba = roachpb.BatchRequest{}
+	ba = &roachpb.BatchRequest{}
 	et, etH := endTxnArgs(txn, true /* commit */)
 	et.LockSpans = []roachpb.Span{{Key: key}}
 	assignSeqNumsForReqs(txn, &et)
@@ -8291,7 +8291,7 @@ func TestMVCCStatsGCCommutesWithWrites(t *testing.T) {
 	require.NoError(t, err)
 
 	write := func() hlc.Timestamp {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		put := putArgs(key, []byte("0"))
 		ba.Add(&put)
 		resp, pErr := store.TestSender().Send(ctx, ba)
@@ -8581,7 +8581,7 @@ func TestGCThresholdRacesWithRead(t *testing.T) {
 				require.NoError(t, err)
 
 				testutils.SucceedsSoon(t, func() error {
-					var ba roachpb.BatchRequest
+					ba := &roachpb.BatchRequest{}
 					ba.RangeID = desc.RangeID
 					ba.ReadConsistency = roachpb.INCONSISTENT
 					ba.Add(&roachpb.QueryResolvedTimestampRequest{
@@ -8687,7 +8687,7 @@ func BenchmarkMVCCGCWithForegroundTraffic(b *testing.B) {
 	send := func(args roachpb.Request) *roachpb.BatchResponse {
 		var header roachpb.Header
 		header.Timestamp = tc.Clock().Now()
-		ba := roachpb.BatchRequest{}
+		ba := &roachpb.BatchRequest{}
 		ba.Header = header
 		ba.Add(args)
 		resp, err := tc.Sender().Send(ctx, ba)
@@ -8834,7 +8834,7 @@ func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
 	txn := newTransaction("test", key, 1, tc.Clock())
 
 	minNewTS := func() hlc.Timestamp {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		scan := scanArgs(key, tc.repl.Desc().EndKey.AsRawKey())
 		ba.Add(scan)
 
@@ -8848,7 +8848,7 @@ func TestReplicaTimestampCacheBumpNotLost(t *testing.T) {
 		return resp.Timestamp
 	}()
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Txn = txn
 	txnPut := putArgs(key, []byte("timestamp should be bumped"))
 	ba.Add(&txnPut)
@@ -8892,7 +8892,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 
 	txn := newTransaction("test", key, 1, tc.Clock())
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Txn = txn
 	ba.Timestamp = txn.WriteTimestamp
 	txnPut := putArgs(key, []byte("foo"))
@@ -8906,7 +8906,7 @@ func TestReplicaEvaluationNotTxnMutation(t *testing.T) {
 	assignSeqNumsForReqs(txn, &txnPut, &txnPut2)
 	origTxn := txn.Clone()
 
-	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), &ba, allSpansGuard(), nil, uncertainty.Interval{})
+	batch, _, _, _, pErr := tc.repl.evaluateWriteBatch(ctx, makeIDKey(), ba, allSpansGuard(), nil, uncertainty.Interval{})
 	defer batch.Close()
 	if pErr != nil {
 		t.Fatal(pErr)
@@ -9324,7 +9324,7 @@ func TestNoopRequestsNotProposed(t *testing.T) {
 	sendReq := func(
 		ctx context.Context, repl *Replica, req roachpb.Request, txn *roachpb.Transaction,
 	) *roachpb.Error {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Header.RangeID = repl.RangeID
 		ba.Add(req)
 		ba.Txn = txn
@@ -9518,7 +9518,7 @@ func TestNoopRequestsNotProposed(t *testing.T) {
 				}
 			repl.mu.Unlock()
 
-			ba := roachpb.BatchRequest{}
+			ba := &roachpb.BatchRequest{}
 			ba.Timestamp = markerTS
 			ba.RangeID = repl.RangeID
 			if c.useTxn {
@@ -9617,7 +9617,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	txn.Sequence++
 	etArgs, _ := endTxnArgs(txn, true /* commit */)
 	etArgs.LockSpans = []roachpb.Span{{Key: roachpb.Key("bb")}}
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header.Txn = txn
 	ba.Add(&etArgs)
 	assignSeqNumsForReqs(txn, &etArgs)
@@ -9636,7 +9636,7 @@ func TestErrorInRaftApplicationClearsIntents(t *testing.T) {
 	exLease, _ := repl.GetLease()
 	st := kvserverpb.LeaseStatus{Lease: exLease, State: kvserverpb.LeaseState_VALID}
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+	ch, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9674,7 +9674,7 @@ func TestProposeWithAsyncConsensus(t *testing.T) {
 	tc.StartWithStoreConfig(ctx, t, stopper, tsc)
 	repl := tc.repl
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	key := roachpb.Key("a")
 	put := putArgs(key, []byte("val"))
 	ba.Add(&put)
@@ -9684,7 +9684,7 @@ func TestProposeWithAsyncConsensus(t *testing.T) {
 	atomic.StoreInt32(&filterActive, 1)
 	st := tc.repl.CurrentLeaseStatus(ctx)
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	ch, _, _, _, pErr := repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+	ch, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9740,7 +9740,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	repl := tc.repl
 
 	// Block command application then propose a command to Raft.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	key := roachpb.Key("a")
 	put := putArgs(key, []byte("val"))
 	ba.Add(&put)
@@ -9749,7 +9749,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	atomic.StoreInt32(&filterActive, 1)
 	st := repl.CurrentLeaseStatus(ctx)
 	_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-	_, _, _, _, pErr := repl.evalAndPropose(ctx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+	_, _, _, _, pErr := repl.evalAndPropose(ctx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -9760,7 +9760,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 	<-blockingRaftApplication
 	var ch chan proposalResult
 	for i := 0; i < 50; i++ {
-		var ba2 roachpb.BatchRequest
+		ba2 := &roachpb.BatchRequest{}
 		key := roachpb.Key("a")
 		put := putArgs(key, make([]byte, 2*tsc.RaftMaxCommittedSizePerReady))
 		ba2.Add(&put)
@@ -9768,7 +9768,7 @@ func TestApplyPaginatedCommittedEntries(t *testing.T) {
 
 		var pErr *roachpb.Error
 		_, tok := repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
-		ch, _, _, _, pErr = repl.evalAndPropose(ctx, &ba2, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
+		ch, _, _, _, pErr = repl.evalAndPropose(ctx, ba2, allSpansGuard(), &st, uncertainty.Interval{}, tok.Move(ctx))
 		if pErr != nil {
 			t.Fatal(pErr)
 		}
@@ -10371,7 +10371,7 @@ func TestConsistenctQueueErrorFromCheckConsistency(t *testing.T) {
 
 	cfg := TestStoreConfig(nil)
 	cfg.TestingKnobs = StoreTestingKnobs{
-		TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 			if _, ok := ba.GetArg(roachpb.ComputeChecksum); ok {
 				return roachpb.NewErrorf("boom")
 			}
@@ -10421,7 +10421,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 		)
 		return &txn
 	}
-	send := func(ba roachpb.BatchRequest) (hlc.Timestamp, error) {
+	send := func(ba *roachpb.BatchRequest) (hlc.Timestamp, error) {
 		br, pErr := tc.Sender().Send(ctx, ba)
 		if pErr != nil {
 			return hlc.Timestamp{}, pErr.GoError()
@@ -10443,13 +10443,13 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 		return br.Timestamp, nil
 	}
 	get := func(key string) (hlc.Timestamp, error) {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		get := getArgs(roachpb.Key(key))
 		ba.Add(&get)
 		return send(ba)
 	}
 	put := func(key, val string) (hlc.Timestamp, error) {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		put := putArgs(roachpb.Key(key), []byte(val))
 		ba.Add(&put)
 		return send(ba)
@@ -10458,7 +10458,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 	testCases := []struct {
 		name    string
 		setupFn func() (hlc.Timestamp, error) // returns expected batch execution timestamp
-		batchFn func(hlc.Timestamp) (roachpb.BatchRequest, hlc.Timestamp)
+		batchFn func(hlc.Timestamp) (*roachpb.BatchRequest, hlc.Timestamp)
 		expErr  string
 	}{
 		{
@@ -10466,7 +10466,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				expTS = ts.Next()
 				put := putArgs(roachpb.Key("a"), []byte("put2"))
@@ -10483,7 +10484,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("b", "put1")
 				return put("b", "put2")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				expTS = ts.Next()
 				cput := cPutArgs(roachpb.Key("b"), []byte("cput"), []byte("put2"))
@@ -10500,7 +10502,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("b-iput", "put1")
 				return put("b-iput", "put2")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				expTS = ts.Next()
 				iput := iPutArgs(roachpb.Key("b-iput"), []byte("put2"))
@@ -10519,7 +10522,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				get := getArgs(roachpb.Key("a"))
 				put := putArgs(roachpb.Key("a"), []byte("put2"))
@@ -10533,7 +10537,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return get("a")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				expTS = ts.Next()
 				put := putArgs(roachpb.Key("a"), []byte("put2"))
@@ -10548,7 +10553,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("c-cput", "put")
 				return put("c-cput", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-cput", ts.Prev())
 				cput := cPutArgs(roachpb.Key("c-cput"), []byte("iput"), []byte("put"))
 				ba.Add(&cput)
@@ -10563,7 +10569,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("c-iput", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-iput", ts.Prev())
 				iput := iPutArgs(roachpb.Key("c-iput"), []byte("iput"))
 				ba.Add(&iput)
@@ -10578,7 +10585,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("c-scan", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-scan", ts.Prev())
 				scan := scanArgs(roachpb.Key("c-scan"), roachpb.Key("c-scan\x00"))
 				scan.KeyLocking = lock.Exclusive
@@ -10595,8 +10603,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("c-cput", "put")
 				return put("c-cput", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-cput", ts.Prev())
 				ba.CanForwardReadTimestamp = true
 				cput := cPutArgs(roachpb.Key("c-cput"), []byte("iput"), []byte("put"))
@@ -10619,7 +10628,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("c-iput", "put1")
 				return put("c-iput", "put2")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-iput", ts.Prev())
 				ba.CanForwardReadTimestamp = true
 				iput := iPutArgs(roachpb.Key("c-iput"), []byte("put2"))
@@ -10636,8 +10646,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("c-scan", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("c-scan", ts.Prev())
 				ba.CanForwardReadTimestamp = true
 				scan := scanArgs(roachpb.Key("c-scan"), roachpb.Key("c-scan\x00"))
@@ -10654,7 +10665,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("d", "put")
 				return put("d", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("d", ts.Prev())
 				cput := cPutArgs(ba.Txn.Key, []byte("cput"), []byte("put"))
 				et, _ := endTxnArgs(ba.Txn, true /* commit */)
@@ -10671,8 +10683,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("e", "put")
 				return put("e", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("e", ts.Prev())
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				cput := cPutArgs(ba.Txn.Key, []byte("cput"), []byte("put"))
@@ -10689,8 +10702,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				_, _ = put("e", "put")
 				return put("e", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("e", ts.Prev())
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				cput := cPutArgs(ba.Txn.Key, []byte("cput"), []byte("put"))
@@ -10711,10 +10725,11 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("e1", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				txn := newTxn("e1", ts.Prev())
 
 				// Send write to another key first to avoid 1PC.
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				put := putArgs([]byte("e1-other-key"), []byte("otherput"))
 				ba.Add(&put)
@@ -10723,7 +10738,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 					panic(err)
 				}
 
-				ba = roachpb.BatchRequest{}
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				// Indicate local retry is possible, even though we don't currently take
 				// advantage of this.
@@ -10753,10 +10768,11 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				}
 				return put("f3", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
 				// We're going to execute before any of the writes in setupFn.
 				ts.Logical = 0
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts
 				for i := 1; i <= 3; i++ {
 					cput := cPutArgs(roachpb.Key(fmt.Sprintf("f%d", i)), []byte("cput"), []byte("put"))
@@ -10780,10 +10796,11 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				}
 				return put("ga3", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
 				// We're going to execute before any of the writes in setupFn.
 				ts.Logical = 0
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("ga1", ts)
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				for i := 1; i <= 3; i++ {
@@ -10806,9 +10823,10 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				}
 				return get("h")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				txn := newTxn("h", ts.Prev())
 				// Send write to another key first to avoid 1PC.
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				put := putArgs([]byte("h2"), []byte("otherput"))
 				ba.Add(&put)
@@ -10818,7 +10836,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				}
 				// Send the remainder of the transaction in another batch.
 				expTS = ts.Next()
-				ba = roachpb.BatchRequest{}
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				cput := cPutArgs(ba.Txn.Key, []byte("cput"), []byte("put"))
@@ -10836,7 +10854,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return get("a")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("a", ts.Prev())
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				expTS = ts.Next()
@@ -10856,9 +10875,10 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("lscan", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				// Txn with (read_ts, write_ts) = (1, 4) finds a value with
 				// `ts = 2`. Final timestamp should be `ts = 4`.
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("lscan", ts.Prev())
 				ba.Txn.WriteTimestamp = ts.Next().Next()
 				ba.CanForwardReadTimestamp = true
@@ -10877,9 +10897,10 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("i", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				txn := newTxn("i", ts.Prev())
 				// Send write to another key first to avoid 1PC.
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				put1 := putArgs([]byte("i2"), []byte("otherput"))
 				ba.Add(&put1)
@@ -10889,7 +10910,7 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 				}
 				// Send the remainder of the transaction in another batch.
 				expTS = ts.Next()
-				ba = roachpb.BatchRequest{}
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = txn
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
 				put2 := putArgs(ba.Txn.Key, []byte("newput"))
@@ -10910,7 +10931,8 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
+				ba = &roachpb.BatchRequest{}
 				ba.Timestamp = ts.Prev()
 				// NOTE: set the TimestampFromServerClock field manually. This is
 				// usually set on the server for non-transactional requests without
@@ -10931,9 +10953,10 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
 				ts = ts.Prev()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("a", ts)
 				ba.Txn.GlobalUncertaintyLimit = expTS
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
@@ -10947,8 +10970,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				ts = ts.Prev()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("a", ts)
 				ba.Txn.GlobalUncertaintyLimit = ts.Next()
 				get := getArgs(roachpb.Key("a"))
@@ -10962,9 +10986,10 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				expTS = ts.Next()
 				ts = ts.Prev()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("a", ts)
 				ba.Txn.GlobalUncertaintyLimit = expTS
 				ba.CanForwardReadTimestamp = true // necessary to indicate serverside-refresh is possible
@@ -10980,8 +11005,9 @@ func TestReplicaServersideRefreshes(t *testing.T) {
 			setupFn: func() (hlc.Timestamp, error) {
 				return put("a", "put")
 			},
-			batchFn: func(ts hlc.Timestamp) (ba roachpb.BatchRequest, expTS hlc.Timestamp) {
+			batchFn: func(ts hlc.Timestamp) (ba *roachpb.BatchRequest, expTS hlc.Timestamp) {
 				ts = ts.Prev()
+				ba = &roachpb.BatchRequest{}
 				ba.Txn = newTxn("a", ts)
 				ba.Txn.GlobalUncertaintyLimit = ts.Next()
 				get := getArgs(roachpb.Key("a"))
@@ -11059,7 +11085,7 @@ func TestReplicaPushed1PC(t *testing.T) {
 	// this difference is difficult to observe in a test. If we had
 	// more detailed metrics we could assert that the 1PC path was
 	// not even attempted here.
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: &txn}
 	put := putArgs(k, []byte("two"))
 	et, _ := endTxnArgs(&txn, true)
@@ -11102,7 +11128,7 @@ func TestReplicaNotifyLockTableOn1PC(t *testing.T) {
 	// Create a new transaction and perform a "for update" scan. This should
 	// acquire unreplicated, exclusive locks on the key.
 	txn := newTransaction("test", key, 1, tc.Clock())
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header = roachpb.Header{Txn: txn}
 	ba.Add(roachpb.NewScan(key, key.Next(), true /* forUpdate */))
 	if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
@@ -11134,7 +11160,7 @@ func TestReplicaNotifyLockTableOn1PC(t *testing.T) {
 
 	// Update the locked value and commit in a single batch. This should release
 	// the "for update" lock.
-	ba = roachpb.BatchRequest{}
+	ba = &roachpb.BatchRequest{}
 	incArgs := incrementArgs(key, 1)
 	et, etH := endTxnArgs(txn, true /* commit */)
 	et.Require1PC = true
@@ -11183,7 +11209,7 @@ func TestReplicaQueryLocks(t *testing.T) {
 			// Create a new transaction and perform a "for update" scan. This should
 			// acquire unreplicated, exclusive locks on keys "a" and "b".
 			txn := newTransaction("test", keyA, 1, tc.Clock())
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.Header = roachpb.Header{Txn: txn}
 			ba.Add(roachpb.NewScan(keyA, keyB.Next(), true /* forUpdate */))
 			if _, pErr := tc.Sender().Send(ctx, ba); pErr != nil {
@@ -11269,7 +11295,7 @@ func TestReplicaQueryLocks(t *testing.T) {
 
 			// Update the locked value and commit in a single batch. This should release
 			// the "for update" lock.
-			ba = roachpb.BatchRequest{}
+			ba = &roachpb.BatchRequest{}
 			incArgs := incrementArgs(keyA, 1)
 			et, etH := endTxnArgs(txn, true /* commit */)
 			et.Require1PC = true
@@ -13207,7 +13233,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	st := tc.repl.CurrentLeaseStatus(ctx)
 	txn := newTransaction("test", key, roachpb.NormalUserPriority, tc.Clock())
 	txnID = txn.ID
-	ba := roachpb.BatchRequest{
+	ba := &roachpb.BatchRequest{
 		Header: roachpb.Header{
 			RangeID: tc.repl.RangeID,
 			Txn:     txn,
@@ -13227,7 +13253,7 @@ func TestProposalNotAcknowledgedOrReproposedAfterApplication(t *testing.T) {
 	_, tok := tc.repl.mu.proposalBuf.TrackEvaluatingRequest(ctx, hlc.MinTimestamp)
 	sp := cfg.AmbientCtx.Tracer.StartSpan("replica send", tracing.WithForceRealSpan())
 	tracedCtx := tracing.ContextWithSpan(ctx, sp)
-	ch, _, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, &ba, allSpansGuard(), &st, uncertainty.Interval{}, tok)
+	ch, _, _, _, pErr := tc.repl.evalAndPropose(tracedCtx, ba, allSpansGuard(), &st, uncertainty.Interval{}, tok)
 	if pErr != nil {
 		t.Fatal(pErr)
 	}
@@ -13305,34 +13331,34 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 		{
 			// Test the case where no bump occurs.
 			name: "no bump", f: func(t *testing.T, r *Replica) {
-				ba := roachpb.BatchRequest{}
+				ba := &roachpb.BatchRequest{}
 				ba.Add(putReq(keyA))
 				minReadTS := r.store.Clock().Now()
 				ba.Timestamp = minReadTS.Next()
-				require.False(t, r.applyTimestampCache(ctx, &ba, minReadTS))
+				require.False(t, r.applyTimestampCache(ctx, ba, minReadTS))
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
 		{
 			// Test the case where the bump occurs due to minReadTS.
 			name: "bump due to minTS", f: func(t *testing.T, r *Replica) {
-				ba := roachpb.BatchRequest{}
+				ba := &roachpb.BatchRequest{}
 				ba.Add(putReq(keyA))
 				ba.Timestamp = r.store.Clock().Now()
 				minReadTS := ba.Timestamp.Next()
-				require.True(t, r.applyTimestampCache(ctx, &ba, minReadTS))
+				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
 				require.Equal(t, int32(1), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
 		{
 			// Test the case where we bump due to the read ts cache rather than the minReadTS.
 			name: "bump due to later read ts cache entry", f: func(t *testing.T, r *Replica) {
-				ba := roachpb.BatchRequest{}
+				ba := &roachpb.BatchRequest{}
 				ba.Add(putReq(keyA))
 				ba.Timestamp = r.store.Clock().Now()
 				minReadTS := ba.Timestamp.Next()
 				r.store.tsCache.Add(keyA, keyA, minReadTS.Next(), uuid.MakeV4())
-				require.True(t, r.applyTimestampCache(ctx, &ba, minReadTS))
+				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
@@ -13340,14 +13366,14 @@ func TestReplicaTelemetryCounterForPushesDueToClosedTimestamp(t *testing.T) {
 			// Test the case where we do initially bump due to the minReadTS but then
 			// bump again to a higher ts due to the read ts cache.
 			name: "higher bump due to read ts cache entry", f: func(t *testing.T, r *Replica) {
-				ba := roachpb.BatchRequest{}
+				ba := &roachpb.BatchRequest{}
 				ba.Add(putReq(keyA))
 				ba.Add(putReq(keyAA))
 				ba.Timestamp = r.store.Clock().Now()
 				minReadTS := ba.Timestamp.Next()
 				t.Log(ba.Timestamp, minReadTS, minReadTS.Next())
 				r.store.tsCache.Add(keyAA, keyAA, minReadTS.Next(), uuid.MakeV4())
-				require.True(t, r.applyTimestampCache(ctx, &ba, minReadTS))
+				require.True(t, r.applyTimestampCache(ctx, ba, minReadTS))
 				require.Equal(t, int32(0), telemetry.Read(batchesPushedDueToClosedTimestamp))
 			},
 		},
@@ -13391,12 +13417,12 @@ func TestContainsEstimatesClampProposal(t *testing.T) {
 
 	someRequestToProposal := func(tc *testContext, ctx context.Context) *ProposalData {
 		cmdIDKey := kvserverbase.CmdIDKey("some-cmdid-key")
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Timestamp = tc.Clock().Now()
 		req := putArgs(roachpb.Key("some-key"), []byte("some-value"))
 		ba.Add(&req)
 		st := tc.repl.CurrentLeaseStatus(ctx)
-		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, &ba, allSpansGuard(), &st, uncertainty.Interval{})
+		proposal, err := tc.repl.requestToProposal(ctx, cmdIDKey, ba, allSpansGuard(), &st, uncertainty.Interval{})
 		if err != nil {
 			t.Error(err)
 		}
@@ -13678,7 +13704,7 @@ func TestRangeInfoReturned(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			ba := roachpb.BatchRequest{}
+			ba := &roachpb.BatchRequest{}
 			ba.Add(&gArgs)
 			ba.Header.ClientRangeInfo = test.req
 			br, pErr := tc.Sender().Send(ctx, ba)
@@ -13869,7 +13895,7 @@ func TestRangeSplitRacesWithRead(t *testing.T) {
 			require.NoError(t, err)
 
 			testutils.SucceedsSoon(t, func() error {
-				var ba roachpb.BatchRequest
+				ba := &roachpb.BatchRequest{}
 				ba.RangeID = desc.RangeID
 				ba.ReadConsistency = roachpb.INCONSISTENT
 				ba.Add(&roachpb.QueryResolvedTimestampRequest{
@@ -14010,7 +14036,7 @@ func TestRangeSplitAndRHSRemovalRacesWithFollowerRead(t *testing.T) {
 	require.NoError(t, err)
 
 	testutils.SucceedsSoon(t, func() error {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.RangeID = desc.RangeID
 		ba.ReadConsistency = roachpb.INCONSISTENT
 		ba.Add(&roachpb.QueryResolvedTimestampRequest{

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -76,7 +76,7 @@ var testIdent = roachpb.StoreIdent{
 }
 
 func (s *Store) TestSender() kv.Sender {
-	return kv.Wrap(s, func(ba roachpb.BatchRequest) roachpb.BatchRequest {
+	return kv.Wrap(s, func(ba *roachpb.BatchRequest) *roachpb.BatchRequest {
 		if ba.RangeID != 0 {
 			return ba
 		}
@@ -1010,7 +1010,7 @@ func TestStoreAnnotateNow(t *testing.T) {
 					txn.GlobalUncertaintyLimit = hlc.MaxTimestamp
 					assignSeqNumsForReqs(txn, &pArgs)
 				}
-				ba := roachpb.BatchRequest{
+				ba := &roachpb.BatchRequest{
 					Header: roachpb.Header{
 						Txn:     txn,
 						Replica: desc,
@@ -1116,7 +1116,7 @@ func TestStoreSendWithZeroTime(t *testing.T) {
 	store, _ := createTestStore(ctx, t, testStoreOpts{createSystemRanges: true}, stopper)
 	args := getArgs([]byte("a"))
 
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&args)
 	br, pErr := store.TestSender().Send(ctx, ba)
 	if pErr != nil {
@@ -1983,7 +1983,7 @@ func TestStoreScanResumeTSCache(t *testing.T) {
 	t3 := timeutil.Unix(4, 0)
 	manualClock.MustAdvanceTo(t3)
 	h.Timestamp = makeTS(t3.UnixNano(), 0)
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Header = h
 	ba.Add(getArgsString("a"), getArgsString("b"), getArgsString("c"))
 	br, pErr := store.TestSender().Send(ctx, ba)
@@ -2053,7 +2053,7 @@ func TestStoreSkipLockedTSCache(t *testing.T) {
 			// Read the span at t2 using a SkipLocked wait policy.
 			t2 := timeutil.Unix(3, 0)
 			manualClock.MustAdvanceTo(t2)
-			ba := roachpb.BatchRequest{}
+			ba := &roachpb.BatchRequest{}
 			ba.Timestamp = makeTS(t2.UnixNano(), 0)
 			ba.WaitPolicy = lock.WaitPolicy_SkipLocked
 			ba.Add(tc.reqs...)
@@ -2338,7 +2338,7 @@ func TestStoreScanMultipleIntents(t *testing.T) {
 	key1 := roachpb.Key("key00")
 	key10 := roachpb.Key("key09")
 	txn := newTransaction("test", key1, 1, store.cfg.Clock)
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	for i := 0; i < 10; i++ {
 		pArgs := putArgs(roachpb.Key(fmt.Sprintf("key%02d", i)), []byte("value"))
 		ba.Add(&pArgs)

--- a/pkg/kv/kvserver/stores.go
+++ b/pkg/kv/kvserver/stores.go
@@ -180,7 +180,7 @@ func (ls *Stores) GetReplicaForRangeID(
 // Send implements the client.Sender interface. The store is looked up from the
 // store map using the ID specified in the request.
 func (ls *Stores) Send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	br, writeBytes, pErr := ls.SendWithWriteBytes(ctx, ba)
 	writeBytes.Release()
@@ -213,7 +213,7 @@ func (wb *StoreWriteBytes) Release() {
 // SendWithWriteBytes is the implementation of Send with an additional
 // *StoreWriteBytes return value.
 func (ls *Stores) SendWithWriteBytes(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *StoreWriteBytes, *roachpb.Error) {
 	if err := ba.ValidateForEvaluation(); err != nil {
 		log.Fatalf(ctx, "invalid batch (%s): %s", ba, err)

--- a/pkg/kv/kvserver/txnwait/queue_test.go
+++ b/pkg/kv/kvserver/txnwait/queue_test.go
@@ -190,7 +190,7 @@ func TestMaybeWaitForPushWithContextCancellation(t *testing.T) {
 
 	var mockSender kv.SenderFunc
 	cfg := makeConfig(func(
-		ctx context.Context, ba roachpb.BatchRequest,
+		ctx context.Context, ba *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error) {
 		return mockSender(ctx, ba)
 	}, stopper)
@@ -203,7 +203,7 @@ func TestMaybeWaitForPushWithContextCancellation(t *testing.T) {
 
 	// Mock out responses to any QueryTxn requests.
 	mockSender = func(
-		ctx context.Context, ba roachpb.BatchRequest,
+		ctx context.Context, ba *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error) {
 		br := ba.CreateReply()
 		resp := br.Responses[0].GetInner().(*roachpb.QueryTxnResponse)
@@ -277,7 +277,7 @@ func TestPushersReleasedAfterAnyQueryTxnFindsAbortedTxn(t *testing.T) {
 	defer stopper.Stop(context.Background())
 	var mockSender kv.SenderFunc
 	cfg := makeConfig(func(
-		ctx context.Context, ba roachpb.BatchRequest,
+		ctx context.Context, ba *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error) {
 		return mockSender(ctx, ba)
 	}, stopper)
@@ -295,7 +295,7 @@ func TestPushersReleasedAfterAnyQueryTxnFindsAbortedTxn(t *testing.T) {
 	const numPushees = 3
 	var queryTxnCount int32
 	mockSender = func(
-		ctx context.Context, ba roachpb.BatchRequest,
+		ctx context.Context, ba *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error) {
 		br := ba.CreateReply()
 		resp := br.Responses[0].GetInner().(*roachpb.QueryTxnResponse)

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -21,7 +21,7 @@ import (
 // MockTransactionalSender allows a function to be used as a TxnSender.
 type MockTransactionalSender struct {
 	senderFunc func(
-		context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error)
 	txn roachpb.Transaction
 }
@@ -30,7 +30,7 @@ type MockTransactionalSender struct {
 // The passed in txn is cloned.
 func NewMockTransactionalSender(
 	f func(
-		context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error),
 	txn *roachpb.Transaction,
 ) *MockTransactionalSender {
@@ -39,7 +39,7 @@ func NewMockTransactionalSender(
 
 // Send is part of the TxnSender interface.
 func (m *MockTransactionalSender) Send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	return m.senderFunc(ctx, &m.txn, ba)
 }
@@ -237,7 +237,7 @@ func (m *MockTransactionalSender) HasPerformedWrites() bool {
 
 // MockTxnSenderFactory is a TxnSenderFactory producing MockTxnSenders.
 type MockTxnSenderFactory struct {
-	senderFunc func(context.Context, *roachpb.Transaction, roachpb.BatchRequest) (
+	senderFunc func(context.Context, *roachpb.Transaction, *roachpb.BatchRequest) (
 		*roachpb.BatchResponse, *roachpb.Error)
 	nonTxnSenderFunc Sender
 }
@@ -249,7 +249,7 @@ var _ TxnSenderFactory = MockTxnSenderFactory{}
 // function is responsible for putting the txn inside the batch, if needed.
 func MakeMockTxnSenderFactory(
 	senderFunc func(
-		context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error),
 ) MockTxnSenderFactory {
 	return MockTxnSenderFactory{
@@ -262,7 +262,7 @@ func MakeMockTxnSenderFactory(
 // requests.
 func MakeMockTxnSenderFactoryWithNonTxnSender(
 	senderFunc func(
-		context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, *roachpb.Error),
 	nonTxnSenderFunc SenderFunc,
 ) MockTxnSenderFactory {

--- a/pkg/kv/range_lookup.go
+++ b/pkg/kv/range_lookup.go
@@ -275,7 +275,7 @@ func lookupRangeFwdScan(
 		return nil, nil, errors.Wrap(err, "could not create scan bounds for range lookup")
 	}
 
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.ReadConsistency = rc
 	if prefetchReverse {
 		// Even if we're prefetching in the reverse direction, we still scan
@@ -368,7 +368,7 @@ func lookupRangeRevScan(
 		return nil, nil, errors.Wrap(err, "could not create scan bounds for reverse range lookup")
 	}
 
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.ReadConsistency = rc
 	ba.MaxSpanRequestKeys = maxKeys
 	ba.Add(&roachpb.ReverseScanRequest{
@@ -430,7 +430,7 @@ func kvsToRangeDescriptors(kvs []roachpb.KeyValue) ([]roachpb.RangeDescriptor, e
 // TestingIsRangeLookup returns if the provided BatchRequest looks like a single
 // RangeLookup scan. It can return false positives and should only be used in
 // tests.
-func TestingIsRangeLookup(ba roachpb.BatchRequest) bool {
+func TestingIsRangeLookup(ba *roachpb.BatchRequest) bool {
 	if ba.IsSingleRequest() {
 		return TestingIsRangeLookupRequest(ba.Requests[0].GetInner())
 	}

--- a/pkg/kv/range_lookup_test.go
+++ b/pkg/kv/range_lookup_test.go
@@ -50,7 +50,7 @@ func TestRangeLookupRaceSplits(t *testing.T) {
 	}
 
 	lookupKey := roachpb.Key("k")
-	assertRangeLookupScan := func(ba roachpb.BatchRequest) {
+	assertRangeLookupScan := func(ba *roachpb.BatchRequest) {
 		if len(ba.Requests) != 1 {
 			t.Fatalf("expected single request, found %v", ba)
 		}
@@ -79,7 +79,7 @@ func TestRangeLookupRaceSplits(t *testing.T) {
 		goodRes := newScanRespFromRangeDescriptors(&desc1AfterSplit)
 
 		attempt := 0
-		sender := SenderFunc(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+		sender := SenderFunc(func(_ context.Context, ba *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 			// Increment the attempt counter after each attempt.
 			defer func() {
 				attempt++
@@ -137,7 +137,7 @@ func TestRangeLookupRaceSplits(t *testing.T) {
 			}
 
 			attempt := 0
-			sender := SenderFunc(func(_ context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+			sender := SenderFunc(func(_ context.Context, ba *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
 				// Increment the attempt counter after each attempt.
 				defer func() {
 					attempt++

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -679,7 +679,7 @@ func (txn *Txn) commit(ctx context.Context) error {
 	// will be subject to admission control, and the zero CreateTime will give
 	// it preference within the tenant.
 	et := endTxnReq(true, txn.deadline())
-	ba := roachpb.BatchRequest{Requests: et.unionArr[:]}
+	ba := &roachpb.BatchRequest{Requests: et.unionArr[:]}
 	_, pErr := txn.Send(ctx, ba)
 	if pErr == nil {
 		for _, t := range txn.commitTriggers {
@@ -853,7 +853,7 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 		// settings, it will be subject to admission control, and the zero
 		// CreateTime will give it preference within the tenant.
 		et := endTxnReq(false, hlc.Timestamp{} /* deadline */)
-		ba := roachpb.BatchRequest{Requests: et.unionArr[:]}
+		ba := &roachpb.BatchRequest{Requests: et.unionArr[:]}
 		_, pErr := txn.Send(ctx, ba)
 		if pErr == nil {
 			return nil
@@ -879,7 +879,7 @@ func (txn *Txn) rollback(ctx context.Context) *roachpb.Error {
 		// settings, it will be subject to admission control, and the zero
 		// CreateTime will give it preference within the tenant.
 		et := endTxnReq(false, hlc.Timestamp{} /* deadline */)
-		ba := roachpb.BatchRequest{Requests: et.unionArr[:]}
+		ba := &roachpb.BatchRequest{Requests: et.unionArr[:]}
 		_ = contextutil.RunWithTimeout(ctx, "async txn rollback", asyncRollbackTimeout,
 			func(ctx context.Context) error {
 				if _, pErr := txn.Send(ctx, ba); pErr != nil {
@@ -1060,7 +1060,7 @@ func (txn *Txn) IsRetryableErrMeantForTxn(
 // commit or clean-up explicitly even when that may not be required
 // (or even erroneous). Returns (nil, nil) for an empty batch.
 func (txn *Txn) Send(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	// Fill in the GatewayNodeID on the batch if the txn knows it.
 	// NOTE(andrei): It seems a bit ugly that we're filling in the batches here as
@@ -1152,7 +1152,7 @@ func (txn *Txn) handleRetryableErrLocked(
 // and perform the read. Callers can use this flexibility to trade off increased
 // staleness for reduced latency.
 func (txn *Txn) NegotiateAndSend(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, *roachpb.Error) {
 	if err := txn.checkNegotiateAndSendPreconditions(ctx, ba); err != nil {
 		return nil, roachpb.NewError(err)
@@ -1215,7 +1215,7 @@ func (txn *Txn) NegotiateAndSend(
 
 // checks preconditions on BatchRequest and Txn for NegotiateAndSend.
 func (txn *Txn) checkNegotiateAndSendPreconditions(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (err error) {
 	assert := func(b bool, s string) {
 		if !b {

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -57,7 +57,7 @@ const (
 
 // SupportsBatch determines whether the methods in the provided batch
 // are supported by the ReadConsistencyType, returning an error if not.
-func (rc ReadConsistencyType) SupportsBatch(ba BatchRequest) error {
+func (rc ReadConsistencyType) SupportsBatch(ba *BatchRequest) error {
 	switch rc {
 	case CONSISTENT:
 		return nil

--- a/pkg/roachpb/api_test.go
+++ b/pkg/roachpb/api_test.go
@@ -13,7 +13,6 @@ package roachpb
 import (
 	"reflect"
 	"testing"
-	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -406,12 +405,4 @@ func TestFlagCombinations(t *testing.T) {
 			}
 		}
 	}
-}
-
-// TestBatchRequestSize asserts that the size of BatchRequest remains below 256
-// bytes. In #86541, we found that once the size reaches or exceeds this size,
-// end-to-end benchmarks observe a large (~10%) performance regression.
-func TestBatchRequestSize(t *testing.T) {
-	size := int(unsafe.Sizeof(BatchRequest{}))
-	require.Less(t, size, 256)
 }

--- a/pkg/roachpb/batch.go
+++ b/pkg/roachpb/batch.go
@@ -50,6 +50,12 @@ func (h Header) RequiredFrontier() hlc.Timestamp {
 	return h.Timestamp
 }
 
+// ShallowCopy returns a shallow copy of the receiver.
+func (ba *BatchRequest) ShallowCopy() *BatchRequest {
+	shallowCopy := *ba
+	return &shallowCopy
+}
+
 // SetActiveTimestamp sets the correct timestamp at which the request is to be
 // carried out. For transactional requests, ba.Timestamp must be zero initially
 // and it will be set to txn.ReadTimestamp (note though this mostly impacts

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -720,6 +720,7 @@ func makeInternalClientAdapter(
 		clientStreamInterceptors: clientStreamInterceptors,
 		serverStreamInterceptors: serverStreamInterceptors,
 		batchHandler: func(ctx context.Context, ba *roachpb.BatchRequest, opts ...grpc.CallOption) (*roachpb.BatchResponse, error) {
+			ba = ba.ShallowCopy()
 			// Mark this as originating locally, which is useful for the decision about
 			// memory allocation tracking.
 			ba.AdmissionHeader.SourceLocation = roachpb.AdmissionHeader_LOCAL

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3118,7 +3118,7 @@ func (s *adminServer) SendKVBatch(
 		}
 		sp.finish(br, redact)
 	}()
-	br, pErr := s.server.db.NonTransactionalSender().Send(ctx, *ba)
+	br, pErr := s.server.db.NonTransactionalSender().Send(ctx, ba)
 	if br == nil {
 		br = &roachpb.BatchResponse{}
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1112,7 +1112,7 @@ func (n *Node) batchInternal(
 		writeBytes.Release()
 	}()
 	var pErr *roachpb.Error
-	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, *args)
+	br, writeBytes, pErr = n.stores.SendWithWriteBytes(ctx, args)
 	if pErr != nil {
 		br = &roachpb.BatchResponse{}
 		log.VErrEventf(ctx, 3, "error from stores.Send: %s", pErr)

--- a/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
+++ b/pkg/server/systemconfigwatcher/systemconfigwatchertest/test_system_config_watcher.go
@@ -131,7 +131,7 @@ func getSystemDescriptorAndZonesSpans(
 	ctx context.Context, t *testing.T, codec keys.SQLCodec, kvDB *kv.DB,
 ) []roachpb.KeyValue {
 	scanSpanForRows := func(startKey, endKey roachpb.Key) (rows []roachpb.KeyValue) {
-		var ba roachpb.BatchRequest
+		ba := &roachpb.BatchRequest{}
 		ba.Add(
 			roachpb.NewScan(
 				append(codec.TenantPrefix(), startKey...),

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -271,7 +271,7 @@ func (ibm *IndexBackfillMerger) scan(
 			}
 			// For now just grab all of the destination KVs and merge the corresponding entries.
 			log.VInfof(ctx, 2, "scanning batch [%s, %s) at %v to merge", startKey, endKey, readAsOf)
-			var ba roachpb.BatchRequest
+			ba := &roachpb.BatchRequest{}
 			ba.TargetBytes = chunkBytes
 			if err := ibm.growBoundAccount(ctx, chunkBytes); err != nil {
 				return errors.Wrap(err, "failed to fetch keys to merge from temp index")

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -155,7 +155,7 @@ func TestTxnClearsCollectionOnRetry(t *testing.T) {
 	var serverArgs base.TestServerArgs
 	params := base.TestClusterArgs{ServerArgs: serverArgs}
 	params.ServerArgs.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, r roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, r *roachpb.BatchRequest) *roachpb.Error {
 			if r.Txn == nil || r.Txn.Name != txnName {
 				return nil
 			}

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -265,7 +265,7 @@ func startConnExecutor(
 	stopper := stop.NewStopper()
 	clock := hlc.NewClockWithSystemTimeSource(0 /* maxOffset */)
 	factory := kv.MakeMockTxnSenderFactory(
-		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		func(context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
 		})

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -584,7 +584,7 @@ func TestQueryProgress(t *testing.T) {
 				TableReaderBatchBytesLimit: 1500,
 			},
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(_ context.Context, req roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(_ context.Context, req *roachpb.BatchRequest) *roachpb.Error {
 					if req.IsSingleRequest() {
 						scan, ok := req.Requests[0].GetInner().(*roachpb.ScanRequest)
 						if ok && getTableSpan().ContainsKey(scan.Key) && atomic.LoadInt64(&queryRunningAtomic) == 1 {
@@ -795,7 +795,7 @@ func TestRetriableErrorDuringUpgradedTransaction(t *testing.T) {
 	testDB.QueryRow(t, "SELECT 'foo'::regclass::oid").Scan(&fooTableId)
 
 	// Inject an error that will happen during execution.
-	filter.setFilter(func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	filter.setFilter(func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if ba.Txn == nil {
 			return nil
 		}
@@ -872,7 +872,7 @@ func TestErrorDuringPrepareInExplicitTransactionPropagates(t *testing.T) {
 	require.NoError(t, err)
 
 	// Inject an error that will happen during planning.
-	filter.setFilter(func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	filter.setFilter(func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if ba.Txn == nil {
 			return nil
 		}
@@ -1131,7 +1131,7 @@ func TestTransactionDeadline(t *testing.T) {
 	// This will be used in the tests for accessing mu.
 	locked := func(f func()) { mu.Lock(); defer mu.Unlock(); f() }
 	// Set up a kvserverbase.ReplicaRequestFilter which will extract the deadline for the test transaction.
-	checkTransactionDeadlineFilter := func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	checkTransactionDeadlineFilter := func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if ba.Txn == nil {
 			return nil
 		}
@@ -1800,13 +1800,13 @@ func (f *dynamicRequestFilter) setFilter(filter kvserverbase.ReplicaRequestFilte
 
 // noopRequestFilter is a kvserverbase.ReplicaRequestFilter.
 func (f *dynamicRequestFilter) filter(
-	ctx context.Context, request roachpb.BatchRequest,
+	ctx context.Context, request *roachpb.BatchRequest,
 ) *roachpb.Error {
 	return f.v.Load().(kvserverbase.ReplicaRequestFilter)(ctx, request)
 }
 
 // noopRequestFilter is a kvserverbase.ReplicaRequestFilter that does nothing.
-func noopRequestFilter(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+func noopRequestFilter(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 	return nil
 }
 

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -527,7 +527,7 @@ func TestDistSQLFlowsVirtualTables(t *testing.T) {
 	params := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(_ context.Context, req roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(_ context.Context, req *roachpb.BatchRequest) *roachpb.Error {
 					if atomic.LoadInt64(&stallAtomic) == 1 {
 						if req.IsSingleRequest() {
 							scan, ok := req.Requests[0].GetInner().(*roachpb.ScanRequest)

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -1091,7 +1091,7 @@ WHERE
 		defer filterState.Unlock()
 		return filterState.txnID
 	}
-	rf.setFilter(func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+	rf.setFilter(func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 		if request.Txn == nil || request.Txn.Name != sql.SQLTxnName {
 			return nil
 		}
@@ -1130,7 +1130,7 @@ WHERE
 	// fail. We'll want to ensure that we get a retriable error. Use the below
 	// pattern to detect when the user transaction has finished planning and is
 	// now executing: we don't want to inject the error during planning.
-	rf.setFilter(func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+	rf.setFilter(func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 		if request.Txn == nil {
 			return nil
 		}

--- a/pkg/sql/gcjob_test/gc_job_test.go
+++ b/pkg/sql/gcjob_test/gc_job_test.go
@@ -278,7 +278,7 @@ func TestGCJobRetry(t *testing.T) {
 	params := base.TestServerArgs{Settings: cs}
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
-		TestingRequestFilter: func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+		TestingRequestFilter: func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 			r, ok := request.GetArg(roachpb.DeleteRange)
 			if !ok || !r.(*roachpb.DeleteRangeRequest).UseRangeTombstone {
 				return nil
@@ -551,7 +551,7 @@ func TestDropIndexWithDroppedDescriptor(t *testing.T) {
 		if !beforeDelRange {
 			knobs.Store = &kvserver.StoreTestingKnobs{
 				TestingRequestFilter: func(
-					ctx context.Context, request roachpb.BatchRequest,
+					ctx context.Context, request *roachpb.BatchRequest,
 				) *roachpb.Error {
 					req, ok := request.GetArg(roachpb.DeleteRange)
 					if !ok {

--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -639,7 +639,7 @@ func TestProcessorEncountersUncertaintyError(t *testing.T) {
 					Knobs: base.TestingKnobs{
 
 						Store: &kvserver.StoreTestingKnobs{
-							TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+							TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 								if atomic.LoadInt64(&trapRead) == 0 {
 									return nil
 								}

--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -7113,7 +7113,7 @@ func TestUDTChangeDuringImport(t *testing.T) {
 						JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 						Store: &kvserver.StoreTestingKnobs{
 							TestingResponseFilter: jobutils.BulkOpResponseFilter(&allowResponse),
-							TestingRequestFilter: func(ctx context.Context, br roachpb.BatchRequest) *roachpb.Error {
+							TestingRequestFilter: func(ctx context.Context, br *roachpb.BatchRequest) *roachpb.Error {
 								for _, ru := range br.Requests {
 									switch ru.GetInner().(type) {
 									case *roachpb.AddSSTableRequest:

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -209,7 +209,8 @@ func (n *insertFastPathNode) runFKChecks(params runParams) error {
 	defer n.run.fkBatch.Reset()
 
 	// Run the FK checks batch.
-	br, err := params.p.txn.Send(params.ctx, n.run.fkBatch)
+	ba := n.run.fkBatch.ShallowCopy()
+	br, err := params.p.txn.Send(params.ctx, ba)
 	if err != nil {
 		return err.GoError()
 	}

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -538,7 +538,7 @@ func (rf *Fetcher) StartInconsistentScan(
 		log.Infof(ctx, "starting inconsistent scan at timestamp %v", txnTimestamp)
 	}
 
-	sendFn := func(ctx context.Context, ba roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
+	sendFn := func(ctx context.Context, ba *roachpb.BatchRequest) (*roachpb.BatchResponse, error) {
 		if now := timeutil.Now(); now.Sub(txnTimestamp.GoTime()) >= maxTimestampAge {
 			// Time to bump the transaction. First commit the old one (should be a no-op).
 			if err := txn.Commit(ctx); err != nil {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -54,7 +54,7 @@ var defaultKVBatchSize = rowinfra.KeyLimit(util.ConstantWithMetamorphicTestValue
 // sendFunc is the function used to execute a KV batch; normally
 // wraps (*client.Txn).Send.
 type sendFunc func(
-	ctx context.Context, ba roachpb.BatchRequest,
+	ctx context.Context, ba *roachpb.BatchRequest,
 ) (*roachpb.BatchResponse, error)
 
 // identifiableSpans is a helper for keeping track of the roachpb.Spans with the
@@ -228,7 +228,7 @@ func (f *txnKVFetcher) getBatchKeyLimitForIdx(batchIdx int) rowinfra.KeyLimit {
 func makeKVBatchFetcherDefaultSendFunc(txn *kv.Txn, batchRequestsIssued *int64) sendFunc {
 	return func(
 		ctx context.Context,
-		ba roachpb.BatchRequest,
+		ba *roachpb.BatchRequest,
 	) (*roachpb.BatchResponse, error) {
 		res, err := txn.Send(ctx, ba)
 		if err != nil {
@@ -394,7 +394,7 @@ func (f *txnKVFetcher) SetupNextFetch(
 
 // fetch retrieves spans from the kv layer.
 func (f *txnKVFetcher) fetch(ctx context.Context) error {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.Header.WaitPolicy = f.lockWaitPolicy
 	ba.Header.LockTimeout = f.lockTimeout
 	ba.Header.TargetBytes = int64(f.batchBytesLimit)

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -80,7 +80,7 @@ func NewKVFetcher(
 		sendFn = makeKVBatchFetcherDefaultSendFunc(txn, &batchRequestsIssued)
 	} else {
 		negotiated := false
-		sendFn = func(ctx context.Context, ba roachpb.BatchRequest) (br *roachpb.BatchResponse, _ error) {
+		sendFn = func(ctx context.Context, ba *roachpb.BatchRequest) (br *roachpb.BatchResponse, _ error) {
 			ba.RoutingPolicy = roachpb.RoutingPolicy_NEAREST
 			var pErr *roachpb.Error
 			// Only use NegotiateAndSend if we have not yet negotiated a timestamp.

--- a/pkg/sql/rowexec/processors_test.go
+++ b/pkg/sql/rowexec/processors_test.go
@@ -459,7 +459,7 @@ func TestDrainingProcessorSwallowsUncertaintyError(t *testing.T) {
 				0: {
 					Knobs: base.TestingKnobs{
 						Store: &kvserver.StoreTestingKnobs{
-							TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+							TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 								if atomic.LoadInt64(&trapRead) == 0 {
 									return nil
 								}
@@ -634,7 +634,7 @@ func TestUncertaintyErrorIsReturned(t *testing.T) {
 			testClusterArgs.ServerArgsPerNode[node] = base.TestServerArgs{
 				Knobs: base.TestingKnobs{
 					Store: &kvserver.StoreTestingKnobs{
-						TestingRequestFilter: func(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+						TestingRequestFilter: func(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 							if atomic.LoadInt64(&trapRead) == 0 {
 								return nil
 							}

--- a/pkg/sql/run_control_test.go
+++ b/pkg/sql/run_control_test.go
@@ -868,8 +868,8 @@ func TestTenantStatementTimeoutAdmissionQueueCancelation(t *testing.T) {
 				TestingDisableSkipEnforcement: true,
 			},
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(ctx context.Context, req roachpb.BatchRequest) *roachpb.Error {
-					if matchBatch(ctx, &req) {
+				TestingRequestFilter: func(ctx context.Context, req *roachpb.BatchRequest) *roachpb.Error {
+					if matchBatch(ctx, req) {
 						// Notify we're blocking.
 						unblockClientCh <- struct{}{}
 						<-qBlockersCh

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -2139,7 +2139,7 @@ func (sp *spanKeyIterator) Next(ctx context.Context) (bool, error) {
 func (sp *spanKeyIterator) scan(
 	ctx context.Context, startKey roachpb.Key, endKey roachpb.Key,
 ) error {
-	var ba roachpb.BatchRequest
+	ba := &roachpb.BatchRequest{}
 	ba.TargetBytes = spanKeyIteratorChunkBytes
 	ba.MaxSpanRequestKeys = spanKeyIteratorChunkKeys
 	ba.Add(&roachpb.ScanRequest{

--- a/pkg/sql/sem/eval/timeconv_test.go
+++ b/pkg/sql/sem/eval/timeconv_test.go
@@ -48,7 +48,7 @@ func TestClusterTimestampConversion(t *testing.T) {
 
 	clock := hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */)
 	senderFactory := kv.MakeMockTxnSenderFactory(
-		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		func(context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			panic("unused")
 		})

--- a/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/compaction_test.go
@@ -475,7 +475,7 @@ func (k *kvScanInterceptor) disable() {
 	atomic.StoreInt32(&k.enabled, 0)
 }
 
-func (k *kvScanInterceptor) intercept(_ context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+func (k *kvScanInterceptor) intercept(_ context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 	if atomic.LoadInt32(&k.enabled) == 0 {
 		return nil
 	}

--- a/pkg/sql/stats/create_stats_job_test.go
+++ b/pkg/sql/stats/create_stats_job_test.go
@@ -487,7 +487,7 @@ func createStatsRequestFilter(
 ) (kvserverbase.ReplicaRequestFilter, func(descpb.ID)) {
 	var tableToBlock atomic.Value
 	tableToBlock.Store(descpb.InvalidID)
-	return func(ctx context.Context, ba roachpb.BatchRequest) *roachpb.Error {
+	return func(ctx context.Context, ba *roachpb.BatchRequest) *roachpb.Error {
 		if req, ok := ba.GetArg(roachpb.Scan); ok {
 			_, tableID, _ := encoding.DecodeUvarintAscending(req.(*roachpb.ScanRequest).Key)
 			// Ensure that the tableID is what we expect it to be.

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -583,7 +583,7 @@ func TestChangePollInterval(t *testing.T) {
 		Settings: settings,
 		Knobs: base.TestingKnobs{
 			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: func(ctx context.Context, request roachpb.BatchRequest) *roachpb.Error {
+				TestingRequestFilter: func(ctx context.Context, request *roachpb.BatchRequest) *roachpb.Error {
 					if request.Txn == nil {
 						return nil
 					}

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1157,7 +1157,7 @@ func TestReacquireLeaseOnRestart(t *testing.T) {
 	var s serverutils.TestServerInterface
 	var clockUpdate, restartDone int32
 	testingResponseFilter := func(
-		ctx context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse,
+		ctx context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse,
 	) *roachpb.Error {
 		for _, ru := range ba.Requests {
 			if req := ru.GetGet(); req != nil {

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -53,7 +53,7 @@ type testContext struct {
 func makeTestContext(stopper *stop.Stopper) testContext {
 	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 123)), time.Nanosecond /* maxOffset */)
 	factory := kv.MakeMockTxnSenderFactory(
-		func(context.Context, *roachpb.Transaction, roachpb.BatchRequest,
+		func(context.Context, *roachpb.Transaction, *roachpb.BatchRequest,
 		) (*roachpb.BatchResponse, *roachpb.Error) {
 			return nil, nil
 		})

--- a/pkg/sql/user_test.go
+++ b/pkg/sql/user_test.go
@@ -59,7 +59,7 @@ func TestGetUserTimeout(t *testing.T) {
 		close(closedCh)
 		unavailableCh.Store(closedCh)
 		knobs := &kvserver.StoreTestingKnobs{
-			TestingRequestFilter: func(ctx context.Context, _ roachpb.BatchRequest) *roachpb.Error {
+			TestingRequestFilter: func(ctx context.Context, _ *roachpb.BatchRequest) *roachpb.Error {
 				select {
 				case <-unavailableCh.Load().(chan struct{}):
 				case <-ctx.Done():

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -134,7 +134,7 @@ func RunJob(
 // related to bulk IO/backup/restore/import: Export, Import and AddSSTable. See
 // discussion on RunJob for where this might be useful.
 func BulkOpResponseFilter(allowProgressIota *chan struct{}) kvserverbase.ReplicaResponseFilter {
-	return func(_ context.Context, ba roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
+	return func(_ context.Context, ba *roachpb.BatchRequest, br *roachpb.BatchResponse) *roachpb.Error {
 		for _, ru := range br.Responses {
 			switch ru.GetInner().(type) {
 			case *roachpb.ExportResponse, *roachpb.AddSSTableResponse:

--- a/pkg/testutils/kvclientutils/txn_recovery.go
+++ b/pkg/testutils/kvclientutils/txn_recovery.go
@@ -73,7 +73,7 @@ func CheckPushResult(
 		// expire.
 		Force: true,
 	}
-	ba := roachpb.BatchRequest{}
+	ba := &roachpb.BatchRequest{}
 	ba.Add(&pushReq)
 
 	recCtx, collectRecAndFinish := tracing.ContextWithRecordingSpan(ctx, tr, "test trace")


### PR DESCRIPTION
This commit switches the omnipresent `Sender` interface from:
```go
type Sender interface {
	Send(context.Context, roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
}
```
to
```go
type Sender interface {
	Send(context.Context, *roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error)
}
```

In doing so, the entire KV layer (client-side and server-side) switches from passing `BatchRequest` objects by pointer instead of by value. These objects are over 200 bytes in size and are passed to hundreds of functions throughout the KV layer in service of a single request, so this is a dramatic reduction in memory copies. Furthermore, these objects were often already escaping to the heap in various intermediate stack frames, so this actually reduces heap allocations by being more deliberate about when we heap allocate and when we perform a shallow clone.

### Macro benchmarks
```
name                           old ops/s    new ops/s    delta
kv95/enc=false/nodes=3/cpu=32    120k ± 4%    122k ± 3%  +2.28%  (p=0.052 n=10+10)

name                           old avg(ms)  new avg(ms)  delta
kv95/enc=false/nodes=3/cpu=32    1.60 ± 0%    1.60 ± 0%    ~     (all equal)

name                           old p99(ms)  new p99(ms)  delta
kv95/enc=false/nodes=3/cpu=32    7.79 ± 4%    7.60 ± 0%  -2.44%  (p=0.013 n=10+8)
```

This commit is based on #86957. Together, they have the following impact on macro benchmark performance:
```
name                           old ops/s    new ops/s    delta
kv95/enc=false/nodes=3/cpu=32    109k ±10%    122k ± 3%  +12.35%  (p=0.000 n=10+10)

name                           old avg(ms)  new avg(ms)  delta
kv95/enc=false/nodes=3/cpu=32    1.79 ±12%    1.60 ± 0%  -10.61%  (p=0.000 n=10+8)

name                           old p99(ms)  new p99(ms)  delta
kv95/enc=false/nodes=3/cpu=32    8.53 ±17%    7.60 ± 0%  -10.90%  (p=0.000 n=10+8)
```

### Micro benchmarks
```
name                        old time/op    new time/op    delta
KV/Scan/Native/rows=1-10      17.1µs ± 1%    16.5µs ± 2%  -3.36%  (p=0.000 n=8+10)
KV/Update/Native/rows=1-10    66.9µs ± 2%    65.2µs ± 2%  -2.52%  (p=0.000 n=9+10)
KV/Insert/Native/rows=1-10    42.1µs ± 3%    41.3µs ± 3%  -1.95%  (p=0.015 n=10+10)
KV/Delete/Native/rows=1-10    41.9µs ± 3%    41.2µs ± 2%  -1.69%  (p=0.035 n=10+10)
KV/Insert/SQL/rows=1-10        125µs ± 2%     126µs ± 6%    ~     (p=0.631 n=10+10)
KV/Update/SQL/rows=1-10        171µs ± 4%     170µs ± 3%    ~     (p=0.579 n=10+10)
KV/Delete/SQL/rows=1-10        138µs ± 4%     138µs ± 4%    ~     (p=0.393 n=10+10)
KV/Scan/SQL/rows=1-10         94.4µs ± 4%    93.6µs ± 3%    ~     (p=0.579 n=10+10)

name                        old alloc/op   new alloc/op   delta
KV/Update/Native/rows=1-10    22.3kB ± 0%    21.6kB ± 0%  -2.83%  (p=0.000 n=9+10)
KV/Insert/Native/rows=1-10    15.8kB ± 0%    15.5kB ± 0%  -1.86%  (p=0.000 n=9+10)
KV/Delete/Native/rows=1-10    15.5kB ± 1%    15.2kB ± 0%  -1.83%  (p=0.000 n=10+10)
KV/Update/SQL/rows=1-10       51.6kB ± 0%    51.0kB ± 0%  -1.11%  (p=0.000 n=10+8)
KV/Insert/SQL/rows=1-10       44.8kB ± 0%    44.4kB ± 0%  -0.80%  (p=0.000 n=10+9)
KV/Scan/Native/rows=1-10      7.57kB ± 0%    7.52kB ± 0%  -0.70%  (p=0.000 n=9+10)
KV/Delete/SQL/rows=1-10       51.6kB ± 0%    51.3kB ± 0%  -0.54%  (p=0.000 n=10+10)
KV/Scan/SQL/rows=1-10         24.3kB ± 0%    24.3kB ± 0%  -0.14%  (p=0.009 n=8+10)

name                        old allocs/op  new allocs/op  delta
KV/Update/Native/rows=1-10       182 ± 0%       181 ± 0%  -0.89%  (p=0.000 n=9+10)
KV/Delete/Native/rows=1-10       127 ± 0%       126 ± 0%  -0.79%  (p=0.000 n=10+10)
KV/Insert/Native/rows=1-10       128 ± 0%       127 ± 0%  -0.78%  (p=0.000 n=9+10)
KV/Update/SQL/rows=1-10          521 ± 0%       519 ± 0%  -0.39%  (p=0.000 n=10+8)
KV/Delete/SQL/rows=1-10          386 ± 0%       385 ± 0%  -0.26%  (p=0.000 n=8+8)
KV/Insert/SQL/rows=1-10          359 ± 0%       359 ± 0%  -0.22%  (p=0.009 n=10+10)
KV/Scan/Native/rows=1-10        55.0 ± 0%      55.0 ± 0%    ~     (all equal)
KV/Scan/SQL/rows=1-10            281 ± 0%       281 ± 0%    ~     (all equal)
```

Epic: None.

Release justification: None. Don't merge until after the branch cut.