### PR TITLE
pgwire: fix txn options for prepared BEGIN 

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -519,6 +519,11 @@ func (ex *connExecutor) execStmtInOpenState(
 	case *tree.BeginTransaction:
 		// BEGIN is only allowed if we are in an implicit txn.
 		if os.ImplicitTxn.Get() {
+			// When executing the BEGIN, we also need to set any transaction modes
+			// that were specified on the BEGIN statement.
+			if _, err := ex.planner.SetTransaction(ctx, &tree.SetTransaction{Modes: s.Modes}); err != nil {
+				return makeErrEvent(err)
+			}
 			ex.sessionDataStack.PushTopClone()
 			return eventTxnUpgradeToExplicit{}, nil, nil
 		}

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -1300,8 +1300,10 @@ func cookTag(
 		tag = strconv.AppendInt(tag, int64(rowsAffected), 10)
 
 	case tree.Rows:
-		tag = append(tag, ' ')
-		tag = strconv.AppendUint(tag, uint64(rowsAffected), 10)
+		if tagStr != "SHOW" {
+			tag = append(tag, ' ')
+			tag = strconv.AppendUint(tag, uint64(rowsAffected), 10)
+		}
 
 	case tree.Ack, tree.DDL:
 		if tagStr == "SELECT" {

--- a/pkg/sql/pgwire/testdata/pgtest/batch_stmt
+++ b/pkg/sql/pgwire/testdata/pgtest/batch_stmt
@@ -198,3 +198,101 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"text":"4"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 4"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SET enable_implicit_transaction_for_batch_statements = 'true'"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that READ ONLY can be configured by BEGIN in the middle of a batch.
+
+send
+Query {"String": "INSERT INTO mytable VALUES(5); BEGIN READ ONLY; COMMIT;"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Query {"String": "INSERT INTO mytable VALUES(6); BEGIN READ ONLY; INSERT INTO mytable VALUES(7); COMMIT;"}
+----
+
+until ignore=RowDescription
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ErrorResponse","Code":"25006"}
+{"Type":"ReadyForQuery","TxStatus":"E"}
+
+send
+Query {"String": "COMMIT"}
+Query {"String": "SELECT * FROM mytable WHERE a >= 5"}
+----
+
+until ignore=RowDescription
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"ROLLBACK"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"DataRow","Values":[{"text":"5"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that BEGIN AOST works in a batch statement. It isn't allowed if
+# writes were already performed.
+
+send crdb_only
+Query {"String": "INSERT INTO mytable VALUES(8); BEGIN AS OF SYSTEM TIME '-1us'; INSERT INTO mytable VALUES(9); COMMIT;"}
+----
+
+until crdb_only ignore=RowDescription
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ErrorResponse","Code":"25000"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SELECT * FROM mytable WHERE a >= 8"}
+----
+
+until crdb_only ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# If no reads/writes were performed, then the timestamp should change.
+
+let $orig_timestamp
+Query {"String": "SELECT now()::TIMESTAMPTZ"}
+----
+
+send crdb_only
+Query {"String": "SELECT 1; BEGIN AS OF SYSTEM TIME '-10s'; SELECT ('$orig_timestamp'::TIMESTAMPTZ - '9 seconds'::INTERVAL) > now(); COMMIT;"}
+----
+
+until crdb_only ignore=RowDescription
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"1"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/implicit_txn
+++ b/pkg/sql/pgwire/testdata/pgtest/implicit_txn
@@ -76,3 +76,78 @@ ReadyForQuery
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"ROLLBACK"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Verify that READ ONLY works on a prepared BEGIN statement.
+
+send
+Parse {"Name": "begin_read_only_stmt", "Query": "BEGIN READ ONLY"}
+Bind {"DestinationPortal": "p4", "PreparedStatement": "begin_read_only_stmt"}
+Execute {"Portal": "p4"}
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send
+Query {"String": "SHOW transaction_read_only"}
+Query {"String": "COMMIT"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"RowDescription","Fields":[{"Name":"transaction_read_only","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
+{"Type":"DataRow","Values":[{"text":"on"}]}
+{"Type":"CommandComplete","CommandTag":"SHOW"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+
+# Verify that READ ONLY AS OF SYSTEM TIME works on a prepared BEGIN statement.
+
+let $orig_timestamp
+Query {"String": "SELECT now()::TIMESTAMPTZ"}
+----
+
+send crdb_only
+Parse {"Name": "begin_read_only_aost_stmt", "Query": "BEGIN READ ONLY AS OF SYSTEM TIME '-10s'"}
+Bind {"DestinationPortal": "p5", "PreparedStatement": "begin_read_only_aost_stmt"}
+Execute {"Portal": "p5"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"BEGIN"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+
+send crdb_only
+Query {"String": "SHOW transaction_read_only"}
+Query {"String": "SELECT ('$orig_timestamp'::TIMESTAMPTZ - '9 seconds'::INTERVAL) > now()"}
+Query {"String": "COMMIT"}
+----
+
+until ignore=RowDescription crdb_only
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"DataRow","Values":[{"text":"on"}]}
+{"Type":"CommandComplete","CommandTag":"SHOW"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"DataRow","Values":[{"text":"t"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"T"}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/pgwire/testdata/pgtest/set
+++ b/pkg/sql/pgwire/testdata/pgtest/set
@@ -23,16 +23,7 @@ send
 Query {"String": "SHOW custom_option.session_setting"}
 ----
 
-# CockroachDB has the command tag SHOW 1, but postgres uses SHOW.
-until crdb_only
-ReadyForQuery
-----
-{"Type":"RowDescription","Fields":[{"Name":"custom_option.session_setting","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}
-{"Type":"DataRow","Values":[{"text":"abc"}]}
-{"Type":"CommandComplete","CommandTag":"SHOW 1"}
-{"Type":"ReadyForQuery","TxStatus":"I"}
-
-until noncrdb_only
+until
 ReadyForQuery
 ----
 {"Type":"RowDescription","Fields":[{"Name":"custom_option.session_setting","TableOID":0,"TableAttributeNumber":0,"DataTypeOID":25,"DataTypeSize":-1,"TypeModifier":-1,"Format":0}]}


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/87012

Release note (bug fix): The statement tag for SHOW command
results in the pgwire protocol no longer contain the number of returned
rows.

Release note (bug fix): Fixed a bug where the options given to the BEGIN
TRANSACTION command would be ignored if the BEGIN was a prepared
statement.

Release justification: low risk bug fix