### PR TITLE
release-22.1: pprofutil: add helper

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//pkg/util/limit",
         "//pkg/util/log",
         "//pkg/util/metric",
+        "//pkg/util/pprofutil",
         "//pkg/util/quotapool",
         "//pkg/util/retry",
         "//pkg/util/shuffle",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/pprofutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -451,7 +452,16 @@ func (ds *DistSender) singleRangeFeed(
 		}
 
 		log.VEventf(ctx, 3, "attempting to create a RangeFeed over replica %s", args.Replica)
+
+		ctx := ds.AnnotateCtx(ctx)
+		ctx = logtags.AddTag(ctx, "dest_n", args.Replica.NodeID)
+		ctx = logtags.AddTag(ctx, "dest_s", args.Replica.StoreID)
+		ctx = logtags.AddTag(ctx, "dest_r", args.RangeID)
+
+		ctx, restore := pprofutil.SetProfilerLabelsFromCtxTags(ctx)
 		stream, err := client.RangeFeed(clientCtx, &args)
+		restore()
+
 		if err != nil {
 			log.VErrEventf(ctx, 2, "RPC error: %s", err)
 			if grpcutil.IsAuthError(err) {

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -182,6 +182,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
+        "//pkg/util/pprofutil",
         "//pkg/util/protoutil",
         "//pkg/util/quotapool",
         "//pkg/util/retry",

--- a/pkg/util/pprofutil/BUILD.bazel
+++ b/pkg/util/pprofutil/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "pprofutil",
+    srcs = ["labels.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/pprofutil",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_logtags//:logtags"],
+)

--- a/pkg/util/pprofutil/labels.go
+++ b/pkg/util/pprofutil/labels.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package pprofutil
+
+import (
+	"context"
+	"runtime/pprof"
+
+	"github.com/cockroachdb/logtags"
+)
+
+// SetProfilerLabels returns a context wrapped with the provided pprof labels
+// provided in alternating key-value format. The returned closure should be
+// defer'ed to restore the original labels from the initial context.
+//
+// This method allocates and isn't suitable for hot code paths.
+func SetProfilerLabels(ctx context.Context, labels ...string) (_ context.Context, undo func()) {
+	origCtx := ctx
+	ctx = pprof.WithLabels(ctx, pprof.Labels(labels...))
+	pprof.SetGoroutineLabels(ctx)
+	return ctx, func() {
+		pprof.SetGoroutineLabels(origCtx)
+	}
+}
+
+// SetProfilerLabelsFromCtxTags is like SetProfilerLabels, but sources the labels from
+// the logtags.Buffer in the context, if any. If there is no buffer or it has no tags,
+// the goroutine labels are not updated.
+func SetProfilerLabelsFromCtxTags(ctx context.Context) (_ context.Context, undo func()) {
+	tags := logtags.FromContext(ctx)
+	if tags == nil || len(tags.Get()) == 0 {
+		return
+	}
+	var labels []string
+	for _, tag := range tags.Get() {
+		labels = append(labels, tag.Key(), tag.ValueStr())
+	}
+	return SetProfilerLabels(ctx, labels...)
+}


### PR DESCRIPTION
Note: this basically needs a new review since stuff had moved around.

----

Backport 2/2 commits from #86939.

/cc @cockroachdb/release

---

Inspired by https://github.com/cockroachlabs/support/issues/1729.


Release justification: low-risk observability improvement for an important production issue
Release note: None
