### PR TITLE
roachpb: clarify parameter name in ConstructStatementFingerprintID

### DIFF
--- a/pkg/roachpb/app_stats.go
+++ b/pkg/roachpb/app_stats.go
@@ -19,15 +19,15 @@ import (
 // StmtFingerprintID is the type of a Statement's fingerprint ID.
 type StmtFingerprintID uint64
 
-// ConstructStatementFingerprintID constructs an ID by hashing an anonymized query, its database
-// and failure status, and if it was part of an implicit txn. At the time of writing,
-// these are the axis' we use to bucket queries for stats collection
-// (see stmtKey).
+// ConstructStatementFingerprintID constructs an ID by hashing query with
+// constants redacted, its database and failure status, and if it was part of an
+// implicit txn. At the time of writing, these are the axis' we use to bucket
+// queries for stats collection (see stmtKey).
 func ConstructStatementFingerprintID(
-	anonymizedStmt string, failed bool, implicitTxn bool, database string,
+	stmtNoConstants string, failed bool, implicitTxn bool, database string,
 ) StmtFingerprintID {
 	fnv := util.MakeFNV64()
-	for _, c := range anonymizedStmt {
+	for _, c := range stmtNoConstants {
 		fnv.Add(uint64(c))
 	}
 	for _, c := range database {


### PR DESCRIPTION
"anonymizedStmt" is incorrect here -- the value passed in should be a
query with constants removed, but identifiers present.

Release note: None

Release justification: low risk change