### PR TITLE
release-22.1: sql: encode either 0 or 1 spans in scan gists

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -104,7 +104,7 @@ SELECT crdb_internal.decode_plan_gist('$index_gist')
 ----
 • scan
   table: t83537@?
-  spans: 1 span
+  spans: 1+ spans
 
 let $insert_gist
 EXPLAIN (GIST) INSERT INTO t83537 VALUES (1, 10)
@@ -146,5 +146,5 @@ SELECT crdb_internal.decode_plan_gist('AgGSARIAAwlAsJ8BE5IBAhcGFg==')
     │
     └── • scan
           table: ?@?
-          spans: 32 spans
+          spans: 1+ spans
           limit: 10200

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_shape
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_shape
@@ -13,4 +13,4 @@ vectorized: true
 ·
 • scan
   table: a@a_pkey
-  spans: 1 span
+  spans: 1+ spans

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -934,6 +934,11 @@ func (e *emitter) spansStr(table cat.Table, index cat.Index, scanParams exec.Sca
 		return "FULL SCAN"
 	}
 
+	// If we are only showing the shape, show a non-specific number of spans.
+	if e.ob.flags.OnlyShape {
+		return "1+ spans"
+	}
+
 	// In verbose mode show the physical spans, unless the table is virtual.
 	if e.ob.flags.Verbose && !table.IsVirtualTable() {
 		return e.spanFormatFn(table, index, scanParams)

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -161,7 +161,7 @@ func DecodePlanGistToRows(gist string, catalog cat.Catalog) (_ []string, retErr 
 		}
 	}()
 
-	flags := Flags{HideValues: true, Redact: RedactAll}
+	flags := Flags{HideValues: true, Redact: RedactAll, OnlyShape: true}
 	ob := NewOutputBuilder(flags)
 	explainPlan, err := DecodePlanGistToPlan(gist, catalog)
 	if err != nil {
@@ -377,13 +377,19 @@ func (f *PlanGistFactory) encodeScanParams(params exec.ScanParams) {
 	f.encodeFastIntSet(params.NeededCols)
 
 	if params.IndexConstraint != nil {
-		f.encodeInt(params.IndexConstraint.Spans.Count())
+		// Encode 1 to represent one or more spans. We don't encode the exact
+		// number of spans so that two queries with the same plan but a
+		// different number of spans have the same gist.
+		f.encodeInt(1)
 	} else {
 		f.encodeInt(0)
 	}
 
 	if params.InvertedConstraint != nil {
-		f.encodeInt(params.InvertedConstraint.Len())
+		// Encode 1 to represent one or more spans. We don't encode the exact
+		// number of spans so that two queries with the same plan but a
+		// different number of spans have the same gist.
+		f.encodeInt(1)
 	} else {
 		f.encodeInt(0)
 	}
@@ -403,10 +409,8 @@ func (f *PlanGistFactory) decodeScanParams() exec.ScanParams {
 	if l > 0 {
 		idxConstraint = new(constraint.Constraint)
 		idxConstraint.Spans.Alloc(l)
-		for i := 0; i < l; i++ {
-			var sp constraint.Span
-			idxConstraint.Spans.Append(&sp)
-		}
+		var sp constraint.Span
+		idxConstraint.Spans.Append(&sp)
 	}
 
 	var invertedConstraint inverted.Spans
@@ -417,7 +421,12 @@ func (f *PlanGistFactory) decodeScanParams() exec.ScanParams {
 
 	hardLimit := f.decodeInt()
 
-	return exec.ScanParams{NeededCols: neededCols, IndexConstraint: idxConstraint, InvertedConstraint: invertedConstraint, HardLimit: int64(hardLimit)}
+	return exec.ScanParams{
+		NeededCols:         neededCols,
+		IndexConstraint:    idxConstraint,
+		InvertedConstraint: invertedConstraint,
+		HardLimit:          int64(hardLimit),
+	}
 }
 
 func (f *PlanGistFactory) encodeRows(rows [][]tree.TypedExpr) {

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -75,7 +75,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	if explainPlan == nil {
 		t.Error("Couldn't ExecBuild memo, use a logictest instead?")
 	}
-	flags := explain.Flags{HideValues: true, Redact: explain.RedactAll}
+	flags := explain.Flags{HideValues: true, Redact: explain.RedactAll, OnlyShape: true}
 	ob := explain.NewOutputBuilder(flags)
 	err = explain.Emit(explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
 	if err != nil {

--- a/pkg/sql/opt/exec/explain/testdata/gists
+++ b/pkg/sql/opt/exec/explain/testdata/gists
@@ -23,7 +23,6 @@ hash: 12007264394566425707
 plan-gist: AgFqAgAHAAACBgY=
 explain(shape):
 • scan
-  missing stats
   table: foo@foo_pkey
   spans: LIMITED SCAN
   limit: 1
@@ -41,9 +40,22 @@ hash: 16614037866652733243
 plan-gist: AgFqAgAHAgAABgY=
 explain(shape):
 • scan
-  missing stats
+  table: foo@foo_pkey
+  spans: 1+ spans
+explain(gist):
+• scan
   table: foo@foo_pkey
   spans: 1 span
+
+gist-explain-roundtrip
+SELECT * from foo WHERE a IN (1, 3, 5)
+----
+hash: 16614037866652733243
+plan-gist: AgFqAgAHAgAABgY=
+explain(shape):
+• scan
+  table: foo@foo_pkey
+  spans: 1+ spans
 explain(gist):
 • scan
   table: foo@foo_pkey
@@ -60,9 +72,8 @@ explain(shape):
 │ table: foo@foo_pkey
 │
 └── • scan
-      missing stats
       table: foo@b_inverted_index
-      spans: 1 span
+      spans: 1+ spans
 explain(gist):
 • index join
 │ table: foo@foo_pkey
@@ -82,9 +93,8 @@ explain(shape):
 │ table: foo@foo_pkey
 │
 └── • scan
-      missing stats
       table: foo@c_idx
-      spans: 1 span
+      spans: 1+ spans
 explain(gist):
 • index join
 │ table: foo@foo_pkey
@@ -103,7 +113,6 @@ explain(shape):
 • render
 │
 └── • scan
-      missing stats
       table: foo@c_idx
       spans: FULL SCAN
 explain(gist):
@@ -124,7 +133,6 @@ explain(shape):
 │ pred: column1 = a
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -147,12 +155,10 @@ explain(shape):
 │ right cols are key
 │
 ├── • scan
-│     missing stats
 │     table: foo@foo_pkey
 │     spans: FULL SCAN
 │
 └── • scan
-      missing stats
       table: bar@bar_pkey
       spans: FULL SCAN
 explain(gist):
@@ -182,12 +188,10 @@ explain(shape):
 │ right cols are key
 │
 ├── • scan
-│     missing stats
 │     table: foo@foo_pkey
 │     spans: FULL SCAN
 │
 └── • scan
-      missing stats
       table: bar@bar_pkey
       spans: FULL SCAN
 explain(gist):
@@ -213,14 +217,12 @@ explain(shape):
 └── • cross join
     │
     ├── • scan
-    │     missing stats
     │     table: bar@bar_pkey
     │     spans: FULL SCAN
     │
     └── • scan
-          missing stats
           table: foo@foo_pkey
-          spans: 1 span
+          spans: 1+ spans
 explain(gist):
 • group (hash)
 │
@@ -244,7 +246,6 @@ explain(shape):
 • group (scalar)
 │
 └── • scan
-      missing stats
       table: foo@c_idx
       spans: FULL SCAN
 explain(gist):
@@ -282,7 +283,6 @@ explain(shape):
 │ distinct on: b, c
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -303,12 +303,10 @@ explain(shape):
 • intersect all
 │
 ├── • scan
-│     missing stats
 │     table: abc@abc_pkey
 │     spans: FULL SCAN
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -338,7 +336,6 @@ explain(shape):
     │   │ order: +b,+a
     │   │
     │   └── • scan
-    │         missing stats
     │         table: abc@abc_pkey
     │         spans: FULL SCAN
     │
@@ -346,7 +343,6 @@ explain(shape):
         │ order: +b,+a
         │
         └── • scan
-              missing stats
               table: abc@abc_pkey
               spans: FULL SCAN
 explain(gist):
@@ -379,12 +375,10 @@ explain(shape):
 • union all
 │
 ├── • scan
-│     missing stats
 │     table: abc@abc_pkey
 │     spans: FULL SCAN
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -408,7 +402,6 @@ explain(shape):
 • ordinality
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -431,7 +424,6 @@ explain(shape):
 │ equality cols are key
 │
 └── • scan
-      missing stats
       table: foo@foo_pkey
       spans: FULL SCAN
 explain(gist):
@@ -454,7 +446,6 @@ explain(shape):
 • cross join
 │
 ├── • scan
-│     missing stats
 │     table: bar@bar_pkey
 │     spans: FULL SCAN
 │
@@ -529,10 +520,8 @@ explain(shape):
     │ exec mode: one row
     │
     └── • max1row
-        │ estimated row count: 1
         │
         └── • scan
-              missing stats
               table: abc@abc_b_idx
               spans: FULL SCAN
               locking strength: for update
@@ -560,7 +549,6 @@ hash: 3230693242836472611
 plan-gist: AgICABoCBgI=
 explain(shape):
 • project set
-│ estimated row count: 10
 │
 └── • emptyrow
 explain(gist):
@@ -578,7 +566,6 @@ explain(shape):
 • window
 │
 └── • scan
-      missing stats
       table: abc@abc_b_idx
       spans: FULL SCAN
 explain(gist):
@@ -633,7 +620,6 @@ explain(shape):
 │ auto commit
 │
 └── • scan
-      missing stats
       table: abc@abc_pkey
       spans: FULL SCAN
 explain(gist):
@@ -660,9 +646,8 @@ explain(shape):
 └── • render
     │
     └── • scan
-          missing stats
           table: abc@abc_pkey
-          spans: 1 span
+          spans: 1+ spans
 explain(gist):
 • update
 │ table: abc
@@ -693,9 +678,8 @@ explain(shape):
     │     size: 3 columns, 1 row
     │
     └── • scan
-          missing stats
           table: abc@abc_pkey
-          spans: 1 span
+          spans: 1+ spans
 explain(gist):
 • upsert
 │ into: abc()
@@ -723,7 +707,6 @@ explain(shape):
 │ auto commit
 │
 └── • scan
-      missing stats
       table: foo@foo_pkey
       spans: FULL SCAN
 explain(gist):
@@ -747,9 +730,8 @@ explain(shape):
 │ auto commit
 │
 └── • scan
-      missing stats
       table: foo@foo_pkey
-      spans: 1 span
+      spans: 1+ spans
 explain(gist):
 • delete
 │ from: foo
@@ -782,7 +764,6 @@ explain(shape):
 └── • render
     │
     └── • scan
-          missing stats
           table: abc@abc_pkey
           spans: FULL SCAN
 explain(gist):
@@ -821,7 +802,6 @@ explain(shape):
 │ k: 10
 │
 └── • scan
-      missing stats
       table: xyz@xyz_pkey
       spans: FULL SCAN
 explain(gist):
@@ -841,7 +821,6 @@ hash: 4348909884410007975
 plan-gist: AigGBg==
 explain(shape):
 • sequence select
-  estimated row count: 1
 explain(gist):
 • sequence select
 
@@ -949,7 +928,6 @@ explain(shape):
             │ into: abc(a, b, c)
             │
             └── • scan
-                  missing stats
                   table: abc@abc_pkey
                   spans: FULL SCAN
 explain(gist):
@@ -1085,7 +1063,6 @@ explain(shape):
 • export
 │
 └── • scan
-      missing stats
       table: foo@foo_pkey
       spans: FULL SCAN
 explain(gist):
@@ -1132,4 +1109,4 @@ AgHyAQIA//8HHgAAByoFKiHyAQAA
     │
     └── • scan
           table: ?@?
-          spans: 15 spans
+          spans: 1 span

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -45,7 +45,6 @@ explain(shape):
                     │ right cols are key
                     │
                     ├── • scan
-                    │     missing stats
                     │     table: trade_request@trade_request_tr_b_id_tr_s_symb_idx
                     │     spans: FULL SCAN
                     │
@@ -62,9 +61,8 @@ explain(shape):
                                 │ equality: (sc_id) = (in_sc_id)
                                 │
                                 └── • scan
-                                      missing stats
                                       table: sector@sector_sc_name_key
-                                      spans: 1 span
+                                      spans: 1+ spans
 explain(gist):
 • sort
 │ order
@@ -145,9 +143,8 @@ explain(shape):
                         │ table: customer_account@customer_account_pkey
                         │
                         └── • scan
-                              missing stats
                               table: customer_account@customer_account_ca_c_id_idx
-                              spans: 1 span
+                              spans: 1+ spans
 explain(gist):
 • top-k
 │ order
@@ -238,9 +235,8 @@ explain(shape):
 │               └── • render
 │                   │
 │                   └── • scan
-│                         missing stats
 │                         table: last_trade@last_trade_pkey
-│                         spans: 1 span
+│                         spans: 1+ spans
 │
 ├── • subquery
 │   │ id: @S2
@@ -256,7 +252,6 @@ explain(shape):
 │               │ filter: (tr_s_symb = _) AND ((((tr_tt_id = _) AND (tr_bid_price >= _)) OR ((tr_tt_id = _) AND (tr_bid_price <= _))) OR ((tr_tt_id = _) AND (tr_bid_price >= _)))
 │               │
 │               └── • scan
-│                     missing stats
 │                     table: trade_request@trade_request_pkey
 │                     spans: FULL SCAN
 │


### PR DESCRIPTION
Backport 1/2 commits from #87152.

/cc @cockroachdb/release

---

#### sql: encode either 0 or 1 spans in scan gists

In plan gists, we no longer encode the exact number of spans for scans
so that two queries with the same plan but a different number of spans
have the same gist.

In addition, plan gists are now decoded with the `OnlyShape` flag which
prints any non-zero number of spans as "1+ spans" and removes attributes
like "missing stats" from scans.

Fixes #87138

Release justification: This is a minor change that makes plan gist
instrumentation more scalable.

Release note (bug fix): The Explain Tab inside the Statement Details
page now groups plans that have the same shape but a different number of
spans in corresponding scans.

