### PR TITLE
sql/copy: DESTINATION in non-external storage copies should be error

### DIFF
--- a/pkg/sql/copy.go
+++ b/pkg/sql/copy.go
@@ -232,6 +232,12 @@ func newCopyMachine(
 
 		c.csvEscape, _ = utf8.DecodeRuneInString(s)
 	}
+	if n.Options.Destination != nil {
+		return nil, pgerror.Newf(
+			pgcode.FeatureNotSupported,
+			"DESTINATION can only be specified when table is external storage table",
+		)
+	}
 
 	flags := tree.ObjectLookupFlagsWithRequiredTableKind(tree.ResolveRequireTableDesc)
 	_, tableDesc, err := resolver.ResolveExistingTableObject(ctx, c.p, &n.Table, flags)

--- a/pkg/sql/logictest/testdata/logic_test/copyfrom
+++ b/pkg/sql/logictest/testdata/logic_test/copyfrom
@@ -135,6 +135,12 @@ COPY t2 FROM STDIN
 ----
 1
 
+copy-error
+COPY t2 FROM STDIN WITH DESTINATION = 'foo.csv'
+
+\N	\N	\N	\N
+----
+DESTINATION can only be specified when table is external storage table
 
 subtest constraints
 


### PR DESCRIPTION
CRDB supports a DESTINATION argument on copy that's only valid on
file upload copies to external storage.

Fixes: #87006
Release justification: low risk updates to new functionality
Release note: None
