### PR TITLE
ui: fix high contention time details label

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -219,7 +219,7 @@ export function insightType(type: InsightType): string {
     case "ReplaceIndex":
       return "Replace Index";
     case "HighContentionTime":
-      return "High Wait Time";
+      return "High Contention Time";
     case "HighRetryCount":
       return "High Retry Counts";
     case "SuboptimalPlan":


### PR DESCRIPTION
Previously, the High Contention Time insight label was incorrectly High Wait Time. This commit fixes that typo.

Release justification: bug fix
Release note: None