### PR TITLE
release-22.1: sql: add COPY to sampled_query logging

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -650,12 +650,12 @@ func (s *Server) GetBytesMonitor() *mon.BytesMonitor {
 //
 // Args:
 // args: The initial session parameters. They are validated by SetupConn
-//   and an error is returned if this validation fails.
+// and an error is returned if this validation fails.
 // stmtBuf: The incoming statement for the new connExecutor.
 // clientComm: The interface through which the new connExecutor is going to
-//   produce results for the client.
+// produce results for the client.
 // memMetrics: The metrics that statements executed on this connection will
-//   contribute to.
+// contribute to.
 func (s *Server) SetupConn(
 	ctx context.Context,
 	args SessionArgs,
@@ -1729,7 +1729,7 @@ func (ex *connExecutor) sessionData() *sessiondata.SessionData {
 // Args:
 // parentMon: The root monitor.
 // reserved: Memory reserved for the connection. The connExecutor takes
-//   ownership of this memory.
+// ownership of this memory.
 func (ex *connExecutor) activate(
 	ctx context.Context, parentMon *mon.BytesMonitor, reserved mon.BoundAccount,
 ) {
@@ -2338,8 +2338,6 @@ func isCopyToExternalStorage(cmd CopyIn) bool {
 func (ex *connExecutor) execCopyIn(
 	ctx context.Context, cmd CopyIn,
 ) (_ fsm.Event, retPayload fsm.EventPayload, retErr error) {
-	logStatements := logStatementsExecuteEnabled.Get(ex.planner.execCfg.SV())
-
 	ex.incrementStartedStmtCounter(cmd.Stmt)
 	defer func() {
 		if retErr == nil && !payloadHasError(retPayload) {
@@ -2349,10 +2347,6 @@ func (ex *connExecutor) execCopyIn(
 			log.SqlExec.Errorf(ctx, "error executing %s: %+v", cmd, retErr)
 		}
 	}()
-
-	if logStatements {
-		log.SqlExec.Infof(ctx, "executing %s", cmd)
-	}
 
 	// When we're done, unblock the network connection.
 	defer cmd.CopyDone.Done()
@@ -2408,12 +2402,53 @@ func (ex *connExecutor) execCopyIn(
 		ex.initPlanner(ctx, p)
 		ex.resetPlanner(ctx, p, txn, stmtTS)
 	}
+
+	// These fields need to be set for logging purposes.
+	ex.planner.stmt = Statement{
+		Statement: cmd.ParsedStmt,
+	}
+	ann := tree.MakeAnnotations(0)
+	ex.planner.extendedEvalCtx.Annotations = &ann
+	ex.planner.extendedEvalCtx.Placeholders = &tree.PlaceholderInfo{}
+	ex.planner.curPlan.stmt = &ex.planner.stmt
+
 	var cm copyMachineInterface
-	var err error
+	var copyErr error
+	// Log the query for sampling.
+	defer func() {
+		var numInsertedRows int
+		if cm != nil {
+			numInsertedRows = cm.numInsertedRows()
+		}
+		// These fields are not available in COPY, so use the empty value.
+		f := tree.NewFmtCtx(tree.FmtHideConstants)
+		f.FormatNode(cmd.Stmt)
+		stmtFingerprintID := roachpb.ConstructStatementFingerprintID(
+			f.CloseAndGetString(),
+			copyErr != nil,
+			ex.implicitTxn(),
+			ex.planner.CurrentDatabase(),
+		)
+		var stats topLevelQueryStats
+		ex.planner.maybeLogStatement(
+			ctx,
+			ex.executorType,
+			int(atomic.LoadInt32(ex.extraTxnState.atomicAutoRetryCounter)),
+			ex.extraTxnState.txnCounter,
+			numInsertedRows,
+			copyErr,
+			ex.statsCollector.PhaseTimes().GetSessionPhaseTime(sessionphase.SessionQueryReceived),
+			&ex.extraTxnState.hasAdminRoleCache,
+			ex.server.TelemetryLoggingMetrics,
+			stmtFingerprintID,
+			&stats,
+		)
+	}()
+
 	if isCopyToExternalStorage(cmd) {
-		cm, err = newFileUploadMachine(ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg)
+		cm, copyErr = newFileUploadMachine(ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg)
 	} else {
-		cm, err = newCopyMachine(
+		cm, copyErr = newCopyMachine(
 			ctx, cmd.Conn, cmd.Stmt, txnOpt, ex.server.cfg,
 			// execInsertPlan
 			func(ctx context.Context, p *planner, res RestrictedCommandResult) error {
@@ -2422,12 +2457,13 @@ func (ex *connExecutor) execCopyIn(
 			},
 		)
 	}
-	if err != nil {
+	if copyErr != nil {
 		ev := eventNonRetriableErr{IsCommit: fsm.False}
-		payload := eventNonRetriableErrPayload{err: err}
+		payload := eventNonRetriableErrPayload{err: copyErr}
 		return ev, payload, nil
 	}
-	if err := cm.run(ctx); err != nil {
+
+	if copyErr = cm.run(ctx); copyErr != nil {
 		// TODO(andrei): We don't have a retriable error story for the copy machine.
 		// When running outside of a txn, the copyMachine should probably do retries
 		// internally. When not, it's unclear what we should do. For now, we abort
@@ -2436,7 +2472,7 @@ func (ex *connExecutor) execCopyIn(
 		// should terminate the connection) from query errors. For now, we treat all
 		// errors as query errors.
 		ev := eventNonRetriableErr{IsCommit: fsm.False}
-		payload := eventNonRetriableErrPayload{err: err}
+		payload := eventNonRetriableErrPayload{err: copyErr}
 		return ev, payload, nil
 	}
 	return nil, nil, nil

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2433,6 +2433,7 @@ func (ex *connExecutor) execCopyIn(
 		ex.planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
+			true, /* isCopy */
 			int(atomic.LoadInt32(ex.extraTxnState.atomicAutoRetryCounter)),
 			ex.extraTxnState.txnCounter,
 			numInsertedRows,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1065,6 +1065,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
+			false, /* isCopy */
 			int(atomic.LoadInt32(ex.extraTxnState.atomicAutoRetryCounter)),
 			ex.extraTxnState.txnCounter,
 			res.RowsAffected(),

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -321,7 +321,8 @@ var _ Command = Flush{}
 
 // CopyIn is the command for execution of the Copy-in pgwire subprotocol.
 type CopyIn struct {
-	Stmt *tree.CopyFrom
+	ParsedStmt parser.Statement
+	Stmt       *tree.CopyFrom
 	// Conn is the network connection. Execution of the CopyFrom statement takes
 	// control of the connection.
 	Conn pgwirebase.Conn

--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -39,6 +39,7 @@ import (
 
 type copyMachineInterface interface {
 	run(ctx context.Context) error
+	numInsertedRows() int
 }
 
 // copyMachine supports the Copy-in pgwire subprotocol (COPY...FROM STDIN). The
@@ -231,6 +232,13 @@ func newCopyMachine(
 	c.bufMemAcc = c.p.extendedEvalCtx.Mon.MakeBoundAccount()
 	c.processRows = c.insertRows
 	return c, nil
+}
+
+func (c *copyMachine) numInsertedRows() int {
+	if c == nil {
+		return 0
+	}
+	return c.insertedRows
 }
 
 // copyTxnOpt contains information about the transaction in which the copying

--- a/pkg/sql/copy_file_upload.go
+++ b/pkg/sql/copy_file_upload.go
@@ -167,6 +167,13 @@ func CopyInFileStmt(destination, schema, table string) string {
 	)
 }
 
+func (f *fileUploadMachine) numInsertedRows() int {
+	if f == nil {
+		return 0
+	}
+	return f.c.numInsertedRows()
+}
+
 func (f *fileUploadMachine) run(ctx context.Context) error {
 	err := f.c.run(ctx)
 	if err != nil && f.cancel != nil {

--- a/pkg/sql/copy_in_test.go
+++ b/pkg/sql/copy_in_test.go
@@ -406,6 +406,80 @@ func TestCopyError(t *testing.T) {
 	}
 }
 
+// TestCopyTrace verifies copy works with tracing turned on.
+func TestCopyTrace(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, strs := range [][]string{
+		{`SET CLUSTER SETTING sql.trace.log_statement_execute = true`},
+		{`SET CLUSTER SETTING sql.telemetry.query_sampling.enabled = true`},
+		{`SET CLUSTER SETTING sql.log.unstructured_entries.enabled = true`, `SET CLUSTER SETTING sql.trace.log_statement_execute = true`},
+	} {
+		t.Run(strs[0], func(t *testing.T) {
+			params, _ := tests.CreateTestServerParams()
+			s, db, _ := serverutils.StartServer(t, params)
+			defer s.Stopper().Stop(context.Background())
+
+			_, err := db.Exec(`
+		CREATE TABLE t (
+			i INT PRIMARY KEY
+		);
+	`)
+			require.NoError(t, err)
+
+			for _, str := range strs {
+				_, err = db.Exec(str)
+				require.NoError(t, err)
+			}
+
+			t.Run("success", func(t *testing.T) {
+				txn, err := db.Begin()
+				const val = 2
+				require.NoError(t, err)
+				{
+					stmt, err := txn.Prepare(pq.CopyIn("t", "i"))
+					require.NoError(t, err)
+					_, err = stmt.Exec(val)
+					require.NoError(t, err)
+					require.NoError(t, stmt.Close())
+				}
+				require.NoError(t, txn.Commit())
+
+				var i int
+				require.NoError(t, db.QueryRow("SELECT i FROM t").Scan(&i))
+				require.Equal(t, val, i)
+			})
+
+			t.Run("error in statement", func(t *testing.T) {
+				txn, err := db.Begin()
+				require.NoError(t, err)
+				{
+					_, err := txn.Prepare(pq.CopyIn("xxx", "yyy"))
+					require.Error(t, err)
+					require.True(t, strings.Contains(err.Error(), `relation "xxx" does not exist`))
+				}
+				require.NoError(t, txn.Rollback())
+			})
+
+			t.Run("error during copy", func(t *testing.T) {
+				txn, err := db.Begin()
+				require.NoError(t, err)
+				{
+					stmt, err := txn.Prepare(pq.CopyIn("t", "i"))
+					require.NoError(t, err)
+					_, err = stmt.Exec("bob")
+					require.NoError(t, err)
+					err = stmt.Close()
+					require.Error(t, err)
+					require.True(t, strings.Contains(err.Error(), `could not parse "bob" as type int`))
+				}
+				require.NoError(t, txn.Rollback())
+			})
+		})
+	}
+}
+
 // TestCopyTransaction verifies that COPY data can be used after it is done
 // within a transaction.
 func TestCopyTransaction(t *testing.T) {

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -168,6 +168,9 @@ type eventLogOptions struct {
 
 	// Additional redaction options, if necessary.
 	rOpts redactionOptions
+
+	// isCopy notes whether the current event is related to COPY.
+	isCopy bool
 }
 
 // redactionOptions contains instructions on how to redact the SQL
@@ -282,7 +285,9 @@ func logEventInternalForSQLStatements(
 	// Inject the common fields into the payload provided by the caller.
 	injectCommonFields := func(entry eventLogEntry) error {
 		event := entry.event
-		if txn != nil {
+		if opts.isCopy {
+			event.CommonDetails().Timestamp = timeutil.Now().UnixNano()
+		} else {
 			event.CommonDetails().Timestamp = txn.ReadTimestamp().WallTime
 		}
 		sqlCommon, ok := event.(eventpb.EventWithCommonSQLPayload)

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -282,7 +282,9 @@ func logEventInternalForSQLStatements(
 	// Inject the common fields into the payload provided by the caller.
 	injectCommonFields := func(entry eventLogEntry) error {
 		event := entry.event
-		event.CommonDetails().Timestamp = txn.ReadTimestamp().WallTime
+		if txn != nil {
+			event.CommonDetails().Timestamp = txn.ReadTimestamp().WallTime
+		}
 		sqlCommon, ok := event.(eventpb.EventWithCommonSQLPayload)
 		if !ok {
 			return errors.AssertionFailedf("unknown event type: %T", event)

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -153,6 +153,7 @@ var sqlPerfInternalLogger log.ChannelLogger = log.SqlInternalPerf
 func (p *planner) maybeLogStatement(
 	ctx context.Context,
 	execType executorType,
+	isCopy bool,
 	numRetries, txnCounter, rows int,
 	err error,
 	queryReceived time.Time,
@@ -161,12 +162,13 @@ func (p *planner) maybeLogStatement(
 	stmtFingerprintID roachpb.StmtFingerprintID,
 	queryStats *topLevelQueryStats,
 ) {
-	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID, queryStats)
+	p.maybeLogStatementInternal(ctx, execType, isCopy, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID, queryStats)
 }
 
 func (p *planner) maybeLogStatementInternal(
 	ctx context.Context,
 	execType executorType,
+	isCopy bool,
 	numRetries, txnCounter, rows int,
 	err error,
 	startTime time.Time,
@@ -374,6 +376,7 @@ func (p *planner) maybeLogStatementInternal(
 				// see a copy of the execution on the DEV Channel.
 				dst:               LogExternally | LogToDevChannelIfVerbose,
 				verboseTraceLevel: execType.vLevel(),
+				isCopy:            isCopy,
 			},
 			eventLogEntry{event: &eventpb.QueryExecute{CommonSQLExecDetails: execDetails}})
 	}


### PR DESCRIPTION
Backport (combined into one commit):
  * 1/1 commits from "sql: add COPY to sampled_query logging" (#86627)
  * 1/1 commits from "sql: properly log copy error on error" (#86870)

Release justification: telemetry only change

/cc @cockroachdb/release
