### PR TITLE
sql: plumb isCopy down to event log

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2457,6 +2457,7 @@ func (ex *connExecutor) execCopyIn(
 		ex.planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
+			true, /* isCopy */
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			numInsertedRows,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1070,6 +1070,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		planner.maybeLogStatement(
 			ctx,
 			ex.executorType,
+			false, /* isCopy */
 			int(ex.state.mu.autoRetryCounter),
 			ex.extraTxnState.txnCounter,
 			res.RowsAffected(),

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -154,6 +154,7 @@ var sqlPerfInternalLogger log.ChannelLogger = log.SqlInternalPerf
 func (p *planner) maybeLogStatement(
 	ctx context.Context,
 	execType executorType,
+	isCopy bool,
 	numRetries, txnCounter, rows int,
 	err error,
 	queryReceived time.Time,
@@ -162,12 +163,13 @@ func (p *planner) maybeLogStatement(
 	stmtFingerprintID roachpb.StmtFingerprintID,
 	queryStats *topLevelQueryStats,
 ) {
-	p.maybeLogStatementInternal(ctx, execType, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID, queryStats)
+	p.maybeLogStatementInternal(ctx, execType, isCopy, numRetries, txnCounter, rows, err, queryReceived, hasAdminRoleCache, telemetryLoggingMetrics, stmtFingerprintID, queryStats)
 }
 
 func (p *planner) maybeLogStatementInternal(
 	ctx context.Context,
 	execType executorType,
+	isCopy bool,
 	numRetries, txnCounter, rows int,
 	err error,
 	startTime time.Time,
@@ -373,6 +375,7 @@ func (p *planner) maybeLogStatementInternal(
 				// see a copy of the execution on the DEV Channel.
 				dst:               LogExternally | LogToDevChannelIfVerbose,
 				verboseTraceLevel: execType.vLevel(),
+				isCopy:            isCopy,
 			},
 			&eventpb.QueryExecute{CommonSQLExecDetails: execDetails})
 	}


### PR DESCRIPTION
Previously, we relied on the `txn` being filled to log `COPY`
statements. This is however inaccurate - `txn` may be nil if `COPY` is
the first statement encountered. This meant that the first COPY
encountered would not be logged.

Instead, plumb down `isCopy` and use `timeutil.Now()` if it is a COPY
related statement.

Release justification: logging related critical fix

Release note: None