### PR TITLE
streamingccl: register more metrics on producer and ingestion

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/metrics.go
+++ b/pkg/ccl/streamingccl/streamingest/metrics.go
@@ -16,9 +16,10 @@ import (
 )
 
 const (
-	streamingFlushHistMaxLatency   = 1 * time.Minute
-	streamingAdmitLatencyMaxValue  = 3 * time.Minute
-	streamingCommitLatencyMaxValue = 10 * time.Minute
+	streamingFlushHistMaxLatency    = 1 * time.Minute
+	streamingAdmitLatencyMaxValue   = 3 * time.Minute
+	streamingCommitLatencyMaxValue  = 10 * time.Minute
+	streamingScanSSTLatencyMaxValue = 3 * time.Minute
 )
 
 var (
@@ -65,6 +66,12 @@ var (
 		Name: "streaming.admit_latency",
 		Help: "Event admission latency: a difference between event MVCC timestamp " +
 			"and the time it was admitted into ingestion processor",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaStreamingSSTScanLatency = metric.Metadata{
+		Name:        "streaming.sst_scan_latency",
+		Help:        "SST scan latency: latency of scanning a received SST from source",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
@@ -116,6 +123,7 @@ type Metrics struct {
 	FlushHistNanos              *metric.Histogram
 	CommitLatency               *metric.Histogram
 	AdmitLatency                *metric.Histogram
+	SSTScanLatency              *metric.Histogram
 	RunningCount                *metric.Gauge
 	EarliestDataCheckpointSpan  *metric.Gauge
 	LatestDataCheckpointSpan    *metric.Gauge
@@ -140,6 +148,8 @@ func MakeMetrics(histogramWindow time.Duration) metric.Struct {
 			histogramWindow, streamingCommitLatencyMaxValue.Nanoseconds(), 1),
 		AdmitLatency: metric.NewHistogram(metaStreamingAdmitLatency,
 			histogramWindow, streamingAdmitLatencyMaxValue.Nanoseconds(), 1),
+		SSTScanLatency: metric.NewHistogram(metaStreamingSSTScanLatency,
+			histogramWindow, streamingScanSSTLatencyMaxValue.Nanoseconds(), 1),
 		RunningCount:                metric.NewGauge(metaStreamsRunning),
 		EarliestDataCheckpointSpan:  metric.NewGauge(metaEarliestDataCheckpointSpan),
 		LatestDataCheckpointSpan:    metric.NewGauge(metaLatestDataCheckpointSpan),

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -604,6 +604,10 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 
 	_, sp := tracing.ChildSpan(sip.Ctx, "stream-ingestion-buffer-sst")
 	defer sp.Finish()
+	preScan := timeutil.Now()
+	defer func() {
+		sip.metrics.SSTScanLatency.RecordValue(timeutil.Since(preScan).Nanoseconds())
+	}()
 	return streamingccl.ScanSST(sst, sst.Span,
 		func(keyVal storage.MVCCKeyValue) error {
 			return sip.bufferKV(&roachpb.KeyValue{

--- a/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
+++ b/pkg/ccl/streamingccl/streamproducer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "streamproducer",
     srcs = [
         "event_stream.go",
+        "metrics.go",
         "producer_job.go",
         "replication_manager.go",
         "stream_lifetime.go",
@@ -39,6 +40,7 @@ go_library(
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",
+        "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/span",

--- a/pkg/ccl/streamingccl/streamproducer/metrics.go
+++ b/pkg/ccl/streamingccl/streamproducer/metrics.go
@@ -1,0 +1,87 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package streamproducer
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/util/metric"
+)
+
+var (
+	metaOutOfBoundSSTs = metric.Metadata{
+		Name:        "streaming.sst_out_of_bound",
+		Help:        "SSTs exceeding the subscribed span",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaOutOfBoundSSTSize = metric.Metadata{
+		Name:        "streaming.sst_out_of_bound_size",
+		Help:        "Size of SST exceeding the subscribed span",
+		Measurement: "Bytes",
+		Unit:        metric.Unit_BYTES,
+	}
+
+	metaRangefeedInitialScanError = metric.Metadata{
+		Name:        "streaming.rangefeed_initial_scan_errors",
+		Help:        "Errors encountered in rangefeed initial scan",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaStreamTerminationError = metric.Metadata{
+		Name:        "streaming.stream_termination_errors",
+		Help:        "Errors that terminated the event stream",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaProducerJobError = metric.Metadata{
+		Name:        "streaming.producer_job_errors",
+		Help:        "Errors encountered in executing the producer job",
+		Measurement: "Errors",
+		Unit:        metric.Unit_COUNT,
+	}
+
+	metaProducerJobTimeouts = metric.Metadata{
+		Name:        "streaming.producer_job_timeouts",
+		Help:        "Producer job timeouts",
+		Measurement: "Timeouts",
+		Unit:        metric.Unit_COUNT,
+	}
+)
+
+type Metrics struct {
+	OutOfBoundSSTs            *metric.Counter
+	OutOfBoundSSTSize         *metric.Gauge
+	RangefeedInitialScanError *metric.Counter
+	StreamTerminationError    *metric.Counter
+	ProducerJobError          *metric.Counter
+	ProducerJobTimeouts       *metric.Counter
+}
+
+// MetricStruct implements the metric.Struct interface.
+func (*Metrics) MetricStruct() {}
+
+func MakeMetrics(histogramWindow time.Duration) metric.Struct {
+	return &Metrics{
+		OutOfBoundSSTs:            metric.NewCounter(metaOutOfBoundSSTs),
+		OutOfBoundSSTSize:         metric.NewGauge(metaOutOfBoundSSTSize),
+		RangefeedInitialScanError: metric.NewCounter(metaRangefeedInitialScanError),
+		StreamTerminationError:    metric.NewCounter(metaStreamTerminationError),
+		ProducerJobError:          metric.NewCounter(metaProducerJobError),
+		ProducerJobTimeouts:       metric.NewCounter(metaProducerJobTimeouts),
+	}
+}
+
+func init() {
+	jobs.MakeStreamProduceMetricsHook = MakeMetrics
+}

--- a/pkg/jobs/metrics.go
+++ b/pkg/jobs/metrics.go
@@ -27,9 +27,10 @@ type Metrics struct {
 	// RunningNonIdleJobs is the total number of running jobs that are not idle.
 	RunningNonIdleJobs *metric.Gauge
 
-	RowLevelTTL  metric.Struct
-	Changefeed   metric.Struct
-	StreamIngest metric.Struct
+	RowLevelTTL   metric.Struct
+	Changefeed    metric.Struct
+	StreamIngest  metric.Struct
+	StreamProduce metric.Struct
 
 	// AdoptIterations counts the number of adopt loops executed by Registry.
 	AdoptIterations *metric.Counter
@@ -201,6 +202,9 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 	if MakeStreamIngestMetricsHook != nil {
 		m.StreamIngest = MakeStreamIngestMetricsHook(histogramWindowInterval)
 	}
+	if MakeStreamProduceMetricsHook != nil {
+		m.StreamProduce = MakeStreamProduceMetricsHook(histogramWindowInterval)
+	}
 	m.AdoptIterations = metric.NewCounter(metaAdoptIterations)
 	m.ClaimedJobs = metric.NewCounter(metaClaimedJobs)
 	m.ResumedJobs = metric.NewCounter(metaResumedClaimedJobs)
@@ -228,9 +232,13 @@ func (m *Metrics) init(histogramWindowInterval time.Duration) {
 // ccl code.
 var MakeChangefeedMetricsHook func(time.Duration) metric.Struct
 
-// MakeStreamIngestMetricsHook allows for registration of streaming metrics from
+// MakeStreamIngestMetricsHook allows for registration of streaming ingestion metrics from
 // ccl code.
 var MakeStreamIngestMetricsHook func(duration time.Duration) metric.Struct
+
+// MakeStreamProduceMetricsHook allows for registration of streaming producer metrics from
+// ccl code.
+var MakeStreamProduceMetricsHook func(duration time.Duration) metric.Struct
 
 // MakeRowLevelTTLMetricsHook allows for registration of row-level TTL metrics.
 var MakeRowLevelTTLMetricsHook func(time.Duration) metric.Struct

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1514,6 +1514,7 @@ var charts = []sectionDescription{
 				Title: "Time spent",
 				Metrics: []string{
 					"streaming.flush_hist_nanos",
+					"streaming.scan_sst_latency",
 				},
 			},
 			{
@@ -1554,6 +1555,30 @@ var charts = []sectionDescription{
 			{
 				Title:   "Job Progress Updates",
 				Metrics: []string{"streaming.job_progress_updates"},
+			},
+			{
+				Title:   "SSTs exceeding the subscribed span",
+				Metrics: []string{"streaming.sst_out_of_bound"},
+			},
+			{
+				Title:   "Size of SST exceeding the subscribed span",
+				Metrics: []string{"streaming.sst_out_of_bound_size"},
+			},
+			{
+				Title:   "Errors encountered in rangefeed initial scan",
+				Metrics: []string{"streaming.rangefeed_initial_scan_errors"},
+			},
+			{
+				Title:   "Errors that terminated the event stream",
+				Metrics: []string{"streaming.stream_termination_errors"},
+			},
+			{
+				Title:   "Errors encountered in executing the producer job",
+				Metrics: []string{"streaming.producer_job_errors"},
+			},
+			{
+				Title:   "Producer job timeouts",
+				Metrics: []string{"streaming.producer_job_timeouts"},
 			},
 		},
 	},


### PR DESCRIPTION
Created more metrics around SST and errors on both ingestion
and producer sides.

Release justification: Cat 4
Release note: None

Closes: https://github.com/cockroachdb/cockroach/issues/85617