### PR TITLE
changefeedccl: advance pts even in deprecated code when behind

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1372,10 +1372,30 @@ func (cf *changeFrontier) deprecatedMaybeReleaseProtectedTimestamp(
 	if progress.ProtectedTimestampRecord == uuid.Nil {
 		return nil
 	}
+
 	if !cf.frontier.schemaChangeBoundaryReached() && cf.isBehind() {
 		log.VEventf(ctx, 2, "not releasing protected timestamp because changefeed is behind")
+
+		// isBehind may be true for a very long time, so try updating the PTS record
+		// to the highwater every so often.
+		ptsUpdateInterval := changefeedbase.ProtectTimestampInterval.Get(&cf.flowCtx.Cfg.Settings.SV)
+		if timeutil.Since(cf.lastProtectedTimestampUpdate) < ptsUpdateInterval {
+			return nil
+		}
+		cf.lastProtectedTimestampUpdate = timeutil.Now()
+		recordID := progress.ProtectedTimestampRecord
+		highWater := cf.frontier.Frontier()
+		if highWater.Less(cf.highWaterAtStart) {
+			highWater = cf.highWaterAtStart
+		}
+		log.VEventf(ctx, 2, "updating protected timestamp %v at %v", recordID, highWater)
+		if err := pts.UpdateTimestamp(ctx, txn, recordID, highWater); err != nil {
+			return err
+		}
+
 		return nil
 	}
+
 	log.VEventf(ctx, 2, "releasing protected timestamp %v",
 		progress.ProtectedTimestampRecord)
 	if err := pts.Release(ctx, txn, progress.ProtectedTimestampRecord); err != nil {


### PR DESCRIPTION
Prior to active protected timestamps, the functionality had an issue
where a pts record could be stuck at the same timestamp in the past for
a very long time if the changefeed was constantly behind.

This change forwards the PTS record to the highwater mark even when
behind to avoid holding garbage we know we don't need.

Release justification: bug fix on deprecated code

Release note (bug fix): When
changefeed.active_protected_timestamps.enabled is false (the default
for <22.1), a changefeed that is constantly considered "Behind"
(according to changefeed.slow_span_log_threshold) will now advance its
protected timestamp record periodically rather than leaving it stuck
until the changefeed caught up.