### PR TITLE
kvcoord: heartbeat immediately to avoid being considered expired

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -47,6 +47,7 @@ go_library(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient/rangecache",
         "//pkg/kv/kvserver/concurrency/lock",
+        "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant",
         "//pkg/multitenant/tenantcostmodel",
         "//pkg/roachpb",

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvbase"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -31,6 +32,18 @@ import (
 // will be abandoned when the timeout expires. We generally want to clean up if
 // possible, but not at any cost, so we set it high at 1 minute.
 const abortTxnAsyncTimeout = time.Minute
+
+// heartbeatTxnBufferPeriod is a buffer period used to determine when to start
+// the heartbeat loop for the transaction. If the first locking operation
+// occurs within this buffer period of expiration of the transaction, the
+// transaction heartbeat should happen immediately, otherwise the heartbeat
+// loop should start (at the latest) by this buffer period prior to the
+// expiration. The buffer period should ensure that it is not possible
+// for intents to be written prior to the transaction being considered expired.
+// This attempts to avoid a transaction being considered expired (due to
+// lacking a transaction record) by another pushing transaction that encounters
+// its intents, as this will result in the transaction being aborted.
+const heartbeatTxnBufferPeriod = 200 * time.Millisecond
 
 // txnHeartbeater is a txnInterceptor in charge of a transaction's heartbeat
 // loop. Transaction coordinators heartbeat their transaction record
@@ -291,10 +304,28 @@ func (h *txnHeartbeater) startHeartbeatLoopLocked(ctx context.Context) {
 	// caller's cancelation or span.
 	hbCtx, hbCancel := context.WithCancel(h.AnnotateCtx(context.Background()))
 
-	// Delay spawning the loop goroutine until the first loopInterval passes, to
+	// If, by the time heartbeatTxnBufferPeriod has passed, this transaction would
+	// be considered expired, then synchronously attempt to heartbeat immediately
+	// before spawning the loop.
+	heartbeatLoopDelay := h.loopInterval
+	if txnwait.IsExpired(
+		h.clock.Now().Add(heartbeatTxnBufferPeriod.Nanoseconds(), 0 /* logical */),
+		h.mu.txn,
+	) {
+		log.VEventf(ctx, 2, "heartbeating immediately to avoid expiration")
+		h.heartbeatLocked(ctx)
+	} else {
+		timeUntilExpiry := txnwait.TxnExpiration(h.mu.txn).GoTime().Sub(h.clock.Now().GoTime())
+		if (timeUntilExpiry - heartbeatTxnBufferPeriod) < heartbeatLoopDelay {
+			log.VEventf(ctx, 2, "scheduling heartbeat early to avoid expiration")
+			heartbeatLoopDelay = timeUntilExpiry - heartbeatTxnBufferPeriod
+		}
+	}
+	// Delay spawning the loop goroutine until the first loopInterval passes or
+	// until a defined buffer period prior to expiration (whichever is first) to
 	// avoid the associated cost for small write transactions. In benchmarks,
 	// this gave a 3% throughput increase for point writes at high concurrency.
-	timer := time.AfterFunc(h.loopInterval, func() {
+	timer := time.AfterFunc(heartbeatLoopDelay, func() {
 		const taskName = "kv.TxnCoordSender: heartbeat loop"
 		var span *tracing.Span
 		hbCtx, span = h.AmbientContext.Tracer.StartSpanCtx(hbCtx, taskName)
@@ -362,22 +393,29 @@ func (h *txnHeartbeater) heartbeatLoop(ctx context.Context) {
 	}
 }
 
-// heartbeat sends a HeartbeatTxnRequest to the txn record.
-// Returns true if heartbeating should continue, false if the transaction is no
-// longer Pending and so there's no point in heartbeating further.
+// heartbeat is a convenience method to be called by the heartbeat loop, acquiring
+// the mutex and issuing a request using heartbeatLocked before releasing it.
+// See comment on heartbeatLocked for more explanation.
 func (h *txnHeartbeater) heartbeat(ctx context.Context) bool {
 	// Like with the TxnCoordSender, the locking here is peculiar. The lock is not
-	// held continuously throughout this method: we acquire the lock here and
-	// then, inside the wrapped.Send() call, the interceptor at the bottom of the
-	// stack will unlock until it receives a response.
+	// held continuously throughout the heartbeatLocked method: we acquire the
+	// lock here and then, inside the wrapped.Send() call, the interceptor at the
+	// bottom of the stack will unlock until it receives a response.
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// The heartbeat loop might have raced with the cancelation of the heartbeat.
+	// The heartbeat loop might have raced with the cancellation of the heartbeat.
 	if ctx.Err() != nil {
 		return false
 	}
 
+	return h.heartbeatLocked(ctx)
+}
+
+// heartbeatLocked sends a HeartbeatTxnRequest to the txn record.
+// Returns true if heartbeating should continue, false if the transaction is no
+// longer Pending and so there's no point in heartbeating further.
+func (h *txnHeartbeater) heartbeatLocked(ctx context.Context) bool {
 	if h.mu.txn.Status != roachpb.PENDING {
 		if h.mu.txn.Status == roachpb.COMMITTED {
 			log.Fatalf(ctx, "txn committed but heartbeat loop hasn't been signaled to stop: %s", h.mu.txn)

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater_test.go
@@ -16,7 +16,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -210,6 +212,185 @@ func TestTxnHeartbeaterLoopStartedOnFirstLock(t *testing.T) {
 		waitForHeartbeatLoopToStop(t, &th)
 		require.True(t, th.mu.loopStarted) // still set
 	})
+}
+
+// Tests that the txnHeartbeater only starts its heartbeat loop immediately
+// (upon observing a request that will acquire locks) when the transaction
+// would otherwise be considered expired. Otherwise, the loop starts after a
+// delay of one interval, or potentially sooner using a 200ms buffer period.
+// E.g. with default heartbeat interval of 1s, and expiration at 5 intervals:
+// 0-3.8s: heartbeat starts after interval
+// 3.8s-4.8s: heartbeat starts by expiration-buffer (by 4.8s)
+// 4.8s-onwards: heartbeat starts immediately.
+func TestTxnHeartbeaterLoopStartsBeforeExpiry(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Represents the time at which the heartbeat loop should begin.
+	type HeartbeatLoopExpectation int
+	const (
+		StartImmediately HeartbeatLoopExpectation = iota
+		StartBeforeInterval
+		StartAfterInterval
+	)
+
+	for _, test := range []struct {
+		lockingRequestDelay time.Duration
+		consideredExpired   bool
+		loopStarts          HeartbeatLoopExpectation
+	}{
+		{
+			// No delay prior to first locking request. Heartbeat after loopInterval.
+			consideredExpired: false,
+			loopStarts:        StartAfterInterval,
+		},
+		{
+			// First locking request happens before expiration, but more than
+			// loopInterval+buffer from expiration. Heartbeat after loopInterval.
+			lockingRequestDelay: 3*time.Second + 799*time.Millisecond,
+			consideredExpired:   false,
+			loopStarts:          StartAfterInterval,
+		},
+		{
+			// First locking request happens before expiration, but less than
+			// loopInterval+buffer from expiration. Heartbeat before loopInterval.
+			lockingRequestDelay: 4*time.Second + 500*time.Millisecond,
+			consideredExpired:   false,
+			loopStarts:          StartBeforeInterval,
+		},
+		{
+			// First locking request happens before expiration, but less than buffer
+			// from expiration. Heartbeat immediately.
+			lockingRequestDelay: 5*time.Second - 100*time.Millisecond,
+			consideredExpired:   false,
+			loopStarts:          StartImmediately,
+		},
+		{
+			// First locking request happens at expiration. Heartbeat immediately.
+			lockingRequestDelay: 5 * time.Second,
+			consideredExpired:   true,
+			loopStarts:          StartImmediately,
+		},
+		{
+			// First locking request happens after expiration. Heartbeat immediately.
+			lockingRequestDelay: 10 * time.Second,
+			consideredExpired:   true,
+			loopStarts:          StartImmediately,
+		},
+	} {
+		t.Run(fmt.Sprintf("delay=%s", test.lockingRequestDelay), func(t *testing.T) {
+			ctx := context.Background()
+			txn := makeTxnProto()
+
+			manualTime := timeutil.NewManualTime(timeutil.Unix(0, 123))
+			clock := hlc.NewClock(manualTime, time.Nanosecond)
+			txn.MinTimestamp, txn.WriteTimestamp = clock.Now(), clock.Now()
+
+			// We attempt to simulate a transaction that heartbeats every 1s, however
+			// it is important to note that a transaction is considered expired when it
+			// has a LastActive timestamp older than 5X the default interval of 1 second.
+			heartbeatInterval := base.DefaultTxnHeartbeatInterval
+			manualTime.Advance(test.lockingRequestDelay)
+
+			var th txnHeartbeater
+			mockSender, mockGatekeeper := &mockLockedSender{}, &mockLockedSender{}
+			th.init(
+				log.MakeTestingAmbientCtxWithNewTracer(),
+				stop.NewStopper(),
+				clock,
+				new(TxnMetrics),
+				heartbeatInterval,
+				mockGatekeeper,
+				new(syncutil.Mutex),
+				&txn,
+			)
+			th.setWrapped(mockSender)
+			defer th.stopper.Stop(ctx)
+
+			th.mu.Lock()
+			require.False(t, th.mu.loopStarted)
+			require.False(t, th.heartbeatLoopRunningLocked())
+			th.mu.Unlock()
+
+			count := 0
+			mockGatekeeper.MockSend(func(ba roachpb.BatchRequest) (*roachpb.BatchResponse, *roachpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				require.IsType(t, &roachpb.HeartbeatTxnRequest{}, ba.Requests[0].GetInner())
+
+				hbReq := ba.Requests[0].GetInner().(*roachpb.HeartbeatTxnRequest)
+				require.Equal(t, &txn, ba.Txn)
+				require.Equal(t, roachpb.Key(txn.Key), hbReq.Key)
+
+				// Check that this transaction isn't already considered expired.
+				if !test.consideredExpired && txnwait.IsExpired(clock.Now(), ba.Txn) {
+					return nil, roachpb.NewError(errors.New("transaction expired before heartbeat"))
+				}
+
+				log.Infof(ctx, "received heartbeat request")
+				count++
+
+				br := ba.CreateReply()
+				br.Txn = ba.Txn
+				return br, nil
+			})
+
+			// Validate that, if delayed, this transaction would be considered expired by now.
+			require.Equal(t, test.consideredExpired, txnwait.IsExpired(clock.Now(), &txn))
+
+			// The heartbeat loop is started on the first locking request, in this case
+			// a GetForUpdate request.
+			var ba roachpb.BatchRequest
+			ba.Header = roachpb.Header{Txn: txn.Clone()}
+			keyA := roachpb.Key("a")
+			keyAHeader := roachpb.RequestHeader{Key: keyA}
+			ba.Add(&roachpb.GetRequest{RequestHeader: keyAHeader, KeyLocking: lock.Exclusive})
+
+			br, pErr := th.SendLocked(ctx, ba)
+			require.Nil(t, pErr)
+			require.NotNil(t, br)
+
+			th.mu.Lock()
+			require.True(t, th.mu.loopStarted)
+			require.True(t, th.heartbeatLoopRunningLocked())
+			if test.loopStarts == StartImmediately {
+				// In the case where we'd already be considered expired, we want to
+				// ensure the transaction heartbeats synchronously, before there are
+				// locks for some other transaction to push (after their 50ms liveness
+				// push delay).
+				require.Positivef(t, count, "expected heartbeat before starting loop")
+			}
+			th.mu.Unlock()
+
+			if test.loopStarts == StartBeforeInterval {
+				// Ensure that we heartbeat before the full interval in the case where
+				// we are within the buffer period of one full loop interval from expiry.
+				testutils.SucceedsWithin(t, func() error {
+					th.mu.Lock()
+					defer th.mu.Unlock()
+					if count < 1 {
+						return errors.Errorf("waiting for more heartbeat requests, found %d", count)
+					}
+					return nil
+				}, heartbeatInterval)
+			}
+
+			// Ensure that we get a heartbeat before we are considered expired,
+			// even if starting the loop after one heartbeat interval has passed.
+			if !test.consideredExpired {
+				expiration := time.Duration(5) * heartbeatInterval
+				testutils.SucceedsWithin(t, func() error {
+					th.mu.Lock()
+					defer th.mu.Unlock()
+					require.True(t, th.mu.loopStarted)
+					require.True(t, th.heartbeatLoopRunningLocked())
+					if count < 1 {
+						return errors.Errorf("waiting for more heartbeat requests, found %d", count)
+					}
+					return nil
+				}, expiration)
+			}
+		})
+	}
 }
 
 // TestTxnHeartbeaterLoopStartedFor1PC tests that the txnHeartbeater


### PR DESCRIPTION
This changes the `txnHeartbeater` to modify when we start our heartbeat
loop in some cases. Previously, we would start the heartbeat loop (which
writes the transaction record) one heartbeat interval (default 1s) after
the first request in the transaction that acquires locks. In the case
that more than 5 heartbeat intervals have passed since the first read in
the transaction by the time that we encounter the first locking request,
however, any other operations that encounter the locks and attempt to
push (before the transaction heartbeats) will consider this transaction
to be expired. To avoid this situation, this changes the interceptor to
heartbeat immediately if the transaction would otherwise be considered
expired before its first heartbeat interval.

Release note (bug fix): Fixes a race condition where some operations
waiting on locks can cause the lockholder transaction to be aborted
if they occur before the transaction can write its record.

Release justification: Bug fix.