### PR TITLE
release-22.1: upgrade/upgrades: downgrade precondition validation failure

### DIFF
--- a/pkg/migration/migrations/BUILD.bazel
+++ b/pkg/migration/migrations/BUILD.bazel
@@ -47,6 +47,8 @@ go_library(
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",

--- a/pkg/migration/migrations/precondition_before_starting_an_upgrade_external_test.go
+++ b/pkg/migration/migrations/precondition_before_starting_an_upgrade_external_test.go
@@ -99,10 +99,10 @@ func TestPreconditionBeforeStartingAnUpgrade(t *testing.T) {
 		// Attempt to upgrade the cluster version and expect to see a failure
 		_, err := sqlDB.Exec(`SET CLUSTER SETTING version = $1`, v1.String())
 		require.Error(t, err, "upgrade should be refused because precondition is violated.")
-		require.Equal(t, "pq: internal error: verifying precondition for version 21.2-2: There exists invalid "+
-			"descriptors as listed below. Fix these descriptors before attempting to upgrade again.\n"+
-			"Invalid descriptor: defaultdb.public.t (52) because 'relation \"t\" (52): invalid depended-on-by relation "+
-			"back reference: referenced table ID 53: referenced descriptor not found'", err.Error())
+		require.Equal(t, "pq: verifying precondition for version 21.2-2: "+
+			"there exists invalid descriptors as listed below; fix these descriptors before attempting to upgrade again:\n"+
+			"invalid descriptor: defaultdb.public.t (52) because 'relation \"t\" (52): invalid depended-on-by relation back reference: referenced table ID 53: referenced descriptor not found'",
+			err.Error())
 		// The cluster version should remain at `v0`.
 		tdb.CheckQueryResults(t, "SHOW CLUSTER SETTING version", [][]string{{v0.String()}})
 	})


### PR DESCRIPTION
Backport 1/1 commits from #86665.

/cc @cockroachdb/release

---

The assertion failure lead to sentry reports we did not want to see.

Backport will address #85952. 

Release justification: For backport.

Release note: None
