### PR TITLE
sql: speed up TestClockSyncErrorsAreNotPermanent

### DIFF
--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7460,6 +7460,7 @@ func TestClockSyncErrorsAreNotPermanent(t *testing.T) {
 						return clock.UpdateAndCheckMaxOffset(ctx, farInTheFuture.UnsafeToClockTimestamp())
 					},
 				},
+				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},
 		},
 	})


### PR DESCRIPTION
Before this change, this test took 60s. Now:
`TestClockSyncErrorsAreNotPermanent (0.48s)`

Release justification: Testing only change

Release note: None