### PR TITLE
sql: add secondary region implicitly

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -17,8 +17,22 @@ CREATE DATABASE non_mr;
 statement error database must be multi-region to support a secondary region
 ALTER DATABASE non_mr SET SECONDARY REGION "ap-southeast2"
 
-statement error pq: region .* has not been added to the database
+statement ok
 CREATE DATABASE no_list PRIMARY REGION "ap-southeast-2" SECONDARY REGION "ca-central-1"
+
+# Verify secondry region is added implicitly
+query TT
+SHOW ZONE CONFIGURATION FOR DATABASE no_list;
+----
+DATABASE no_list  ALTER DATABASE no_list CONFIGURE ZONE USING
+                  range_min_bytes = 134217728,
+                  range_max_bytes = 536870912,
+                  gc.ttlseconds = 90000,
+                  num_replicas = 4,
+                  num_voters = 3,
+                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1}',
+                  voter_constraints = '[+region=ap-southeast-2]',
+                  lease_preferences = '[[+region=ap-southeast-2, +region=ca-central-1]]'
 
 statement ok
 CREATE DATABASE db PRIMARY REGION "ap-southeast-2" REGIONS "ca-central-1" SECONDARY REGION "ca-central-1"
@@ -466,12 +480,12 @@ ALTER DATABASE mr1 ALTER SUPER REGION "test1" VALUES "us-east-1"
 query TTTTT colnames
 SHOW REGIONS
 ----
-region          zones                      database_names    primary_region_of  secondary_region_of
-ap-southeast-2  {ap-az1,ap-az2,ap-az3}     {db,mr1,mr2,mr3}  {db,mr2}           {}
-ca-central-1    {ca-az1,ca-az2,ca-az3}     {db,mr1,mr2,mr3}  {mr3}              {mr2}
-us-central-1    {usc-az1,usc-az2,usc-az3}  {mr1,mr2,mr3}     {}                 {mr3}
-us-east-1       {us-az1,us-az2,us-az3}     {db,mr1,mr2,mr3}  {mr1}              {}
-us-west-1       {usw-az1,usw-az2,usw-az3}  {mr1,mr2,mr3}     {}                 {mr1}
+region          zones                      database_names            primary_region_of  secondary_region_of
+ap-southeast-2  {ap-az1,ap-az2,ap-az3}     {db,mr1,mr2,mr3,no_list}  {db,mr2,no_list}   {}
+ca-central-1    {ca-az1,ca-az2,ca-az3}     {db,mr1,mr2,mr3,no_list}  {mr3}              {mr2,no_list}
+us-central-1    {usc-az1,usc-az2,usc-az3}  {mr1,mr2,mr3}             {}                 {mr3}
+us-east-1       {us-az1,us-az2,us-az3}     {db,mr1,mr2,mr3}          {mr1}              {}
+us-west-1       {usw-az1,usw-az2,usw-az3}  {mr1,mr2,mr3}             {}                 {mr1}
 
 query TTBBT colnames
 SHOW REGIONS FROM DATABASE mr1
@@ -512,6 +526,7 @@ defaultdb      {}                                                              N
 mr1            {ap-southeast-2,ca-central-1,us-central-1,us-east-1,us-west-1}  us-east-1       us-west-1
 mr2            {ap-southeast-2,ca-central-1,us-central-1,us-east-1,us-west-1}  ap-southeast-2  ca-central-1
 mr3            {ap-southeast-2,ca-central-1,us-central-1,us-east-1,us-west-1}  ca-central-1    us-central-1
+no_list        {ap-southeast-2,ca-central-1}                                   ap-southeast-2  ca-central-1
 non_mr         {}                                                              NULL            NULL
 postgres       {}                                                              NULL            NULL
 system         {}                                                              NULL            NULL

--- a/pkg/ccl/multiregionccl/multiregion.go
+++ b/pkg/ccl/multiregionccl/multiregion.go
@@ -95,6 +95,12 @@ func initializeMultiRegionMetadata(
 		regionNames = append(regionNames, primaryRegion)
 	}
 
+	if secondaryRegion != catpb.RegionName(tree.SecondaryRegionNotSpecifiedName) {
+		if _, ok := seenRegions[secondaryRegion]; !ok {
+			regionNames = append(regionNames, secondaryRegion)
+		}
+	}
+
 	sort.SliceStable(regionNames, func(i, j int) bool {
 		return regionNames[i] < regionNames[j]
 	})

--- a/pkg/sql/create_database.go
+++ b/pkg/sql/create_database.go
@@ -149,21 +149,6 @@ func (p *planner) CreateDatabase(ctx context.Context, n *tree.CreateDatabase) (p
 		)
 	}
 
-	if n.SecondaryRegion != tree.SecondaryRegionNotSpecifiedName {
-		if !n.Regions.Contains(n.SecondaryRegion) {
-			return nil, errors.WithHintf(
-				pgerror.Newf(pgcode.InvalidName,
-					"region %s has not been added to the database",
-					n.SecondaryRegion.String(),
-				),
-				"you must add the region to the database before setting it as primary region, using "+
-					"ALTER DATABASE %s ADD REGION %s",
-				n.Name.String(),
-				n.SecondaryRegion.String(),
-			)
-		}
-	}
-
 	return &createDatabaseNode{n: n}, nil
 }
 


### PR DESCRIPTION
fixes #86880

This commit adds the secondary region onto the database when
it is declared.

Release justification: Low risk changes to existing functionality
Release note (sql change): The SECONDARY REGION is added onto the db, when it is declared. The region assigned as the SECONDARY REGION  doesn't need to be explicitly listed in REGIONS