### PR TITLE
backupccl: drop admin only check for `CREATE SCHEDULE`

### DIFF
--- a/pkg/ccl/backupccl/create_scheduled_backup.go
+++ b/pkg/ccl/backupccl/create_scheduled_backup.go
@@ -250,10 +250,6 @@ const scheduleBackupOp = "CREATE SCHEDULE FOR BACKUP"
 func doCreateBackupSchedules(
 	ctx context.Context, p sql.PlanHookState, eval *scheduledBackupEval, resultsCh chan<- tree.Datums,
 ) error {
-	if err := p.RequireAdminRole(ctx, scheduleBackupOp); err != nil {
-		return err
-	}
-
 	if eval.ScheduleLabelSpec.IfNotExists {
 		scheduleLabel, err := eval.scheduleLabel()
 		if err != nil {

--- a/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
+++ b/pkg/ccl/backupccl/testdata/backup-restore/schedule-privileges
@@ -1,0 +1,90 @@
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE foo;
+----
+
+exec-sql
+CREATE TABLE foo.foo (id INT);
+----
+
+exec-sql
+CREATE EXTERNAL CONNECTION foo AS 'userfile:///foo';
+----
+
+# Admin can create all schedules.
+exec-sql
+CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
+----
+
+exec-sql
+CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';
+----
+
+exec-sql
+CREATE SCHEDULE footable FOR BACKUP TABLE foo.foo INTO 'external://foo/table' RECURRING '@hourly';
+----
+
+# Non-root admin can create all schedules.
+exec-sql
+CREATE USER testuser;
+GRANT ADMIN TO testuser;
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE footable FOR BACKUP TABLE foo.foo INTO 'external://foo/table' RECURRING '@hourly';
+----
+
+# Non-root non-admin cannot create any schedules.
+exec-sql
+REVOKE ADMIN FROM testuser;
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
+----
+pq: failed to dry run backup: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups
+
+exec-sql user=testuser
+CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';
+----
+pq: failed to dry run backup: user testuser does not have SELECT privilege on relation foo
+HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here <link>. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database foo.
+
+exec-sql user=testuser
+CREATE SCHEDULE footable FOR BACKUP TABLE foo.foo INTO 'external://foo/table' RECURRING '@hourly';
+----
+pq: failed to dry run backup: user testuser does not have SELECT privilege on relation foo
+HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here <link>. In a future release, to run BACKUP TABLE, user testuser will exclusively require the BACKUP privilege on tables: foo.
+
+# Grant `BACKUP` privileges to testuser.
+exec-sql
+GRANT SYSTEM BACKUP TO testuser;
+GRANT BACKUP ON DATABASE foo TO testuser;
+GRANT BACKUP ON TABLE foo.foo TO testuser;
+----
+
+exec-sql
+GRANT USAGE ON EXTERNAL CONNECTION foo TO testuser;
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';
+----
+
+exec-sql user=testuser
+CREATE SCHEDULE footable FOR BACKUP TABLE foo.foo INTO 'external://foo/table' RECURRING '@hourly';
+----


### PR DESCRIPTION
In #86495 we introduced a `BACKUP` privilege that governs
what targets a user is able to backup. `CREATE SCHEDULE FOR BACKUP`
under the hood is responsible for running backup statements
at fixed intervals and so it makes sense for the same privilege
checks that apply to the backup statement that will be run to
also apply to `CREATE SCHEDULE`. We get this for free because
`CREATE SCHEDULE` runs a dry-run backup when the schedule is being
created, that has all the relevant privilege checks. So similar to
the new backup privilege model:

Cluster backups - require admin or system privilege BACKUP

DB backups - require datbase privilege BACKUP

Table backups - require table privilege BACKUP

Note, in 22.2 since we are continuining to support the old
privilege model the following privilege will also permit a user to
`CREATE SCHEDULE`  albeit with a deprecation notice warning users
that this model will be unsupported in a future release:

Cluster backups - require admin

DB backups - users must have CONNECT on the database,
SELECT on every table in the db, and USAGE on every schema, and
type in the db

Table backups - users must have SELECT on the table, and
USAGE on every schema, and type referenced by the table

Release note (sql change): CREATE SCHEDULE is no longer an
admin only operation. Users should grant the appropriate BACKUP
privileges on the targets they wish to back up as part of the schedule.

Cluster backups - require admin or system privilege BACKUP

DB backups - require datbase privilege BACKUP

Table backups - require table privilege BACKUP

Release justification: high impact change for fine grained permission control