### PR TITLE
sql: SHOW QUERIES lazily interpolates placeholders

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2140,6 +2140,7 @@ ActiveQuery represents a query in flight on some Session.
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
+| placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
 
 
 
@@ -2283,6 +2284,7 @@ ActiveQuery represents a query in flight on some Session.
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
 | plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
+| placeholders | [string](#cockroach.server.serverpb.ListSessionsResponse-string) | repeated | The placeholders if any. | [reserved](#support-status) |
 
 
 

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -916,6 +916,10 @@ message ActiveQuery {
   // The compressed plan that can be converted back into the statement's logical plan.
   // Empty if the statement is in the PREPARING state.
   string plan_gist = 12;
+
+  // The placeholders if any.
+  repeated string placeholders = 13;
+
 }
 
 // Request object for ListSessions and ListLocalSessions.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3177,12 +3177,16 @@ func (ex *connExecutor) serialize() serverpb.Session {
 		if query.hidden {
 			continue
 		}
-		ast, err := query.getStatement()
-		if err != nil {
-			continue
+		sqlNoConstants := truncateSQL(formatStatementHideConstants(query.stmt.AST))
+		nPlaceholders := 0
+		if query.placeholders != nil {
+			nPlaceholders = len(query.placeholders.Values)
 		}
-		sqlNoConstants := truncateSQL(formatStatementHideConstants(ast))
-		sql := truncateSQL(ast.String())
+		placeholders := make([]string, nPlaceholders)
+		for i := range placeholders {
+			placeholders[i] = tree.AsStringWithFlags(query.placeholders.Values[i], tree.FmtSimple)
+		}
+		sql := truncateSQL(query.stmt.SQL)
 		progress := math.Float64frombits(atomic.LoadUint64(&query.progressAtomic))
 		queryStart := query.start.UTC()
 		activeQueries = append(activeQueries, serverpb.ActiveQuery{
@@ -3192,7 +3196,8 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			ElapsedTime:    timeNow.Sub(queryStart),
 			Sql:            sql,
 			SqlNoConstants: sqlNoConstants,
-			SqlSummary:     formatStatementSummary(ast),
+			SqlSummary:     formatStatementSummary(query.stmt.AST),
+			Placeholders:   placeholders,
 			IsDistributed:  query.isDistributed,
 			Phase:          (serverpb.ActiveQuery_Phase)(query.phase),
 			Progress:       float32(progress),

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1928,10 +1928,11 @@ type queryMeta struct {
 	// The timestamp when this query began execution.
 	start time.Time
 
-	// The string of the SQL statement being executed. This string may
-	// contain sensitive information, so it must be converted back into
-	// an AST and dumped before use in logging.
-	rawStmt string
+	// The SQL statement being executed.
+	stmt parser.Statement
+
+	// The placeholders that the query was executed with if any.
+	placeholders *tree.PlaceholderInfo
 
 	// States whether this query is distributed. Note that all queries,
 	// including those that are distributed, have this field set to false until
@@ -1968,16 +1969,6 @@ type queryMeta struct {
 // associated stmt context.
 func (q *queryMeta) cancel() {
 	q.cancelQuery()
-}
-
-// getStatement returns a cleaned version of the query associated
-// with this queryMeta.
-func (q *queryMeta) getStatement() (tree.Statement, error) {
-	parsed, err := parser.ParseOne(q.rawStmt)
-	if err != nil {
-		return nil, err
-	}
-	return parsed.AST, nil
 }
 
 // SessionDefaults mirrors fields in Session, for restoring default

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -185,7 +185,6 @@ func (p *Parser) scanOneStmt() (sql string, tokens []sqlSymType, done bool) {
 			return p.scanner.In()[startPos:], tokens, true
 		}
 		preValID = lval.id
-		posBeforeScan := p.scanner.Pos()
 		tokens = append(tokens, sqlSymType{})
 		lval = &tokens[len(tokens)-1]
 		p.scanner.Scan(lval)
@@ -197,8 +196,13 @@ func (p *Parser) scanOneStmt() (sql string, tokens []sqlSymType, done bool) {
 			curFuncBodyCnt--
 		}
 		if lval.id == 0 || (curFuncBodyCnt == 0 && lval.id == ';') {
+			endPos := p.scanner.Pos()
+			if lval.id == ';' {
+				// Don't include the ending semicolon, if there is one, in the raw SQL.
+				endPos--
+			}
 			tokens = tokens[:len(tokens)-1]
-			return p.scanner.In()[startPos:posBeforeScan], tokens, (lval.id == 0)
+			return p.scanner.In()[startPos:endPos], tokens, (lval.id == 0)
 		}
 		lval.pos -= startPos
 	}

--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -43,6 +43,9 @@ type Statement struct {
 	// AST is the root of the AST tree for the parsed statement.
 	AST tree.Statement
 
+	// Comments is the list of parsed SQL comments.
+	Comments []string
+
 	// SQL is the original SQL from which the statement was parsed. Note that this
 	// is not appropriate for use in logging, as it may contain passwords and
 	// other sensitive data.
@@ -253,6 +256,7 @@ func (p *Parser) parse(
 	return Statement{
 		AST:             p.lexer.stmt,
 		SQL:             sql,
+		Comments:        p.scanner.Comments,
 		NumPlaceholders: p.lexer.numPlaceholders,
 		NumAnnotations:  p.lexer.numAnnotations,
 	}, nil

--- a/pkg/sql/parser/parse_internal_test.go
+++ b/pkg/sql/parser/parse_internal_test.go
@@ -44,7 +44,7 @@ func TestScanOneStmt(t *testing.T) {
 		{
 			sql: `SELECT 1 /* comment */  ; /* comment */  ; /* comment */ `,
 			exp: []stmt{{
-				sql: `SELECT 1`,
+				sql: `SELECT 1 /* comment */  `,
 				tok: []int{SELECT, ICONST},
 			}},
 		},
@@ -73,11 +73,11 @@ func TestScanOneStmt(t *testing.T) {
 			sql: ` ; /* x */ SELECT 1  ; SET /* y */ ; ;  INSERT INTO table;  ;`,
 			exp: []stmt{
 				{
-					sql: `SELECT 1`,
+					sql: `SELECT 1  `,
 					tok: []int{SELECT, ICONST},
 				},
 				{
-					sql: `SET`,
+					sql: `SET /* y */ `,
 					tok: []int{SET},
 				},
 				{

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -57,6 +57,9 @@ type Scanner struct {
 	in            string
 	pos           int
 	bytesPrealloc []byte
+
+	// Comments is the list of parsed comments from the SQL statement.
+	Comments []string
 }
 
 // In returns the input string.
@@ -453,6 +456,7 @@ func (s *Scanner) next() int {
 func (s *Scanner) skipWhitespace(lval ScanSymType, allowComments bool) (newline, ok bool) {
 	newline = false
 	for {
+		startPos := s.pos
 		ch := s.peek()
 		if ch == '\n' {
 			s.pos++
@@ -467,6 +471,8 @@ func (s *Scanner) skipWhitespace(lval ScanSymType, allowComments bool) (newline,
 			if present, cok := s.ScanComment(lval); !cok {
 				return false, false
 			} else if present {
+				// Mark down the comments that we found.
+				s.Comments = append(s.Comments, s.in[startPos:s.pos])
 				continue
 			}
 		}

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -726,6 +726,16 @@ func TestShowQueriesFillsInValuesForPlaceholders(t *testing.T) {
 			[]interface{}{"hello"},
 			"SELECT upper('hello')",
 		},
+		{
+			"SELECT /* test */ upper($1)",
+			[]interface{}{"hello"},
+			"SELECT upper('hello') /* test */",
+		},
+		{
+			"SELECT /* test */ 'hi'::string",
+			[]interface{}{},
+			"SELECT 'hi'::STRING /* test */",
+		},
 	}
 
 	// Perform both as a simple execution and as a prepared statement,
@@ -761,7 +771,14 @@ func TestShowQueriesFillsInValuesForPlaceholders(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				require.Equal(t, test.expected, recordedQueries[test.statement])
+				// parse and stringify the statement so that it matches the key in the
+				// recordedQueries map.
+				stmt, err := parser.ParseOne(test.statement)
+				if err != nil {
+					t.Fatal(err)
+				}
+				sql := stmt.AST.String()
+				require.Equal(t, test.expected, recordedQueries[sql])
 			})
 		}
 	}

--- a/pkg/sql/show_test.go
+++ b/pkg/sql/show_test.go
@@ -736,6 +736,11 @@ func TestShowQueriesFillsInValuesForPlaceholders(t *testing.T) {
 			[]interface{}{},
 			"SELECT 'hi'::STRING /* test */",
 		},
+		{
+			"SELECT /* test */ 'hi'::string /* fnord */",
+			[]interface{}{},
+			"SELECT 'hi'::STRING /* test */ /* fnord */",
+		},
 	}
 
 	// Perform both as a simple execution and as a prepared statement,


### PR DESCRIPTION
SHOW QUERIES (and crdb_internal.node_queries, cluster_queries)
interpolates placeholder values into the statement so that it is
possible to see the placeholder values of a prepared statement - but it
used to do this unconditionally during statement execution.

This is an expensive process that spends a lot of CPU for little reason,
since the interpolation was happening in the hot path of every query.

Now, we include the placeholder values as a separate array in the
internal representation of active queries, and interpolate the values
only when they're being pulled out to examine, to avoid the
unconditional runtime interpolation costs.

As a side effect of this change, the original comments in a query are
now included in SHOW QUERIES and the two active queries tables.

Release note (sql change): the query field in the
crdb_internal.node_queries, crdb_internal.cluster_queries, and SHOW
QUERIES commands now includes the original comments in the queries.

Informs CRDB-17299