### PR TITLE
rowexec: close all ValueGenerators in the project set processor

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_tables_builtin
@@ -412,3 +412,18 @@ CREATE TABLE sc2.t (
     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
+
+# Regression test for not closing the ValueGenerators when they are recreated
+# multiple times (#85418).
+statement ok
+CREATE DATABASE db_85418_1;
+USE db_85418_1;
+CREATE TABLE t_85418_1();
+CREATE TABLE t_85418_2();
+CREATE DATABASE db_85418_2;
+USE db_85418_2;
+CREATE TABLE t_85418_1();
+CREATE TABLE t_85418_2();
+CREATE TABLE dbs_85418(db STRING);
+INSERT INTO dbs_85418 VALUES ('db_85418_1'), ('db_85418_2');
+SELECT crdb_internal.show_create_all_tables(db) FROM dbs_85418;

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -156,6 +156,13 @@ func (ps *projectSetProcessor) nextInputRow() (
 		if fn := ps.funcs[i]; fn != nil {
 			// A set-generating function. Prepare its ValueGenerator.
 
+			// First, make sure to close its ValueGenerator from the previous
+			// input row (if it exists).
+			if ps.gens[i] != nil {
+				ps.gens[i].Close(ps.Ctx)
+				ps.gens[i] = nil
+			}
+
 			// Set ExprHelper.row so that we can use it as an IndexedVarContainer.
 			ps.exprHelpers[i].Row = row
 


### PR DESCRIPTION
Previously, we forgot to close the value generators when a new input row
is read by the project set processor which could lead to leaking of the
resources. This is now fixed. Most of the value generators don't need to
release any resources, a few need to close their memory account
(previously this would result in a sentry report, but no actual leak
would occur in production builds), the only concerning one is
`crdb_internal.payloads_for_trace` where we would not close the
`InternalRows` iterator. But that seems like an internal debugging tool,
so most likely the users weren't impacted.

Fixes: #85418.

Release justification: bug fix.

Release note: None (It seems like in most cases the users would not see
the impact.)