### PR TITLE
sql: make UDF more robust with db/schema renaming

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2648,7 +2648,11 @@ CREATE TABLE crdb_internal.create_function_statements (
 			}
 			for i := range treeNode.Options {
 				if body, ok := treeNode.Options[i].(tree.FunctionBodyStr); ok {
-					stmtStrs := strings.Split(string(body), "\n")
+					seqReplacedBody, err := formatQuerySequencesForDisplay(ctx, &p.semaCtx, string(body), true /* multiStmt */)
+					if err != nil {
+						return err
+					}
+					stmtStrs := strings.Split(seqReplacedBody, "\n")
 					for i := range stmtStrs {
 						stmtStrs[i] = "\t" + stmtStrs[i]
 					}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2648,7 +2648,11 @@ CREATE TABLE crdb_internal.create_function_statements (
 			}
 			for i := range treeNode.Options {
 				if body, ok := treeNode.Options[i].(tree.FunctionBodyStr); ok {
-					seqReplacedBody, err := formatQuerySequencesForDisplay(ctx, &p.semaCtx, string(body), true /* multiStmt */)
+					typeReplacedBody, err := formatFunctionQueryTypesForDisplay(ctx, &p.semaCtx, p.SessionData(), string(body))
+					if err != nil {
+						return err
+					}
+					seqReplacedBody, err := formatQuerySequencesForDisplay(ctx, &p.semaCtx, typeReplacedBody, true /* multiStmt */)
 					if err != nil {
 						return err
 					}

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -353,6 +353,10 @@ $$;
 			testName: "drop database",
 			stmt:     "DROP DATABASE test_db CASCADE",
 		},
+		{
+			testName: "drop schema",
+			stmt:     "DROP SCHEMA test_sc CASCADE",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -132,24 +132,31 @@ CREATE SCHEMA yourschema
 statement error pq: schema "yourschema" already exists
 ALTER SCHEMA myschema RENAME TO yourschema
 
-statement ok
+statement error cannot rename schema because relation "test.myschema.v" depends on relation "test.myschema.tb"
 ALTER SCHEMA myschema RENAME TO myschema2
+
+statement ok
+CREATE SCHEMA myschema2;
+CREATE TABLE myschema2.tb2 (a INT PRIMARY KEY);
+
+statement ok
+ALTER SCHEMA myschema2 RENAME TO myschema3
 
 # We should be able to resolve objects under the new schema name.
 query T
-SELECT * FROM myschema2.tb2
+SELECT * FROM myschema3.tb2
 ----
 
 # The names should be drained after executing, so we should be able
 # to make another schema with the old name.
 statement ok
-CREATE SCHEMA myschema
+CREATE SCHEMA myschema2
 
 statement ok
 BEGIN
 
 statement ok
-ALTER SCHEMA myschema RENAME TO another_schema
+ALTER SCHEMA myschema2 RENAME TO another_schema
 
 statement ok
 ALTER SCHEMA another_schema RENAME TO another_one
@@ -163,39 +170,41 @@ CREATE SCHEMA empty;
 DROP SCHEMA empty
 
 let $schema_id
-SELECT id FROM system.namespace WHERE name = 'myschema'
+SELECT id FROM system.namespace WHERE name = 'myschema2'
 
-# Create some objects under myschema, and have them reference some objects
+# Create some objects under myschema2, and have them reference some objects
 # in other schemas.
 statement ok
-CREATE TABLE myschema.myschema_t1 (x INT);
-CREATE TABLE myschema.myschema_t2 (x INT);
-CREATE SEQUENCE myschema.myschema_seq1;
-CREATE TABLE myschema.myschema_t3 (x INT DEFAULT nextval('myschema.myschema_seq1'));
-CREATE TYPE myschema.myschema_ty1 AS ENUM ('schema');
+CREATE TABLE myschema2.myschema_t1 (x INT);
+CREATE TABLE myschema2.myschema_t2 (x INT);
+CREATE SEQUENCE myschema2.myschema_seq1;
+CREATE TABLE myschema2.myschema_t3 (x INT DEFAULT nextval('myschema2.myschema_seq1'));
+CREATE TYPE myschema2.myschema_ty1 AS ENUM ('schema');
 CREATE SCHEMA otherschema;
-CREATE VIEW otherschema.otherschema_v1 AS SELECT x FROM myschema.myschema_t1;
+CREATE VIEW otherschema.otherschema_v1 AS SELECT x FROM myschema2.myschema_t1;
 CREATE TABLE otherschema.otherschema_t1 (x INT);
-CREATE SEQUENCE otherschema.otherschema_seq1 OWNED BY myschema.myschema_t1.x;
+CREATE SEQUENCE otherschema.otherschema_seq1 OWNED BY myschema2.myschema_t1.x;
 
-statement error pq: schema "myschema" is not empty and CASCADE was not specified
-DROP SCHEMA myschema
+statement error pq: schema "myschema2" is not empty and CASCADE was not specified
+DROP SCHEMA myschema2
 
 # Now drop with cascade.
 statement ok
-DROP SCHEMA myschema CASCADE
+DROP SCHEMA myschema2 CASCADE
 
 query T
-SELECT table_name FROM [SHOW TABLES] WHERE table_name LIKE 'myschema%' OR table_name LIKE 'otherschema%'
+SELECT table_name FROM [SHOW TABLES] WHERE table_name LIKE 'myschema2%' OR table_name LIKE 'otherschema%'
 ----
 otherschema_t1
 
 query T
-SELECT name FROM [SHOW ENUMS] WHERE name LIKE 'myschema%'
+SELECT name FROM [SHOW ENUMS] WHERE name LIKE 'myschema2%'
+----
 
 # The schema should be gone.
 query I
-SELECT id FROM system.namespace WHERE name = 'myschema'
+SELECT id FROM system.namespace WHERE name = 'myschema2'
+----
 
 query IT
 SELECT * FROM system.descriptor WHERE id = $schema_id

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1251,7 +1251,7 @@ CREATE FUNCTION public.f_udt_rewrite()
     CALLED ON NULL INPUT
     LANGUAGE SQL
     AS $$
-    SELECT b'@':::@100115;
+    SELECT 'Monday':::test.public.notmyworkday;
 $$
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1296,6 +1296,86 @@ CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_
 statement error pq: the function cannot refer to other databases
 CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_db1.sc.v $$;
 
+subtest db_rename
+
+statement ok
+CREATE DATABASE rename_db1;
+SET DATABASE = rename_db1;
+
+statement ok
+CREATE SCHEMA sc1;
+CREATE SCHEMA sc2;
+CREATE TYPE sc1.workday AS ENUM ('Mon');
+CREATE TABLE sc1.tbl(a INT PRIMARY KEY);
+CREATE SEQUENCE sc1.sq;
+
+statement ok
+CREATE FUNCTION sc1.f_tbl() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc1.tbl $$;
+CREATE FUNCTION sc1.f_type() RETURNS sc1.workday LANGUAGE SQL AS $$ SELECT 'Mon'::sc1.workday $$;
+CREATE FUNCTION sc1.f_seq() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('sc1.sq') $$;
+CREATE FUNCTION sc2.f_tbl() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc1.tbl $$;
+CREATE FUNCTION sc2.f_type() RETURNS sc1.workday LANGUAGE SQL AS $$ SELECT 'Mon'::sc1.workday $$;
+CREATE FUNCTION sc2.f_seq() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('sc1.sq') $$;
+
+query T
+SELECT sc1.f_type()
+----
+Mon
+
+query I
+SELECT sc1.f_seq()
+----
+1
+
+query T
+SELECT sc2.f_type()
+----
+Mon
+
+query I
+SELECT sc2.f_seq()
+----
+2
+
+statement error pq: cannot rename database because relation "rename_db1.sc1.f_tbl" depends on relation "rename_db1.sc1.tbl"
+ALTER DATABASE rename_db1 RENAME TO rename_db2;
+
+statement ok
+DROP FUNCTION sc1.f_tbl()
+
+statement error pq: cannot rename database because relation "rename_db1.sc2.f_tbl" depends on relation "rename_db1.sc1.tbl"
+ALTER DATABASE rename_db1 RENAME TO rename_db2;
+
+statement ok
+DROP FUNCTION sc2.f_tbl()
+
+statement ok
+ALTER DATABASE rename_db1 RENAME TO rename_db2;
+
+# Make sure that db renaming does not affect types and sequences in UDF.
+query T
+SELECT sc1.f_type()
+----
+Mon
+
+query I
+SELECT sc1.f_seq()
+----
+3
+
+query T
+SELECT sc2.f_type()
+----
+Mon
+
+query I
+SELECT sc2.f_seq()
+----
+4
+
+statement ok
+SET DATABASE = test
+
 subtest execution
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1376,6 +1376,135 @@ SELECT sc2.f_seq()
 statement ok
 SET DATABASE = test
 
+statement ok
+CREATE DATABASE rename_sc1;
+SET DATABASE = rename_sc1;
+
+statement ok
+CREATE SCHEMA sc1;
+CREATE SCHEMA sc2;
+CREATE TYPE sc1.workday AS ENUM ('Mon');
+CREATE TABLE sc1.tbl(a INT PRIMARY KEY);
+CREATE SEQUENCE sc1.sq;
+
+statement ok
+CREATE FUNCTION sc1.f_tbl() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc1.tbl $$;
+CREATE FUNCTION sc1.f_type() RETURNS sc1.workday LANGUAGE SQL AS $$ SELECT 'Mon'::sc1.workday $$;
+CREATE FUNCTION sc1.f_seq() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('sc1.sq') $$;
+CREATE FUNCTION sc2.f_tbl() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc1.tbl $$;
+CREATE FUNCTION sc2.f_type() RETURNS sc1.workday LANGUAGE SQL AS $$ SELECT 'Mon'::sc1.workday $$;
+CREATE FUNCTION sc2.f_seq() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('sc1.sq') $$;
+
+query T
+SELECT sc1.f_type()
+----
+Mon
+
+query I
+SELECT sc1.f_seq()
+----
+5
+
+query T
+SELECT sc2.f_type()
+----
+Mon
+
+query I
+SELECT sc2.f_seq()
+----
+6
+
+statement error pq: cannot rename schema because relation "rename_sc1.sc1.f_tbl" depends on relation "rename_sc1.sc1.tbl"
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+statement ok
+DROP FUNCTION sc1.f_tbl()
+
+statement error pq: cannot rename schema because relation "rename_sc1.sc2.f_tbl" depends on relation "rename_sc1.sc1.tbl"
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+statement ok
+DROP FUNCTION sc2.f_tbl()
+
+statement ok
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+# Make sure that db renaming does not affect types and sequences in UDF.
+query T
+SELECT sc1.f_type()
+----
+Mon
+
+query I
+SELECT sc1.f_seq()
+----
+7
+
+query T
+SELECT sc2.f_type()
+----
+Mon
+
+query I
+SELECT sc2.f_seq()
+----
+8
+
+statement ok
+SET DATABASE = test
+
+subtest select_from_seq_rename
+
+statement ok
+CREATE DATABASE tdb_seq_select;
+SET DATABASE = tdb_seq_select;
+
+statement ok
+CREATE SCHEMA sc;
+CREATE SEQUENCE sc.sq;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT last_value FROM sc.sq $$;
+
+query I
+SELECT f()
+----
+0
+
+statement ok
+ALTER SEQUENCE sc.sq RENAME TO sq_new;
+
+statement error pq: relation "tdb_seq_select.sc.sq" does not exist
+SELECT f()
+
+statement ok
+ALTER SEQUENCE sc.sq_new RENAME TO sq;
+SELECT f();
+
+statement ok
+ALTER SCHEMA sc RENAME TO sc_new;
+
+statement error pq: unknown schema "sc"
+SELECT f()
+
+statement ok
+ALTER SCHEMA sc_new RENAME TO sc;
+SELECT f()
+
+statement ok
+ALTER DATABASE tdb_seq_select RENAME TO tdb_seq_select_new;
+SET DATABASE = tdb_seq_select_new;
+
+statement error pq: database "tdb_seq_select" does not exist
+SELECT f()
+
+statement ok
+ALTER DATABASE tdb_seq_select_new RENAME TO tdb_seq_select;
+SET DATABASE = tdb_seq_select;
+SELECT f()
+
+statement ok
+SET DATABASE = test;
+
 subtest execution
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -143,7 +143,7 @@ CREATE FUNCTION public.f(IN a test.public.notmyworkday)
     SELECT a FROM test.public.t;
     SELECT b FROM test.public.t@t_idx_b;
     SELECT c FROM test.public.t@t_idx_c;
-    SELECT nextval(114:::REGCLASS);
+    SELECT nextval('public.sq1'::REGCLASS);
 $$
 
 statement error pq: unimplemented: alter function depends on extension not supported.*

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1236,6 +1236,66 @@ SELECT f_seq_qualified_name_quoted()
 ----
 2
 
+subtest udt_rewrite
+
+statement ok
+CREATE FUNCTION f_udt_rewrite() RETURNS notmyworkday LANGUAGE SQL AS $$ SELECT 'Monday':: notmyworkday $$;
+
+query T
+SELECT @2 FROM [SHOW CREATE FUNCTION f_udt_rewrite];
+----
+CREATE FUNCTION public.f_udt_rewrite()
+    RETURNS test.public.notmyworkday
+    VOLATILE
+    NOT LEAKPROOF
+    CALLED ON NULL INPUT
+    LANGUAGE SQL
+    AS $$
+    SELECT b'@':::@100115;
+$$
+
+query T
+SELECT f_udt_rewrite()
+----
+Monday
+
+statement ok
+ALTER TYPE notmyworkday RENAME TO notmyworkday_new;
+
+query T
+SELECT f_udt_rewrite()
+----
+Monday
+
+statement ok
+ALTER TYPE notmyworkday_new RENAME TO notmyworkday;
+
+query T
+SELECT f_udt_rewrite()
+----
+Monday
+
+subtest cross_db
+
+statement ok
+CREATE DATABASE cross_db1;
+CREATE SCHEMA cross_db1.sc;
+CREATE TYPE cross_db1.sc.workday AS ENUM ('MON');
+CREATE TABLE cross_db1.sc.tbl(a INT PRIMARY KEY, b cross_db1.sc.workday);
+CREATE VIEW cross_db1.sc.v AS SELECT a FROM cross_db1.sc.tbl;
+
+statement error pq: cross database type references are not supported: cross_db1.sc.workday
+CREATE FUNCTION f_cross_db(cross_db1.sc.workday) RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+
+statement error pq: cross database type references are not supported: cross_db1.sc.workday
+CREATE FUNCTION f_cross_db() RETURNS cross_db1.sc.workday LANGUAGE SQL AS $$ SELECT 'MON'::cross_db1.sc.workday $$;
+
+statement error pq: the function cannot refer to other databases
+CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_db1.sc.tbl $$;
+
+statement error pq: the function cannot refer to other databases
+CREATE FUNCTION f_cross_db() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM cross_db1.sc.v $$;
+
 subtest execution
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1361,3 +1361,135 @@ query I
 SELECT * FROM v_seq_rewrite_quoted
 ----
 2
+
+subtest rename_schema
+
+statement ok
+CREATE DATABASE rename_sc1;
+SET DATABASE = rename_sc1;
+
+statement ok
+CREATE SCHEMA sc1;
+CREATE SCHEMA sc2;
+CREATE TYPE sc1.workday AS ENUM ('Mon');
+CREATE TABLE sc1.tbl(a INT PRIMARY KEY);
+CREATE SEQUENCE sc1.sq;
+
+statement ok
+CREATE VIEW sc1.v_tbl AS SELECT a FROM sc1.tbl;
+CREATE VIEW sc1.v_type AS SELECT 'Mon'::sc1.workday;
+CREATE VIEW sc1.v_seq AS SELECT nextval('sc1.sq');
+CREATE VIEW sc2.v_tbl AS SELECT a FROM sc1.tbl;
+CREATE VIEW sc2.v_type AS SELECT 'Mon'::sc1.workday;
+CREATE VIEW sc2.v_seq AS SELECT nextval('sc1.sq');
+
+query T
+SELECT * FROM sc1.v_type
+----
+Mon
+
+query I
+SELECT * FROM sc1.v_seq
+----
+1
+
+query T
+SELECT * FROM sc2.v_type
+----
+Mon
+
+query I
+SELECT * FROM sc2.v_seq
+----
+2
+
+statement error pq: cannot rename schema because relation "rename_sc1.sc1.v_tbl" depends on relation "rename_sc1.sc1.tbl"
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+statement ok
+DROP VIEW sc1.v_tbl
+
+statement error pq: cannot rename schema because relation "rename_sc1.sc2.v_tbl" depends on relation "rename_sc1.sc1.tbl"
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+statement ok
+DROP VIEW sc2.v_tbl
+
+statement ok
+ALTER SCHEMA sc1 RENAME TO sc1_new
+
+# Make sure that db renaming does not affect types and sequences in UDF.
+query T
+SELECT * FROM sc1_new.v_type
+----
+Mon
+
+query I
+SELECT * FROM sc1_new.v_seq
+----
+3
+
+query T
+SELECT * FROM sc2.v_type
+----
+Mon
+
+query I
+SELECT * FROM sc2.v_seq
+----
+4
+
+statement ok
+SET DATABASE = test
+
+subtest select_from_seq_rename
+
+statement ok
+CREATE DATABASE tdb_seq_select;
+SET DATABASE = tdb_seq_select;
+
+statement ok
+CREATE SCHEMA sc;
+CREATE SEQUENCE sc.sq;
+CREATE VIEW v AS SELECT last_value FROM sc.sq;
+
+query I
+SELECT * FROM v;
+----
+0
+
+statement ok
+ALTER SEQUENCE sc.sq RENAME TO sq_new;
+
+statement error pq: relation "tdb_seq_select.sc.sq" does not exist
+SELECT * FROM v;
+
+statement ok
+ALTER SEQUENCE sc.sq_new RENAME TO sq;
+SELECT * FROM v;
+
+statement ok
+ALTER SCHEMA sc RENAME TO sc_new;
+
+statement error pq: unknown schema "sc"
+SELECT * FROM v;
+
+statement ok
+ALTER SCHEMA sc_new RENAME TO sc;
+SELECT * FROM v;
+
+statement ok
+ALTER DATABASE tdb_seq_select RENAME TO tdb_seq_select_new;
+SET DATABASE = tdb_seq_select_new;
+
+statement error pq: database "tdb_seq_select" does not exist
+SELECT * FROM v;
+
+statement ok
+ALTER DATABASE tdb_seq_select_new RENAME TO tdb_seq_select;
+SET DATABASE = tdb_seq_select;
+SELECT * FROM v;
+
+statement ok
+SET DATABASE = test;
+

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -12,20 +12,16 @@ package sql
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/roleoption"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
@@ -157,24 +153,16 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 				continue
 			}
 
-			if err := tbDesc.ForeachDependedOnBy(func(dependedOn *descpb.TableDescriptor_Reference) error {
-				dependentDesc, err := p.Descriptors().Direct().MustGetTableDescByID(ctx, p.txn, dependedOn.ID)
-				if err != nil {
-					return err
-				}
+			// Since we now only reference sequences with IDs, it's always safe to
+			// rename a db or schema containing the sequence.
+			if tbDesc.IsSequence() {
+				continue
+			}
 
-				isAllowed, referencedCol, err := isAllowedDependentDescInRenameDatabase(
-					ctx,
-					dependedOn,
-					tbDesc,
-					dependentDesc,
-					dbDesc.GetName(),
-				)
+			if err := tbDesc.ForeachDependedOnBy(func(dependedOn *descpb.TableDescriptor_Reference) error {
+				dependentDesc, err := p.Descriptors().GetMutableDescriptorByID(ctx, p.txn, dependedOn.ID)
 				if err != nil {
 					return err
-				}
-				if isAllowed {
-					return nil
 				}
 
 				tbTableName := tree.MakeTableNameWithSchema(
@@ -182,52 +170,17 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 					tree.Name(schema),
 					tree.Name(tbDesc.GetName()),
 				)
-				var dependentDescQualifiedString string
-				if dbDesc.GetID() != dependentDesc.GetParentID() || tbDesc.GetParentSchemaID() != dependentDesc.GetParentSchemaID() {
-					descFQName, err := p.getQualifiedTableName(ctx, dependentDesc)
-					if err != nil {
-						log.Warningf(
-							ctx,
-							"unable to retrieve fully-qualified name of %s (id: %d): %v",
-							tbTableName.String(),
-							dependentDesc.GetID(),
-							err,
-						)
-						return sqlerrors.NewDependentObjectErrorf(
-							"cannot rename database because a relation depends on relation %q",
-							tbTableName.String())
-					}
-					dependentDescQualifiedString = descFQName.FQString()
-				} else {
-					dependentDescTableName := tree.MakeTableNameWithSchema(
-						tree.Name(dbDesc.GetName()),
-						tree.Name(schema),
-						tree.Name(dependentDesc.GetName()),
-					)
-					dependentDescQualifiedString = dependentDescTableName.String()
+				dependentDescQualifiedString, err := getQualifiedDependentObjectName(
+					ctx, p, dbDesc.GetName(), schema, tbDesc, dependentDesc,
+				)
+				if err != nil {
+					return err
 				}
 				depErr := sqlerrors.NewDependentObjectErrorf(
 					"cannot rename database because relation %q depends on relation %q",
 					dependentDescQualifiedString,
 					tbTableName.String(),
 				)
-
-				// We can have a more specific error message for sequences.
-				if tbDesc.IsSequence() {
-					hint := fmt.Sprintf(
-						"you can drop the column default %q of %q referencing %q",
-						referencedCol,
-						tbTableName.String(),
-						dependentDescQualifiedString,
-					)
-					if dependentDesc.GetParentID() == dbDesc.GetID() {
-						hint += fmt.Sprintf(
-							" or modify the default to not reference the database name %q",
-							dbDesc.GetName(),
-						)
-					}
-					return errors.WithHint(depErr, hint)
-				}
 
 				// Otherwise, we default to the view error message.
 				return errors.WithHintf(depErr,
@@ -252,81 +205,52 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 		})
 }
 
-// isAllowedDependentDescInRename determines when rename database is allowed with
-// a given {tbDesc, dependentDesc} with the relationship dependedOn on a db named dbName.
-// Returns a bool representing whether it's allowed, a string indicating the column name
-// found to contain the database (if it exists), and an error if any.
-// This is a workaround for #45411 until #34416 is resolved.
-func isAllowedDependentDescInRenameDatabase(
+func getQualifiedDependentObjectName(
 	ctx context.Context,
-	dependedOn *descpb.TableDescriptor_Reference,
-	tbDesc catalog.TableDescriptor,
-	dependentDesc catalog.TableDescriptor,
+	p *planner,
 	dbName string,
-) (bool, string, error) {
-	// If it is a sequence, and it does not contain the database name, then we have
-	// no reason to block it's deletion.
-	if !tbDesc.IsSequence() {
-		return false, "", nil
-	}
+	scName string,
+	desc catalog.TableDescriptor,
+	depDesc catalog.Descriptor,
+) (string, error) {
+	tbTableName := tree.MakeTableNameWithSchema(
+		tree.Name(dbName),
+		tree.Name(scName),
+		tree.Name(desc.GetName()),
+	)
 
-	colIDs := util.MakeFastIntSet()
-	for _, colID := range dependedOn.ColumnIDs {
-		colIDs.Add(int(colID))
-	}
-
-	for _, column := range dependentDesc.PublicColumns() {
-		if !colIDs.Contains(int(column.GetID())) {
-			continue
+	if desc.GetParentID() != depDesc.GetParentID() || desc.GetParentSchemaID() != depDesc.GetParentSchemaID() {
+		var descFQName tree.ObjectName
+		var err error
+		switch t := depDesc.(type) {
+		case catalog.TableDescriptor:
+			descFQName, err = p.getQualifiedTableName(ctx, t)
+		case catalog.FunctionDescriptor:
+			descFQName, err = p.getQualifiedFunctionName(ctx, t)
+		default:
+			return "", errors.AssertionFailedf("expected only function or table descriptor, but got %s", t.DescriptorType())
 		}
-		colIDs.Remove(int(column.GetID()))
-
-		if !column.HasDefault() {
-			return false, "", errors.AssertionFailedf(
-				"rename_database: expected column id %d in table id %d to have a default expr",
-				dependedOn.ID,
-				dependentDesc.GetID(),
+		if err != nil {
+			log.Warningf(ctx, "unable to retrieve fully-qualified name of %s (id: %d): %v", tbTableName.String(), depDesc.GetID(), err)
+			return "", sqlerrors.NewDependentObjectErrorf(
+				"cannot rename database because a relation depends on relation %q",
+				tbTableName.String(),
 			)
 		}
-		// Try parse the default expression and find the table name direct reference.
-		parsedExpr, err := parser.ParseExpr(column.GetDefaultExpr())
-		if err != nil {
-			return false, "", err
-		}
-		typedExpr, err := tree.TypeCheck(ctx, parsedExpr, nil, column.GetType())
-		if err != nil {
-			return false, "", err
-		}
-		seqIdentifiers, err := seqexpr.GetUsedSequences(typedExpr)
-		if err != nil {
-			return false, "", err
-		}
-		for _, seqIdentifier := range seqIdentifiers {
-			if seqIdentifier.IsByID() {
-				continue
-			}
-			parsedSeqName, err := parser.ParseTableName(seqIdentifier.SeqName)
-			if err != nil {
-				return false, "", err
-			}
-			// There must be at least two parts for this to work.
-			if parsedSeqName.NumParts >= 2 {
-				// We only don't allow this if the database name is in there.
-				// This is always the last argument.
-				if tree.Name(parsedSeqName.Parts[parsedSeqName.NumParts-1]).Normalize() == tree.Name(dbName).Normalize() {
-					return false, column.GetName(), nil
-				}
-			}
-		}
+
+		return descFQName.FQString(), nil
 	}
-	if colIDs.Len() > 0 {
-		return false, "", errors.AssertionFailedf(
-			"expected to find column ids %s in table id %d",
-			colIDs.String(),
-			dependentDesc.GetID(),
-		)
+
+	switch t := depDesc.(type) {
+	case catalog.TableDescriptor:
+		depTblName := tree.MakeTableNameWithSchema(tree.Name(dbName), tree.Name(scName), tree.Name(t.GetName()))
+		return depTblName.String(), nil
+	case catalog.FunctionDescriptor:
+		depFnName := tree.MakeQualifiedFunctionName(dbName, scName, t.GetName())
+		return depFnName.String(), nil
+	default:
+		return "", errors.AssertionFailedf("expected only function or table descriptor, but got %s", t.DescriptorType())
 	}
-	return true, "", nil
 }
 
 func (n *renameDatabaseNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/rename_database.go
+++ b/pkg/sql/rename_database.go
@@ -126,68 +126,8 @@ func (n *renameDatabaseNode) startExec(params runParams) error {
 		return err
 	}
 	for _, schema := range schemas {
-		tbNames, _, err := p.Descriptors().GetObjectNamesAndIDs(
-			ctx,
-			p.txn,
-			dbDesc,
-			schema,
-			tree.DatabaseListFlags{
-				CommonLookupFlags: lookupFlags,
-				ExplicitPrefix:    true,
-			},
-		)
-		if err != nil {
+		if err := maybeFailOnDependentDescInRename(ctx, p, dbDesc, schema, lookupFlags, catalog.Database); err != nil {
 			return err
-		}
-		lookupFlags.Required = false
-		// TODO(ajwerner): Make this do something better than one-at-a-time lookups
-		// followed by catalogkv reads on each dependency.
-		for i := range tbNames {
-			found, tbDesc, err := p.Descriptors().GetImmutableTableByName(
-				ctx, p.txn, &tbNames[i], tree.ObjectLookupFlags{CommonLookupFlags: lookupFlags},
-			)
-			if err != nil {
-				return err
-			}
-			if !found {
-				continue
-			}
-
-			// Since we now only reference sequences with IDs, it's always safe to
-			// rename a db or schema containing the sequence.
-			if tbDesc.IsSequence() {
-				continue
-			}
-
-			if err := tbDesc.ForeachDependedOnBy(func(dependedOn *descpb.TableDescriptor_Reference) error {
-				dependentDesc, err := p.Descriptors().GetMutableDescriptorByID(ctx, p.txn, dependedOn.ID)
-				if err != nil {
-					return err
-				}
-
-				tbTableName := tree.MakeTableNameWithSchema(
-					tree.Name(dbDesc.GetName()),
-					tree.Name(schema),
-					tree.Name(tbDesc.GetName()),
-				)
-				dependentDescQualifiedString, err := getQualifiedDependentObjectName(
-					ctx, p, dbDesc.GetName(), schema, tbDesc, dependentDesc,
-				)
-				if err != nil {
-					return err
-				}
-				depErr := sqlerrors.NewDependentObjectErrorf(
-					"cannot rename database because relation %q depends on relation %q",
-					dependentDescQualifiedString,
-					tbTableName.String(),
-				)
-
-				// Otherwise, we default to the view error message.
-				return errors.WithHintf(depErr,
-					"you can drop %q instead", dependentDescQualifiedString)
-			}); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -251,6 +191,83 @@ func getQualifiedDependentObjectName(
 	default:
 		return "", errors.AssertionFailedf("expected only function or table descriptor, but got %s", t.DescriptorType())
 	}
+}
+
+func maybeFailOnDependentDescInRename(
+	ctx context.Context,
+	p *planner,
+	dbDesc catalog.DatabaseDescriptor,
+	schema string,
+	lookupFlags tree.CommonLookupFlags,
+	renameDescType catalog.DescriptorType,
+) error {
+	tbNames, _, err := p.Descriptors().GetObjectNamesAndIDs(
+		ctx,
+		p.txn,
+		dbDesc,
+		schema,
+		tree.DatabaseListFlags{
+			CommonLookupFlags: lookupFlags,
+			ExplicitPrefix:    true,
+		},
+	)
+	if err != nil {
+		return err
+	}
+	lookupFlags.Required = false
+	// TODO(ajwerner): Make this do something better than one-at-a-time lookups
+	// followed by catalogkv reads on each dependency.
+	for i := range tbNames {
+		found, tbDesc, err := p.Descriptors().GetImmutableTableByName(
+			ctx, p.txn, &tbNames[i], tree.ObjectLookupFlags{CommonLookupFlags: lookupFlags},
+		)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+
+		// Since we now only reference sequences with IDs, it's always safe to
+		// rename a db or schema containing the sequence. There is one exception
+		// being tracked with issue #87509.
+		if tbDesc.IsSequence() {
+			continue
+		}
+
+		if err := tbDesc.ForeachDependedOnBy(func(dependedOn *descpb.TableDescriptor_Reference) error {
+			dependentDesc, err := p.Descriptors().GetMutableDescriptorByID(ctx, p.txn, dependedOn.ID)
+			if err != nil {
+				return err
+			}
+
+			tbTableName := tree.MakeTableNameWithSchema(
+				tree.Name(dbDesc.GetName()),
+				tree.Name(schema),
+				tree.Name(tbDesc.GetName()),
+			)
+			dependentDescQualifiedString, err := getQualifiedDependentObjectName(
+				ctx, p, dbDesc.GetName(), schema, tbDesc, dependentDesc,
+			)
+			if err != nil {
+				return err
+			}
+			depErr := sqlerrors.NewDependentObjectErrorf(
+				"cannot rename %s because relation %q depends on relation %q",
+				renameDescType,
+				dependentDescQualifiedString,
+				tbTableName.String(),
+			)
+
+			// Otherwise, we default to the view error message.
+			return errors.WithHintf(depErr,
+				"you can drop %q instead", dependentDescQualifiedString)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (n *renameDatabaseNode) Next(runParams) (bool, error) { return false, nil }

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -224,6 +224,28 @@ func (sr *schemaResolver) getQualifiedTableName(
 	return &tbName, nil
 }
 
+func (sr *schemaResolver) getQualifiedFunctionName(
+	ctx context.Context, fnDesc catalog.FunctionDescriptor,
+) (*tree.FunctionName, error) {
+	lookupFlags := tree.CommonLookupFlags{
+		Required:       true,
+		IncludeOffline: true,
+		IncludeDropped: true,
+		AvoidLeased:    true,
+	}
+	_, dbDesc, err := sr.descCollection.GetImmutableDatabaseByID(ctx, sr.txn, fnDesc.GetParentID(), lookupFlags)
+	if err != nil {
+		return nil, err
+	}
+	scDesc, err := sr.descCollection.GetImmutableSchemaByID(ctx, sr.txn, fnDesc.GetParentSchemaID(), lookupFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	fnName := tree.MakeQualifiedFunctionName(dbDesc.GetName(), scDesc.GetName(), fnDesc.GetName())
+	return &fnName, nil
+}
+
 // ResolveType implements the tree.TypeReferenceResolver interface.
 func (sr *schemaResolver) ResolveType(
 	ctx context.Context, name *tree.UnresolvedObjectName,

--- a/pkg/sql/sem/tree/object_name.go
+++ b/pkg/sql/sem/tree/object_name.go
@@ -22,6 +22,7 @@ type ObjectName interface {
 
 var _ ObjectName = &TableName{}
 var _ ObjectName = &TypeName{}
+var _ ObjectName = &FunctionName{}
 
 // objName is the internal type for a qualified object.
 type objName struct {

--- a/pkg/sql/sem/tree/udf.go
+++ b/pkg/sql/sem/tree/udf.go
@@ -66,6 +66,20 @@ func (f *FunctionName) Format(ctx *FmtCtx) {
 
 func (f *FunctionName) String() string { return AsString(f) }
 
+// FQString renders the function name in full, not omitting the prefix
+// schema and catalog names. Suitable for logging, etc.
+func (f *FunctionName) FQString() string {
+	ctx := NewFmtCtx(FmtSimple)
+	ctx.FormatNode(&f.CatalogName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&f.SchemaName)
+	ctx.WriteByte('.')
+	ctx.FormatNode(&f.ObjectName)
+	return ctx.CloseAndGetString()
+}
+
+func (f *FunctionName) objectName() {}
+
 // CreateFunction represents a CREATE FUNCTION statement.
 type CreateFunction struct {
 	IsProcedure bool


### PR DESCRIPTION
There are 5 commits:
1. disallow cross-db references in udf. Also a side effect to serialize user defined type names in udf body as type OIDs.
2. check udf dependencies before renaming a db.
3. check dependencies before renaming a schema.
4. deserialize sequence OID for `SHOW CREATE FUNCTION`.
5. deserialize type OID for `SHOW CREATE FUNCTION`.

Release justification: necessary and low risk bug fixes to make UDF more robust with schema/db renaming.