### PR TITLE
roachtest: skip flaky acceptance/version-upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -75,6 +75,7 @@ func registerAcceptance(r registry.Registry) {
 				// to head after 19.2 fails.
 				minVersion: "v19.2.0",
 				timeout:    30 * time.Minute,
+				skip:       "https://github.com/cockroachdb/cockroach/issues/87104",
 			},
 		},
 	}


### PR DESCRIPTION
Skipping the flaky roachtest while we stabilize it.

Informs: #87104

Release note: None

Release justification: testing only change