### PR TITLE
server: skip TestDatabasesTablesV2 under race

### DIFF
--- a/pkg/server/api_v2_sql_schema_test.go
+++ b/pkg/server/api_v2_sql_schema_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -61,6 +62,7 @@ func TestUsersV2(t *testing.T) {
 
 func TestDatabasesTablesV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.UnderRaceWithIssue(t, 87074, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testCluster := serverutils.StartNewTestCluster(t, 3, base.TestClusterArgs{})


### PR DESCRIPTION
Refs: #87074

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None