### PR TITLE
backupccl: skipping restore-grant datadriven test

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -388,12 +388,17 @@ func TestDataDriven(t *testing.T) {
 		ds := newDatadrivenTestState()
 		defer ds.cleanup(ctx)
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
-
 			for v := range ds.vars {
 				d.Input = strings.Replace(d.Input, v, ds.vars[v], -1)
 				d.Expected = strings.Replace(d.Expected, v, ds.vars[v], -1)
 			}
 			switch d.Cmd {
+			case "skip":
+				var issue int
+				d.ScanArgs(t, "issue-num", &issue)
+				skip.WithIssue(t, issue)
+				return ""
+
 			case "reset":
 				ds.cleanup(ctx)
 				ds = newDatadrivenTestState()

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-grants
@@ -1,3 +1,6 @@
+skip issue-num=87129
+----
+
 # Ensure that non-cluster restores appropriately wipes the grants on the
 # restored descriptors. Since we're not restoring the users, the users that
 # the restoring descriptors reference may not be the same users as they


### PR DESCRIPTION
Informs: #87129

Release note: None

Release justification: low risk test only change