### PR TITLE
release-22.1: sql/backfill: include virtual key columns in column backfiller

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -129,9 +129,12 @@ func (cb *ColumnBackfiller) init(
 		cb.updateExprs[j+len(cb.added)] = tree.DNull
 	}
 
-	// We need all the non-virtual columns.
+	// We need all the non-virtual columns and any primary key virtual columns.
+	// Note that hash-sharded primary indexes use a virtual column in their
+	// primary key.
+	keyColumns := desc.GetPrimaryIndex().CollectKeyColumnIDs()
 	for _, c := range desc.PublicColumns() {
-		if !c.IsVirtual() {
+		if !c.IsVirtual() || keyColumns.Contains(c.GetID()) {
 			cb.fetcherCols = append(cb.fetcherCols, c.GetID())
 		}
 	}

--- a/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
+++ b/pkg/sql/logictest/testdata/logic_test/hash_sharded_index
@@ -1024,3 +1024,43 @@ x  duped
 # This session variable has noop and is just kept for backward compatibility.
 statement ok
 set experimental_enable_hash_sharded_indexes = on
+
+
+# This is a regression test for a bug whereby the virtual shard column would
+# not be included in the fetch columns when it was a key in the primary index.
+# This caused the column backfiller to return an error and fail permanently and
+# irrecoverably in the case that the a column backfill were to occur.
+subtest add_non_null_column_to_hash_sharded_primary_key
+
+statement ok
+CREATE TABLE products (
+    id INT8 PRIMARY KEY USING HASH DEFAULT unique_rowid(),
+    title VARCHAR(150) NOT NULL,
+    price INT8 NOT NULL
+);
+
+statement ok
+INSERT INTO products (title, price) VALUES ('Test Product', '55');
+INSERT INTO products (title, price) VALUES ('Test Product B', '60');
+
+
+statement ok
+ALTER TABLE products ADD COLUMN description STRING NOT NULL DEFAULT '';
+
+statement ok
+ALTER TABLE products DROP COLUMN description;
+
+statement ok
+BEGIN;
+SET LOCAL use_declarative_schema_changer = off;
+ALTER TABLE products ADD COLUMN description STRING NOT NULL DEFAULT '';
+COMMIT;
+
+statement ok
+BEGIN;
+SET LOCAL use_declarative_schema_changer = off;
+ALTER TABLE products DROP COLUMN description;
+COMMIT;
+
+statement ok
+DROP TABLE products;

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1257,6 +1257,45 @@ JOIN t75147 AS t2 ON
   AND t1.b = t2.b
 JOIN t75147 AS t3 ON t1.a = t3.a;
 
+# This is a regression test for #80780. Prior to the patch introducing this
+# test, any attempt to add or remove a column using the column backfiller
+# (i.e. the legacy schema changer) would fail and retry forever.
+subtest add_column_to_table_with_virtual_primary_key
+
+statement ok
+CREATE TABLE virtual_pk (
+  a INT,
+  b INT,
+  c INT,
+  v1 INT AS (c) VIRTUAL,
+  v2 INT AS (c) VIRTUAL,
+  PRIMARY KEY (b, v1, v2),
+  INDEX (a)
+);
+
+statement ok
+INSERT INTO virtual_pk(a, b, c) values (1, 2, 3), (4, 5, 6);
+
+statement ok
+ALTER TABLE virtual_pk ADD COLUMN d INT NOT NULL DEFAULT 42;
+
+statement ok
+ALTER TABLE virtual_pk DROP COLUMN d;
+
+# Run the operations in an explicit transaction, explicitly using
+# the legacy schema changer.
+statement ok
+BEGIN;
+SET LOCAL use_declarative_schema_changer = off;
+ALTER TABLE virtual_pk ADD COLUMN d INT NOT NULL DEFAULT 42;
+COMMIT;
+
+statement ok
+BEGIN;
+SET LOCAL use_declarative_schema_changer = off;
+ALTER TABLE virtual_pk DROP COLUMN d;
+COMMIT;
+
 # Regression test for #81675. The schema change logic must validate that
 # NOT NULL virtual columns indeed validate to non-NULL values for the existing
 # data in the table.


### PR DESCRIPTION
Backport 1/1 commits from #87207.

/cc @cockroachdb/release

---

We need these columns to encode the row. This rather egregious bug meant that
any table with a primary key which included a virtual column could not have
any columns added or dropped using the legacy schema changer's column
backfiller.

Backports will fix #80780
Backports will fix #86889

Release justification: Serious bug fix
Release note (bug fix): A bug in the column backfiller, which is used to add
or remove columns from tables, failed to account for the need to read virtual
columns which were part of a primary key. Hash-sharded indexes, starting in
22.1, use virtual columns. Any hash-sharded table created in 22.1 or any
table created with a virtual column as part of its primary key would
indefinitely fail to complete a schema change which adds or removes
columns. This bug has been fixed.
