### PR TITLE
backupccl: prevent SHOW BACKUP with check_files failure when missing metadata

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -507,6 +507,10 @@ func checkBackupFiles(
 			backupinfo.MetadataSSTName,
 			backupbase.BackupManifestName + backupinfo.BackupManifestChecksumSuffix} {
 			if _, err := defaultStore.Size(ctx, metaFile); err != nil {
+				if metaFile == backupinfo.FileInfoPath || metaFile == backupinfo.MetadataSSTName {
+					log.Warningf(ctx, `%v not found. This is only relevant if kv.bulkio.write_metadata_sst.enabled = true`, metaFile)
+					continue
+				}
 				return nil, errors.Wrapf(err, "Error checking metadata file %s/%s",
 					info.defaultURIs[layer], metaFile)
 			}

--- a/pkg/ccl/backupccl/show_test.go
+++ b/pkg/ccl/backupccl/show_test.go
@@ -870,7 +870,6 @@ func TestShowBackupCheckFiles(t *testing.T) {
 	_, sqlDB, tempDir, cleanupFn := backupRestoreTestSetup(t, multiNode, numAccounts,
 		InitManualReplication)
 	defer cleanupFn()
-	sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = true`)
 
 	collectionRoot := "full"
 	incLocRoot := "inc"


### PR DESCRIPTION
Previously SHOW BACKUP with check_files would fail if the backup was missing
certain metadata files (e.g. fileinfo.sst and metadata.sst). These files are
only written when the kv.bulkio.write_metadata_sst.enabled is set to true,
which it is not by default, causing a false positive error of SHOW BACKUP with
check_files.

This patch prevents SHOW BACKUP with check_files from failing on a missing
fileinfo.sst file, and instead logs a warning.

Release justification: bug fix

Release note: none