### PR TITLE
storage: fix leaked iterators in unit tests

### DIFF
--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -2301,7 +2301,8 @@ func metamorphicReader(e *evalCtx) (r Reader, closer func()) {
 	case "engine":
 		return e.engine, nil
 	case "readonly":
-		return e.engine.NewReadOnly(StandardDurability), nil
+		readOnly := e.engine.NewReadOnly(StandardDurability)
+		return readOnly, readOnly.Close
 	case "batch":
 		batch := e.engine.NewBatch()
 		return batch, batch.Close

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -5955,6 +5955,7 @@ func TestMVCCGarbageCollectClearRange(t *testing.T) {
 				LowerBound: rangeStart,
 				UpperBound: rangeEnd,
 			})
+			defer it.Close()
 			expMs, err := ComputeStatsForIter(it, tsMax.WallTime)
 			require.NoError(t, err, "failed to compute stats for range")
 			require.EqualValues(t, expMs, ms, "computed range stats vs gc'd")


### PR DESCRIPTION
Fix a couple instances of leaked iterators in unit tests in the storage
package.

This should also resolve the goroutine leak observed in #86256.

Informs #71481.

Release justification: Non-production code changes
Release note: None