### PR TITLE
storage: default to TableFormatPebblev1 in backups

### DIFF
--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -77,7 +77,7 @@ func MakeBackupSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer)
 	// By default, take a conservative approach and assume we don't have newer
 	// table features available. Upgrade to an appropriate version only if the
 	// cluster supports it.
-	opts := DefaultPebbleOptions().MakeWriterOptions(0, sstable.TableFormatRocksDBv2)
+	opts := DefaultPebbleOptions().MakeWriterOptions(0, sstable.TableFormatPebblev1)
 	if cs.Version.IsActive(ctx, clusterversion.EnablePebbleFormatVersionRangeKeys) {
 		opts.TableFormat = sstable.TableFormatPebblev2 // Range keys.
 	}


### PR DESCRIPTION
If the v22.2 upgrade has not yet been finalized, so we're not permitted
to use the new TableFormatPebblev2 sstable format, default to
TableFormatPebblev1 which is the format used by v22.1 internally.

This change is intended to allow us to remove code for understanding the
old RocksDB table format version sooner (eg, v23.1).

Release justification: low-risk updates to existing functionality
Release note: None