### PR TITLE
workload/mixed-version/schemachanger: re-enable mixed version workload

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -27,7 +27,8 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 		// This tests the work done for 20.1 that made schema changes jobs and in
 		// addition prevented making any new schema changes on a mixed cluster in
 		// order to prevent bugs during upgrades.
-		Cluster: r.MakeClusterSpec(4),
+		Cluster:    r.MakeClusterSpec(4),
+		NativeLibs: registry.LibGEOS,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			maxOps := 100
 			concurrency := 5

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -57,12 +57,6 @@ func runSchemaChangeWorkloadStep(loadNode, maxOps, concurrency int) versionStep 
 		t.L().Printf("Workload step run: %d", numFeatureRuns)
 		runCmd := []string{
 			"./workload run schemachange --verbose=1",
-			// The workload is still in development and occasionally discovers schema
-			// change errors so for now we don't fail on them but only on panics, server
-			// crashes, deadlocks, etc.
-			// TODO(spaskob): remove when https://github.com/cockroachdb/cockroach/issues/47430
-			// is closed.
-			"--tolerate-errors=true",
 			fmt.Sprintf("--max-ops %d", maxOps),
 			fmt.Sprintf("--concurrency %d", concurrency),
 			fmt.Sprintf("{pgurl:1-%d}", u.c.Spec().NodeCount),

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2373,6 +2373,18 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (stmt *o
 	if err != nil {
 		return nil, err
 	}
+	// If we aren't on 22.2 then disable the insert plugin, since 21.X
+	// can have schema instrospection queries fail due to an optimizer bug.
+	skipInserts, err := isClusterVersionLessThan(ctx, tx, clusterversion.ByKey(clusterversion.Start22_2))
+	if err != nil {
+		return nil, err
+	}
+	// If inserts are to be skipped, we will intentionally, target the insert towards
+	// a non-existent table, so that they become no-ops.
+	if skipInserts {
+		tableExists = false
+		tableName.SchemaName = "InvalidObjectName"
+	}
 	if !tableExists {
 		return makeOpStmtForSingleError(OpStmtDML,
 			fmt.Sprintf(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1183,6 +1183,29 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 	stmt := randgen.RandCreateTableWithColumnIndexNumberGenerator(og.params.rng, "table", tableIdx, databaseHasMultiRegion, og.newUniqueSeqNum)
 	stmt.Table = *tableName
 	stmt.IfNotExists = og.randIntn(2) == 0
+	trigramIsNotSupported, err := isClusterVersionLessThan(
+		ctx,
+		tx,
+		clusterversion.ByKey(clusterversion.TrigramInvertedIndexes))
+	if err != nil {
+		return nil, err
+	}
+	hasTrigramIdxUnsupported := func() bool {
+		if !trigramIsNotSupported {
+			return false
+		}
+		// Check if any of the indexes have trigrams involved.
+		for _, def := range stmt.Defs {
+			if idx, ok := def.(*tree.IndexTableDef); ok && idx.Inverted {
+				lastColumn := idx.Columns[len(idx.Columns)-1]
+				switch lastColumn.OpClass {
+				case "gin_trgm_ops", "gist_trgm_ops":
+					return true
+				}
+			}
+		}
+		return false
+	}()
 
 	tableExists, err := og.tableExists(ctx, tx, tableName)
 	if err != nil {
@@ -1197,6 +1220,11 @@ func (og *operationGenerator) createTable(ctx context.Context, tx pgx.Tx) (*opSt
 		{code: pgcode.DuplicateRelation, condition: tableExists && !stmt.IfNotExists},
 		{code: pgcode.UndefinedSchema, condition: !schemaExists},
 	}.add(opStmt.expectedExecErrors)
+	// Compatibility errors aren't guaranteed since the cluster version update is not
+	// fully transaction aware.
+	codesWithConditions{
+		{code: pgcode.FeatureNotSupported, condition: hasTrigramIdxUnsupported},
+	}.add(opStmt.potentialExecErrors)
 	opStmt.sql = tree.Serialize(stmt)
 	return opStmt, nil
 }


### PR DESCRIPTION
Fixes: #58489 #87477

Previously the mixed version schema changer workload was disabled because of the lack of version gates. These changes will do the following:

- Start reporting errors on this workload again.
- Disable trigrams in a mixed version state.
- Disable the insert part of the workload in a mixed version state (there is an optimizer on 22.1 that can cause some of the queries to fail)

Release justification: low risk only extends test coverage