### PR TITLE
kvserver: export per-store metric for number of invalid leases #84656

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -60,6 +60,12 @@ var (
 		Measurement: "Replicas",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRaftLeaderInValidLeaseCount = metric.Metadata{
+		Name:        "replicas.leaders_invalid_leases",
+		Help:        "Number of replicas that are Raft leaders which have invalid leases",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaLeaseHolderCount = metric.Metadata{
 		Name:        "replicas.leaseholders",
 		Help:        "Number of lease holders",
@@ -2138,6 +2144,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReservedReplicaCount:          metric.NewGauge(metaReservedReplicaCount),
 		RaftLeaderCount:               metric.NewGauge(metaRaftLeaderCount),
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
+		RaftLeaderInValidLeaseCount: metric.NewGauge(metaRaftLeaderInValidLeaseCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
 		UninitializedCount:            metric.NewGauge(metaUninitializedCount),

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1614,6 +1614,7 @@ type StoreMetrics struct {
 	ReservedReplicaCount          *metric.Gauge
 	RaftLeaderCount               *metric.Gauge
 	RaftLeaderNotLeaseHolderCount *metric.Gauge
+	RaftLeaderInValidLeaseCount   *metric.Gauge
 	LeaseHolderCount              *metric.Gauge
 	QuiescentCount                *metric.Gauge
 	UninitializedCount            *metric.Gauge

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2144,7 +2144,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		ReservedReplicaCount:          metric.NewGauge(metaReservedReplicaCount),
 		RaftLeaderCount:               metric.NewGauge(metaRaftLeaderCount),
 		RaftLeaderNotLeaseHolderCount: metric.NewGauge(metaRaftLeaderNotLeaseHolderCount),
-		RaftLeaderInValidLeaseCount: metric.NewGauge(metaRaftLeaderInValidLeaseCount),
+		RaftLeaderInValidLeaseCount:   metric.NewGauge(metaRaftLeaderInValidLeaseCount),
 		LeaseHolderCount:              metric.NewGauge(metaLeaseHolderCount),
 		QuiescentCount:                metric.NewGauge(metaQuiescentCount),
 		UninitializedCount:            metric.NewGauge(metaUninitializedCount),

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3126,6 +3126,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 		leaseExpirationCount          int64
 		leaseEpochCount               int64
 		raftLeaderNotLeaseHolderCount int64
+		raftLeaderInValidLeaseCount   int64
 		quiescentCount                int64
 		uninitializedCount            int64
 		averageQueriesPerSecond       float64
@@ -3171,6 +3172,9 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 			raftLeaderCount++
 			if metrics.LeaseValid && !metrics.Leaseholder {
 				raftLeaderNotLeaseHolderCount++
+			}
+			if !metrics.LeaseValid {
+				raftLeaderInValidLeaseCount++
 			}
 		}
 		if metrics.Leaseholder {
@@ -3242,6 +3246,7 @@ func (s *Store) updateReplicationGauges(ctx context.Context) error {
 
 	s.metrics.RaftLeaderCount.Update(raftLeaderCount)
 	s.metrics.RaftLeaderNotLeaseHolderCount.Update(raftLeaderNotLeaseHolderCount)
+	s.metrics.RaftLeaderInValidLeaseCount.Update(raftLeaderInValidLeaseCount)
 	s.metrics.LeaseHolderCount.Update(leaseHolderCount)
 	s.metrics.LeaseExpirationCount.Update(leaseExpirationCount)
 	s.metrics.LeaseEpochCount.Update(leaseEpochCount)


### PR DESCRIPTION
Added metric of number of invalid leases per Store. 
@irfansharif 

Release justification: low-risk.
Release note: None