### PR TITLE
bazci: fix output path computation

### DIFF
--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -185,6 +185,7 @@ func processBuildEventProtocolLog(action, bepLoc string) error {
 			outputDir = filepath.Join("bazel-testlogs", outputDir)
 			summary := event.GetTestSummary()
 			for _, testResult := range testResults[label] {
+				outputDir := outputDir
 				if testResult.run > 1 {
 					outputDir = filepath.Join(outputDir, fmt.Sprintf("run_%d", testResult.run))
 				}


### PR DESCRIPTION
These updates were happening in-place so `bazci` was constructing big,
silly paths like `backupccl_test/shard_6_of_16/shard_7_of_16/shard_13_of_16/...`
We just need to copy the variable here.

Release justification: Non-production code changes
Release note: None