### PR TITLE
ui: make the warning about performance more prominent

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -128,9 +128,7 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
       >
         <Text>
           This action will apply the single-statement index recommendation by
-          executing {descriptionDocs}. Schema changes consume additional
-          resources and can potentially negatively impact workload
-          responsiveness.{" "}
+          executing {descriptionDocs}.{" "}
           <Anchor href={onlineSchemaChanges} target="_blank">
             Learn more
           </Anchor>
@@ -138,6 +136,13 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
         <Text textType={TextTypes.Code} className={"code-area"}>
           {query}
         </Text>
+        <InlineAlert
+          intent="warning"
+          className={cx("alert-area")}
+          title={`Schema changes consume additional
+          resources and can potentially negatively impact workload
+          responsiveness.`}
+        />
         {error.length > 0 && (
           <InlineAlert
             intent="danger"


### PR DESCRIPTION
Previously the warning about schema changes affecting
performance was too discrete. This commit adds a warning
component, so the message is more prominent and the user
can see more easily.

<img width="590" alt="Screen Shot 2022-08-31 at 11 20 59 AM" src="https://user-images.githubusercontent.com/1017486/187718454-c82c55a1-ae29-4dee-af78-dc5dbdbb9621.png">



Release justification: low risk change, improve UX
Release note (ui change): Add warning about
performance being affected when executing an index
recommendation.