### PR TITLE
jobspb,server: inject cloud.SanitizeExternalStorageURI

### DIFF
--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/cloud",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/protoreflect",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -23,9 +23,11 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -1742,4 +1744,9 @@ func (s *Server) Drain(
 	ctx context.Context, verbose bool,
 ) (remaining uint64, info redact.RedactableString, err error) {
 	return s.drain.runDrain(ctx, verbose)
+}
+
+// Inject the sanitization logic into the jobspb package.
+func init() {
+	jobspb.SanitizeExternalStorageURIFunc = cloud.SanitizeExternalStorageURI
 }


### PR DESCRIPTION
jobspb depending on cloud meant that it transitively depended on quite a
bit. serverutils depends on jobspb via serverpb. This was a mess, though
the current injection is not great either. I thought about injecting it
via changefeedccl, but that felt bad in case somebody later runs a non-ccl
binary in a cluster which had a changefeed job.

Release justification: part of a bug fix

Release note: None