### PR TITLE
ui: fixes to high contention copy in insight workload pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/detailsPanels/waitTimeInsightsPanel.tsx
@@ -24,7 +24,7 @@ import styles from "../statementDetails/statementDetails.module.scss";
 const cx = classNames.bind(styles);
 
 export const WaitTimeInsightsLabels = {
-  SECTION_HEADING: "Contention Time Insights",
+  SECTION_HEADING: "Contention Insights",
   BLOCKED_SCHEMA: "Blocked Schema",
   BLOCKED_DATABASE: "Blocked Database",
   BLOCKED_TABLE: "Blocked Table",
@@ -36,6 +36,8 @@ export const WaitTimeInsightsLabels = {
     `${capitalize(execType)} ID: ${id} waiting on`,
   WAITING_TXNS_TABLE_TITLE: (id: string, execType: ExecutionType): string =>
     `${capitalize(execType)}s waiting for ID: ${id}`,
+  WAITED_TXNS_TABLE_TITLE: (id: string, execType: ExecutionType): string =>
+    `${capitalize(execType)}s that waited for ID: ${id}`,
 };
 
 type WaitTimeInsightsPanelProps = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -219,7 +219,7 @@ export function insightType(type: InsightType): string {
     case "ReplaceIndex":
       return "Replace Index";
     case "HighContentionTime":
-      return "High Contention Time";
+      return "High Contention";
     case "HighRetryCount":
       return "High Retry Counts";
     case "SuboptimalPlan":

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -74,7 +74,7 @@ export class StatementInsightDetails extends React.Component<StatementInsightDet
 
       insightDetails.insights.forEach(insight => {
         switch (insight.name) {
-          case InsightNameEnum.highContentionTime:
+          case InsightNameEnum.highContention:
             rec = {
               type: "HighContentionTime",
               execution: execDetails,

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -112,7 +112,7 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
       let rec: InsightRecommendation;
       insightDetails.insights.forEach(insight => {
         switch (insight.name) {
-          case InsightNameEnum.highContentionTime:
+          case InsightNameEnum.highContention:
             rec = {
               type: "HighContentionTime",
               details: {
@@ -189,7 +189,7 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
             <Col>
               <Row>
                 <Heading type="h5">
-                  {WaitTimeInsightsLabels.WAITING_TXNS_TABLE_TITLE(
+                  {WaitTimeInsightsLabels.WAITED_TXNS_TABLE_TITLE(
                     insightDetails.executionID,
                     insightDetails.execType,
                   )}


### PR DESCRIPTION
Previously, the High Contention insight type was labeled
"High Contention Time", and the waiting transactions list
was labeled in the incorrect tense. This commit fixes those
typos.

Release justification: bug fix
Release note: None