### PR TITLE
storage: fix non-empty tombstone handling in intent resolution

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -225,17 +224,17 @@ stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_
 >> resolve_intent k=f t=A status=ABORTED
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5630 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=g t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+194 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=h t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
->> resolve_intent k=i t=A status=ABORTED
 stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+194 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
+>> resolve_intent k=i t=A status=ABORTED
+stats: key_bytes=-12 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 gc_bytes_age=+198 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=j t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5630 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=k t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5634 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=l t=A status=ABORTED
-stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5630 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=m t=A status=ABORTED
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=n t=A status=ABORTED
@@ -254,10 +253,10 @@ data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/1.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /<empty>
-data: "g"/1.000000000,0 -> /BYTES/g1
-data: "h"/1.000000000,0 -> /<empty>
-data: "i"/1.000000000,0 -> /BYTES/i1
-data: "j"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
+data: "i"/1.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
+data: "l"/1.000000000,0 -> /<empty>
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/5.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,16 +181,16 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 with t=A status=ABORTED
@@ -222,7 +224,7 @@ stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 
 >> resolve_intent k=e t=A status=ABORTED
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7614 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=f t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5630 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6852 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=g t=A status=ABORTED
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=h t=A status=ABORTED
@@ -234,7 +236,7 @@ stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 
 >> resolve_intent k=k t=A status=ABORTED
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5634 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=l t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5630 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6852 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=m t=A status=ABORTED
 stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-55 live_count=-1 live_bytes=-69 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=n t=A status=ABORTED
@@ -246,19 +248,19 @@ stats: key_count=-1 key_bytes=-14 val_count=-1 val_bytes=-48 gc_bytes_age=-5828 
 >> resolve_intent k=q t=A status=ABORTED
 stats: key_bytes=-12 val_count=-1 val_bytes=-48 live_count=+1 live_bytes=+21 gc_bytes_age=-7614 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=r t=A status=ABORTED
-stats: key_bytes=-12 val_count=-1 val_bytes=-48 gc_bytes_age=-5638 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: key_bytes=-12 val_count=-1 val_bytes=-61 gc_bytes_age=-6860 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> at end:
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "b"/1.000000000,0 -> /BYTES/b1
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "h"/1.000000000,0 -> /BYTES/h1
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "n"/5.000000000,0 -> /BYTES/n5
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=12 key_bytes=168 val_count=12 val_bytes=42 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=4 live_bytes=84 gc_bytes_age=14399
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=12 key_bytes=168 val_count=12 val_bytes=96 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=4 live_bytes=84 gc_bytes_age=19673

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -261,15 +260,15 @@ data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 data: "m"/6.000000000,0 -> /BYTES/m6
 data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,16 +181,16 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 with t=A status=COMMITTED
@@ -222,7 +224,7 @@ stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=e t=A status=COMMITTED
 stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=f t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=g t=A status=COMMITTED
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=h t=A status=COMMITTED
@@ -234,7 +236,7 @@ stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=k t=A status=COMMITTED
 stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=l t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=m t=A status=COMMITTED
 stats: val_bytes=-48 live_bytes=-48 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=n t=A status=COMMITTED
@@ -246,37 +248,37 @@ stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=q t=A status=COMMITTED
 stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=r t=A status=COMMITTED
-stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4512 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> at end:
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "a"/6.000000000,0 -> /BYTES/a6
 data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "d"/6.000000000,0 -> /<empty>
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "g"/6.000000000,0 -> /BYTES/g6
 data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "j"/6.000000000,0 -> /<empty>
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "m"/6.000000000,0 -> /BYTES/m6
 data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "p"/6.000000000,0 -> /<empty>
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=105 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=189 gc_bytes_age=31827
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=198 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=189 gc_bytes_age=40767

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -263,15 +262,15 @@ data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "f"/1.000000000,0 -> /<empty>
 data: "g"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 data: "h"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 data: "j"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "j"/1.000000000,0 -> /<empty>
 data: "k"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 data: "l"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
+data: "l"/1.000000000,0 -> /<empty>
 data: "m"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/m6
 data: "n"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,16 +181,16 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 with t=A status=COMMITTED
@@ -223,7 +225,7 @@ stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=e t=A status=COMMITTED
 stats: val_bytes=-35 gc_bytes_age=-3336 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=f t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4539 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=g t=A status=COMMITTED
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=h t=A status=COMMITTED
@@ -235,7 +237,7 @@ stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=k t=A status=COMMITTED
 stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=l t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4539 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=m t=A status=COMMITTED
 stats: val_bytes=-35 live_bytes=-35 intent_count=-1 intent_bytes=-19 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=n t=A status=COMMITTED
@@ -247,7 +249,7 @@ stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separat
 >> resolve_intent k=q t=A status=COMMITTED
 stats: val_bytes=-35 gc_bytes_age=-3336 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
 >> resolve_intent k=r t=A status=COMMITTED
-stats: val_bytes=-35 gc_bytes_age=-3317 intent_count=-1 intent_bytes=-12 separated_intent_count=-1 intent_age=-94
+stats: val_bytes=-48 gc_bytes_age=-4539 intent_count=-1 intent_bytes=-25 separated_intent_count=-1 intent_age=-94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -255,30 +257,30 @@ data: "a"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/a6
 data: "b"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "d"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "e"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "g"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/g6
 data: "h"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "j"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "k"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "m"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/m6
 data: "n"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "p"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "q"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=339 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=306 gc_bytes_age=42506
+data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=393 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=306 gc_bytes_age=47780

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -202,10 +201,10 @@ data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/1.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/1.000000000,0 -> /<empty>
-data: "g"/1.000000000,0 -> /BYTES/g1
-data: "h"/1.000000000,0 -> /<empty>
-data: "i"/1.000000000,0 -> /BYTES/i1
-data: "j"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
+data: "i"/1.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
+data: "l"/1.000000000,0 -> /<empty>
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/5.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,34 +181,34 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 resolve_intent_range t=A k=a end=z status=ABORTED
 ----
 >> resolve_intent_range t=A k=a end=z status=ABORTED
-stats: key_count=-6 key_bytes=-228 val_count=-18 val_bytes=-927 live_count=-5 live_bytes=-537 gc_bytes_age=-58036 intent_count=-18 intent_bytes=-279 separated_intent_count=-18 intent_age=-1692
+stats: key_count=-6 key_bytes=-228 val_count=-18 val_bytes=-966 live_count=-5 live_bytes=-537 gc_bytes_age=-61702 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1692
 >> at end:
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "b"/1.000000000,0 -> /BYTES/b1
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "h"/1.000000000,0 -> /BYTES/h1
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "n"/5.000000000,0 -> /BYTES/n5
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=12 key_bytes=168 val_count=12 val_bytes=42 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=4 live_bytes=84 gc_bytes_age=14399
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=12 key_bytes=168 val_count=12 val_bytes=96 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=4 live_bytes=84 gc_bytes_age=19673

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -209,15 +208,15 @@ data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 data: "m"/6.000000000,0 -> /BYTES/m6
 data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,52 +181,52 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
-stats: val_bytes=-864 live_bytes=-432 gc_bytes_age=-40608 intent_count=-18 intent_bytes=-279 separated_intent_count=-18 intent_age=-1692
+stats: val_bytes=-864 live_bytes=-432 gc_bytes_age=-40608 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1692
 >> at end:
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "a"/6.000000000,0 -> /BYTES/a6
 data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "d"/6.000000000,0 -> /<empty>
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "g"/6.000000000,0 -> /BYTES/g6
 data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "j"/6.000000000,0 -> /<empty>
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "m"/6.000000000,0 -> /BYTES/m6
 data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "p"/6.000000000,0 -> /<empty>
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=105 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=189 gc_bytes_age=31827
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=198 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=189 gc_bytes_age=40767

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,23 +181,23 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 run stats ok
 txn_advance t=A ts=7
 resolve_intent_range t=A k=a end=z status=COMMITTED
 ----
 >> resolve_intent_range t=A k=a end=z status=COMMITTED
-stats: val_bytes=-630 live_bytes=-315 gc_bytes_age=-29929 intent_count=-18 intent_bytes=-279 separated_intent_count=-18 intent_age=-1692
+stats: val_bytes=-669 live_bytes=-315 gc_bytes_age=-33595 intent_count=-18 intent_bytes=-318 separated_intent_count=-18 intent_age=-1692
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -203,30 +205,30 @@ data: "a"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/a6
 data: "b"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "d"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "e"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-data: "f"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "g"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/g6
 data: "h"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "j"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "k"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-data: "l"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "m"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/m6
 data: "n"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 data: "o"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 data: "p"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "q"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-data: "r"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=339 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=306 gc_bytes_age=42506
+data: "r"/7.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=393 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=306 gc_bytes_age=47780

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -211,15 +210,15 @@ data: "e"/1.000000000,0 -> /BYTES/e1
 data: "f"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
 data: "f"/1.000000000,0 -> /<empty>
 data: "g"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 data: "h"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 data: "i"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 data: "j"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
-data: "j"/1.000000000,0 -> /<empty>
 data: "k"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 data: "l"/7.000000000,0 -> {localTs=6.000000000,0}/<empty>
+data: "l"/1.000000000,0 -> /<empty>
 data: "m"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/m6
 data: "n"/7.000000000,0 -> {localTs=6.000000000,0}/BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
@@ -3,10 +3,9 @@
 #
 # (x is tombstone, o---o is range tombstone, [] is intent)
 #
-# 7
-# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6] x   x   x
+# 6 [a6][b6][c6][x] [x] [x] [g6][h6][i6][x] [x] [x] [m6][n6][o6][x] [x] [x]
 # 5                                                      n5  x       q5  x
-# 4                          o-----------------------------------------------o   
+# 4                          o-----------------------------------------------o
 # 3                          o-----------------------------------------------o
 # 2 
 # 1      b1  x       e1  x       h1  x       k1  x
@@ -27,10 +26,10 @@ with ts=1
   del k=c
   put k=e v=e1
   del k=f
-  put k=g v=g1
-  del k=h
-  put k=i v=i1
-  del k=j
+  put k=h v=h1
+  del k=i
+  put k=k v=k1
+  del k=l
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
@@ -69,15 +68,15 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del k=f ts=1
 del: "f": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=g v=g1 ts=1
+>> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=h ts=1
-del: "h": found key false
+>> del k=i ts=1
+del: "i": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
->> put k=i v=i1 ts=1
+>> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=j ts=1
-del: "j": found key false
+>> del k=l ts=1
+del: "l": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
@@ -109,20 +108,20 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_
 del: "f": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
-stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
->> put k=i v=i6 t=A
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
+>> put k=i v=i6 t=A
+stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> del k=j t=A
 del: "j": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=k t=A
 del: "k": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> del k=l t=A
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -159,20 +158,20 @@ data: "f"/6.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "h"/6.000000000,0 -> /BYTES/h6
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "l"/6.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -281,20 +280,20 @@ data: "f"/7.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "g"/7.000000000,0 -> /BYTES/g7
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "h"/7.000000000,0 -> /BYTES/h7
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/7.000000000,0 -> /BYTES/i7
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "j"/7.000000000,0 -> /<empty>
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/7.000000000,0 -> /<empty>
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "l"/7.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "m"/7.000000000,0 -> /BYTES/m7
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -382,20 +381,20 @@ data: "f"/8.000000000,0 -> /BYTES/f8
 data: "f"/1.000000000,0 -> /<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "g"/8.000000000,0 -> /<empty>
-data: "g"/1.000000000,0 -> /BYTES/g1
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "h"/8.000000000,0 -> /<empty>
-data: "h"/1.000000000,0 -> /<empty>
+data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/8.000000000,0 -> /<empty>
-data: "i"/1.000000000,0 -> /BYTES/i1
+data: "i"/1.000000000,0 -> /<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "j"/8.000000000,0 -> /BYTES/j8
-data: "j"/1.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/8.000000000,0 -> /BYTES/k8
+data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "l"/8.000000000,0 -> /BYTES/l8
+data: "l"/1.000000000,0 -> /<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "m"/7.000000000,0 -> /BYTES/m7
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
@@ -14,7 +14,9 @@
 # This uses two range tombstones, since the lowest is the one that matters for
 # point key GCBytesAge. It also uses points below/above range tombstones,
 # because iterators surface range keys separately from point keys, which can
-# cause bugs if callers don't step onto the point key.
+# cause bugs if callers don't step onto the point key. Additionally, it sets a
+# local timestamp for some tombstones, to ensure non-empty tombstone values are
+# handled correctly.
 #
 # TODO(erikgrinaker): This is probably better handled by randomized or
 # generative testing, since the combinations are getting unwieldy. But it'll do
@@ -23,20 +25,20 @@
 run stats ok
 with ts=1
   put k=b v=b1
-  del k=c
+  del k=c localTs=0.9
   put k=e v=e1
-  del k=f
+  del k=f localTs=0.9
   put k=h v=h1
-  del k=i
+  del k=i localTs=0.9
   put k=k v=k1
-  del k=l
+  del k=l localTs=0.9
 del_range_ts k=g end=s ts=3
 del_range_ts k=g end=s ts=4
 with ts=5
   put k=n v=n5
-  del k=o
+  del k=o localTs=0.9
   put k=q v=q5
-  del k=r
+  del k=r localTs=0.9
 with t=A
   txn_begin ts=6
   put k=a v=a6
@@ -44,54 +46,54 @@ with t=A
   put k=c v=c6
   del k=d
   del k=e
-  del k=f
+  del k=f localTs=5.9
   put k=g v=g6
   put k=h v=h6
   put k=i v=i6
   del k=j
   del k=k
-  del k=l
+  del k=l localTs=5.9
   put k=m v=m6
   put k=n v=n6
   put k=o v=o6
   del k=p
   del k=q
-  del k=r
+  del k=r localTs=5.9
 ----
 >> put k=b v=b1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=c ts=1
+>> del k=c localTs=0.9 ts=1
 del: "c": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=e v=e1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=f ts=1
+>> del k=f localTs=0.9 ts=1
 del: "f": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=h v=h1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=i ts=1
+>> del k=i localTs=0.9 ts=1
 del: "i": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> put k=k v=k1 ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=l ts=1
+>> del k=l localTs=0.9 ts=1
 del: "l": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1386
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2277
 >> del_range_ts k=g end=s ts=3
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
 >> del_range_ts k=g end=s ts=4
 stats: range_key_bytes=+9 range_val_count=+1 gc_bytes_age=+860
 >> put k=n v=n5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=o ts=5
+>> del k=o localTs=0.9 ts=5
 del: "o": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=q v=q5 ts=5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del k=r ts=5
+>> del k=r localTs=0.9 ts=5
 del: "r": found key false
-stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1330
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2185
 >> put k=a v=a6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=b v=b6 t=A
@@ -104,9 +106,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=e t=A
 del: "e": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=f t=A
+>> del k=f localTs=5.9 t=A
 del: "f": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=g v=g6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=h v=h6 t=A
@@ -119,9 +121,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=k t=A
 del: "k": found key false
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5634 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=l t=A
+>> del k=l localTs=5.9 t=A
 del: "l": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5630 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6852 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> put k=m v=m6 t=A
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 separated_intent_count=+1 intent_age=+94
 >> put k=n v=n6 t=A
@@ -134,9 +136,9 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5828 
 >> del k=q t=A
 del: "q": found key true
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7614 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
->> del k=r t=A
+>> del k=r localTs=5.9 t=A
 del: "r": found key false
-stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5638 intent_count=+1 intent_bytes=+12 separated_intent_count=+1 intent_age=+94
+stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6860 intent_count=+1 intent_bytes=+25 separated_intent_count=+1 intent_age=+94
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -147,15 +149,15 @@ data: "b"/6.000000000,0 -> /BYTES/b6
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/6.000000000,0 -> /BYTES/c6
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "d"/6.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "e"/6.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
-meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "f"/6.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "f"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "g"/6.000000000,0 -> /BYTES/g6
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -163,15 +165,15 @@ data: "h"/6.000000000,0 -> /BYTES/h6
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/6.000000000,0 -> /BYTES/i6
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "j"/6.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/6.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
-meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "l"/6.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "l"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "m"/6.000000000,0 -> /BYTES/m6
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -179,16 +181,16 @@ data: "n"/6.000000000,0 -> /BYTES/n6
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "o"/6.000000000,0 -> /BYTES/o6
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "p"/6.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "q"/6.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
-meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
-data: "r"/6.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=72435 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1692
+meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} ts=6.000000000,0 del=true klen=12 vlen=13 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "r"/6.000000000,0 -> {localTs=5.000000009,0}/<empty>
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1062 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=81375 intent_count=18 intent_bytes=318 separated_intent_count=18 intent_age=1692
 
 # Rewrite the same keys at a higher timestamp.
 run stats ok
@@ -228,7 +230,7 @@ del: "e": found key true
 stats: gc_bytes_age=-81 intent_age=-1
 >> del k=f t=A ts=7
 del: "f": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1284 intent_bytes=-13 intent_age=-1
 >> put k=g v=g7 t=A ts=7
 stats: intent_age=-1
 >> put k=h v=h7 t=A ts=7
@@ -243,7 +245,7 @@ del: "k": found key false
 stats: gc_bytes_age=-62 intent_age=-1
 >> del k=l t=A ts=7
 del: "l": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1284 intent_bytes=-13 intent_age=-1
 >> put k=m v=m7 t=A ts=7
 stats: intent_age=-1
 >> put k=n v=n7 t=A ts=7
@@ -258,7 +260,7 @@ del: "q": found key true
 stats: gc_bytes_age=-81 intent_age=-1
 >> del k=r t=A ts=7
 del: "r": found key false
-stats: gc_bytes_age=-62 intent_age=-1
+stats: val_bytes=-13 gc_bytes_age=-1284 intent_bytes=-13 intent_age=-1
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {g-s}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -269,7 +271,7 @@ data: "b"/7.000000000,0 -> /BYTES/b7
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "c"/7.000000000,0 -> /BYTES/c7
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "d"/7.000000000,0 -> /<empty>
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -277,7 +279,7 @@ data: "e"/7.000000000,0 -> /<empty>
 data: "e"/1.000000000,0 -> /BYTES/e1
 meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "f"/7.000000000,0 -> /<empty>
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "g"/7.000000000,0 -> /BYTES/g7
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -285,7 +287,7 @@ data: "h"/7.000000000,0 -> /BYTES/h7
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/7.000000000,0 -> /BYTES/i7
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "j"/7.000000000,0 -> /<empty>
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -293,7 +295,7 @@ data: "k"/7.000000000,0 -> /<empty>
 data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "l"/7.000000000,0 -> /<empty>
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "m"/7.000000000,0 -> /BYTES/m7
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -301,7 +303,7 @@ data: "n"/7.000000000,0 -> /BYTES/n7
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/7.000000000,0 -> /BYTES/o7
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "p"/7.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -309,8 +311,8 @@ data: "q"/7.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
 meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/7.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=71801 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1674
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=77075 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1674
 
 # Rewrite keys<->tombstones at a higher timestamp.
 run stats ok
@@ -370,7 +372,7 @@ data: "b"/8.000000000,0 -> /<empty>
 data: "b"/1.000000000,0 -> /BYTES/b1
 meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "c"/8.000000000,0 -> /<empty>
-data: "c"/1.000000000,0 -> /<empty>
+data: "c"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "d"/8.000000000,0 -> /BYTES/d8
 meta: "e"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -378,7 +380,7 @@ data: "e"/8.000000000,0 -> /BYTES/e8
 data: "e"/1.000000000,0 -> /BYTES/e1
 meta: "f"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "f"/8.000000000,0 -> /BYTES/f8
-data: "f"/1.000000000,0 -> /<empty>
+data: "f"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "g"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "g"/8.000000000,0 -> /<empty>
 meta: "h"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -386,7 +388,7 @@ data: "h"/8.000000000,0 -> /<empty>
 data: "h"/1.000000000,0 -> /BYTES/h1
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "i"/8.000000000,0 -> /<empty>
-data: "i"/1.000000000,0 -> /<empty>
+data: "i"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "j"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "j"/8.000000000,0 -> /BYTES/j8
 meta: "k"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -394,7 +396,7 @@ data: "k"/8.000000000,0 -> /BYTES/k8
 data: "k"/1.000000000,0 -> /BYTES/k1
 meta: "l"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=2 ts=8.000000000,0 min=0,0 seq=0} ts=8.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "l"/8.000000000,0 -> /BYTES/l8
-data: "l"/1.000000000,0 -> /<empty>
+data: "l"/1.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "m"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "m"/7.000000000,0 -> /BYTES/m7
 meta: "n"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -402,7 +404,7 @@ data: "n"/7.000000000,0 -> /BYTES/n7
 data: "n"/5.000000000,0 -> /BYTES/n5
 meta: "o"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "o"/7.000000000,0 -> /BYTES/o7
-data: "o"/5.000000000,0 -> /<empty>
+data: "o"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
 meta: "p"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "p"/7.000000000,0 -> /<empty>
 meta: "q"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -410,5 +412,5 @@ data: "q"/7.000000000,0 -> /<empty>
 data: "q"/5.000000000,0 -> /BYTES/q5
 meta: "r"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=1 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/7.000000000,0 -> /<empty>
-data: "r"/5.000000000,0 -> /<empty>
-stats: key_count=18 key_bytes=396 val_count=30 val_bytes=969 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=71391 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1662
+data: "r"/5.000000000,0 -> {localTs=0.000000009,0}/<empty>
+stats: key_count=18 key_bytes=396 val_count=30 val_bytes=1023 range_key_count=1 range_key_bytes=22 range_val_count=2 live_count=9 live_bytes=621 gc_bytes_age=76665 intent_count=18 intent_bytes=279 separated_intent_count=18 intent_age=1662


### PR DESCRIPTION
**storage: fix `TestMVCCHistories` intent resolution test diagram**

This patch updates the MVCC range tombstone intent resolution test cases
in `TestMVCCHistories` to correctly reflect the state of the diagram.

Release justification: non-production code changes

Release note: None
  
**storage: fix non-empty tombstone handling in intent resolution**

This patch fixes the `GCBytesAge` MVCC stats calculation when an intent
is aborted above a point tombstone with a non-empty value (i.e. an
`MVCCValueHeader` with `LocalTimestamp` set) covered by an MVCC range
tombstone, e.g.:

```
3     [b3]    intent b@3=b3 which will be aborted
2  [-------)  range tombstone [a-c)@2
1      x      point tombstone b@1 with `MVCCValueHeader.LocalTimestamp`
   a   b   c
```

Previously, the point tombstone was not correctly detected as such,
since the `MVCCValueHeader` was not decoded first, only the raw byte
value was checked. Incorrectly considered a live key, the `GCBytesAge`
contribution was therefore calculated from the range tombstone's
timestamp (`@2`) instead of its own timestamp (`@1`).

This was originally caused by merge skew with the MVCC stats handling
for range tombstones and the introduction of the `MVCCValueHeader` with
`LocalTimestamp`.

Resolves #87096.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None