### PR TITLE
release-22.1: ui: add Transaction and Statement fingerprint id

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.fixture.ts
@@ -288,6 +288,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
   statements: [
     {
       aggregatedFingerprintID: "1253500548539870016",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(1253500548539870016).toString(16),
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT code FROM promo_codes WHERE code > $1 ORDER BY code LIMIT _) AS a, (SELECT code FROM promo_codes ORDER BY code LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
@@ -300,6 +302,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "1985666523427702831",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(1985666523427702831).toString(16),
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__)",
       summary: "INSERT INTO vehicles",
       aggregatedTs,
@@ -311,6 +315,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "13649565517143827225",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13649565517143827225).toString(16),
       label:
         "SELECT IFNULL(a, b) FROM (SELECT (SELECT id FROM users WHERE (city = $1) AND (id > $2) ORDER BY id LIMIT _) AS a, (SELECT id FROM users WHERE city = $1 ORDER BY id LIMIT _) AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
@@ -323,6 +329,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "1533636712988872414",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(1533636712988872414).toString(16),
       label:
         "UPSERT INTO vehicle_location_histories VALUES ($1, $2, now(), $3, $4)",
       summary: "UPSERT INTO vehicle_location_histories",
@@ -335,6 +343,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "2461578209191418170",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(2461578209191418170).toString(16),
       label: "INSERT INTO user_promo_codes VALUES ($1, $2, $3, now(), _)",
       summary: "INSERT INTO user_promo_codes",
       aggregatedTs,
@@ -346,6 +356,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "4705782015019656142",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(4705782015019656142).toString(16),
       label: "SELECT city, id FROM vehicles WHERE city = $1",
       summary: "SELECT city, id FROM vehicles",
       aggregatedTs,
@@ -357,6 +369,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "2298970482983227199",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(2298970482983227199).toString(16),
       label:
         "INSERT INTO rides VALUES ($1, $2, $2, $3, $4, $5, _, now(), _, $6)",
       summary: "INSERT INTO rides",
@@ -369,6 +383,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "4716433305747424413",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(4716433305747424413).toString(16),
       label: "SELECT IFNULL(a, b) FROM (SELECT  AS a, AS b)",
       summary: "SELECT IFNULL(a, b) FROM (SELECT)",
       aggregatedTs,
@@ -380,6 +396,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "367828504526856403",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(367828504526856403).toString(16),
       label:
         "UPDATE rides SET end_address = $3, end_time = now() WHERE (city = $1) AND (id = $2)",
       summary: "UPDATE rides SET end_address = $... WHERE (city = $1) AND...",
@@ -392,6 +410,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "14972494059652918390",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(14972494059652918390).toString(16),
       label: "INSERT INTO users VALUES ($1, $2, __more3__)",
       summary: "INSERT INTO users",
       aggregatedTs,
@@ -403,6 +423,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "15897033026745880862",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(15897033026745880862).toString(16),
       label:
         "SELECT count(*) FROM user_promo_codes WHERE ((city = $1) AND (user_id = $2)) AND (code = $3)",
       summary: "SELECT count(*) FROM user_promo_codes",
@@ -415,6 +437,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '49958554803360403681',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(49958554803360403681).toString(16),
       label: "INSERT INTO promo_codes VALUES ($1, $2, __more3__)",
       summary: "INSERT INTO promo_codes",
       aggregatedTs,
@@ -426,6 +450,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '9233296116064220812',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(9233296116064220812).toString(16),
       label: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE users SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -437,6 +463,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '6117473345491440803',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(6117473345491440803).toString(16),
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (vehicle_city, vehicle_id) REFERENCES vehicles (city, id)",
       summary:
@@ -450,6 +478,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '1301242584620444873',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(1301242584620444873).toString(16),
       label: "SHOW database",
       summary: "SHOW database",
       aggregatedTs,
@@ -462,6 +492,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '11195381626529102926',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(11195381626529102926).toString(16),
       label:
         "CREATE TABLE IF NOT EXISTS promo_codes (code VARCHAR NOT NULL, description VARCHAR NULL, creation_time TIMESTAMP NULL, expiration_time TIMESTAMP NULL, rules JSONB NULL, PRIMARY KEY (code ASC))",
       summary:
@@ -475,6 +507,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '18127289707013477303',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(18127289707013477303).toString(16),
       label: "ALTER TABLE users SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE users SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -486,6 +520,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '2499764450427976233',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(2499764450427976233).toString(16),
       label: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE vehicles SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -497,6 +533,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '818321793552651414',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(818321793552651414).toString(16),
       label:
         "ALTER TABLE vehicle_location_histories ADD FOREIGN KEY (city, ride_id) REFERENCES rides (city, id)",
       summary:
@@ -510,6 +548,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '13217779306501326587',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13217779306501326587).toString(16),
       label:
         'CREATE TABLE IF NOT EXISTS user_promo_codes (city VARCHAR NOT NULL, user_id UUID NOT NULL, code VARCHAR NOT NULL, "timestamp" TIMESTAMP NULL, usage_count INT8 NULL, PRIMARY KEY (city ASC, user_id ASC, code ASC))',
       summary:
@@ -523,6 +563,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '6325213731862855938',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(6325213731862855938).toString(16),
       label: "INSERT INTO users VALUES ($1, $2, __more3__), (__more40__)",
       summary: "INSERT INTO users VALUES",
       aggregatedTs,
@@ -534,6 +576,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '17372586739449521577',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(17372586739449521577).toString(16),
       label: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
       summary: "ALTER TABLE rides SCATTER FROM (_, _) TO (_, _)",
       aggregatedTs,
@@ -545,6 +589,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '17098541896015126122',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(17098541896015126122).toString(16),
       label: 'SET CLUSTER SETTING "cluster.organization" = $1',
       summary: 'SET CLUSTER SETTING "cluster.organization" = $1',
       aggregatedTs,
@@ -556,6 +602,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '13350023170184726428',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13350023170184726428).toString(16),
       label:
         "ALTER TABLE vehicles ADD FOREIGN KEY (city, owner_id) REFERENCES users (city, id)",
       summary:
@@ -569,6 +617,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '2695725667586429780',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(2695725667586429780).toString(16),
       label:
         "CREATE TABLE IF NOT EXISTS rides (id UUID NOT NULL, city VARCHAR NOT NULL, vehicle_city VARCHAR NULL, rider_id UUID NULL, vehicle_id UUID NULL, start_address VARCHAR NULL, end_address VARCHAR NULL, start_time TIMESTAMP NULL, end_time TIMESTAMP NULL, revenue DECIMAL(10,2) NULL, PRIMARY KEY (city ASC, id ASC), INDEX rides_auto_index_fk_city_ref_users (city ASC, rider_id ASC), INDEX rides_auto_index_fk_vehicle_city_ref_vehicles (vehicle_city ASC, vehicle_id ASC), CONSTRAINT check_vehicle_city_city CHECK (vehicle_city = city))",
       summary:
@@ -582,6 +632,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '6754865160812330169',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(6754865160812330169).toString(16),
       label:
         "CREATE TABLE IF NOT EXISTS vehicles (id UUID NOT NULL, city VARCHAR NOT NULL, type VARCHAR NULL, owner_id UUID NULL, creation_time TIMESTAMP NULL, status VARCHAR NULL, current_location VARCHAR NULL, ext JSONB NULL, PRIMARY KEY (city ASC, id ASC), INDEX vehicles_auto_index_fk_city_ref_users (city ASC, owner_id ASC))",
       summary:
@@ -595,6 +647,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '6810471486115018510',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(6810471486115018510).toString(16),
       label: "INSERT INTO rides VALUES ($1, $2, __more8__), (__more400__)",
       summary: "INSERT INTO rides",
       aggregatedTs,
@@ -606,6 +660,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '13265908854908549668',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13265908854908549668).toString(16),
       label: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE vehicles SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -617,6 +673,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '18377382163116490400',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(18377382163116490400).toString(16),
       label: "SET sql_safe_updates = _",
       summary: "SET sql_safe_updates = _",
       aggregatedTs,
@@ -628,6 +686,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '8695470234690735168',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(8695470234690735168).toString(16),
       label:
         "CREATE TABLE IF NOT EXISTS users (id UUID NOT NULL, city VARCHAR NOT NULL, name VARCHAR NULL, address VARCHAR NULL, credit_card VARCHAR NULL, PRIMARY KEY (city ASC, id ASC))",
       summary:
@@ -641,6 +701,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '9261848985398568228',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(9261848985398568228).toString(16),
       label:
         'CREATE TABLE IF NOT EXISTS vehicle_location_histories (city VARCHAR NOT NULL, ride_id UUID NOT NULL, "timestamp" TIMESTAMP NOT NULL, lat FLOAT8 NULL, long FLOAT8 NULL, PRIMARY KEY (city ASC, ride_id ASC, "timestamp" ASC))',
       summary:
@@ -654,6 +716,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: '4176684928840388768',
+      aggregatedFingerprintHexID:
+        Long.fromNumber(4176684928840388768).toString(16),
       label: "SELECT * FROM crdb_internal.node_build_info",
       summary: "SELECT * FROM crdb_internal.node_build_info",
       aggregatedTs,
@@ -665,6 +729,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "15868120298061590648",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(15868120298061590648).toString(16),
       label: "CREATE DATABASE movr",
       summary: "CREATE DATABASE movr",
       implicitTxn: true,
@@ -677,6 +743,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "13070583869906258880",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13070583869906258880).toString(16),
       label:
         "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS _ (v) WHERE v = _",
       summary: "SELECT count(*) > _ FROM [SHOW ALL CLUSTER SETTINGS] AS...",
@@ -689,6 +757,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "641287435601027145",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(641287435601027145).toString(16),
       label: 'SET CLUSTER SETTING "enterprise.license" = $1',
       summary: 'SET CLUSTER SETTING "enterprise.license" = $1',
       aggregatedTs,
@@ -700,6 +770,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "16743225271705059729",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(16743225271705059729).toString(16),
       label:
         "ALTER TABLE rides ADD FOREIGN KEY (city, rider_id) REFERENCES users (city, id)",
       summary:
@@ -713,6 +785,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "6075815909800602827",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(6075815909800602827).toString(16),
       label:
         "ALTER TABLE user_promo_codes ADD FOREIGN KEY (city, user_id) REFERENCES users (city, id)",
       summary:
@@ -726,6 +800,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "5158086166870396309",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(5158086166870396309).toString(16),
       label:
         "INSERT INTO promo_codes VALUES ($1, $2, __more3__), (__more900__)",
       summary: "INSERT INTO promo_codes",
@@ -738,6 +814,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "13494397675172244644",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(13494397675172244644).toString(16),
       label: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
       summary: "ALTER TABLE rides SPLIT AT VALUES (_, _)",
       aggregatedTs,
@@ -749,6 +827,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "101921598584277094",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(101921598584277094).toString(16),
       label: "SELECT value FROM crdb_internal.node_build_info WHERE field = _",
       summary: "SELECT value FROM crdb_internal.node_build_info",
       aggregatedTs,
@@ -760,6 +840,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "7880339715822034020",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(7880339715822034020).toString(16),
       label:
         "INSERT INTO vehicle_location_histories VALUES ($1, $2, __more3__), (__more900__)",
       summary: "INSERT INTO vehicle_location_histories",
@@ -772,6 +854,8 @@ const statementsPagePropsFixture: StatementsPageProps = {
     },
     {
       aggregatedFingerprintID: "16819876564846676829",
+      aggregatedFingerprintHexID:
+        Long.fromNumber(16819876564846676829).toString(16),
       label: "INSERT INTO vehicles VALUES ($1, $2, __more6__), (__more10__)",
       summary: "INSERT INTO vehicles",
       aggregatedTs,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.selectors.ts
@@ -34,6 +34,7 @@ import { SQLStatsState } from "../store/sqlStats";
 type ICollectedStatementStatistics = cockroach.server.serverpb.StatementsResponse.ICollectedStatementStatistics;
 export interface StatementsSummaryData {
   statementFingerprintID: string;
+  statementFingerprintHexID: string;
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
@@ -178,6 +179,9 @@ export const selectStatements = createSelector(
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
           statementFingerprintID: stmt.statement_fingerprint_id?.toString(),
+          statementFingerprintHexID: stmt.statement_fingerprint_id?.toString(
+            16,
+          ),
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
@@ -195,6 +199,7 @@ export const selectStatements = createSelector(
       const stmt = statsByStatementKey[key];
       return {
         aggregatedFingerprintID: stmt.statementFingerprintID,
+        aggregatedFingerprintHexID: stmt.statementFingerprintHexID,
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.spec.tsx
@@ -86,6 +86,7 @@ describe("StatementsPage", () => {
 
     const statement: AggregateStatistics = {
       aggregatedFingerprintID: "",
+      aggregatedFingerprintHexID: "",
       aggregatedTs: 0,
       aggregationInterval: 0,
       database: "",

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -163,16 +163,21 @@ export function filterBySearchQuery(
   search: string,
 ): boolean {
   const matchString = statement.label.toLowerCase();
+  const matchFingerPrintId = statement.aggregatedFingerprintHexID;
+
   // If search term is wrapped by quotes, do the exact search term.
   if (search.startsWith('"') && search.endsWith('"')) {
     search = search.substring(1, search.length - 1);
-    return matchString.includes(search);
+
+    return matchString.includes(search) || matchFingerPrintId.includes(search);
   }
 
   return search
     .toLowerCase()
     .split(" ")
-    .every(val => matchString.includes(val));
+    .every(
+      val => matchString.includes(val) || matchFingerPrintId.includes(val),
+    );
 }
 
 export class StatementsPage extends React.Component<

--- a/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsTable/statementsTable.tsx
@@ -191,11 +191,19 @@ function makeCommonColumns(
         TimestampToNumber(stmt.stats.last_exec_timestamp),
       showByDefault: false,
     },
+    {
+      name: "statementFingerprintId",
+      title: statisticsTableTitles.statementFingerprintId(statType),
+      cell: (stmt: AggregateStatistics) => stmt.aggregatedFingerprintHexID,
+      sort: (stmt: AggregateStatistics) => stmt.aggregatedFingerprintHexID,
+      showByDefault: false,
+    },
   ];
 }
 
 export interface AggregateStatistics {
   aggregatedFingerprintID: string;
+  aggregatedFingerprintHexID: string;
   // label is either shortStatement (StatementsPage) or nodeId (StatementDetails).
   label: string;
   // summary exists only for SELECT/INSERT/UPSERT/UPDATE statements, and is

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -58,6 +58,8 @@ export const statisticsColumnLabels = {
   transactions: "Transactions",
   workloadPct: "% of All Runtime",
   lastExecTimestamp: "Last Execution Time (UTC)",
+  statementFingerprintId: "Statement Fingerprint ID",
+  transactionFingerprintId: "Transaction Fingerprint ID",
 };
 
 export const contentModifiers = {
@@ -213,6 +215,32 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         content={"The application that ran the session."}
       >
         {getLabel("applicationName")}
+      </Tooltip>
+    );
+  },
+  statementFingerprintId: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The statement fingerprint id is the combination of the statement fingerprint, the database it was executed on, the transaction type (implicit or explicit) and whether execution has failed (true or false)."
+        }
+      >
+        {getLabel("statementFingerprintId")}
+      </Tooltip>
+    );
+  },
+  transactionFingerprintId: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={
+          "The transaction fingerprint id represents the list of statement fingerprint ids in order of execution within that transaction."
+        }
+      >
+        {getLabel("transactionFingerprintId")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/utils.ts
@@ -100,6 +100,7 @@ export const aggregateStatements = (
     if (!(key in statsKey)) {
       statsKey[key] = {
         aggregatedFingerprintID: s.statement_fingerprint_id?.toString(),
+        aggregatedFingerprintHexID: s.statement_fingerprint_id.toString(16),
         label: s.statement,
         summary: s.statement_summary,
         aggregatedTs: s.aggregated_ts,
@@ -127,19 +128,29 @@ export const searchTransactionsData = (
     searchTerms = [search.substring(1, search.length - 1)];
   }
 
+  if (!search) {
+    return transactions;
+  }
+
   return transactions.filter((t: Transaction) =>
-    search
-      ? searchTerms.every(val =>
-          collectStatementsText(
-            getStatementsByFingerprintId(
-              t.stats_data.statement_fingerprint_ids,
-              statements,
-            ),
-          )
-            .toLowerCase()
-            .includes(val.toLowerCase()),
+    searchTerms.every(val => {
+      if (
+        collectStatementsText(
+          getStatementsByFingerprintId(
+            t.stats_data.statement_fingerprint_ids,
+            statements,
+          ),
         )
-      : true,
+          .toLowerCase()
+          .includes(val.toLowerCase())
+      ) {
+        return true;
+      }
+
+      return t.stats_data.transaction_fingerprint_id
+        ?.toString(16)
+        ?.includes(val);
+    }),
   );
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -227,6 +227,15 @@ export function makeTransactionsColumns(
       sort: (item: TransactionInfo) =>
         item.stats_data.statement_fingerprint_ids.length,
     },
+    {
+      name: "transactionFingerprintId",
+      title: statisticsTableTitles.transactionFingerprintId(statType),
+      cell: (item: TransactionInfo) =>
+        item.stats_data?.transaction_fingerprint_id.toString(16),
+      sort: (item: TransactionInfo) =>
+        item.stats_data?.transaction_fingerprint_id.toString(16),
+      showByDefault: false,
+    },
   ].filter(c => !(isTenant && c.hideIfTenant));
 }
 

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsPage.tsx
@@ -68,6 +68,7 @@ type StatementStatistics = util.StatementStatistics;
 
 interface StatementsSummaryData {
   statementFingerprintID: string;
+  statementFingerprintHexID: string;
   statement: string;
   statementSummary: string;
   aggregatedTs: number;
@@ -127,6 +128,9 @@ export const selectStatements = createSelector(
       if (!(key in statsByStatementKey)) {
         statsByStatementKey[key] = {
           statementFingerprintID: stmt.statement_fingerprint_id?.toString(),
+          statementFingerprintHexID: stmt.statement_fingerprint_id?.toString(
+            16,
+          ),
           statement: stmt.statement,
           statementSummary: stmt.statement_summary,
           aggregatedTs: stmt.aggregated_ts,
@@ -144,6 +148,7 @@ export const selectStatements = createSelector(
       const stmt = statsByStatementKey[key];
       return {
         aggregatedFingerprintID: stmt.statementFingerprintID,
+        aggregatedFingerprintHexID: stmt.statementFingerprintHexID,
         label: stmt.statement,
         summary: stmt.statementSummary,
         aggregatedTs: stmt.aggregatedTs,


### PR DESCRIPTION
Backport 1/1 commits from #85464.

/cc @cockroachdb/release

---

This adds the Transaction and Statement fingerprint id
to SQL Activity Statements overview page. The columns
are hidden by default.

closes #78509

<img width="1337" alt="Screen Shot 2022-08-03 at 7 14 21 AM" src="https://user-images.githubusercontent.com/8868107/182594974-73bea276-0fb0-4cd4-a106-60e31962b1b9.png">

<img width="1341" alt="Screen Shot 2022-08-03 at 7 21 43 AM" src="https://user-images.githubusercontent.com/8868107/182596064-7a02e7da-3e07-4616-9be9-1a807b87b33d.png">

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note (ui change): Adds Transaction and Statement fingerprint
id to correlating SQL Activity overview pages. New columns are
hidden by default.
