### PR TITLE
ui: add optional white background to PageConfig

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.module.scss
@@ -17,6 +17,10 @@
   z-index: 2;
   background-color: $colors--background;
 
+  &__white-background {
+    background-color: $colors--white
+  }
+
   &__list {
     display: flex;
     justify-content: flex-start;

--- a/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pageConfig/pageConfig.tsx
@@ -15,6 +15,7 @@ import styles from "./pageConfig.module.scss";
 export interface PageConfigProps {
   layout?: "list" | "spread";
   children?: React.ReactNode;
+  pageHasWhiteBackground?: boolean;
 }
 
 const cx = classnames.bind(styles);
@@ -26,7 +27,7 @@ export function PageConfig(props: PageConfigProps): React.ReactElement {
   });
 
   return (
-    <div className={cx("page-config")}>
+    <div className={cx("page-config", { "page-config__white-background": props.pageHasWhiteBackground })}>
       <ul className={classes}>{props.children}</ul>
     </div>
   );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -133,6 +133,7 @@ export interface StatementsPageStateProps {
   search: string;
   isTenant?: UIConfigState["isTenant"];
   hasViewActivityRedactedRole?: UIConfigState["hasViewActivityRedactedRole"];
+  pageHasWhiteBackground?: UIConfigState["pageHasWhiteBackground"];
 }
 
 export interface StatementsPageState {
@@ -624,6 +625,7 @@ export class StatementsPage extends React.Component<
       databases,
       search,
       isTenant,
+      pageHasWhiteBackground,
       nodeRegions,
     } = this.props;
 
@@ -649,7 +651,7 @@ export class StatementsPage extends React.Component<
 
     return (
       <div className={cx("root", "table-area")}>
-        <PageConfig>
+        <PageConfig pageHasWhiteBackground={pageHasWhiteBackground}>
           <PageConfigItem>
             <Search
               onSubmit={this.onSubmitSearchField as any}

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPageConnected.tsx
@@ -39,6 +39,7 @@ import {
 import {
   selectIsTenant,
   selectHasViewActivityRedactedRole,
+  selectPageHasWhiteBackground,
 } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -68,6 +69,7 @@ export const ConnectedStatementsPage = withRouter(
       filters: selectFilters(state),
       isTenant: selectIsTenant(state),
       hasViewActivityRedactedRole: selectHasViewActivityRedactedRole(state),
+      pageHasWhiteBackground: selectPageHasWhiteBackground(state),
       lastReset: selectLastReset(state),
       nodeRegions: selectIsTenant(state) ? {} : nodeRegionsByIDSelector(state),
       search: selectSearch(state),

--- a/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/uiConfig/uiConfig.reducer.ts
@@ -20,6 +20,7 @@ export type UIConfigState = {
   isTenant: boolean;
   userSQLRoles: string[];
   hasViewActivityRedactedRole: boolean;
+  pageHasWhiteBackground: boolean;
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: boolean;
@@ -34,6 +35,7 @@ const initialState: UIConfigState = {
   isTenant: false,
   userSQLRoles: [],
   hasViewActivityRedactedRole: false,
+  pageHasWhiteBackground: false,
   pages: {
     statementDetails: {
       showStatementDiagnosticsLink: true,
@@ -74,6 +76,11 @@ export const selectIsTenant = createSelector(
 export const selectHasViewActivityRedactedRole = createSelector(
   selectUIConfig,
   uiConfig => uiConfig.userSQLRoles.includes("VIEWACTIVITYREDACTED"),
+);
+
+export const selectPageHasWhiteBackground = createSelector(
+  selectUIConfig,
+  uiConfig => uiConfig.pageHasWhiteBackground,
 );
 
 export const { actions, reducer } = uiConfigSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -88,6 +88,7 @@ export interface TransactionsPageStateProps {
   error?: Error | null;
   filters: Filters;
   isTenant?: UIConfigState["isTenant"];
+  pageHasWhiteBackground?: UIConfigState["pageHasWhiteBackground"];
   nodeRegions: { [nodeId: string]: string };
   pageSize?: number;
   search: string;
@@ -350,6 +351,7 @@ export class TransactionsPage extends React.Component<
       columns: userSelectedColumnsToShow,
       sortSetting,
       search,
+      pageHasWhiteBackground,
     } = this.props;
     const internal_app_name_prefix = data?.internal_app_name_prefix || "";
     const statements = data?.statements || [];
@@ -397,7 +399,7 @@ export class TransactionsPage extends React.Component<
 
     return (
       <>
-        <PageConfig>
+        <PageConfig pageHasWhiteBackground={pageHasWhiteBackground}>
           <PageConfigItem>
             <Search
               onSubmit={this.onSubmitSearchField as any}

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageConnected.tsx
@@ -27,7 +27,7 @@ import {
   selectFilters,
   selectSearch,
 } from "./transactionsPage.selectors";
-import { selectIsTenant } from "../store/uiConfig";
+import { selectIsTenant, selectPageHasWhiteBackground } from "../store/uiConfig";
 import { nodeRegionsByIDSelector } from "../store/nodes";
 import { selectTimeScale } from "src/statementsPage/statementsPage.selectors";
 import { StatementsRequest } from "src/api/statementsApi";
@@ -49,6 +49,7 @@ export const TransactionsPageConnected = withRouter(
       error: selectTransactionsLastError(state),
       filters: selectFilters(state),
       isTenant: selectIsTenant(state),
+      pageHasWhiteBackground: selectPageHasWhiteBackground(state),
       nodeRegions: nodeRegionsByIDSelector(state),
       search: selectSearch(state),
       sortSetting: selectSortSetting(state),


### PR DESCRIPTION
Previously, the PageConfig component had a fixed grey
background to match the page background, since it is a sticky
component that needs a background color to cover content that
scrolls beneath it. However, the background color is changing
to white in CockroachCloud, so the background color needs to
be able to match the new background. Until we apply the layout
changes to `db-console`, this change allows us to specify a
different background color in CockroachCloud.

This change adds an optional `hasWhiteBackground` prop to the
`PageConfig` component, which sets the background color
accordingly. This props is also added to the `StatementsPage` and
`TransactionsPage` components, and a `pageHasWhiteBackground`
bool is added to `UIConfig`, so that it can be set when
configuring the components in CockroachCloud.

Release note: None

**Without white background**
<img width="1783" alt="Screen Shot 2022-08-31 at 12 11 39 PM" src="https://user-images.githubusercontent.com/16804318/187727284-9535aa46-e91e-4e9c-974f-7dec62f9b4e3.png">

**With white background**
<img width="1788" alt="Screen Shot 2022-08-31 at 12 11 56 PM" src="https://user-images.githubusercontent.com/16804318/187727321-034b83b2-6229-4de8-8860-b1a94be6dd9a.png">
