### PR TITLE
storage: check error on Engine close 

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -921,6 +921,7 @@ func TestEvalAddSSTable(t *testing.T) {
 						// Write initial data.
 						intentTxn := roachpb.MakeTransaction("intentTxn", nil, 0, hlc.Timestamp{WallTime: intentTS * 1e9}, 0, 1)
 						b := engine.NewBatch()
+						defer b.Close()
 						for i := len(tc.data) - 1; i >= 0; i-- { // reverse, older timestamps first
 							switch kv := tc.data[i].(type) {
 							case storage.MVCCKeyValue:
@@ -1135,6 +1136,7 @@ func TestEvalAddSSTableRangefeed(t *testing.T) {
 			engine := storage.NewDefaultInMemForTesting()
 			defer engine.Close()
 			opLogger := storage.NewOpLoggerBatch(engine.NewBatch())
+			defer opLogger.Close()
 
 			// Build and add SST.
 			sst, start, end := storageutils.MakeSST(t, st, tc.sst)

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -525,8 +525,8 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 
 	rangeMs := ms
 	pointMs := ms
-	deleteWithTombstone(eng.NewBatch(), deletionTime, &rangeMs)
-	deleteWithPoints(eng.NewBatch(), deletionTime, &pointMs)
+	withBatch(eng, func(b storage.Batch) { deleteWithTombstone(b, deletionTime, &rangeMs) })
+	withBatch(eng, func(b storage.Batch) { deleteWithPoints(b, deletionTime, &pointMs) })
 
 	gcTTL := time.Minute * 30
 	for _, d := range []struct {
@@ -547,6 +547,12 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 			require.Equal(t, d.rangeDel, dr, "expect enqueue metric for range deletion")
 		})
 	}
+}
+
+func withBatch(eng storage.Engine, fn func(b storage.Batch)) {
+	b := eng.NewBatch()
+	defer b.Close()
+	fn(b)
 }
 
 // TestMVCCGCQueueProcess creates test data in the range over various time

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//pkg/storage/fs",
         "//pkg/util",
         "//pkg/util/bufalloc",
+        "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/hlc",

--- a/pkg/storage/intent_interleaving_iter_test.go
+++ b/pkg/storage/intent_interleaving_iter_test.go
@@ -840,6 +840,7 @@ func BenchmarkIntentInterleavingIterNext(b *testing.B) {
 				} else {
 					iter = state.eng.NewMVCCIterator(MVCCKeyIterKind, opts)
 				}
+				defer iter.Close()
 				startKey := MVCCKey{Key: state.keyPrefix}
 				iter.SeekGE(startKey)
 				b.ResetTimer()
@@ -878,6 +879,7 @@ func BenchmarkIntentInterleavingIterPrev(b *testing.B) {
 				} else {
 					iter = state.eng.NewMVCCIterator(MVCCKeyIterKind, opts)
 				}
+				defer iter.Close()
 				iter.SeekLT(endKey)
 				b.ResetTimer()
 				var unsafeKey MVCCKey
@@ -920,6 +922,7 @@ func BenchmarkIntentInterleavingSeekGEAndIter(b *testing.B) {
 					} else {
 						iter = state.eng.NewMVCCIterator(MVCCKeyIterKind, opts)
 					}
+					defer iter.Close()
 					b.ResetTimer()
 					for i := 0; i < b.N; i++ {
 						j := i % len(seekKeys)


### PR DESCRIPTION
Panic if an error is encountered while closing the Engine. This ensures
unit tests and the like observe errors, especially related to leaked
iterators.

Close #71481.
Close #87507.

Release justification: low-risk bug fixes and non-production code changes
Release note: None