### PR TITLE
sql: minor fixes for opclasses in trigram indexes

### DIFF
--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -219,7 +219,8 @@ func FormatIndexElements(
 		} else {
 			f.FormatNameP(&index.KeyColumnNames[i])
 		}
-		if index.Type == descpb.IndexDescriptor_INVERTED && len(index.InvertedColumnKinds) > 0 {
+		if index.Type == descpb.IndexDescriptor_INVERTED &&
+			col.GetID() == index.InvertedColumnID() && len(index.InvertedColumnKinds) > 0 {
 			switch index.InvertedColumnKinds[0] {
 			case catpb.InvertedIndexColumnKind_TRIGRAM:
 				f.WriteString(" gin_trgm_ops")

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1781,7 +1781,7 @@ func NewTableDesc(
 			); err != nil {
 				return nil, err
 			}
-			if err := checkIndexColumns(&desc, d.Columns, d.Storing); err != nil {
+			if err := checkIndexColumns(&desc, d.Columns, d.Storing, d.Inverted); err != nil {
 				return nil, err
 			}
 			idx := descpb.IndexDescriptor{

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -347,7 +347,7 @@ FROM (
 /103/Table/114/1  /103/Table/114/1/100  /114/1/100  /114/2
 
 # resume the job and ensure it completes, which includes validation.
-statement ok 
+statement ok
 RESUME JOB (SELECT job_id FROM crdb_internal.jobs WHERE description LIKE 'CREATE INDEX pauseidx%');
 
 query T
@@ -398,10 +398,14 @@ CREATE TABLE opclasses (a INT PRIMARY KEY, b TEXT, c JSON)
 
 # Make sure that we don't permit creating indexes with opclasses that aren't
 # inverted.
-statement error operator class "blah_ops" does not exist
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
 CREATE INDEX ON opclasses(b blah_ops)
 
 # Make sure that we don't permit creating indexes with opclasses that aren't
 # inverted, even if the type is invertible.
-statement error operator class "blah_ops" does not exist
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
 CREATE INDEX ON opclasses(c blah_ops)
+
+# Make sure that we don't permit creating indexes with opclasses that don't exist
+statement error pgcode 42704 operator class "blah_ops" does not exist
+CREATE INVERTED INDEX ON opclasses(c blah_ops)

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -218,3 +218,21 @@ create table err (a int, b int, index (a gin_trgm_ops, b));
 
 statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
 create table err (a int, j json, inverted index (a gin_trgm_ops, j));
+
+# Regression test for #86614. Do not display opclasses for non-inverted columns
+# in SHOW CREATE TABLE.
+
+statement ok
+CREATE TABLE t86614 (a int, s STRING, INVERTED INDEX (a, s gist_trgm_ops), FAMILY (a, s))
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t86614]
+----
+CREATE TABLE public.t86614 (
+   a INT8 NULL,
+   s STRING NULL,
+   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+   CONSTRAINT t86614_pkey PRIMARY KEY (rowid ASC),
+   INVERTED INDEX t86614_a_s_idx (a ASC, s gin_trgm_ops),
+   FAMILY fam_0_a_s_rowid (a, s, rowid)
+)

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -7,6 +7,12 @@ CREATE INVERTED INDEX ON a(t)
 statement error data type text has no default operator class for access method \"gin\"
 CREATE INDEX ON a USING GIN(t)
 
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+CREATE INDEX ON a (t gin_trgm_ops)
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+CREATE INVERTED INDEX ON a (a gin_trgm_ops, t gin_trgm_ops)
+
 statement error operator class \"blah_ops\" does not exist
 CREATE INVERTED INDEX ON a(t blah_ops)
 
@@ -194,3 +200,21 @@ query T
 SELECT * FROM b WHERE a = 'foobar 367'
 ----
 foobar 367
+
+
+# Regression tests for #84512. Do not allow opclasses for non-inverted columns.
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+create table err (a int, index (a jsonb_ops));
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+create table err (a int, index (a gin_trgm_ops));
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+create table err (a int, index (a gist_trgm_ops));
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+create table err (a int, b int, index (a gin_trgm_ops, b));
+
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+create table err (a int, j json, inverted index (a gin_trgm_ops, j));


### PR DESCRIPTION
#### sql: err when an opclass is provided for a non-inverted index column

Fixes #84512

Release justification: This is a minor fix for new features.

Release note: None

#### sql: do not show opclasses for non-inverted index columns

Fixes #86614

Release justification: This is a minor bug fix for a new feature.

Release note: None
