### PR TITLE
sql_test: skip TestInvertedIndexMergeEveryStateWrite under race

### DIFF
--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -468,6 +468,8 @@ func TestInvertedIndexMergeEveryStateWrite(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderRace(t, "very slow")
+
 	var chunkSize int64 = 1000
 	var initialRows = 10000
 	rowIdx := 0


### PR DESCRIPTION
It takes over 5 minutes.
`--- PASS: TestInvertedIndexMergeEveryStateWrite (335.71s)`

Release justification: testing-only change

Epic: None

Release note: None