### PR TITLE
ci: fix nightlies that are invoking `bazci` incorrectly

### DIFF
--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -22,7 +22,7 @@ GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
 
 exit_status=0
 $BAZCI --artifacts_dir=$ARTIFACTS_DIR -- \
-       test --config=ci //pkg/compose:compose_test -- \
+       test --config=ci //pkg/compose:compose_test \
        --test_env=GO_TEST_WRAP_TESTV=1 \
        --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE \
        --test_arg -cockroach --test_arg $COCKROACH \

--- a/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
+++ b/build/teamcity/cockroach/nightlies/lint_urls_impl.sh
@@ -9,9 +9,9 @@ bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
-XML_OUTPUT_FILE=/artifacts/test.xml GO_TEST_WRAP_TESTV=1 GO_TEST_WRAP=1 bazel \
-	       run --config=ci --config=test --define gotags=bazel,gss,nightly \
-	       //build/bazelutil:lint || exit_status=$?
+XML_OUTPUT_FILE=/artifacts/test.xml GO_TEST_WRAP_TESTV=1 GO_TEST_WRAP=1 GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE bazel \
+    run --config=ci --config=test --define gotags=bazel,gss,nightly \
+    //build/bazelutil:lint || exit_status=$?
 # The schema of the output test.xml will be slightly wrong -- ask `bazci` to fix
 # it up.
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci munge-test-xml /artifacts/test.xml

--- a/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/optimizer_tests_impl.sh
@@ -34,8 +34,9 @@ ARTIFACTS_DIR=/artifacts/fast_int_set_small
 mkdir $ARTIFACTS_DIR
 GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
 exit_status_small=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --config=ci \
-    test //pkg/sql/opt:opt_test -- \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci --artifacts_dir $ARTIFACTS_DIR -- \
+    test --config=ci \
+    //pkg/sql/opt:opt_test \
     --define gotags=bazel,crdb_test,fast_int_set_small \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status_small=$?
 process_test_json \

--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -9,8 +9,8 @@ bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci \
-    test //pkg/sql/tests:tests_test \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
+    //pkg/sql/tests:tests_test \
     --test_arg -rsg=5m --test_arg -rsg-routines=8 --test_arg -rsg-exec-timeout=1m \
     --test_timeout 3600 --test_filter 'TestRandomSyntax' \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?

--- a/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqlite_logic_test_impl.sh
@@ -9,8 +9,8 @@ bazel build //pkg/cmd/bazci //pkg/cmd/github-post //pkg/cmd/testfilter --config=
 BAZEL_BIN=$(bazel info bazel-bin --config=ci)
 GO_TEST_JSON_OUTPUT_FILE=/artifacts/test.json.txt
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci --config=crdb_test_off \
-    test //pkg/sql/sqlitelogictest/tests/... \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=crdb_test_off \
+    //pkg/sql/sqlitelogictest/tests/... \
     --test_arg -bigtest --test_arg -flex-types --test_timeout 86400 \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?
 process_test_json \

--- a/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_hi_vmodule_nightly_impl.sh
@@ -12,8 +12,8 @@ ARTIFACTS_DIR=/artifacts
 GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt
 
 exit_status=0
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci \
-    test //pkg/sql/logictest/tests/... \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
+    //pkg/sql/logictest/tests/... \
     --test_arg=--vmodule=*=10 \
     --test_arg=-show-sql \
     --test_env=GO_TEST_WRAP_TESTV=1 \


### PR DESCRIPTION
Some of these nightlies were broken as a result of
`c8d66a9c334dd87acd62190f314a4f3ec236ce82`.

Release justification: Non-production code changes
Release note: None