### PR TITLE
rangefeed: fix nil pointer dereference on missing `DeleteRange` handler

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -366,7 +366,7 @@ func (f *RangeFeed) processEvents(
 				f.onSSTable(ctx, ev.SST, ev.RegisteredSpan)
 			case ev.DeleteRange != nil:
 				if f.onDeleteRange == nil {
-					if f.knobs.IgnoreOnDeleteRangeError {
+					if f.knobs != nil && f.knobs.IgnoreOnDeleteRangeError {
 						continue
 					}
 					return errors.AssertionFailedf(


### PR DESCRIPTION
Release justification: bug fixes and low-risk updates to new functionality

Release note: None