### PR TITLE
roachtest: ensure to use the same random seed when enabling assertions

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -21,12 +21,10 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
@@ -94,13 +92,12 @@ func registerSQLSmith(r registry.Registry) {
 		rng, seed := randutil.NewTestRand()
 		t.L().Printf("seed: %d", seed)
 
-		// With 50% chance use the cockroach-short binary that was compiled with
-		// --crdb_test build tag.
-		maybeUseBuildWithEnabledAssertions(ctx, t, c, rng, 0.5)
 		if err := c.PutLibraries(ctx, "./lib"); err != nil {
 			t.Fatalf("could not initialize libraries: %v", err)
 		}
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+		// With 50% chance use the cockroach-short binary that was compiled with
+		// --crdb_test build tag.
+		maybeUseBuildWithEnabledAssertions(ctx, t, c, rng, 0.5 /* eaProb */)
 
 		setupFunc, ok := setups[setupName]
 		if !ok {


### PR DESCRIPTION
We've recently merged a change to run sqlsmith roachtest using a binary
compiled with enabled assertions. However, each node in the cluster
would start out with a different random seed, so some assumptions could
be violated. This is now fixed by starting all nodes in the cluster with
the same `COCKROACH_RANDOM_SEED`.

Fixes: #86982.

Release justification: test-only change.

Release note: None