### PR TITLE
release-21.2: opt: disable normalization rules when remapping join lookup expressions

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1527,11 +1527,18 @@ func (c *CustomFuncs) GetLocalityOptimizedLookupJoinExprs(
 	// partitions or only remote partitions.
 	localExpr = make(memo.FiltersExpr, len(private.LookupExpr))
 	copy(localExpr, private.LookupExpr)
-	localExpr[filterIdx] = c.makeConstFilter(col, localValues)
+	c.e.f.DisableOptimizationsTemporarily(func() {
+		// Disable normalization rules when constructing the lookup expression
+		// so that it does not get normalized into a non-canonical expression.
+		localExpr[filterIdx] = c.makeConstFilter(col, localValues)
+	})
 
 	remoteExpr = make(memo.FiltersExpr, len(private.LookupExpr))
 	copy(remoteExpr, private.LookupExpr)
-	remoteExpr[filterIdx] = c.makeConstFilter(col, remoteValues)
+	c.e.f.DisableOptimizationsTemporarily(func() {
+		// Disable normalization rules when constructing the lookup expression
+		remoteExpr[filterIdx] = c.makeConstFilter(col, remoteValues)
+	})
 
 	return localExpr, remoteExpr, true
 }


### PR DESCRIPTION
Backport 1/2 commits from #86816.

/cc @cockroachdb/release

---

#### opt: disable norm rules when building locality-optimized join lookup exprs

This commit disables normalization rules when constructing
locality-optimized join lookup expressions. I was unable to come up with
a reproduction of the issue for this case, but it theoretically possible
if the partition values are booleans.

Related to #81591

Release justification: This fixes a bug that causes internal errors for
some types of queries.

Release note: None

