### PR TITLE
sql: Prevent primary region being same as secondary region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -372,7 +372,7 @@ ALTER DATABASE db DROP SECONDARY REGION
 query T noticetrace
 ALTER DATABASE db DROP SECONDARY REGION IF EXISTS
 ----
- NOTICE: No secondary region is not defined on the database; skipping
+NOTICE: No secondary region is defined on the database; skipping
 
 
 query TT

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -52,6 +52,9 @@ CREATE TABLE db.rbt_in_primary() LOCALITY REGIONAL BY TABLE;
 statement ok
 ALTER DATABASE db ADD REGION "us-east-1"
 
+statement error pq: region .* is currently the secondary region
+ALTER DATABASE db SET PRIMARY REGION "ca-central-1"
+
 statement ok
 ALTER DATABASE db SET SECONDARY REGION "us-east-1"
 

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -736,6 +736,17 @@ func (n *alterDatabasePrimaryRegionNode) switchPrimaryRegion(params runParams) e
 		)
 	}
 
+	if prevRegionConfig.HasSecondaryRegion() && catpb.RegionName(n.n.PrimaryRegion) == prevRegionConfig.SecondaryRegion() {
+		return errors.WithHintf(
+			pgerror.Newf(pgcode.InvalidDatabaseDefinition,
+				"region %s is currently the secondary region",
+				n.n.PrimaryRegion.String(),
+			),
+			"you must drop the secondary region using ALTER DATABASE %s DROP SECONDARY REGION",
+			n.n.Name.String(),
+		)
+	}
+
 	// Get the type descriptor for the multi-region enum.
 	typeDesc, err := params.p.Descriptors().GetMutableTypeVersionByID(
 		params.ctx,

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -1898,7 +1898,7 @@ func (n *alterDatabaseDropSecondaryRegion) startExec(params runParams) error {
 		if n.n.IfExists {
 			params.p.BufferClientNotice(
 				params.ctx,
-				pgnotice.Newf("No secondary region is not defined on the database; skipping"),
+				pgnotice.Newf("No secondary region is defined on the database; skipping"),
 			)
 			return nil
 		}

--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -255,6 +255,10 @@ func (desc *immutable) validateMultiRegion(vea catalog.ValidationErrorAccumulato
 		vea.Report(errors.AssertionFailedf(
 			"primary region unset on a multi-region db %d", desc.GetID()))
 	}
+	if desc.RegionConfig.PrimaryRegion == desc.RegionConfig.SecondaryRegion {
+		vea.Report(errors.AssertionFailedf(
+			"primary region is same as secondary region on multi-region db %d", desc.GetID()))
+	}
 }
 
 // GetReferencedDescIDs returns the IDs of all descriptors referenced by


### PR DESCRIPTION
fixes #86879

We found that the primary region could be assigned the same region as the secondary region. This commit adds an error to prevent that.

Release justification: Low risk high benefit change to existing functionality
Release note: None