### PR TITLE
sql: fix COPY internal error in optimizer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/copyfrom
+++ b/pkg/sql/logictest/testdata/logic_test/copyfrom
@@ -479,3 +479,40 @@ SELECT id, data AS got, array[chr(id)] AS want FROM test_copy_array WHERE data !
 ----
 
 subtest end
+
+# Regression test for #87011
+statement ok
+CREATE TABLE tab (
+  col1 STRING,
+  col2 STRING,
+  col3 STRING,
+  col4 STRING,
+  col5 STRING,
+  col6 STRING NOT NULL, index(col5) where col3 like '%ride%', index ((col2 || col3)),
+  PRIMARY KEY (col1, col2, col3, col4, col5) using hash,
+  UNIQUE (col5, col6)
+);
+CREATE TABLE tab_child (
+  col1 STRING,
+  col2 STRING,
+  col3 STRING,
+  col4 STRING,
+  col5 STRING,
+  col6 STRING NOT NULL, index(col5) where col3 like '%ride%', index ((col2 || col3)),
+  PRIMARY KEY (col1, col2, col3, col4, col5) using hash,
+  FOREIGN KEY (col5, col6) REFERENCES tab (col5, col6)
+)
+
+copy-error
+COPY tab_child FROM STDIN
+
+'high'	'straight'	'writer'	'develop'	'shells'	'bean'
+'basic'	'tent'	'compound'	'it'	'future'	'held'
+'bite'	'bring'	'taught'	'world'	'themselves'	'airplane'
+'island'	'number'	'has'	'blow'	'prize'	'cookies'
+'hole'	'wear'	'way'	'troops'	'eye'	'sure'
+'thick'	'joy'	'impossible'	'area'	'ordinary'	'piano'
+'grabbed'	'reader'	'number'	'serve'	'fill'	'wonderful'
+'tower'	'former'	'mainly'	'point'	'class'	'idea'
+----
+insert on table "tab_child" violates foreign key constraint "tab_child_col5_col6_fkey"

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -2134,13 +2134,13 @@ func (sb *statisticsBuilder) colStatLiteralValues(
 	// Determine null count by looking at tuples that have only NullOps in them.
 	nullCount := 0
 
-	for i := 0; i < values.Len(); i++ {
+	for rowIndex := 0; rowIndex < values.Len(); rowIndex++ {
 		var h hasher
 		h.Init()
 		hasNonNull := false
-		for j := 0; j < len(values.Cols); j++ {
-			if colSet.Contains(values.Cols[i]) {
-				elem := values.Rows.Rows.Get(i, j).(tree.Datum)
+		for colIndex, col := range values.Cols {
+			if colSet.Contains(col) {
+				elem := values.Rows.Rows.Get(rowIndex, colIndex).(tree.Datum)
 				if elem.ResolvedType().Family() == types.UnknownFamily {
 					hasNonNull = true
 				}


### PR DESCRIPTION
Statistics builder code to evaluate distinct count had a typo and would
crash if there were more rows than columns.  Fix bug and rewrite to be a
little clearer.

Fixes: #87011

Release justification: low-risk high priority fix to new funcationality
Release note: None
