### PR TITLE
sql: miscellaneous improvements to reduce allocations

### DIFF
--- a/pkg/ccl/partitionccl/partition_test.go
+++ b/pkg/ccl/partitionccl/partition_test.go
@@ -1293,7 +1293,7 @@ func TestRepartitioning(t *testing.T) {
 				} else {
 					fmt.Fprintf(&repartition, `ALTER INDEX %s@%s `, test.new.parsed.tableName, testIndex.GetName())
 				}
-				if testIndex.GetPartitioning().NumColumns() == 0 {
+				if testIndex.PartitioningColumnCount() == 0 {
 					repartition.WriteString(`PARTITION BY NOTHING`)
 				} else {
 					if err := sql.ShowCreatePartitioning(

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -897,7 +897,7 @@ func addDefaultLocalityConfigToAllTables(
 func checkCanConvertTableToMultiRegion(
 	dbDesc catalog.DatabaseDescriptor, tableDesc catalog.TableDescriptor,
 ) error {
-	if tableDesc.GetPrimaryIndex().GetPartitioning().NumColumns() > 0 {
+	if tableDesc.GetPrimaryIndex().PartitioningColumnCount() > 0 {
 		return errors.WithDetailf(
 			pgerror.Newf(
 				pgcode.ObjectNotInPrerequisiteState,
@@ -909,7 +909,7 @@ func checkCanConvertTableToMultiRegion(
 		)
 	}
 	for _, idx := range tableDesc.AllIndexes() {
-		if idx.GetPartitioning().NumColumns() > 0 {
+		if idx.PartitioningColumnCount() > 0 {
 			return errors.WithDetailf(
 				pgerror.Newf(
 					pgcode.ObjectNotInPrerequisiteState,

--- a/pkg/sql/alter_index.go
+++ b/pkg/sql/alter_index.go
@@ -79,7 +79,7 @@ func (n *alterIndexNode) startExec(params runParams) error {
 					"cannot change the partitioning of an index if the table has PARTITION ALL BY defined",
 				)
 			}
-			if n.index.GetPartitioning().NumImplicitColumns() > 0 {
+			if n.index.ImplicitPartitioningColumnCount() > 0 {
 				return unimplemented.New(
 					"ALTER INDEX PARTITION BY",
 					"cannot ALTER INDEX PARTITION BY on an index which already has implicit column partitioning",

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1964,12 +1964,12 @@ func countIndexRowsAndMaybeCheckUniqueness(
 
 			// For implicitly partitioned unique indexes, we need to independently
 			// validate that the non-implicitly partitioned columns are unique.
-			if idx.IsUnique() && idx.GetPartitioning().NumImplicitColumns() > 0 && !skipUniquenessChecks {
+			if idx.IsUnique() && idx.ImplicitPartitioningColumnCount() > 0 && !skipUniquenessChecks {
 				if err := validateUniqueConstraint(
 					ctx,
 					tableDesc,
 					idx.GetName(),
-					idx.IndexDesc().KeyColumnIDs[idx.GetPartitioning().NumImplicitColumns():],
+					idx.IndexDesc().KeyColumnIDs[idx.ImplicitPartitioningColumnCount():],
 					idx.GetPredicate(),
 					ie,
 					txn,

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -154,6 +154,8 @@ type Index interface {
 	IsValidReferencedUniqueConstraint(referencedColIDs descpb.ColumnIDs) bool
 
 	GetPartitioning() Partitioning
+	PartitioningColumnCount() int
+	ImplicitPartitioningColumnCount() int
 
 	ExplicitColumnStartIdx() int
 

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -130,6 +130,24 @@ func (w index) GetPartitioning() catalog.Partitioning {
 	return &partitioning{desc: &w.desc.Partitioning}
 }
 
+// PartitioningColumnCount is how large of a prefix of the columns in an index
+// are used in the function mapping column values to partitions. If this is a
+// subpartition, this is offset to start from the end of the parent partition's
+// columns. If PartitioningColumnCount is 0, then there is no partitioning.
+func (w index) PartitioningColumnCount() int {
+	return int(w.desc.Partitioning.NumColumns)
+}
+
+// ImplicitPartitioningColumnCount specifies the number of columns that
+// implicitly prefix a given index. This occurs if a user specifies a PARTITION
+// BY which is not a prefix of the given index, in which case the KeyColumnIDs
+// are added in front of the index and this field denotes the number of columns
+// added as a prefix. If ImplicitPartitioningColumnCount is 0, no implicit
+// columns are defined for the index.
+func (w index) ImplicitPartitioningColumnCount() int {
+	return int(w.desc.Partitioning.NumImplicitColumns)
+}
+
 // ExplicitColumnStartIdx returns the first index in which the column is
 // explicitly part of the index.
 func (w index) ExplicitColumnStartIdx() int {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -418,7 +418,7 @@ func (desc *wrapper) validateInboundFK(
 
 func (desc *wrapper) matchingPartitionbyAll(indexI catalog.Index) bool {
 	primaryIndexPartitioning := desc.PrimaryIndex.KeyColumnIDs[:desc.PrimaryIndex.Partitioning.NumColumns]
-	indexPartitioning := indexI.IndexDesc().KeyColumnIDs[:indexI.GetPartitioning().NumColumns()]
+	indexPartitioning := indexI.IndexDesc().KeyColumnIDs[:indexI.PartitioningColumnCount()]
 	if len(primaryIndexPartitioning) != len(indexPartitioning) {
 		return false
 	}

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -441,12 +441,12 @@ func (p *planner) RevalidateUniqueConstraint(
 			if !index.IsUnique() {
 				return errors.Newf("%s is not a unique constraint", constraintName)
 			}
-			if index.GetPartitioning().NumImplicitColumns() > 0 {
+			if index.ImplicitPartitioningColumnCount() > 0 {
 				return validateUniqueConstraint(
 					ctx,
 					tableDesc,
 					index.GetName(),
-					index.IndexDesc().KeyColumnIDs[index.GetPartitioning().NumImplicitColumns():],
+					index.IndexDesc().KeyColumnIDs[index.ImplicitPartitioningColumnCount():],
 					index.GetPredicate(),
 					p.ExecCfg().InternalExecutor,
 					p.Txn(),
@@ -524,7 +524,7 @@ func (p *planner) IsConstraintActive(
 // constraints that are validated by RevalidateUniqueConstraintsInTable.
 func HasVirtualUniqueConstraints(tableDesc catalog.TableDescriptor) bool {
 	for _, index := range tableDesc.ActiveIndexes() {
-		if index.IsUnique() && index.GetPartitioning().NumImplicitColumns() > 0 {
+		if index.IsUnique() && index.ImplicitPartitioningColumnCount() > 0 {
 			return true
 		}
 	}
@@ -553,12 +553,12 @@ func RevalidateUniqueConstraintsInTable(
 ) error {
 	// Check implicitly partitioned UNIQUE indexes.
 	for _, index := range tableDesc.ActiveIndexes() {
-		if index.IsUnique() && index.GetPartitioning().NumImplicitColumns() > 0 {
+		if index.IsUnique() && index.ImplicitPartitioningColumnCount() > 0 {
 			if err := validateUniqueConstraint(
 				ctx,
 				tableDesc,
 				index.GetName(),
-				index.IndexDesc().KeyColumnIDs[index.GetPartitioning().NumImplicitColumns():],
+				index.IndexDesc().KeyColumnIDs[index.ImplicitPartitioningColumnCount():],
 				index.GetPredicate(),
 				ie,
 				txn,

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -379,21 +379,17 @@ func (r opResult) createDiskBackedSort(
 		// The input is already partially ordered. Use a chunks sorter to avoid
 		// loading all the rows into memory.
 		opName := opNamePrefix + "sort-chunks"
-		deselectorUnlimitedAllocator := colmem.NewAllocator(
-			ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, opName, processorID,
-			), factory,
+		accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+			ctx, flowCtx, opName, processorID, 2, /* numAccounts */
 		)
+		deselectorUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[0], factory)
 		var sortChunksMemAccount *mon.BoundAccount
 		sortChunksMemAccount, sorterMemMonitorName = args.MonitorRegistry.CreateMemAccountForSpillStrategyWithLimit(
 			ctx, flowCtx, spoolMemLimit, opName, processorID,
 		)
-		unlimitedMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-			ctx, flowCtx, opName, processorID,
-		)
 		inMemorySorter = colexec.NewSortChunks(
 			deselectorUnlimitedAllocator,
-			colmem.NewLimitedAllocator(ctx, sortChunksMemAccount, unlimitedMemAcc, factory),
+			colmem.NewLimitedAllocator(ctx, sortChunksMemAccount, accounts[1], factory),
 			input, inputTypes, ordering.Columns, int(matchLen), maxOutputBatchMemSize,
 		)
 	} else {
@@ -425,21 +421,15 @@ func (r opResult) createDiskBackedSort(
 		sorterMemMonitorName,
 		func(input colexecop.Operator) colexecop.Operator {
 			opName := opNamePrefix + "external-sorter"
-			// We are using unlimited memory monitors here because external
+			// We are using unlimited memory accounts here because external
 			// sort itself is responsible for making sure that we stay within
 			// the memory limit.
-			sortUnlimitedAllocator := colmem.NewAllocator(
-				ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(
-					ctx, flowCtx, opName+"-sort", processorID,
-				), factory)
-			mergeUnlimitedAllocator := colmem.NewAllocator(
-				ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(
-					ctx, flowCtx, opName+"-merge", processorID,
-				), factory)
-			outputUnlimitedAllocator := colmem.NewAllocator(
-				ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(
-					ctx, flowCtx, opName+"-output", processorID,
-				), factory)
+			accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+				ctx, flowCtx, opName, processorID, 3, /* numAccounts */
+			)
+			sortUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[0], factory)
+			mergeUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[1], factory)
+			outputUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[2], factory)
 			diskAccount := args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, opName, processorID)
 			es := colexecdisk.NewExternalSorter(
 				sortUnlimitedAllocator,
@@ -748,16 +738,14 @@ func NewColOperator(
 			// We have to create a separate account in order for the cFetcher to
 			// be able to precisely track the size of its output batch. This
 			// memory account is "streaming" in its nature, so we create an
-			// unlimited one.
-			cFetcherMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, "cfetcher" /* opName */, spec.ProcessorID,
-			)
-			kvFetcherMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, "kvfetcher" /* opName */, spec.ProcessorID,
+			// unlimited one. We also need another unlimited account for the
+			// KV fetcher.
+			accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+				ctx, flowCtx, "cfetcher" /* opName */, spec.ProcessorID, 2, /* numAccounts */
 			)
 			estimatedRowCount := spec.EstimatedRowCount
 			scanOp, err := colfetcher.NewColBatchScan(
-				ctx, colmem.NewAllocator(ctx, cFetcherMemAcc, factory), kvFetcherMemAcc,
+				ctx, colmem.NewAllocator(ctx, accounts[0], factory), accounts[1],
 				flowCtx, core.TableReader, post, estimatedRowCount, args.TypeResolver,
 			)
 			if err != nil {
@@ -775,17 +763,12 @@ func NewColOperator(
 			// We have to create a separate account in order for the cFetcher to
 			// be able to precisely track the size of its output batch. This
 			// memory account is "streaming" in its nature, so we create an
-			// unlimited one.
-			cFetcherMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, "cfetcher" /* opName */, spec.ProcessorID,
-			)
-			kvFetcherMemAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, "kvfetcher" /* opName */, spec.ProcessorID,
-			)
-			// We might use the Streamer API which requires a separate memory
-			// account that is bound to an unlimited memory monitor.
-			streamerBudgetAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-				ctx, flowCtx, "streamer" /* opName */, spec.ProcessorID,
+			// unlimited one. We also need another unlimited account for the
+			// KV fetcher. Additionally, we might use the Streamer API which
+			// requires yet another separate memory account that is bound to an
+			// unlimited memory monitor.
+			accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+				ctx, flowCtx, "index-join" /* opName */, spec.ProcessorID, 3, /* numAccounts */
 			)
 			streamerDiskMonitor := args.MonitorRegistry.CreateDiskMonitor(
 				ctx, flowCtx, "streamer" /* opName */, spec.ProcessorID,
@@ -794,8 +777,8 @@ func NewColOperator(
 			copy(inputTypes, spec.Input[0].ColumnTypes)
 			indexJoinOp, err := colfetcher.NewColIndexJoin(
 				ctx, getStreamingAllocator(ctx, args),
-				colmem.NewAllocator(ctx, cFetcherMemAcc, factory),
-				kvFetcherMemAcc, streamerBudgetAcc, flowCtx,
+				colmem.NewAllocator(ctx, accounts[0], factory),
+				accounts[1], accounts[2], flowCtx,
 				inputs[0].Root, core.JoinReader, post, inputTypes,
 				streamerDiskMonitor, args.TypeResolver,
 			)
@@ -873,11 +856,6 @@ func NewColOperator(
 
 			if needHash {
 				opName := redact.RedactableString("hash-aggregator")
-				outputUnlimitedAllocator := colmem.NewAllocator(
-					ctx,
-					args.MonitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName+"-output", spec.ProcessorID),
-					factory,
-				)
 				// We have separate unit tests that instantiate the in-memory
 				// hash aggregators, so we don't need to look at
 				// args.TestingKnobs.DiskSpillingDisabled and always instantiate
@@ -885,20 +863,20 @@ func NewColOperator(
 				diskSpillingDisabled := !colexec.HashAggregationDiskSpillingEnabled.Get(&flowCtx.Cfg.Settings.SV)
 				if diskSpillingDisabled {
 					// The disk spilling is disabled by the cluster setting, so
-					// we give an unlimited memory account to the in-memory
-					// hash aggregator and don't set up the disk spiller.
-					hashAggregatorUnlimitedMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
-						ctx, flowCtx, opName, spec.ProcessorID,
+					// we give unlimited memory accounts to the in-memory hash
+					// aggregator and all of its components and don't set up the
+					// disk spiller.
+					accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+						ctx, flowCtx, opName, spec.ProcessorID, 3, /* numAccounts */
 					)
-					hashTableUnlimitedMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
-						ctx, flowCtx, opName+"-hashtable", spec.ProcessorID,
-					)
+					hashAggregatorUnlimitedMemAccount := accounts[0]
 					newAggArgs.Allocator = colmem.NewAllocator(
 						ctx, hashAggregatorUnlimitedMemAccount, factory,
 					)
 					newAggArgs.MemAccount = hashAggregatorUnlimitedMemAccount
 					evalCtx.SingleDatumAggMemAccount = hashAggregatorUnlimitedMemAccount
-					hashTableAllocator := colmem.NewAllocator(ctx, hashTableUnlimitedMemAccount, factory)
+					hashTableAllocator := colmem.NewAllocator(ctx, accounts[1], factory)
+					outputUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[2], factory)
 					maxOutputBatchMemSize := execinfra.GetWorkMemLimit(flowCtx)
 					// The second argument is nil because we disable the
 					// tracking of the input tuples.
@@ -931,38 +909,40 @@ func NewColOperator(
 					hashTableMemAccount := args.MonitorRegistry.CreateExtraMemAccountForSpillStrategy(
 						string(hashAggregatorMemMonitorName),
 					)
-					spillingQueueMemMonitorName := hashAggregatorMemMonitorName + "-spilling-queue"
-					// We need to create a separate memory account for the
-					// spilling queue because it looks at how much memory it has
-					// already used in order to decide when to spill to disk.
-					spillingQueueMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
-						ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID,
+					// We need to create four unlimited memory accounts so that
+					// each component could track precisely its own usage. The
+					// components are
+					// - the hash aggregator
+					// - the hash table
+					// - output batch of the hash aggregator
+					// - the spilling queue for the input tuples tracking.
+					accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+						ctx, flowCtx, opName, spec.ProcessorID, 4, /* numAccounts */
 					)
-					hashAggUnlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-						ctx, flowCtx, opName, spec.ProcessorID,
-					)
-					newAggArgs.Allocator = colmem.NewLimitedAllocator(ctx, hashAggregatorMemAccount, hashAggUnlimitedAcc, factory)
+					newAggArgs.Allocator = colmem.NewLimitedAllocator(ctx, hashAggregatorMemAccount, accounts[0], factory)
 					newAggArgs.MemAccount = hashAggregatorMemAccount
-					hashTableUnlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-						ctx, flowCtx, opName, spec.ProcessorID,
-					)
-					hashTableAllocator := colmem.NewLimitedAllocator(ctx, hashTableMemAccount, hashTableUnlimitedAcc, factory)
+					hashTableAllocator := colmem.NewLimitedAllocator(ctx, hashTableMemAccount, accounts[1], factory)
 					inMemoryHashAggregator := colexec.NewHashAggregator(
 						newAggArgs,
 						&colexecutils.NewSpillingQueueArgs{
-							UnlimitedAllocator: colmem.NewAllocator(ctx, spillingQueueMemAccount, factory),
+							UnlimitedAllocator: colmem.NewAllocator(ctx, accounts[2], factory),
 							Types:              inputTypes,
 							MemoryLimit:        inputTuplesTrackingMemLimit,
 							DiskQueueCfg:       args.DiskQueueCfg,
 							FDSemaphore:        args.FDSemaphore,
-							DiskAcc:            args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, spillingQueueMemMonitorName, spec.ProcessorID),
+							DiskAcc: args.MonitorRegistry.CreateDiskAccount(
+								ctx, flowCtx, hashAggregatorMemMonitorName+"-spilling-queue", spec.ProcessorID,
+							),
 						},
 						hashTableAllocator,
-						outputUnlimitedAllocator,
+						colmem.NewAllocator(ctx, accounts[3], factory),
 						maxOutputBatchMemSize,
 					)
 					ehaOpName := redact.RedactableString("external-hash-aggregator")
-					ehaMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, ehaOpName, spec.ProcessorID)
+					ehaAccounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+						ctx, flowCtx, ehaOpName, spec.ProcessorID, 3, /* numAccounts */
+					)
+					ehaMemAccount := ehaAccounts[0]
 					// Note that we will use an unlimited memory account here
 					// even for the in-memory hash aggregator since it is easier
 					// to do so than to try to replace the memory account if the
@@ -982,10 +962,7 @@ func NewColOperator(
 							newAggArgs.Allocator = colmem.NewAllocator(ctx, ehaMemAccount, factory)
 							newAggArgs.MemAccount = ehaMemAccount
 							newAggArgs.Input = input
-							ehaHashTableMemAccount := args.MonitorRegistry.CreateUnlimitedMemAccount(
-								ctx, flowCtx, ehaOpName+"-hashtable", spec.ProcessorID,
-							)
-							ehaHashTableAllocator := colmem.NewAllocator(ctx, ehaHashTableMemAccount, factory)
+							ehaHashTableAllocator := colmem.NewAllocator(ctx, ehaAccounts[1], factory)
 							eha, toClose := colexecdisk.NewExternalHashAggregator(
 								flowCtx,
 								args,
@@ -993,12 +970,7 @@ func NewColOperator(
 								result.makeDiskBackedSorterConstructor(ctx, flowCtx, args, ehaOpName, factory),
 								args.MonitorRegistry.CreateDiskAccount(ctx, flowCtx, ehaOpName, spec.ProcessorID),
 								ehaHashTableAllocator,
-								// Note that here we can use the same allocator
-								// object as we passed to the in-memory hash
-								// aggregator because only one (either in-memory
-								// or external) operator will reach the output
-								// state.
-								outputUnlimitedAllocator,
+								colmem.NewAllocator(ctx, ehaAccounts[2], factory),
 								maxOutputBatchMemSize,
 							)
 							result.ToClose = append(result.ToClose, toClose)
@@ -1116,9 +1088,13 @@ func NewColOperator(
 				hashJoinerMemAccount, hashJoinerMemMonitorName := args.MonitorRegistry.CreateMemAccountForSpillStrategy(
 					ctx, flowCtx, opName, spec.ProcessorID,
 				)
-				hashJoinerUnlimitedAllocator := colmem.NewAllocator(
-					ctx, args.MonitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, spec.ProcessorID), factory,
+				// Create two unlimited memory accounts (one for the output
+				// batch and another for the "overdraft" accounting when
+				// spilling to disk occurs).
+				accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
+					ctx, flowCtx, opName, spec.ProcessorID, 2, /* numAccounts */
 				)
+				outputUnlimitedAllocator := colmem.NewAllocator(ctx, accounts[0], factory)
 				hjSpec := colexecjoin.MakeHashJoinerSpec(
 					core.HashJoiner.Type,
 					core.HashJoiner.LeftEqColumns,
@@ -1128,12 +1104,9 @@ func NewColOperator(
 					core.HashJoiner.RightEqColumnsAreKey,
 				)
 
-				hashJoinerUnlimitedAcc := args.MonitorRegistry.CreateUnlimitedMemAccount(
-					ctx, flowCtx, opName, spec.ProcessorID,
-				)
 				inMemoryHashJoiner := colexecjoin.NewHashJoiner(
-					colmem.NewLimitedAllocator(ctx, hashJoinerMemAccount, hashJoinerUnlimitedAcc, factory),
-					hashJoinerUnlimitedAllocator, hjSpec, inputs[0].Root, inputs[1].Root,
+					colmem.NewLimitedAllocator(ctx, hashJoinerMemAccount, accounts[1], factory),
+					outputUnlimitedAllocator, hjSpec, inputs[0].Root, inputs[1].Root,
 					colexecjoin.HashJoinerInitialNumBuckets,
 				)
 				if args.TestingKnobs.DiskSpillingDisabled {
@@ -1807,12 +1780,15 @@ func (r opResult) finishBufferedWindowerArgs(
 	needsBuffer bool,
 ) {
 	args.DiskAcc = monitorRegistry.CreateDiskAccount(ctx, flowCtx, opName, processorID)
-	mainAcc := monitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, processorID)
-	args.MainAllocator = colmem.NewAllocator(ctx, mainAcc, factory)
+	var mainAcc *mon.BoundAccount
 	if needsBuffer {
-		bufferAcc := monitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, processorID)
-		args.BufferAllocator = colmem.NewAllocator(ctx, bufferAcc, factory)
+		accounts := monitorRegistry.CreateUnlimitedMemAccounts(ctx, flowCtx, opName, processorID, 2 /* numAccounts */)
+		mainAcc = accounts[0]
+		args.BufferAllocator = colmem.NewAllocator(ctx, accounts[1], factory)
+	} else {
+		mainAcc = monitorRegistry.CreateUnlimitedMemAccount(ctx, flowCtx, opName, processorID)
 	}
+	args.MainAllocator = colmem.NewAllocator(ctx, mainAcc, factory)
 }
 
 func (r opResult) finishScanPlanning(op colfetcher.ScanOperator, resultTypes []*types.T) {

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -55,19 +55,18 @@ type OpWithMetaInfo struct {
 // NewColOperatorArgs is a helper struct that encompasses all of the input
 // arguments to NewColOperator call.
 type NewColOperatorArgs struct {
-	Spec                   *execinfrapb.ProcessorSpec
-	Inputs                 []OpWithMetaInfo
-	StreamingMemAccount    *mon.BoundAccount
-	StreamingMemAccFactory func() *mon.BoundAccount
-	ProcessorConstructor   execinfra.ProcessorConstructor
-	LocalProcessors        []execinfra.LocalProcessor
-	DiskQueueCfg           colcontainer.DiskQueueCfg
-	FDSemaphore            semaphore.Semaphore
-	ExprHelper             *ExprHelper
-	Factory                coldata.ColumnFactory
-	MonitorRegistry        *MonitorRegistry
-	TypeResolver           *descs.DistSQLTypeResolver
-	TestingKnobs           struct {
+	Spec                 *execinfrapb.ProcessorSpec
+	Inputs               []OpWithMetaInfo
+	StreamingMemAccount  *mon.BoundAccount
+	ProcessorConstructor execinfra.ProcessorConstructor
+	LocalProcessors      []execinfra.LocalProcessor
+	DiskQueueCfg         colcontainer.DiskQueueCfg
+	FDSemaphore          semaphore.Semaphore
+	ExprHelper           *ExprHelper
+	Factory              coldata.ColumnFactory
+	MonitorRegistry      *MonitorRegistry
+	TypeResolver         *descs.DistSQLTypeResolver
+	TestingKnobs         struct {
 		// SpillingCallbackFn will be called when the spilling from an in-memory
 		// to disk-backed operator occurs. It should only be set in tests.
 		SpillingCallbackFn func()

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -794,7 +794,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 	}
 	mmName := "hash-router-[" + streamIDs + "]"
 
-	hashRouterMemMonitor, accounts := s.monitorRegistry.CreateUnlimitedMemAccounts(ctx, flowCtx, mmName, len(output.Streams))
+	hashRouterMemMonitor, accounts := s.monitorRegistry.CreateUnlimitedMemAccountsWithName(ctx, flowCtx, mmName, len(output.Streams))
 	allocators := make([]*colmem.Allocator, len(output.Streams))
 	for i := range allocators {
 		allocators[i] = colmem.NewAllocator(ctx, accounts[i], factory)

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1171,12 +1171,9 @@ func (s *vectorizedFlowCreator) setupFlow(
 			}
 
 			args := &colexecargs.NewColOperatorArgs{
-				Spec:                pspec,
-				Inputs:              inputs,
-				StreamingMemAccount: s.monitorRegistry.NewStreamingMemAccount(flowCtx),
-				StreamingMemAccFactory: func() *mon.BoundAccount {
-					return s.monitorRegistry.NewStreamingMemAccount(flowCtx)
-				},
+				Spec:                 pspec,
+				Inputs:               inputs,
+				StreamingMemAccount:  s.monitorRegistry.NewStreamingMemAccount(flowCtx),
 				ProcessorConstructor: rowexec.NewProcessor,
 				LocalProcessors:      localProcessors,
 				DiskQueueCfg:         s.diskQueueCfg,
@@ -1223,7 +1220,7 @@ func (s *vectorizedFlowCreator) setupFlow(
 
 			if s.recordingStats {
 				newMonitors := s.monitorRegistry.GetMonitors()[numOldMonitors:]
-				if err := s.wrapWithVectorizedStatsCollectorBase(
+				if err = s.wrapWithVectorizedStatsCollectorBase(
 					&result.OpWithMetaInfo, result.KVReader, result.Columnarizer, inputs,
 					flowCtx.ProcessorComponentID(pspec.ProcessorID), newMonitors,
 				); err != nil {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -950,7 +950,7 @@ func (s *Server) newConnExecutor(
 			execTestingKnobs: s.GetExecutorConfig().TestingKnobs,
 		},
 		memMetrics: memMetrics,
-		planner:    planner{execCfg: s.cfg, alloc: &tree.DatumAlloc{}},
+		planner:    planner{execCfg: s.cfg},
 
 		// ctxHolder will be reset at the start of run(). We only define
 		// it here so that an early call to close() doesn't panic.
@@ -2428,7 +2428,7 @@ func (ex *connExecutor) execCopyIn(
 		cm, err = newFileUploadMachine(ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg, ex.state.mon)
 	} else {
 		// The planner will be prepared before use.
-		p := planner{execCfg: ex.server.cfg, alloc: &tree.DatumAlloc{}}
+		p := planner{execCfg: ex.server.cfg}
 		cm, err = newCopyMachine(
 			ctx, cmd.Conn, cmd.Stmt, &p, txnOpt, ex.state.mon,
 			// execInsertPlan

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -90,7 +90,7 @@ func newFileUploadMachine(
 	c := &copyMachine{
 		conn: conn,
 		// The planner will be prepared before use.
-		p: &planner{execCfg: execCfg, alloc: &tree.DatumAlloc{}},
+		p: &planner{execCfg: execCfg},
 	}
 	f = &fileUploadMachine{
 		c: c,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2750,7 +2750,7 @@ CREATE TABLE crdb_internal.create_statements (
 			createNofk = stmt
 		}
 		hasPartitions := nil != catalog.FindIndex(table, catalog.IndexOpts{}, func(idx catalog.Index) bool {
-			return idx.GetPartitioning().NumColumns() != 0
+			return idx.PartitioningColumnCount() != 0
 		})
 		return addRow(
 			dbDescID,

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -741,7 +741,7 @@ func (n *createIndexNode) startExec(params runParams) error {
 	// Avoid the warning if we have PARTITION ALL BY as all indexes will implicitly
 	// have relevant partitioning columns prepended at the front.
 	if n.n.PartitionByIndex == nil &&
-		n.tableDesc.GetPrimaryIndex().GetPartitioning().NumColumns() > 0 &&
+		n.tableDesc.GetPrimaryIndex().PartitioningColumnCount() > 0 &&
 		!n.tableDesc.IsPartitionAllBy() {
 		params.p.BufferClientNotice(
 			params.ctx,

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -533,7 +533,7 @@ func (n *createTableNode) startExec(params runParams) error {
 				params.ExecCfg().Codec,
 				desc.ImmutableCopy().(catalog.TableDescriptor),
 				desc.PublicColumns(),
-				params.p.alloc,
+				&tree.DatumAlloc{},
 				&params.ExecCfg().Settings.SV,
 				internal,
 				params.ExecCfg().GetRowMetrics(internal),

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -926,7 +926,7 @@ func ResolveFK(
 	referencedColNames := d.ToCols
 	// If no columns are specified, attempt to default to PK, ignoring implicit columns.
 	if len(referencedColNames) == 0 {
-		numImplicitCols := target.GetPrimaryIndex().GetPartitioning().NumImplicitColumns()
+		numImplicitCols := target.GetPrimaryIndex().ImplicitPartitioningColumnCount()
 		referencedColNames = make(
 			tree.NameList,
 			0,
@@ -2237,7 +2237,7 @@ func NewTableDesc(
 			if idx.NumKeyColumns() > 1 {
 				telemetry.Inc(sqltelemetry.MultiColumnInvertedIndexCounter)
 			}
-			if idx.GetPartitioning().NumColumns() != 0 {
+			if idx.PartitioningColumnCount() != 0 {
 				telemetry.Inc(sqltelemetry.PartitionedInvertedIndexCounter)
 			}
 		}

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -102,7 +102,7 @@ func (d *deleteRangeNode) startExec(params runParams) error {
 		params.ctx,
 		row.FetcherInitArgs{
 			WillUseCustomKVBatchFetcher: true,
-			Alloc:                       params.p.alloc,
+			Alloc:                       &tree.DatumAlloc{},
 			Spec:                        &spec,
 		},
 	); err != nil {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4121,74 +4121,82 @@ func checkScanParallelizationIfLocal(
 		// the scan parallelization.
 		return true, false
 	}
-	o := planObserver{
-		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
-			if prohibitParallelization {
-				return false, nil
-			}
-			switch n := plan.(type) {
-			case *distinctNode:
-				return true, nil
-			case *explainPlanNode:
-				// walkPlan doesn't recurse into explainPlanNode, so we have to
-				// manually walk over the wrapped plan.
-				plan := n.plan.WrappedPlan.(*planComponents)
-				prohibit, has := checkScanParallelizationIfLocal(ctx, plan)
-				prohibitParallelization = prohibitParallelization || prohibit
-				hasScanNodeToParallelize = hasScanNodeToParallelize || has
-				return false, nil
-			case *explainVecNode:
-				return true, nil
-			case *filterNode:
-				// Some filter expressions might be handled by falling back to
-				// the wrapped processors, so we choose to be safe.
-				prohibitParallelization = true
-				return false, nil
-			case *groupNode:
-				for _, f := range n.funcs {
-					prohibitParallelization = f.hasFilter()
-				}
-				return true, nil
-			case *indexJoinNode:
-				return true, nil
-			case *joinNode:
-				prohibitParallelization = n.pred.onCond != nil
-				return true, nil
-			case *limitNode:
-				return true, nil
-			case *ordinalityNode:
-				return true, nil
-			case *renderNode:
-				// Only support projections since render expressions might be
-				// handled via a wrapped row-by-row processor.
-				for _, e := range n.render {
-					if _, isIVar := e.(*tree.IndexedVar); !isIVar {
-						prohibitParallelization = true
-					}
-				}
-				return true, nil
-			case *scanNode:
-				if len(n.reqOrdering) == 0 && n.parallelize {
-					hasScanNodeToParallelize = true
-				}
-				return true, nil
-			case *sortNode:
-				return true, nil
-			case *unionNode:
-				return true, nil
-			case *valuesNode:
-				return true, nil
-			default:
-				prohibitParallelization = true
-				return false, nil
-			}
-		},
-	}
+	var c localScanParallelizationChecker
+	o := planObserver{enterNode: c.enterNode}
 	_ = walkPlan(ctx, plan.main.planNode, o)
 	for _, s := range plan.subqueryPlans {
 		_ = walkPlan(ctx, s.plan.planNode, o)
 	}
-	return prohibitParallelization, hasScanNodeToParallelize
+	return c.prohibitParallelization, c.hasScanNodeToParallelize
+}
+
+type localScanParallelizationChecker struct {
+	prohibitParallelization  bool
+	hasScanNodeToParallelize bool
+}
+
+func (c *localScanParallelizationChecker) enterNode(
+	ctx context.Context, _ string, plan planNode,
+) (bool, error) {
+	if c.prohibitParallelization {
+		return false, nil
+	}
+	switch n := plan.(type) {
+	case *distinctNode:
+		return true, nil
+	case *explainPlanNode:
+		// walkPlan doesn't recurse into explainPlanNode, so we have to manually
+		// walk over the wrapped plan.
+		plan := n.plan.WrappedPlan.(*planComponents)
+		prohibit, has := checkScanParallelizationIfLocal(ctx, plan)
+		c.prohibitParallelization = c.prohibitParallelization || prohibit
+		c.hasScanNodeToParallelize = c.hasScanNodeToParallelize || has
+		return false, nil
+	case *explainVecNode:
+		return true, nil
+	case *filterNode:
+		// Some filter expressions might be handled by falling back to the
+		// wrapped processors, so we choose to be safe.
+		c.prohibitParallelization = true
+		return false, nil
+	case *groupNode:
+		for _, f := range n.funcs {
+			c.prohibitParallelization = f.hasFilter()
+		}
+		return true, nil
+	case *indexJoinNode:
+		return true, nil
+	case *joinNode:
+		c.prohibitParallelization = n.pred.onCond != nil
+		return true, nil
+	case *limitNode:
+		return true, nil
+	case *ordinalityNode:
+		return true, nil
+	case *renderNode:
+		// Only support projections since render expressions might be handled
+		// via a wrapped row-by-row processor.
+		for _, e := range n.render {
+			if _, isIVar := e.(*tree.IndexedVar); !isIVar {
+				c.prohibitParallelization = true
+			}
+		}
+		return true, nil
+	case *scanNode:
+		if len(n.reqOrdering) == 0 && n.parallelize {
+			c.hasScanNodeToParallelize = true
+		}
+		return true, nil
+	case *sortNode:
+		return true, nil
+	case *unionNode:
+		return true, nil
+	case *valuesNode:
+		return true, nil
+	default:
+		c.prohibitParallelization = true
+		return false, nil
+	}
 }
 
 // NewPlanningCtx returns a new PlanningCtx. When distribute is false, a

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -226,11 +226,6 @@ type planner struct {
 	nameResolutionVisitor schemaexpr.NameResolutionVisitor
 	tableName             tree.TableName
 
-	// Use a common datum allocator across all the plan nodes. This separates the
-	// plan lifetime from the lifetime of returned results allowing plan nodes to
-	// be pool allocated.
-	alloc *tree.DatumAlloc
-
 	// optPlanningCtx stores the optimizer planning context, which contains
 	// data structures that can be reused between queries (for efficiency).
 	optPlanningCtx optPlanningCtx
@@ -347,7 +342,7 @@ func newInternalPlanner(
 		ts = readTimestamp.GoTime()
 	}
 
-	p := &planner{execCfg: execCfg, alloc: &tree.DatumAlloc{}}
+	p := &planner{execCfg: execCfg}
 
 	p.txn = txn
 	p.stmt = Statement{}

--- a/pkg/sql/planner_test.go
+++ b/pkg/sql/planner_test.go
@@ -25,7 +25,7 @@ func TestTypeAsString(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	p := planner{alloc: &tree.DatumAlloc{}}
+	p := planner{}
 	testData := []struct {
 		expr        tree.Expr
 		expected    string

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -339,9 +339,13 @@ func NewMonitorInheritWithLimit(
 	)
 }
 
+// noReserved is safe to be used by multiple monitors as the "reserved" account
+// since only its 'used' field will ever be read.
+var noReserved = BoundAccount{}
+
 // StartNoReserved is the same as Start when there is no pre-reserved budget.
 func (mm *BytesMonitor) StartNoReserved(ctx context.Context, pool *BytesMonitor) {
-	mm.Start(ctx, pool, &BoundAccount{})
+	mm.Start(ctx, pool, &noReserved)
 }
 
 // Start begins a monitoring region.
@@ -459,7 +463,9 @@ func (mm *BytesMonitor) doStop(ctx context.Context, check bool) {
 	mm.mu.curBudget.mon = nil
 
 	// Release the reserved budget to its original pool, if any.
-	mm.reserved.Clear(ctx)
+	if mm.reserved != &noReserved {
+		mm.reserved.Clear(ctx)
+	}
 }
 
 // MaximumBytes returns the maximum number of bytes that were allocated by this


### PR DESCRIPTION
See individual commits for details.

All 6 commits together provide the following improvement
```
name                                           old time/op    new time/op    delta
FlowSetup/vectorize=true/distribute=true-24       168µs ± 5%     162µs ± 5%  -3.56%  (p=0.000 n=20+20)
FlowSetup/vectorize=true/distribute=false-24      162µs ± 5%     159µs ± 3%  -1.89%  (p=0.028 n=17+19)
FlowSetup/vectorize=false/distribute=true-24      160µs ± 2%     162µs ± 5%    ~     (p=0.104 n=17+20)
FlowSetup/vectorize=false/distribute=false-24     156µs ± 4%     158µs ± 5%    ~     (p=0.057 n=19+19)

name                                           old alloc/op   new alloc/op   delta
FlowSetup/vectorize=true/distribute=true-24      18.9kB ± 2%    18.4kB ± 5%  -2.78%  (p=0.000 n=17+17)
FlowSetup/vectorize=true/distribute=false-24     17.7kB ± 2%    17.2kB ± 2%  -3.11%  (p=0.000 n=16+17)
FlowSetup/vectorize=false/distribute=true-24     25.4kB ± 1%    25.3kB ± 0%  -0.58%  (p=0.000 n=17+17)
FlowSetup/vectorize=false/distribute=false-24    24.3kB ± 0%    24.5kB ± 6%  +0.51%  (p=0.019 n=17+18)

name                                           old allocs/op  new allocs/op  delta
FlowSetup/vectorize=true/distribute=true-24         206 ± 2%       192 ± 2%  -6.35%  (p=0.000 n=20+20)
FlowSetup/vectorize=true/distribute=false-24        196 ± 2%       182 ± 2%  -7.17%  (p=0.000 n=18+19)
FlowSetup/vectorize=false/distribute=true-24        197 ± 0%       193 ± 0%  -2.03%  (p=0.000 n=16+17)
FlowSetup/vectorize=false/distribute=false-24       188 ± 0%       183 ± 1%  -2.63%  (p=0.000 n=17+16)
```

Release justification: low-risk improvement.

Release note: None