### PR TITLE
bazel: set `GORACE` variable appropriately when testing w/ `race`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -32,7 +32,7 @@ query --ui_event_filters=-DEBUG
 clean --ui_event_filters=-WARNING
 info --ui_event_filters=-WARNING
 
-build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
+build:race --@io_bazel_rules_go//go/config:race "--test_env=GORACE=halt_on_error=1 log_path=stdout" --test_sharding_strategy=disabled
 test:test --test_env=TZ=
 test:race --test_timeout=1200,6000,18000,72000
 


### PR DESCRIPTION
By default the `race` data is output to `stderr`, which means it ends up
in the `test.log` file but NOT the `test.xml` file. Changing it to
`stdout` means that this instead ends up `test.xml` as well as
`test.log` and any output JSON files.

Closes #74105.

Release justification: Non-production code changes
Release note: None