### PR TITLE
cli: revert marking the --multitenant flag as hidden

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -767,9 +767,6 @@ func init() {
 		cliflagcfg.BoolFlag(f, &demoCtx.DefaultEnableRangefeeds, cliflags.DemoEnableRangefeeds)
 
 		cliflagcfg.BoolFlag(f, &demoCtx.Multitenant, cliflags.DemoMultitenant)
-		// TODO(knz): Currently the multitenant UX for 'demo' is not
-		// satisfying for end-users. Let's not advertise it too much.
-		_ = f.MarkHidden(cliflags.DemoMultitenant.Name)
 
 		cliflagcfg.BoolFlag(f, &demoCtx.SimulateLatency, cliflags.Global)
 		// The --empty flag is only valid for the top level demo command,


### PR DESCRIPTION
This commit reverts the changes made by 28ec27a4 in #79994.

Release justification: low-risk update
Release note (cli change): the --multitenant flag for cockroach demo is
listed in --help.