### PR TITLE
ui: update sub-optimal label

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -144,7 +144,7 @@ const suboptimalPlanInsight = (execType: InsightExecEnum): Insight => {
     `due to outdated statistics or missing indexes.`;
   return {
     name: InsightNameEnum.suboptimalPlan,
-    label: "Suboptimal Plan",
+    label: "Sub-Optimal Plan",
     description: description,
     tooltipDescription:
       description + ` Click the ${execType} execution ID to see more details.`,


### PR DESCRIPTION
Update label from `Suboptimal Plan` to `Sub-Optimal Plan`.

Release justification: low risk change
Release note: None