### PR TITLE
sql: clean up node dialer fields

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -662,7 +662,6 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		SQLLivenessReader: cfg.sqlLivenessProvider,
 		JobRegistry:       jobRegistry,
 		Gossip:            cfg.gossip,
-		NodeDialer:        cfg.nodeDialer,
 		PodNodeDialer:     cfg.podNodeDialer,
 		LeaseManager:      leaseMgr,
 
@@ -807,7 +806,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			cfg.gossip,
 			cfg.stopper,
 			isAvailable,
-			cfg.nodeDialer,
+			cfg.nodeDialer.ConnHealthTryDial,
 			cfg.podNodeDialer,
 			codec,
 			cfg.sqlInstanceProvider,

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -594,7 +594,7 @@ type vectorizedFlowCreator struct {
 	recordingStats    bool
 	isGatewayNode     bool
 	waitGroup         *sync.WaitGroup
-	nodeDialer        *nodedialer.Dialer
+	podNodeDialer     *nodedialer.Dialer
 	flowID            execinfrapb.FlowID
 	exprHelper        *colexecargs.ExprHelper
 	typeResolver      descs.DistSQLTypeResolver
@@ -650,7 +650,7 @@ func newVectorizedFlowCreator(
 	waitGroup *sync.WaitGroup,
 	rowSyncFlowConsumer execinfra.RowReceiver,
 	batchSyncFlowConsumer execinfra.BatchReceiver,
-	nodeDialer *nodedialer.Dialer,
+	podNodeDialer *nodedialer.Dialer,
 	flowID execinfrapb.FlowID,
 	diskQueueCfg colcontainer.DiskQueueCfg,
 	fdSemaphore semaphore.Semaphore,
@@ -668,7 +668,7 @@ func newVectorizedFlowCreator(
 		waitGroup:              waitGroup,
 		rowReceiver:            rowSyncFlowConsumer,
 		batchReceiver:          batchSyncFlowConsumer,
-		nodeDialer:             nodeDialer,
+		podNodeDialer:          podNodeDialer,
 		flowID:                 flowID,
 		exprHelper:             creator.exprHelper,
 		typeResolver:           typeResolver,
@@ -751,7 +751,7 @@ func (s *vectorizedFlowCreator) setupRemoteOutputStream(
 	run := func(ctx context.Context, flowCtxCancel context.CancelFunc) {
 		outbox.Run(
 			ctx,
-			s.nodeDialer,
+			s.podNodeDialer,
 			stream.TargetNodeID,
 			s.flowID,
 			stream.StreamID,
@@ -898,7 +898,7 @@ func (s *vectorizedFlowCreator) setupInput(
 
 			// Retrieve the latency from the origin node (the one that has the
 			// outbox).
-			latency, err := s.nodeDialer.Latency(roachpb.NodeID(inputStream.OriginNodeID))
+			latency, err := s.podNodeDialer.Latency(roachpb.NodeID(inputStream.OriginNodeID))
 			if err != nil {
 				// If an error occurred, latency's nil value of 0 is used. If latency is
 				// 0, it is not included in the displayed stats for EXPLAIN ANALYZE

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -232,7 +232,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	var wg sync.WaitGroup
 	vfc := newVectorizedFlowCreator(
 		&vectorizedFlowCreatorHelper{f: f}, componentCreator, false, false, &wg, &execinfra.RowChannel{},
-		nil /* batchSyncFlowConsumer */, nil /* nodeDialer */, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
+		nil /* batchSyncFlowConsumer */, nil /* podNodeDialer */, execinfrapb.FlowID{}, colcontainer.DiskQueueCfg{},
 		nil /* fdSemaphore */, descs.DistSQLTypeResolver{}, admission.WorkInfo{},
 	)
 

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -322,7 +322,7 @@ func startConnExecutor(
 			gw,
 			stopper,
 			func(base.SQLInstanceID) bool { return true }, // everybody is available
-			nil, /* nodeDialer */
+			nil, /* connHealthCheckerSystem */
 			nil, /* podNodeDialer */
 			keys.SystemSQLCodec,
 			nil, /* sqlInstanceProvider */

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -92,7 +92,6 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 	flowCtx := execinfra.FlowCtx{
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
-			NodeDialer:    nodeDialer,
 			PodNodeDialer: nodeDialer,
 			Stopper:       outboxStopper,
 		},

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -103,9 +103,6 @@ type DistSQLPlanner struct {
 	// gossip handle used to check node version compatibility.
 	gossip gossip.OptionalGossip
 
-	// nodeDialer handles communication between SQL and KV nodes.
-	nodeDialer *nodedialer.Dialer
-
 	// podNodeDialer handles communication between SQL nodes/pods.
 	podNodeDialer *nodedialer.Dialer
 
@@ -173,7 +170,7 @@ func NewDistSQLPlanner(
 	gw gossip.OptionalGossip,
 	stopper *stop.Stopper,
 	isAvailable func(base.SQLInstanceID) bool,
-	nodeDialer *nodedialer.Dialer,
+	connHealthCheckerSystem func(roachpb.NodeID, rpc.ConnectionClass) error, // will only be used by the system tenant
 	podNodeDialer *nodedialer.Dialer,
 	codec keys.SQLCodec,
 	sqlInstanceProvider sqlinstance.Provider,
@@ -186,11 +183,10 @@ func NewDistSQLPlanner(
 		stopper:              stopper,
 		distSQLSrv:           distSQLSrv,
 		gossip:               gw,
-		nodeDialer:           nodeDialer,
 		podNodeDialer:        podNodeDialer,
 		nodeHealth: distSQLNodeHealth{
 			gossip:      gw,
-			connHealth:  nodeDialer.ConnHealthTryDial,
+			connHealth:  connHealthCheckerSystem,
 			isAvailable: isAvailable,
 		},
 		distSender:          distSender,

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -86,7 +86,7 @@ var distSQLNumRunnersMax = 256 * int64(runtime.GOMAXPROCS(0))
 // runnerRequest is the request that is sent (via a channel) to a worker.
 type runnerRequest struct {
 	ctx           context.Context
-	nodeDialer    *nodedialer.Dialer
+	podNodeDialer *nodedialer.Dialer
 	flowReq       *execinfrapb.SetupFlowRequest
 	sqlInstanceID base.SQLInstanceID
 	resultChan    chan<- runnerResult
@@ -102,7 +102,7 @@ type runnerResult struct {
 func (req runnerRequest) run() {
 	res := runnerResult{nodeID: req.sqlInstanceID}
 
-	conn, err := req.nodeDialer.Dial(req.ctx, roachpb.NodeID(req.sqlInstanceID), rpc.DefaultClass)
+	conn, err := req.podNodeDialer.Dial(req.ctx, roachpb.NodeID(req.sqlInstanceID), rpc.DefaultClass)
 	if err != nil {
 		res.err = err
 	} else {
@@ -423,7 +423,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 			req.Flow = *flowSpec
 			runReq := runnerRequest{
 				ctx:           ctx,
-				nodeDialer:    dsp.podNodeDialer,
+				podNodeDialer: dsp.podNodeDialer,
 				flowReq:       &req,
 				sqlInstanceID: nodeID,
 				resultChan:    resultChan,

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -143,9 +143,6 @@ type ServerConfig struct {
 	// draining state.
 	Gossip gossip.OptionalGossip
 
-	// Dialer for communication between SQL and KV nodes.
-	NodeDialer *nodedialer.Dialer
-
 	// Dialer for communication between SQL nodes/pods.
 	PodNodeDialer *nodedialer.Dialer
 

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -93,7 +93,6 @@ func newFlowCtxForExplainPurposes(planCtx *PlanningCtx, p *planner) *execinfra.F
 			Settings:         p.execCfg.Settings,
 			LogicalClusterID: p.DistSQLPlanner().distSQLSrv.ServerConfig.LogicalClusterID,
 			VecFDSemaphore:   p.execCfg.DistSQLSrv.VecFDSemaphore,
-			NodeDialer:       p.DistSQLPlanner().nodeDialer,
 			PodNodeDialer:    p.DistSQLPlanner().podNodeDialer,
 		},
 		Descriptors: p.Descriptors(),

--- a/pkg/sql/flowinfra/outbox_test.go
+++ b/pkg/sql/flowinfra/outbox_test.go
@@ -76,7 +76,6 @@ func TestOutbox(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
 			Stopper:       stopper,
-			NodeDialer:    dialer,
 			PodNodeDialer: dialer,
 		},
 		NodeID: base.TestingIDContainer,
@@ -242,7 +241,6 @@ func TestOutboxInitializesStreamBeforeReceivingAnyRows(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
 			Stopper:       stopper,
-			NodeDialer:    dialer,
 			PodNodeDialer: dialer,
 		},
 		NodeID: base.TestingIDContainer,
@@ -315,7 +313,6 @@ func TestOutboxClosesWhenConsumerCloses(t *testing.T) {
 				Cfg: &execinfra.ServerConfig{
 					Settings:      st,
 					Stopper:       stopper,
-					NodeDialer:    dialer,
 					PodNodeDialer: dialer,
 				},
 				NodeID: base.TestingIDContainer,
@@ -393,7 +390,6 @@ func TestOutboxCancelsFlowOnError(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings:      st,
 			Stopper:       stopper,
-			NodeDialer:    dialer,
 			PodNodeDialer: dialer,
 		},
 		NodeID: base.TestingIDContainer,
@@ -449,8 +445,7 @@ func TestOutboxUnblocksProducers(t *testing.T) {
 		Cfg: &execinfra.ServerConfig{
 			Settings: st,
 			Stopper:  stopper,
-			// a nil nodeDialer will always fail to connect.
-			NodeDialer:    nil,
+			// a nil PodNodeDialer will always fail to connect.
 			PodNodeDialer: nil,
 		},
 		NodeID: base.TestingIDContainer,
@@ -525,7 +520,6 @@ func BenchmarkOutbox(b *testing.B) {
 				Cfg: &execinfra.ServerConfig{
 					Settings:      st,
 					Stopper:       stopper,
-					NodeDialer:    dialer,
 					PodNodeDialer: dialer,
 				},
 				NodeID: base.TestingIDContainer,


### PR DESCRIPTION
This commit removes no longer used `nodeDialer` field (for SQL - KV
communication) as well as renames some of the similarly named fields to
`podNodeDialer` to indicate that its only a SQL - SQL dialer.

Release justification: low-risk cleanup.

Release note: None