### PR TITLE
roachtest,sqlinstance: fix multitenant_upgrade test

### DIFF
--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -53,7 +53,6 @@ func registerAcceptance(r registry.Registry) {
 		registry.OwnerMultiTenant: {
 			{
 				name: "multitenant",
-				skip: "https://github.com/cockroachdb/cockroach/issues/81506",
 				fn:   runAcceptanceMultitenant,
 			},
 		},

--- a/pkg/sql/sqlinstance/instancestorage/instancereader.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancereader.go
@@ -162,6 +162,7 @@ func (r *Reader) maybeStartRangeFeed(ctx context.Context) *rangefeed.RangeFeed {
 		updateCacheFn,
 		rangefeed.WithInitialScan(initialScanDoneFn),
 		rangefeed.WithOnInitialScanError(initialScanErrFn),
+		rangefeed.WithRowTimestampInInitialScan(true),
 	)
 	r.setStarted()
 	if err != nil {


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/81517
fixes https://github.com/cockroachdb/cockroach/issues/81506

### roachtest: fix ordering of multitenant upgrade test step

The tenant must be initialized by a system tenant using an old binary in
order to be running on an old binary itself.

Also, we no longer finalize the secondary tenant upgrade before finalizing the
system tenant upgrade.

### sqlinstance: use the correct timestamp when populating the cache

Previously, the sql instance cache would be populated using the
timestamp of the initial rangefeed scan. This was a bug since the
timestamp is used to determine which sql instance ID to use when there
are two IDs for the same address (i.e., it should use the most recent
one).

This caused problems if a tenant node was shutdown, then started with
the same address. Other layers like DistSQL would try to route requests
to an old sql instance, which would actually be the same as the
requesting node.

Release note: None

Release justification: test only change, and critical bug fix