### PR TITLE
storage: assert iterator invariants

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1460,7 +1460,11 @@ func assertSimpleMVCCIteratorInvariants(iter SimpleMVCCIterator) error {
 	// Any valid position must have either a point and/or range key.
 	hasPoint, hasRange := iter.HasPointAndRange()
 	if !hasPoint && !hasRange {
-		return errors.AssertionFailedf("valid iterator without point/range keys at %s", key)
+		// NB: MVCCIncrementalIterator can return hasPoint=false,hasRange=false
+		// following a NextIgnoringTime() call. We explicitly allow this here.
+		if incrIter, ok := iter.(*MVCCIncrementalIterator); !ok || !incrIter.ignoringTime {
+			return errors.AssertionFailedf("valid iterator without point/range keys at %s", key)
+		}
 	}
 
 	// Range key assertions.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -43,6 +43,8 @@ func init() {
 // noted. SimpleMVCCIterator is a subset of the functionality offered by
 // MVCCIterator.
 //
+// API invariants are asserted via assertSimpleMVCCIteratorInvariants().
+//
 // The iterator exposes both point keys and range keys. Range keys are only
 // emitted when enabled via IterOptions.KeyTypes. Currently, all range keys are
 // MVCC range tombstones, and this is enforced during writes.
@@ -215,7 +217,8 @@ type IteratorStats struct {
 // over the key space that never has multiple versions (i.e.,
 // MVCCKey.Timestamp.IsEmpty()).
 //
-// MVCCIterator implementations are thread safe unless otherwise noted.
+// MVCCIterator implementations are thread safe unless otherwise noted. API
+// invariants are asserted via assertMVCCIteratorInvariants().
 //
 // For details on range keys and iteration, see comment on SimpleMVCCIterator.
 type MVCCIterator interface {
@@ -1434,5 +1437,154 @@ func iterateOnReader(
 			return iterutil.Map(err)
 		}
 	}
+	return nil
+}
+
+// assertSimpleMVCCIteratorInvariants asserts invariants in the
+// SimpleMVCCIterator interface that should hold for all implementations,
+// returning errors.AssertionFailedf for any violations. The iterator
+// must be valid.
+func assertSimpleMVCCIteratorInvariants(iter SimpleMVCCIterator) error {
+	key := iter.UnsafeKey()
+
+	// Keys can't be empty.
+	if len(key.Key) == 0 {
+		return errors.AssertionFailedf("valid iterator returned empty key")
+	}
+
+	// Can't be positioned in the lock table.
+	if bytes.HasPrefix(key.Key, keys.LocalRangeLockTablePrefix) {
+		return errors.AssertionFailedf("MVCC iterator positioned in lock table at %s", key)
+	}
+
+	// Any valid position must have either a point and/or range key.
+	hasPoint, hasRange := iter.HasPointAndRange()
+	if !hasPoint && !hasRange {
+		return errors.AssertionFailedf("valid iterator without point/range keys at %s", key)
+	}
+
+	// Range key assertions.
+	if hasRange {
+		// Must have bounds. The MVCCRangeKey.Validate() call below will make
+		// further bounds assertions.
+		bounds := iter.RangeBounds()
+		if len(bounds.Key) == 0 && len(bounds.EndKey) == 0 {
+			return errors.AssertionFailedf("hasRange=true but empty range bounds at %s", key)
+		}
+
+		// Iterator position must be within range key bounds.
+		if !bounds.ContainsKey(key.Key) {
+			return errors.AssertionFailedf("iterator position %s outside range bounds %s", key, bounds)
+		}
+
+		// Bounds must match range key stack.
+		rangeKeys := iter.RangeKeys()
+		if !rangeKeys.Bounds.Equal(bounds) {
+			return errors.AssertionFailedf("range bounds %s does not match range key %s",
+				bounds, rangeKeys.Bounds)
+		}
+
+		// Must have range keys.
+		if rangeKeys.IsEmpty() {
+			return errors.AssertionFailedf("hasRange=true but no range key versions at %s", key)
+		}
+
+		for i, v := range rangeKeys.Versions {
+			// Range key must be valid.
+			rangeKey := rangeKeys.AsRangeKey(v)
+			if err := rangeKey.Validate(); err != nil {
+				return errors.NewAssertionErrorWithWrappedErrf(err, "invalid range key at %s", key)
+			}
+			// Range keys must be in descending timestamp order.
+			if i > 0 && !v.Timestamp.Less(rangeKeys.Versions[i-1].Timestamp) {
+				return errors.AssertionFailedf("range key %s not below version %s",
+					rangeKey, rangeKeys.Versions[i-1].Timestamp)
+			}
+			// Range keys must currently be tombstones.
+			if value, err := DecodeMVCCValue(v.Value); err != nil {
+				return errors.NewAssertionErrorWithWrappedErrf(err, "invalid range key value at %s",
+					rangeKey)
+			} else if !value.IsTombstone() {
+				return errors.AssertionFailedf("non-tombstone range key %s with value %x",
+					rangeKey, value.Value.RawBytes)
+			}
+		}
+
+	} else {
+		// Bounds and range keys must be empty.
+		if bounds := iter.RangeBounds(); !bounds.Equal(roachpb.Span{}) {
+			return errors.AssertionFailedf("hasRange=false but RangeBounds=%s", bounds)
+		}
+		if r := iter.RangeKeys(); !r.IsEmpty() || !r.Bounds.Equal(roachpb.Span{}) {
+			return errors.AssertionFailedf("hasRange=false but RangeKeys=%s", r)
+		}
+	}
+
+	return nil
+}
+
+// assertMVCCIteratorInvariants asserts invariants in the MVCCIterator interface
+// that should hold for all implementations, returning errors.AssertionFailedf
+// for any violations. It calls through to assertSimpleMVCCIteratorInvariants().
+// The iterator must be valid.
+func assertMVCCIteratorInvariants(iter MVCCIterator) error {
+	// Assert SimpleMVCCIterator invariants.
+	if err := assertSimpleMVCCIteratorInvariants(iter); err != nil {
+		return err
+	}
+
+	key := iter.Key()
+
+	// Key must equal UnsafeKey.
+	if u := iter.UnsafeKey(); !key.Equal(u) {
+		return errors.AssertionFailedf("Key %s does not match UnsafeKey %s", key, u)
+	}
+
+	// UnsafeRawMVCCKey must match Key.
+	if r, err := DecodeMVCCKey(iter.UnsafeRawMVCCKey()); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "failed to decode UnsafeRawMVCCKey at %s",
+			key)
+	} else if !r.Equal(key) {
+		return errors.AssertionFailedf("UnsafeRawMVCCKey %s does not match Key %s", r, key)
+	}
+
+	// UnsafeRawKey must either be an MVCC key matching Key, or a lock table key
+	// that refers to it.
+	if engineKey, ok := DecodeEngineKey(iter.UnsafeRawKey()); !ok {
+		return errors.AssertionFailedf("failed to decode UnsafeRawKey as engine key at %s", key)
+	} else if engineKey.IsMVCCKey() {
+		if k, err := engineKey.ToMVCCKey(); err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "invalid UnsafeRawKey at %s", key)
+		} else if !k.Equal(key) {
+			return errors.AssertionFailedf("UnsafeRawKey %s does not match Key %s", k, key)
+		}
+	} else if engineKey.IsLockTableKey() {
+		if k, err := engineKey.ToLockTableKey(); err != nil {
+			return errors.NewAssertionErrorWithWrappedErrf(err, "invalid UnsafeRawKey at %s", key)
+		} else if !k.Key.Equal(key.Key) {
+			return errors.AssertionFailedf("UnsafeRawKey lock table key %s does not match Key %s", k, key)
+		} else if !key.Timestamp.IsEmpty() {
+			return errors.AssertionFailedf(
+				"UnsafeRawKey lock table key %s for Key %s with non-zero timestamp", k, key)
+		}
+	} else {
+		return errors.AssertionFailedf("unknown type for engine key %s", engineKey)
+	}
+
+	// Value must equal UnsafeValue.
+	if v, u := iter.Value(), iter.UnsafeValue(); !bytes.Equal(v, u) {
+		return errors.AssertionFailedf("Value %x does not match UnsafeValue %x at %s", v, u, key)
+	}
+
+	// For prefix iterators, any range keys must be point-sized. We've already
+	// asserted that the range key covers the iterator position.
+	if iter.IsPrefix() {
+		if _, hasRange := iter.HasPointAndRange(); hasRange {
+			if bounds := iter.RangeBounds(); !bounds.EndKey.Equal(bounds.Key.Next()) {
+				return errors.AssertionFailedf("prefix iterator with wide range key %s", bounds)
+			}
+		}
+	}
+
 	return nil
 }

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -377,28 +378,35 @@ func (p *pebbleIterator) Valid() (bool, error) {
 	}
 	// NB: A Pebble Iterator always returns Valid()==false when an error is
 	// present. If Valid() is true, there is no error.
-	if ok := p.iter.Valid(); ok {
-		// The MVCCIterator interface is broken in that it silently discards
-		// the error when UnsafeKey(), Key() are unable to parse the key as
-		// an MVCCKey. This is especially problematic if the caller is
-		// accidentally iterating into the lock table key space, since that
-		// parsing will fail. We do a cheap check here to make sure we are
-		// not in the lock table key space.
-		//
-		// TODO(sumeer): fix this properly by changing those method signatures.
-		k := p.iter.Key()
-		if len(k) == 0 {
-			return false, errors.Errorf("iterator encountered 0 length key")
-		}
-		// Last byte is the version length + 1 or 0.
-		versionLen := int(k[len(k)-1])
-		if versionLen == engineKeyVersionLockTableLen+1 {
-			p.mvccDone = true
-			return false, nil
-		}
-		return ok, nil
+	if !p.iter.Valid() {
+		return false, p.iter.Error()
 	}
-	return false, p.iter.Error()
+
+	// The MVCCIterator interface is broken in that it silently discards
+	// the error when UnsafeKey(), Key() are unable to parse the key as
+	// an MVCCKey. This is especially problematic if the caller is
+	// accidentally iterating into the lock table key space, since that
+	// parsing will fail. We do a cheap check here to make sure we are
+	// not in the lock table key space.
+	//
+	// TODO(sumeer): fix this properly by changing those method signatures.
+	k := p.iter.Key()
+	if len(k) == 0 {
+		return false, errors.Errorf("iterator encountered 0 length key")
+	}
+	// Last byte is the version length + 1 or 0.
+	versionLen := int(k[len(k)-1])
+	if versionLen == engineKeyVersionLockTableLen+1 {
+		p.mvccDone = true
+		return false, nil
+	}
+
+	if util.RaceEnabled {
+		if err := p.assertMVCCInvariants(); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 // Next implements the MVCCIterator interface.
@@ -955,4 +963,47 @@ func (p *pebbleIterator) destroy() {
 		rangeKeyMaskingBuf: p.rangeKeyMaskingBuf,
 		reusable:           p.reusable,
 	}
+}
+
+// assertMVCCInvariants asserts internal MVCC iterator invariants, returning an
+// AssertionFailedf on any failures. It must be called on a valid iterator after
+// a complete state transition.
+func (p *pebbleIterator) assertMVCCInvariants() error {
+	// Assert general MVCCIterator API invariants.
+	if err := assertMVCCIteratorInvariants(p); err != nil {
+		return err
+	}
+
+	// The underlying iterator must be valid, with !mvccDone.
+	if !p.iter.Valid() {
+		errMsg := p.iter.Error().Error()
+		return errors.AssertionFailedf("underlying iter is invalid, with err=%s", errMsg)
+	}
+	if p.mvccDone {
+		return errors.AssertionFailedf("valid iter with mvccDone set")
+	}
+
+	// The position must match the underlying iter.
+	if key, iterKey := p.UnsafeKey(), p.iter.Key(); !bytes.Equal(EncodeMVCCKey(key), iterKey) {
+		return errors.AssertionFailedf("UnsafeKey %s does not match iterator key %x", key, iterKey)
+	}
+
+	// The iterator must be marked as in use.
+	if !p.inuse {
+		return errors.AssertionFailedf("valid iter with inuse=false")
+	}
+
+	// Prefix must be exposed.
+	if p.prefix != p.IsPrefix() {
+		return errors.AssertionFailedf("IsPrefix() does not match prefix=%v", p.prefix)
+	}
+
+	// Ensure !supportsRangeKeys never exposes range keys.
+	if !p.supportsRangeKeys {
+		if _, hasRange := p.HasPointAndRange(); hasRange {
+			return errors.AssertionFailedf("hasRange=true but supportsRangeKeys=false")
+		}
+	}
+
+	return nil
 }

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -503,15 +503,10 @@ func (p *pebbleIterator) NextKey() {
 
 // UnsafeKey implements the MVCCIterator interface.
 func (p *pebbleIterator) UnsafeKey() MVCCKey {
-	if valid, err := p.Valid(); err != nil || !valid {
-		return MVCCKey{}
-	}
-
 	mvccKey, err := DecodeMVCCKey(p.iter.Key())
 	if err != nil {
 		return MVCCKey{}
 	}
-
 	return mvccKey
 }
 

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -576,15 +576,17 @@ func (i *pointSynthesizingIter) Prev() {
 
 // Valid implements MVCCIterator.
 func (i *pointSynthesizingIter) Valid() (bool, error) {
-	if util.RaceEnabled {
+	valid := i.iterValid ||
+		// On synthetic point key.
+		(i.iterErr == nil && !i.atPoint && i.rangeKeysIdx >= 0 && i.rangeKeysIdx < i.rangeKeysEnd)
+
+	if util.RaceEnabled && valid {
 		if err := i.assertInvariants(); err != nil {
 			panic(err)
 		}
 	}
-	if i.iterErr == nil && !i.atPoint && i.rangeKeysIdx >= 0 && i.rangeKeysIdx < i.rangeKeysEnd {
-		return true, nil // on synthetic point key
-	}
-	return i.iterValid, i.iterErr
+
+	return valid, i.iterErr
 }
 
 // Key implements MVCCIterator.
@@ -688,8 +690,13 @@ func (i *pointSynthesizingIter) SupportsPrev() bool {
 	return i.iter.SupportsPrev()
 }
 
-// assertInvariants asserts iterator invariants.
+// assertInvariants asserts iterator invariants. The iterator must be valid.
 func (i *pointSynthesizingIter) assertInvariants() error {
+	// Check general MVCCIterator API invariants.
+	if err := assertMVCCIteratorInvariants(i); err != nil {
+		return err
+	}
+
 	// If the underlying iterator has errored, make sure we're not positioned on a
 	// synthetic point such that Valid() will surface the error.
 	if _, err := i.iter.Valid(); err != nil {

--- a/pkg/storage/point_synthesizing_iter.go
+++ b/pkg/storage/point_synthesizing_iter.go
@@ -589,7 +589,7 @@ func (i *pointSynthesizingIter) Valid() (bool, error) {
 
 // Key implements MVCCIterator.
 func (i *pointSynthesizingIter) Key() MVCCKey {
-	return i.iterKey.Clone()
+	return i.UnsafeKey().Clone()
 }
 
 // UnsafeKey implements MVCCIterator.
@@ -611,7 +611,7 @@ func (i *pointSynthesizingIter) UnsafeRawKey() []byte {
 	if i.atPoint {
 		return i.iter.UnsafeRawKey()
 	}
-	return EncodeMVCCKeyPrefix(i.rangeKeysPos)
+	return EncodeMVCCKey(i.UnsafeKey())
 }
 
 // UnsafeRawMVCCKey implements MVCCIterator.

--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -364,36 +364,6 @@ prev: output: value k=a ts=10.000000000,0 v=a10
 prev: output: meta k=a ts=10.000000000,0 txn=1
 prev: output: .
 
-# Error case: Multiple separated intents with no provisional values
-define
-locks
-meta k=b ts=20 txn=2
-meta k=d ts=40 txn=4
-----
-
-iter lower=a upper=f
-seek-ge k=a
-next
-seek-lt k=e
-next
-seek-ge k=d
-next-key
-seek-ge k=d
-prev
-seek-lt k=e
-prev
-----
-seek-ge "a"/0,0: output: meta k=b ts=20.000000000,0 txn=2
-next: output: err: intentIter at intent, but iter not at provisional value
-seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
-next: output: err: intent has no provisional value
-seek-ge "d"/0,0: output: meta k=d ts=40.000000000,0 txn=4
-next-key: output: err: intentIter at intent, but iter not at provisional value
-seek-ge "d"/0,0: output: meta k=d ts=40.000000000,0 txn=4
-prev: output: err: iter not at provisional value, cmp: -1
-seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
-prev: output: err: reverse iteration discovered intent without provisional value
-
 # Local range keys. This exercises local keys having separated locks.
 define
 locks

--- a/pkg/storage/testdata/intent_interleaving_iter/error_race
+++ b/pkg/storage/testdata/intent_interleaving_iter/error_race
@@ -3,6 +3,36 @@
 # when RaceEnabled=true. This file contains the output when
 # RaceEnabled=true
 
+# Error case: Multiple separated intents with no provisional values
+define
+locks
+meta k=b ts=20 txn=2
+meta k=d ts=40 txn=4
+----
+
+iter lower=a upper=f
+seek-ge k=a
+next
+seek-lt k=e
+next
+seek-ge k=d
+next-key
+seek-ge k=d
+prev
+seek-lt k=e
+prev
+----
+seek-ge "a"/0,0: output: err: missing provisional value for i.intentKey="b": i.iter exhausted
+next: output: err: intentIter at intent, but iter not at provisional value
+seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+next: output: err: intent has no provisional value
+seek-ge "d"/0,0: output: err: missing provisional value for i.intentKey="d": i.iter exhausted
+next-key: output: err: intentIter at intent, but iter not at provisional value
+seek-ge "d"/0,0: output: err: missing provisional value for i.intentKey="d": i.iter exhausted
+prev: output: err: iter not at provisional value, cmp: -1
+seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+prev: output: err: reverse iteration discovered intent without provisional value
+
 # Error case: Multiple intents for a key
 define
 locks
@@ -32,9 +62,9 @@ prev
 seek-ge "a"/0,0: output: meta k=a ts=10.000000000,0 txn=1
 next: output: value k=a ts=10.000000000,0 v=a10
 next: output: meta k=b ts=20.000000000,0 txn=4
-next: output: err: intentIter incorrectly positioned, cmp: 0
-next: output: err: intentIter incorrectly positioned, cmp: 0
-next: output: err: intentIter incorrectly positioned, cmp: 0
+next: output: err: i.intentCmp=1 does not match 0 for intentKey="b" iterKey="b"/20.000000000,0
+next: output: err: missing provisional value for i.intentKey="b": i.intentCmp=-1 is not 0
+next: output: err: intentIter at intent, but iter not at provisional value
 seek-lt "d"/0,0: output: value k=c ts=30.000000000,0 v=c30
 prev: output: meta k=c ts=30.000000000,0 txn=4
 prev: output: value k=b ts=20.000000000,0 v=b20

--- a/pkg/storage/testdata/intent_interleaving_iter/error_race_off
+++ b/pkg/storage/testdata/intent_interleaving_iter/error_race_off
@@ -3,6 +3,36 @@
 # when RaceEnabled=true. This file contains the output when
 # RaceEnabled=false
 
+# Error case: Multiple separated intents with no provisional values
+define
+locks
+meta k=b ts=20 txn=2
+meta k=d ts=40 txn=4
+----
+
+iter lower=a upper=f
+seek-ge k=a
+next
+seek-lt k=e
+next
+seek-ge k=d
+next-key
+seek-ge k=d
+prev
+seek-lt k=e
+prev
+----
+seek-ge "a"/0,0: output: meta k=b ts=20.000000000,0 txn=2
+next: output: err: intentIter at intent, but iter not at provisional value
+seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+next: output: err: intent has no provisional value
+seek-ge "d"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+next-key: output: err: intentIter at intent, but iter not at provisional value
+seek-ge "d"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+prev: output: err: iter not at provisional value, cmp: -1
+seek-lt "e"/0,0: output: meta k=d ts=40.000000000,0 txn=4
+prev: output: err: reverse iteration discovered intent without provisional value
+
 # Error case: Multiple intents for a key
 define
 locks


### PR DESCRIPTION
Resolves #86651.

**storage: remove `Valid()` call in `pebbleIterator.UnsafeKey()`**

This patch removes an unnecessary `Valid()` call in
`pebbleIterator.UnsafeKey()`. The `SimpleMVCCIterator` API contract
already mandates that the caller must call `Valid()` before calling
`UnsafeKey()`.

This is done in preparation for iterator invariant checks. These will be
performed in `Valid()` and this call would cause infinite recursion.
This additionally gives a nice performance boost (using the
`SSTIterator` benchmark since `MVCCScan` does not call `UnsafeKey`):

```
name                                                   old time/op  new time/op  delta
SSTIterator/keys=10000/variant=pebble/verify=false-24  1.08ms ± 0%  1.05ms ± 0%  -2.51%  (p=0.000 n=10+8)
```

Release note: None
  
**storage: add `pebbleIterator` invariant assertions**

This patch adds invariant checks for `pebbleIterator`. General API
invariant checks for the `SimpleMVCCIterator` and `MVCCIterator`
interfaces are also added, and applied to `pebbleIterator`.

Release note: None
  
**storage: add `intentInterleavingIter` invariant assertions**

This patch adds invariant assertions for `intentInterleavingIter` using
a similar pattern as `pointSynthesizingIter`: by calling
`assertInvariants()` under race during `Valid()`. This allows specifying
all internal invariants in a simple-to-understand form and asserting
them all after every state transition.

Existing race assertions have been migrated.

Release note: None
  
**storage: fix `pointSynthesizingIter.Key()` and `UnsafeRawKey()`**

`pointSynthesizingIter.Key()` could return a different key than
`UnsafeKey()`. Additionally, `UnsafeRawKey()` would omit the key's
timestamp. Luckily, these methods have no current callers.

Release note: None

**storage: add `pointSynthesizingIter` invariant assertions**

Release note: None

**storage: add `MVCCIncrementalIterator` invariant assertions**

Release note: None
  
**storage: add `ReadAsOfIterator` invariant assertions**

Release note: None