### PR TITLE
build: remove newly-added node_modules/ trees in ui-maintainer-clean

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -98,6 +98,9 @@ exports_files([
 # gazelle:exclude pkg/ui/node_modules
 # gazelle:exclude pkg/ui/workspaces/cluster-ui/node_modules
 # gazelle:exclude pkg/ui/workspaces/db-console/node_modules
+# gazelle:exclude pkg/ui/workspaces/db-console/src/js/node_modules
+# gazelle:exclude pkg/ui/workspaces/e2e-tests/node_modules
+# gazelle:exclude pkg/ui/workspaces/eslint-plugin-crdb/node_modules
 # gazelle:exclude vendor
 # gazelle:exclude .vendor.tmp.*
 # gazelle:exclude **/zcgo_flags.go

--- a/Makefile
+++ b/Makefile
@@ -1488,7 +1488,13 @@ ui-clean: ## Remove build artifacts.
 ui-maintainer-clean: ## Like clean, but also remove installed dependencies
 ui-maintainer-clean: ui-clean
 	$(info $(yellow)[WARNING] Use `dev ui clean --all` instead.$(term-reset))
-	rm -rf pkg/ui/node_modules pkg/ui/workspaces/db-console/node_modules pkg/ui/yarn.installed pkg/ui/workspaces/cluster-ui/node_modules pkg/ui/workspaces/db-console/src/js/node_modules
+	rm -rf pkg/ui/node_modules \
+		pkg/ui/workspaces/db-console/node_modules \
+		pkg/ui/yarn.installed \
+		pkg/ui/workspaces/cluster-ui/node_modules \
+		pkg/ui/workspaces/db-console/src/js/node_modules \
+		pkg/ui/workspaces/e2e-tests/node_modules \
+		pkg/ui/workspaces/eslint-plugin-crdb/node_modules
 
 pkg/roachprod/vm/aws/embedded.go: bin/.bootstrap pkg/roachprod/vm/aws/config.json pkg/roachprod/vm/aws/old.json bin/terraformgen
 	(cd pkg/roachprod/vm/aws && $(GO) generate)


### PR DESCRIPTION
A few recent features [1, 2] introduced new node_modules/ trees for
dependencies, but didn't update the ui-maintainer-clean Make target to
remove them. This allowed those directories to leak between TeamCity
builds with Docker user permissions, preventing a `yarn install` in
those packages from properly laying out a `node_modules/.bin` directory
for executables like `tsc`. Remove the recently-introduced
`node_modules/` directories as part of `make ui-maintainer-clean`, to
restore a clean state between jobs.

[1] https://github.com/cockroachdb/cockroach/commit/d28c07293803b158531a00bd2d5c8948c82cdf09 (ui: add eslint-plugin-crdb package with custom eslint rules, 2022-05-27)
[2] https://github.com/cockroachdb/cockroach/commit/c58279d4ce53c26987ef238e2ef268d6f6125f04 (ui: reintroduce end-to-end UI tests with cypress, 2022-08-12)

Release justification: Non-production code changes