### PR TITLE
sql: fix exporting of events to Obs Service

### DIFF
--- a/pkg/obs/event_exporter.go
+++ b/pkg/obs/event_exporter.go
@@ -34,6 +34,8 @@ import (
 // implemented by EventsServer.
 type EventsExporter interface {
 	// SendEvent buffers an event to be sent to subscribers.
+	//
+	// SendEvent does not block. If the buffer is full, old events are dropped.
 	SendEvent(ctx context.Context, typ obspb.EventType, event otel_logs_pb.LogRecord)
 }
 

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -565,7 +565,7 @@ func insertEventRecords(
 	if txn != nil && syncWrites {
 		// Yes, do it now.
 		query, args, otelEvents := prepareEventWrite(ctx, execCfg, entries)
-		txn.AddCommitTrigger(func(ctx context.Context) { sendOtelEvents(ctx, execCfg, otelEvents) })
+		txn.AddCommitTrigger(func(ctx context.Context) { sendEventsToObsService(ctx, execCfg, otelEvents) })
 		return writeToSystemEventsTable(ctx, execCfg.InternalExecutor, txn, len(entries), query, args)
 	}
 	// No: do them async.
@@ -607,15 +607,14 @@ func asyncWriteToOtelAndSystemEventsTable(
 			ctx = logtags.AddTags(ctx, logtags.FromContext(origCtx))
 
 			// Stop writing the event when the server shuts down.
-			stopCtx, stopCancel := stopper.WithCancelOnQuiesce(ctx)
+			ctx, stopCancel := stopper.WithCancelOnQuiesce(ctx)
 			defer stopCancel()
-			ctx = stopCtx
 
 			// Prepare the data to send.
 			query, args, otelEvents := prepareEventWrite(ctx, execCfg, entries)
 
-			// Export to OpenTelemetry.
-			sendOtelEvents(ctx, execCfg, otelEvents)
+			// Send to the Obs Service.
+			sendEventsToObsService(ctx, execCfg, otelEvents)
 
 			// We use a retry loop in case there are transient
 			// non-retriable errors on the cluster during the table write.
@@ -644,21 +643,11 @@ func asyncWriteToOtelAndSystemEventsTable(
 	}
 }
 
-func sendOtelEvents(ctx context.Context, execCfg *ExecutorConfig, events []otel_logs_pb.LogRecord) {
-	// Export to OpenTelemetry.
-	// We use another async task here so that a clogged Otel output pipe
-	// cannot hinder the system table write below.
-	if err := execCfg.RPCContext.Stopper.RunAsyncTask(ctx, "send-otel", func(ctx context.Context) {
-		for i := range events {
-			select {
-			case <-ctx.Done():
-				return
-			default:
-			}
-			execCfg.EventsExporter.SendEvent(ctx, obspb.EventlogEvent, events[i])
-		}
-	}); err != nil {
-		log.Warningf(ctx, "error spawning task to send otel events: %v", err)
+func sendEventsToObsService(
+	ctx context.Context, execCfg *ExecutorConfig, events []otel_logs_pb.LogRecord,
+) {
+	for i := range events {
+		execCfg.EventsExporter.SendEvent(ctx, obspb.EventlogEvent, events[i])
 	}
 }
 


### PR DESCRIPTION
In #86174, exporting of events to the Obs Service was doubly-decoupled
from the SQL statement causing the event: it ran in an async task inside
another async task. The inner task was given a context canceled when the
outer task finished - thus introducing a race causing the event to not
be passed along. This was caught by TestEventIngestionIntegration
flakiness.
The second task was unnecessary. Its purpose was to shield the caller
from slow communication with the Obs Service, but the client library
being used already does that (it's non-blocking).

Release note: None
Release justification: bug fix, test flakiness