### PR TITLE
ci: disable sharding in random syntax tests

### DIFF
--- a/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
+++ b/build/teamcity/cockroach/nightlies/random_syntax_tests_impl.sh
@@ -13,6 +13,7 @@ $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
     //pkg/sql/tests:tests_test \
     --test_arg -rsg=5m --test_arg -rsg-routines=8 --test_arg -rsg-exec-timeout=1m \
     --test_timeout 3600 --test_filter 'TestRandomSyntax' \
+    --test_sharding_strategy=disabled \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE || exit_status=$?
 process_test_json \
         $BAZEL_BIN/pkg/cmd/testfilter/testfilter_/testfilter \


### PR DESCRIPTION
The different shards were trampling each other's test.json.txt,
preventing failures from being reported accurately.

Release justification: Non-production code changes
Release note: None