### PR TITLE
sql: fix TestTelemetryLogging test

### DIFF
--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -385,7 +385,7 @@ func (p *planner) maybeLogStatementInternal(
 		// We only log to the telemetry channel if enough time has elapsed from
 		// the last event emission.
 		requiredTimeElapsed := 1.0 / float64(maxEventFrequency)
-		_, tracingEnabled := p.curPlan.instrumentation.Tracing()
+		tracingEnabled := telemetryMetrics.isTracing(p.curPlan.instrumentation.Tracing())
 		// Always sample if the current statement is not of type DML or tracing
 		// is enabled for this statement.
 		if p.stmt.AST.StatementType() != tree.TypeDML || tracingEnabled {


### PR DESCRIPTION
Resolves: #86118

Previously, the `TestTelemetryLogging` test was failing due to a change
causing traced statements to always be sampled. This in turn caused a
discrepancy with the number of skipped queries we were expecting in
tests. This change fixes this bug by stubbing the tracing status of the
test case, allowing predictable numbers of skipped queries.

Release justification: bug fixes and low-risk updates to new
functionality

Release note: None