### PR TITLE
sql: change when txn is checked refresh materialized views

### DIFF
--- a/pkg/sql/materialized_view_test.go
+++ b/pkg/sql/materialized_view_test.go
@@ -69,8 +69,17 @@ REFRESH MATERIALIZED VIEW t.v;
 		t.Fatal(err)
 	}
 
+	// Verify that refreshing with a prepared statement works.
+	preparedStmt, err := sqlDB.Prepare(`REFRESH MATERIALIZED VIEW t.v;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := preparedStmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Add a zone config to delete all table data.
-	_, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, descBeforeRefresh.GetID())
+	_, err = sqltestutils.AddImmediateGCZoneConfig(sqlDB, descBeforeRefresh.GetID())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/refresh_materialized_view.go
+++ b/pkg/sql/refresh_materialized_view.go
@@ -31,9 +31,6 @@ type refreshMaterializedViewNode struct {
 func (p *planner) RefreshMaterializedView(
 	ctx context.Context, n *tree.RefreshMaterializedView,
 ) (planNode, error) {
-	if !p.extendedEvalCtx.TxnIsSingleStmt {
-		return nil, pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in a multi-statement transaction")
-	}
 	_, desc, err := p.ResolveMutableTableDescriptorEx(ctx, n.Name, true /* required */, tree.ResolveRequireViewDesc)
 	if err != nil {
 		return nil, err
@@ -79,6 +76,10 @@ func (n *refreshMaterializedViewNode) startExec(params runParams) error {
 	// will return consistent data. The schema change process will backfill the
 	// results of the view query into the new set of indexes, and then change the
 	// set of indexes over to the new set of indexes atomically.
+
+	if !params.p.extendedEvalCtx.TxnIsSingleStmt {
+		return pgerror.Newf(pgcode.InvalidTransactionState, "cannot refresh view in a multi-statement transaction")
+	}
 
 	telemetry.Inc(sqltelemetry.SchemaRefreshMaterializedView)
 


### PR DESCRIPTION

Due to the transaction being checked during planning
and not during execution, refresh materialized views
would fail from the client. Now the transaction is checked
during execution .

Release justification: Bug fix for refresh materialized views

Release note: None