### PR TITLE
sql: deflake TestDistSQLReceiverReportsContention

### DIFF
--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -293,6 +293,12 @@ func TestDistSQLReceiverReportsContention(t *testing.T) {
 		// events.
 		s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
 		defer s.Stopper().Stop(ctx)
+
+		// Disable sampling so that only our query (below) gets a trace.
+		// Otherwise, we're subject to flakes when internal queries experience contention.
+		_, err := db.Exec("SET CLUSTER SETTING sql.txn_stats.sample_rate = 0")
+		require.NoError(t, err)
+
 		sqlutils.CreateTable(
 			t, db, "test", "x INT PRIMARY KEY", 1, sqlutils.ToRowFn(sqlutils.RowIdxFn),
 		)


### PR DESCRIPTION
Fixes #86112.

Turning off sampling altogether means we'll only trace the query of
interest, avoiding flakes when internal queries also experience
contention and happen to get sampled.

Before this change,
`TestDistSQLReceiverReportsContention/contention=false` would reliably
fail under stress[^1]; now it succeeds.

[^1]: Run as:
    ```
    ./dev test pkg/sql:sql_test \
      --filter 'TestDistSQLReceiverReportsContention' \
      --stress -v --show-logs --timeout=10m
    ```

Release justification: Category 1: Non-production code changes

Release note: None