### PR TITLE
sql: fake a txn for logging COPY

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2435,6 +2435,7 @@ func (ex *connExecutor) execCopyIn(
 	ex.planner.extendedEvalCtx.Context.Annotations = &ann
 	ex.planner.extendedEvalCtx.Context.Placeholders = &tree.PlaceholderInfo{}
 	ex.planner.curPlan.stmt = &ex.planner.stmt
+	ex.planner.txn = kv.NewTxn(ctx, ex.planner.execCfg.DB, 0)
 
 	var cm copyMachineInterface
 	var copyErr error

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -276,9 +276,7 @@ func logEventInternalForSQLStatements(
 ) error {
 	// Inject the common fields into the payload provided by the caller.
 	injectCommonFields := func(event logpb.EventPayload) error {
-		if txn != nil {
-			event.CommonDetails().Timestamp = txn.ReadTimestamp().WallTime
-		}
+		event.CommonDetails().Timestamp = txn.ReadTimestamp().WallTime
 		sqlCommon, ok := event.(eventpb.EventWithCommonSQLPayload)
 		if !ok {
 			return errors.AssertionFailedf("unknown event type: %T", event)


### PR DESCRIPTION
Previously, txn for the event_log for COPY may be nil, meaning
the statement does not get logged in the event log. We previously relied
on assigning Timestamp from kv.Txn if the txn not nil, but this
triggers an assertion error (which is ignored) if that is the case.

Work around that by faking a txn during logging for copy instead.

Release justification: low-risk bug fix for logging

Release note: None

