### PR TITLE
githooks: improve UX of release note template

### DIFF
--- a/githooks/prepare-commit-msg
+++ b/githooks/prepare-commit-msg
@@ -75,8 +75,22 @@ fi
 # Add an explicit "Release note: None" if no release note was specified.
 if ! grep -q '^Release note' "$1"; then
 	sed_script+="/$cchar Please enter the commit message for your changes./i\\
-$cchar Use 'Release note: None' if there is no user-visible change.\\
-${tchar}Release note (<category, see below>): <what> <show> <why>\\
+${cchar}Release note: None\\
+${cchar}              ^-- no user-visible change\\
+${cchar}Release note(cli change): \\
+${cchar}Release note(ops change): \\
+${cchar}Release note(sql change): \\
+${cchar}Release note(ui change): \\
+${cchar}Release note(security update): \\
+${cchar}Release note(general change): \\
+${cchar}              ^-- e.g., change of required Go version\\
+${cchar}Release note(build change): \\
+${cchar}              ^-- e.g., compatibility with older CPUs\\
+${cchar}Release note(enterprise change): \\
+${cchar}              ^-- e.g., change to backup/restore\\
+${cchar}Release note(backwards-incompatible change): \\
+${cchar}Release note(performance improvement): \\
+${cchar}Release note(bug fix): \\
 
 ;
 "
@@ -144,18 +158,7 @@ $cchar   Release note (bug fix): The system.replication_stats report no longer\\
 $cchar   erroneously considers some ranges belonging to table partitions to be\\
 $cchar   over-replicated. This bug was present since version 19.2.\\
 $cchar\\
-$cchar Categories for release notes:\\
-$cchar   - cli change\\
-$cchar   - ops change\\
-$cchar   - sql change\\
-$cchar   - ui change\\
-$cchar   - security update\\
-$cchar   - general change (e.g., change of required Go version)\\
-$cchar   - build change (e.g., compatibility with older CPUs)\\
-$cchar   - enterprise change (e.g., change to backup/restore)\\
-$cchar   - backwards-incompatible change\\
-$cchar   - performance improvement\\
-$cchar   - bug fix
+$cchar Categories for release notes: see template above.
 ;
 "
 


### PR DESCRIPTION
Now you can just select the one you like, which at least for me is None
a lot of the time.

Sample: https://gist.github.com/tbg/5e77e1baea1ce5e26817587b3a45c991

Release justification: CRL eng UX improvement
Release note: None
