### PR TITLE
storage: fix mvcc stats on gc of range tombstone over del

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4810,16 +4810,16 @@ func MVCCGarbageCollect(
 
 		unsafeKey := iter.UnsafeKey()
 		implicitMeta := unsafeKey.IsValue()
-		// First check for the case of range tombstone covering keys when no
-		// metadata is available.
-		//
 		// Note that we naively can't terminate GC'ing keys loop early if we
 		// enter any of branches below, as it will update the stats under the
 		// provision that the (implicit or explicit) meta key (and thus all
 		// versions) are being removed. We had this faulty functionality at some
 		// point; it should no longer be necessary since the higher levels already
 		// make sure each individual GCRequest does bounded work.
-		if implicitMeta && meta.Deleted && !unsafeKey.Timestamp.Equal(realKeyChanged) {
+		//
+		// First check for the case of range tombstone covering keys when no
+		// metadata is available.
+		if implicitMeta && meta.Deleted && !meta.Timestamp.Equal(unsafeKey.Timestamp) {
 			// If we have implicit deletion meta, and realKeyChanged is not the first
 			// key in history, that means it is covered by a range tombstone (which
 			// was used to synthesize meta).

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4767,6 +4767,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				{roachpb.Key("r-2"), []roachpb.Value{val1}, false},
 				{roachpb.Key("r-3"), []roachpb.Value{val1}, false},
 				{roachpb.Key("r-4"), []roachpb.Value{val1}, false},
+				{roachpb.Key("r-6"), []roachpb.Value{val1}, true},
 				{roachpb.Key("t"), []roachpb.Value{val1}, false},
 			}
 
@@ -4840,6 +4841,8 @@ func TestMVCCGarbageCollect(t *testing.T) {
 				// This is a non-existing key that needs to skip gracefully without
 				// distorting stats. Checking that absence of next key is handled.
 				{Key: roachpb.Key("r-5"), Timestamp: ts4},
+				// Delete key covered by range delete key.
+				{Key: roachpb.Key("r-6"), Timestamp: ts4},
 
 				{Key: roachpb.Key("t"), Timestamp: ts4},
 			}


### PR DESCRIPTION
Previously if range tombstone was placed over delete, GC would
not correctly update GC bytes age incorrectly using range tombstone ts
as age of underlying tombstone.

Release justification: Bugfix
Release note: None

Fixing: #87042