### PR TITLE
sql: support implicit record arg and return types in UDFs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -79,12 +79,6 @@ CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
 statement ok
 CREATE TABLE t_implicit_type(a INT PRIMARY KEY, b STRING);
 
-statement error pq: unimplemented: implicit record types as argument or return types in user-defined functions are not supported
-CREATE FUNCTION f() RETURNS t_implicit_type IMMUTABLE LANGUAGE SQL AS $$ SELECT a, b from t_implicit_type $$
-
-statement error pq: unimplemented: implicit record types as argument or return types in user-defined functions are not supported
-CREATE FUNCTION f(t_implicit_type) RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT 1 $$
-
 statement error pq: return type mismatch in function declared to return int\nDETAIL: Actual return type is record
 CREATE FUNCTION f() RETURNS INT IMMUTABLE LANGUAGE SQL AS $$ SELECT a, b from t_implicit_type $$
 
@@ -1546,7 +1540,7 @@ a  b
 
 statement ok
 CREATE FUNCTION max_in_values() RETURNS INT LANGUAGE SQL AS $$
-SELECT i FROM (VALUES (1, 0), (2, 0), (3, 0)) AS v(i, j) ORDER BY i DESC
+  SELECT i FROM (VALUES (1, 0), (2, 0), (3, 0)) AS v(i, j) ORDER BY i DESC
 $$
 
 query I
@@ -1863,3 +1857,153 @@ l1  l2  i1  i2  s1  s2  v1  v2
 1   1   1   1   1   1   11  11
 2   2   2   2   2   2   12  12
 3   3   3   3   3   3   13  13
+
+
+subtest implicit_record_types
+
+statement ok
+CREATE TABLE imp(k INT PRIMARY KEY, a INT, b TEXT);
+INSERT INTO imp VALUES (1, 2, 'a');
+
+statement ok
+CREATE FUNCTION imp_const_tup() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (11, 22, 'b')
+$$
+
+# TODO(mgartner): The type of imp_const_tup() should be imp, not record.
+query TBT
+SELECT imp_const_tup(), (11,22,'b')::imp = imp_const_tup(), pg_typeof(imp_const_tup())
+----
+(11,22,b)  true  record
+
+statement ok
+CREATE FUNCTION imp_const_cast() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (11, 22, 'b')::imp
+$$
+
+# TODO(mgartner): The type of imp_const_tup() should be imp, not record.
+query TBT
+SELECT imp_const_cast(), (11,22,'b')::imp = imp_const_cast(), pg_typeof(imp_const_cast())
+----
+(11,22,b)  true  imp
+
+statement ok
+CREATE FUNCTION imp_const() RETURNS imp LANGUAGE SQL AS $$
+  SELECT 11 AS k, 22 AS a, 'b' AS b
+$$
+
+query TBT
+SELECT imp_const(), (11,22,'b')::imp = imp_const(), pg_typeof(imp_const())
+----
+(11,22,b)  true  imp
+
+statement ok
+CREATE FUNCTION imp_const_unnamed() RETURNS imp LANGUAGE SQL AS $$
+  SELECT 11, 22, 'b'
+$$
+
+query TBT
+SELECT imp_const_unnamed(), (11,22,'b')::imp = imp_const_unnamed(), pg_typeof(imp_const_unnamed())
+----
+(11,22,b)  true  imp
+
+statement ok
+CREATE FUNCTION imp_tup() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (k, a, b) FROM imp
+$$
+
+# TODO(mgartner): The type of imp_tup() should be imp, not record.
+query TBT
+SELECT imp_tup(), (1,2,'a')::imp = imp_tup(), pg_typeof(imp_tup())
+----
+(1,2,a)  true  record
+
+statement ok
+CREATE FUNCTION imp() RETURNS imp LANGUAGE SQL AS $$
+  SELECT k, a, b FROM imp
+$$
+
+query TBT
+SELECT imp(), (1,2,'a')::imp = imp(), pg_typeof(imp())
+----
+(1,2,a)  true  imp
+
+statement ok
+CREATE FUNCTION imp_star() RETURNS imp LANGUAGE SQL AS $$
+  SELECT * FROM imp
+$$
+
+query TBT
+SELECT imp_star(), (1,2,'a')::imp = imp_star(), pg_typeof(imp_star())
+----
+(1,2,a)  true  imp
+
+statement ok
+INSERT INTO imp VALUES (100, 200, 'z')
+
+statement ok
+CREATE FUNCTION imp_tup_ordered() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (k, a, b) FROM imp ORDER BY b DESC
+$$
+
+query TBT
+SELECT imp_tup_ordered(), (100,200,'z')::imp = imp_tup_ordered(), pg_typeof(imp_tup_ordered())
+----
+(100,200,z)  true  record
+
+statement ok
+CREATE FUNCTION imp_ordered() RETURNS imp LANGUAGE SQL AS $$
+  SELECT k, a, b FROM imp ORDER BY b DESC
+$$
+
+query TBT
+SELECT imp_ordered(), (100,200,'z')::imp = imp_ordered(), pg_typeof(imp_ordered())
+----
+(100,200,z)  true  imp
+
+statement ok
+CREATE FUNCTION imp_identity(i imp) RETURNS imp LANGUAGE SQL AS $$
+  SELECT i
+$$
+
+query TT
+SELECT imp_identity((1,2,'a')), imp_identity((1,2,'a')::imp)
+----
+(1,2,a)  (1,2,a)
+
+statement ok
+CREATE FUNCTION imp_a(i imp) RETURNS INT LANGUAGE SQL AS $$
+  SELECT (i).a
+$$
+
+query II
+SELECT imp_a((1,2,'a')), imp_a((1,2,'a')::imp)
+----
+2  2
+
+statement error return type mismatch in function declared to return imp
+CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (1, 2)
+$$
+
+statement error return type mismatch in function declared to return imp
+CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (1, 2, 3)
+$$
+
+# TODO(mgartner): The error message should say "imp" instead of "record".
+statement error return type mismatch in function declared to return record
+CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
+  SELECT k, a FROM imp
+$$
+
+# TODO(mgartner): The error message should say "imp" instead of "record".
+statement error return type mismatch in function declared to return record
+CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
+  SELECT k, a, b::INT FROM imp
+$$
+
+statement error return type mismatch in function declared to return int
+CREATE FUNCTION err(i imp) RETURNS INT LANGUAGE SQL AS $$
+  SELECT i
+$$

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1666,6 +1666,15 @@ SELECT fetch_b(99999999)
 ----
 NULL
 
+statement ok
+CREATE FUNCTION one_nth(n INT) RETURNS INT LANGUAGE SQL AS 'SELECT 1/n'
+
+statement error pgcode 22012 division by zero
+SELECT one_nth(0)
+
+statement error pgcode 22012 division by zero
+SELECT int_identity((1/0)::INT)
+
 
 subtest args
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -55,16 +55,6 @@ CREATE FUNCTION err(i INT) RETURNS INT LANGUAGE SQL AS 'SELECT * FROM ab WHERE a
 statement ok
 CREATE FUNCTION d(i INT2) RETURNS INT4 LANGUAGE SQL AS 'SELECT i'
 
-# TODO(mgartner): This should be allowed because the cast from INT2::FLOAT4 is
-# allowed in implicit contexts.
-statement error return type mismatch in function declared to return float4\nDETAIL: Actual return type is int2
-CREATE FUNCTION e(i INT2) RETURNS FLOAT4 LANGUAGE SQL AS 'SELECT i'
-
-# TODO(mgartner): This should be allowed because the cast from BOOL::STRING is
-# allowed in assignment contexts.
-statement error return type mismatch in function declared to return string\nDETAIL: Actual return type is bool
-CREATE FUNCTION f(b BOOL) RETURNS STRING LANGUAGE SQL AS 'SELECT b'
-
 statement error return type mismatch in function declared to return bool\nDETAIL: Actual return type is int
 CREATE FUNCTION err(i INT, j INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i - j'
 
@@ -1879,18 +1869,16 @@ CREATE FUNCTION imp_const_tup() RETURNS imp LANGUAGE SQL AS $$
   SELECT (11, 22, 'b')
 $$
 
-# TODO(mgartner): The type of imp_const_tup() should be imp, not record.
 query TBT
 SELECT imp_const_tup(), (11,22,'b')::imp = imp_const_tup(), pg_typeof(imp_const_tup())
 ----
-(11,22,b)  true  record
+(11,22,b)  true  imp
 
 statement ok
 CREATE FUNCTION imp_const_cast() RETURNS imp LANGUAGE SQL AS $$
   SELECT (11, 22, 'b')::imp
 $$
 
-# TODO(mgartner): The type of imp_const_tup() should be imp, not record.
 query TBT
 SELECT imp_const_cast(), (11,22,'b')::imp = imp_const_cast(), pg_typeof(imp_const_cast())
 ----
@@ -1921,11 +1909,12 @@ CREATE FUNCTION imp_tup() RETURNS imp LANGUAGE SQL AS $$
   SELECT (k, a, b) FROM imp
 $$
 
-# TODO(mgartner): The type of imp_tup() should be imp, not record.
-query TBT
-SELECT imp_tup(), (1,2,'a')::imp = imp_tup(), pg_typeof(imp_tup())
+# TODO(mgartner): pg_typeof(imp_tup()) is omitted because we get different
+# results for different configurations, due to #58252.
+query TB
+SELECT imp_tup(), (1,2,'a')::imp = imp_tup()
 ----
-(1,2,a)  true  record
+(1,2,a)  true
 
 statement ok
 CREATE FUNCTION imp() RETURNS imp LANGUAGE SQL AS $$
@@ -1955,10 +1944,12 @@ CREATE FUNCTION imp_tup_ordered() RETURNS imp LANGUAGE SQL AS $$
   SELECT (k, a, b) FROM imp ORDER BY b DESC
 $$
 
-query TBT
-SELECT imp_tup_ordered(), (100,200,'z')::imp = imp_tup_ordered(), pg_typeof(imp_tup_ordered())
+# TODO(mgartner): pg_typeof(imp_tup_ordered()) is omitted because we get
+# different results for different configurations, due to #58252.
+query TB
+SELECT imp_tup_ordered(), (100,200,'z')::imp = imp_tup_ordered()
 ----
-(100,200,z)  true  record
+(100,200,z)  true
 
 statement ok
 CREATE FUNCTION imp_ordered() RETURNS imp LANGUAGE SQL AS $$
@@ -1990,29 +1981,61 @@ SELECT imp_a((1,2,'a')), imp_a((1,2,'a')::imp)
 ----
 2  2
 
+statement ok
+CREATE FUNCTION imp_cast() RETURNS imp LANGUAGE SQL AS $$
+  SELECT (1, 2, 3)
+$$
+
+query TBT
+SELECT imp_cast(), (1,2,'3') = imp_cast(), pg_typeof(imp_cast())
+----
+(1,2,3)  true  imp
+
 statement error return type mismatch in function declared to return imp
 CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
   SELECT (1, 2)
 $$
 
-statement error return type mismatch in function declared to return imp
-CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
-  SELECT (1, 2, 3)
-$$
-
 # TODO(mgartner): The error message should say "imp" instead of "record".
-statement error return type mismatch in function declared to return record
+statement error pgcode 42P13 return type mismatch in function declared to return record
 CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
   SELECT k, a FROM imp
 $$
 
 # TODO(mgartner): The error message should say "imp" instead of "record".
-statement error return type mismatch in function declared to return record
+statement error pgcode 42P13 return type mismatch in function declared to return record
 CREATE FUNCTION err() RETURNS imp LANGUAGE SQL AS $$
   SELECT k, a, b::INT FROM imp
 $$
 
-statement error return type mismatch in function declared to return int
+statement error pgcode 42P13 return type mismatch in function declared to return int
 CREATE FUNCTION err(i imp) RETURNS INT LANGUAGE SQL AS $$
   SELECT i
 $$
+
+
+subtest return_type_assignment_casts
+
+# Do not allow functions with return type mismatches that cannot be cast in an
+# implicit or assignment context.
+statement error pgcode 42P13 return type mismatch in function declared to return bool
+CREATE FUNCTION err(i INT) RETURNS BOOL LANGUAGE SQL AS 'SELECT i'
+
+statement ok
+CREATE FUNCTION itof(i INT) RETURNS FLOAT8 LANGUAGE SQL AS 'SELECT i'
+
+query FT
+SELECT itof(123), pg_typeof(itof(123))
+----
+123  double precision
+
+statement ok
+CREATE FUNCTION stoc(s STRING) RETURNS CHAR LANGUAGE SQL AS 'SELECT s'
+
+query FT
+SELECT stoc('a'), pg_typeof(stoc('a'))
+----
+a  text
+
+statement error pgcode 22001 value too long for type CHAR
+SELECT stoc('abc')

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -223,8 +223,12 @@ func (f *ExprFmtCtx) formatExpr(e opt.Expr, tp treeprinter.Node) {
 
 func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 	md := f.Memo.Metadata()
-	relational := e.Relational()
 	required := e.RequiredPhysical()
+	if r, ok := e.(RelRequiredPropsExpr); ok {
+		e = r.RelExpr
+		required = r.PhysProps
+	}
+	relational := e.Relational()
 	if required == nil {
 		// required can be nil before optimization has taken place.
 		required = physical.MinRequired

--- a/pkg/sql/opt/memo/testdata/logprops/udf
+++ b/pkg/sql/opt/memo/testdata/logprops/udf
@@ -39,17 +39,23 @@ project
            ├── variable: a:1 [type=int]
            └── udf: fn_volatile [type=int]
                 └── body
-                     └── project
+                     └── limit
                           ├── columns: "?column?":5(int!null)
                           ├── cardinality: [1 - 1]
                           ├── key: ()
                           ├── fd: ()-->(5)
-                          ├── values
+                          ├── project
+                          │    ├── columns: "?column?":5(int!null)
                           │    ├── cardinality: [1 - 1]
                           │    ├── key: ()
-                          │    └── tuple [type=tuple]
-                          └── projections
-                               └── const: 1 [as="?column?":5, type=int]
+                          │    ├── fd: ()-->(5)
+                          │    ├── values
+                          │    │    ├── cardinality: [1 - 1]
+                          │    │    ├── key: ()
+                          │    │    └── tuple [type=tuple]
+                          │    └── projections
+                          │         └── const: 1 [as="?column?":5, type=int]
+                          └── const: 1 [type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_immutable()
@@ -78,17 +84,23 @@ project
                 ├── variable: b:2 [type=int]
                 └── udf: fn_immutable [type=int]
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":5(int!null)
                                ├── cardinality: [1 - 1]
                                ├── key: ()
                                ├── fd: ()-->(5)
-                               ├── values
+                               ├── project
+                               │    ├── columns: "?column?":5(int!null)
                                │    ├── cardinality: [1 - 1]
                                │    ├── key: ()
-                               │    └── tuple [type=tuple]
-                               └── projections
-                                    └── const: 1 [as="?column?":5, type=int]
+                               │    ├── fd: ()-->(5)
+                               │    ├── values
+                               │    │    ├── cardinality: [1 - 1]
+                               │    │    ├── key: ()
+                               │    │    └── tuple [type=tuple]
+                               │    └── projections
+                               │         └── const: 1 [as="?column?":5, type=int]
+                               └── const: 1 [type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_immutable() + fn_stable()
@@ -118,30 +130,42 @@ project
                 └── plus [type=int]
                      ├── udf: fn_immutable [type=int]
                      │    └── body
-                     │         └── project
+                     │         └── limit
                      │              ├── columns: "?column?":5(int!null)
                      │              ├── cardinality: [1 - 1]
                      │              ├── key: ()
                      │              ├── fd: ()-->(5)
-                     │              ├── values
+                     │              ├── project
+                     │              │    ├── columns: "?column?":5(int!null)
                      │              │    ├── cardinality: [1 - 1]
                      │              │    ├── key: ()
-                     │              │    └── tuple [type=tuple]
-                     │              └── projections
-                     │                   └── const: 1 [as="?column?":5, type=int]
+                     │              │    ├── fd: ()-->(5)
+                     │              │    ├── values
+                     │              │    │    ├── cardinality: [1 - 1]
+                     │              │    │    ├── key: ()
+                     │              │    │    └── tuple [type=tuple]
+                     │              │    └── projections
+                     │              │         └── const: 1 [as="?column?":5, type=int]
+                     │              └── const: 1 [type=int]
                      └── udf: fn_stable [type=int]
                           └── body
-                               └── project
+                               └── limit
                                     ├── columns: "?column?":6(int!null)
                                     ├── cardinality: [1 - 1]
                                     ├── key: ()
                                     ├── fd: ()-->(6)
-                                    ├── values
+                                    ├── project
+                                    │    ├── columns: "?column?":6(int!null)
                                     │    ├── cardinality: [1 - 1]
                                     │    ├── key: ()
-                                    │    └── tuple [type=tuple]
-                                    └── projections
-                                         └── const: 1 [as="?column?":6, type=int]
+                                    │    ├── fd: ()-->(6)
+                                    │    ├── values
+                                    │    │    ├── cardinality: [1 - 1]
+                                    │    │    ├── key: ()
+                                    │    │    └── tuple [type=tuple]
+                                    │    └── projections
+                                    │         └── const: 1 [as="?column?":6, type=int]
+                                    └── const: 1 [type=int]
 
 build
 SELECT a FROM ab WHERE b = fn_leakproof()
@@ -168,14 +192,20 @@ project
                 ├── variable: b:2 [type=int]
                 └── udf: fn_leakproof [type=int]
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":5(int!null)
                                ├── cardinality: [1 - 1]
                                ├── key: ()
                                ├── fd: ()-->(5)
-                               ├── values
+                               ├── project
+                               │    ├── columns: "?column?":5(int!null)
                                │    ├── cardinality: [1 - 1]
                                │    ├── key: ()
-                               │    └── tuple [type=tuple]
-                               └── projections
-                                    └── const: 1 [as="?column?":5, type=int]
+                               │    ├── fd: ()-->(5)
+                               │    ├── values
+                               │    │    ├── cardinality: [1 - 1]
+                               │    │    ├── key: ()
+                               │    │    └── tuple [type=tuple]
+                               │    └── projections
+                               │         └── const: 1 [as="?column?":5, type=int]
+                               └── const: 1 [type=int]

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/cast"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -211,7 +212,8 @@ func validateReturnType(expected *types.T, cols []scopeColumn) error {
 	}
 
 	if len(cols) == 1 {
-		if !expected.Equivalent(cols[0].typ) {
+		if !expected.Equivalent(cols[0].typ) &&
+			!cast.ValidCast(cols[0].typ, expected, cast.ContextAssignment) {
 			return pgerror.WithCandidateCode(
 				errors.WithDetailf(
 					errors.Newf("return type mismatch in function declared to return %s", expected.Name()),

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -104,9 +104,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 		if err != nil {
 			panic(err)
 		}
-		if err := maybeFailOnImplicitRecordType(typ); err != nil {
-			panic(err)
-		}
 
 		// Add the argument to the base scope of the body.
 		argColName := funcArgColName(arg.Name, i)
@@ -126,9 +123,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateFunction, inScope *scope) (
 	// Collect the user defined type dependency of the return type.
 	funcReturnType, err := tree.ResolveType(b.ctx, cf.ReturnType.Type, b.semaCtx.TypeResolver)
 	if err != nil {
-		panic(err)
-	}
-	if err := maybeFailOnImplicitRecordType(funcReturnType); err != nil {
 		panic(err)
 	}
 	typeIDs, err := typedesc.GetTypeDescriptorClosure(funcReturnType)
@@ -279,15 +273,5 @@ func validateReturnType(expected *types.T, cols []scopeColumn) error {
 		)
 	}
 
-	return nil
-}
-
-func maybeFailOnImplicitRecordType(t *types.T) error {
-	if types.IsOIDUserDefinedType(t.Oid()) && t.Family() == types.TupleFamily {
-		return unimplemented.NewWithIssue(
-			86393,
-			"implicit record types as argument or return types in user-defined functions are not supported",
-		)
-	}
 	return nil
 }

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -661,9 +662,24 @@ func (b *Builder) buildUDF(
 	rels := make(memo.RelListExpr, len(stmts))
 	for i := range stmts {
 		stmtScope := b.buildStmt(stmts[i].AST, nil /* desiredTypes */, bodyScope)
+		expr := stmtScope.expr
+		physProps := stmtScope.makePhysicalProps()
+
+		// Add a LIMIT 1 to the last statement. This is valid because any other
+		// rows after the first can simply be ignored. The limit could be
+		// beneficial because it could allow additional optimization.
+		if i == len(stmts)-1 {
+			b.buildLimit(&tree.Limit{Count: tree.NewDInt(1)}, b.allocScope(), stmtScope)
+			expr = stmtScope.expr
+			// The limit expression will maintain the desired ordering, if any,
+			// so the physical props ordering can be cleared. The presentation
+			// must remain.
+			physProps.Ordering = props.OrderingChoice{}
+		}
+
 		rels[i] = memo.RelRequiredPropsExpr{
-			RelExpr:   stmtScope.expr,
-			PhysProps: stmtScope.makePhysicalProps(),
+			RelExpr:   expr,
+			PhysProps: physProps,
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -675,6 +675,20 @@ func (b *Builder) buildUDF(
 			// so the physical props ordering can be cleared. The presentation
 			// must remain.
 			physProps.Ordering = props.OrderingChoice{}
+
+			// If there are multiple output columns, we must combine them into a
+			// tuple - only a single column can be returned from a UDF.
+			if cols := physProps.Presentation; len(cols) > 1 {
+				elems := make(memo.ScalarListExpr, len(cols))
+				for i := range cols {
+					elems[i] = b.factory.ConstructVariable(cols[i].ID)
+				}
+				tup := b.factory.ConstructTuple(elems, f.ResolvedType())
+				projScope := bodyScope.push()
+				col := b.synthesizeColumn(projScope, scopeColName(""), f.ResolvedType(), nil /* expr */, tup)
+				expr = b.constructProject(expr, []scopeColumn{*col})
+				physProps = projScope.makePhysicalProps()
+			}
 		}
 
 		rels[i] = memo.RelRequiredPropsExpr{

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -960,3 +960,72 @@ project
                      │         └── column-access: 1 [as=b:2]
                      │              └── variable: i:1
                      └── const: 1
+
+
+# --------------------------------------------------
+# UDFs that cast return values.
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION itof(i INT) RETURNS FLOAT8 LANGUAGE SQL AS 'SELECT i'
+----
+
+build format=show-scalars
+SELECT itof(123)
+----
+project
+ ├── columns: itof:4
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: itof [as=itof:4]
+           ├── args: i:1
+           ├── input
+           │    └── const: 123
+           └── body
+                └── project
+                     ├── columns: column3:3
+                     ├── limit
+                     │    ├── columns: i:2
+                     │    ├── project
+                     │    │    ├── columns: i:2
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── variable: i:1 [as=i:2]
+                     │    └── const: 1
+                     └── projections
+                          └── assignment-cast: FLOAT8 [as=column3:3]
+                               └── variable: i:2
+
+exec-ddl
+CREATE FUNCTION stoc(s STRING) RETURNS CHAR LANGUAGE SQL AS 'SELECT s'
+----
+
+build format=show-scalars
+SELECT stoc('a')
+----
+project
+ ├── columns: stoc:4
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: stoc [as=stoc:4]
+           ├── args: s:1
+           ├── input
+           │    └── const: 'a'
+           └── body
+                └── project
+                     ├── columns: column3:3
+                     ├── limit
+                     │    ├── columns: s:2
+                     │    ├── project
+                     │    │    ├── columns: s:2
+                     │    │    ├── values
+                     │    │    │    └── tuple
+                     │    │    └── projections
+                     │    │         └── variable: s:1 [as=s:2]
+                     │    └── const: 1
+                     └── projections
+                          └── assignment-cast: CHAR [as=column3:3]
+                               └── variable: s:2

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -36,12 +36,15 @@ project
  └── projections
       └── udf: one [as=one:2]
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":1!null
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── const: 1 [as="?column?":1]
+                     ├── project
+                     │    ├── columns: "?column?":1!null
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── const: 1 [as="?column?":1]
+                     └── const: 1
 
 build format=show-scalars
 SELECT *, one() FROM abc
@@ -53,12 +56,15 @@ project
  └── projections
       └── udf: one [as=one:7]
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":6!null
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── const: 1 [as="?column?":6]
+                     ├── project
+                     │    ├── columns: "?column?":6!null
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── const: 1 [as="?column?":6]
+                     └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE one() = c
@@ -73,12 +79,15 @@ project
            └── eq
                 ├── udf: one
                 │    └── body
-                │         └── project
+                │         └── limit
                 │              ├── columns: "?column?":6!null
-                │              ├── values
-                │              │    └── tuple
-                │              └── projections
-                │                   └── const: 1 [as="?column?":6]
+                │              ├── project
+                │              │    ├── columns: "?column?":6!null
+                │              │    ├── values
+                │              │    │    └── tuple
+                │              │    └── projections
+                │              │         └── const: 1 [as="?column?":6]
+                │              └── const: 1
                 └── variable: c:3
 
 build format=show-scalars
@@ -101,23 +110,29 @@ project
  │                        │    │    └── tuple
  │                        │    └── projections
  │                        │         └── const: 1 [as="?column?":6]
- │                        └── project
+ │                        └── limit
  │                             ├── columns: "?column?":7!null
- │                             ├── values
- │                             │    └── tuple
- │                             └── projections
- │                                  └── const: 2 [as="?column?":7]
+ │                             ├── project
+ │                             │    ├── columns: "?column?":7!null
+ │                             │    ├── values
+ │                             │    │    └── tuple
+ │                             │    └── projections
+ │                             │         └── const: 2 [as="?column?":7]
+ │                             └── const: 1
  └── projections
       ├── plus [as="?column?":9]
       │    ├── variable: a:1
       │    └── udf: one
       │         └── body
-      │              └── project
+      │              └── limit
       │                   ├── columns: "?column?":8!null
-      │                   ├── values
-      │                   │    └── tuple
-      │                   └── projections
-      │                        └── const: 1 [as="?column?":8]
+      │                   ├── project
+      │                   │    ├── columns: "?column?":8!null
+      │                   │    ├── values
+      │                   │    │    └── tuple
+      │                   │    └── projections
+      │                   │         └── const: 1 [as="?column?":8]
+      │                   └── const: 1
       └── plus [as="?column?":12]
            ├── variable: b:2
            └── udf: two
@@ -128,12 +143,40 @@ project
                      │    │    └── tuple
                      │    └── projections
                      │         └── const: 1 [as="?column?":10]
-                     └── project
+                     └── limit
                           ├── columns: "?column?":11!null
-                          ├── values
-                          │    └── tuple
-                          └── projections
-                               └── const: 2 [as="?column?":11]
+                          ├── project
+                          │    ├── columns: "?column?":11!null
+                          │    ├── values
+                          │    │    └── tuple
+                          │    └── projections
+                          │         └── const: 2 [as="?column?":11]
+                          └── const: 1
+
+exec-ddl
+CREATE FUNCTION ordered() RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM abc ORDER BY b DESC
+$$;
+----
+
+build format=show-scalars
+SELECT ordered()
+----
+project
+ ├── columns: ordered:6
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: ordered [as=ordered:6]
+           └── body
+                └── limit
+                     ├── columns: a:1!null  [hidden: b:2]
+                     ├── internal-ordering: -2
+                     ├── project
+                     │    ├── columns: a:1!null b:2
+                     │    └── scan abc
+                     │         └── columns: a:1!null b:2 c:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+                     └── const: 1
 
 
 # --------------------------------------------------
@@ -160,14 +203,17 @@ project
            │    ├── const: 1
            │    └── const: 2
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":3
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":3]
-                               ├── variable: x:1
-                               └── variable: y:2
+                     ├── project
+                     │    ├── columns: "?column?":3
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":3]
+                     │              ├── variable: x:1
+                     │              └── variable: y:2
+                     └── const: 1
 
 build format=show-scalars
 SELECT add(add(1, 2), 3)
@@ -186,24 +232,30 @@ project
            │    │    │    ├── const: 1
            │    │    │    └── const: 2
            │    │    └── body
-           │    │         └── project
+           │    │         └── limit
            │    │              ├── columns: "?column?":3
-           │    │              ├── values
-           │    │              │    └── tuple
-           │    │              └── projections
-           │    │                   └── plus [as="?column?":3]
-           │    │                        ├── variable: x:1
-           │    │                        └── variable: y:2
+           │    │              ├── project
+           │    │              │    ├── columns: "?column?":3
+           │    │              │    ├── values
+           │    │              │    │    └── tuple
+           │    │              │    └── projections
+           │    │              │         └── plus [as="?column?":3]
+           │    │              │              ├── variable: x:1
+           │    │              │              └── variable: y:2
+           │    │              └── const: 1
            │    └── const: 3
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":6
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":6]
-                               ├── variable: x:4
-                               └── variable: y:5
+                     ├── project
+                     │    ├── columns: "?column?":6
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":6]
+                     │              ├── variable: x:4
+                     │              └── variable: y:5
+                     └── const: 1
 
 build format=show-scalars
 SELECT add(a, b) FROM abc
@@ -219,14 +271,17 @@ project
            │    ├── variable: a:1
            │    └── variable: b:2
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":8
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":8]
-                               ├── variable: x:6
-                               └── variable: y:7
+                     ├── project
+                     │    ├── columns: "?column?":8
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":8]
+                     │              ├── variable: x:6
+                     │              └── variable: y:7
+                     └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE a = add(b, c)
@@ -246,14 +301,17 @@ project
                      │    ├── variable: b:2
                      │    └── variable: c:3
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":8
-                               ├── values
-                               │    └── tuple
-                               └── projections
-                                    └── plus [as="?column?":8]
-                                         ├── variable: x:6
-                                         └── variable: y:7
+                               ├── project
+                               │    ├── columns: "?column?":8
+                               │    ├── values
+                               │    │    └── tuple
+                               │    └── projections
+                               │         └── plus [as="?column?":8]
+                               │              ├── variable: x:6
+                               │              └── variable: y:7
+                               └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE a = add(add(b, c), 3)
@@ -276,24 +334,30 @@ project
                      │    │    │    ├── variable: b:2
                      │    │    │    └── variable: c:3
                      │    │    └── body
-                     │    │         └── project
+                     │    │         └── limit
                      │    │              ├── columns: "?column?":8
-                     │    │              ├── values
-                     │    │              │    └── tuple
-                     │    │              └── projections
-                     │    │                   └── plus [as="?column?":8]
-                     │    │                        ├── variable: x:6
-                     │    │                        └── variable: y:7
+                     │    │              ├── project
+                     │    │              │    ├── columns: "?column?":8
+                     │    │              │    ├── values
+                     │    │              │    │    └── tuple
+                     │    │              │    └── projections
+                     │    │              │         └── plus [as="?column?":8]
+                     │    │              │              ├── variable: x:6
+                     │    │              │              └── variable: y:7
+                     │    │              └── const: 1
                      │    └── const: 3
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":11
-                               ├── values
-                               │    └── tuple
-                               └── projections
-                                    └── plus [as="?column?":11]
-                                         ├── variable: x:9
-                                         └── variable: y:10
+                               ├── project
+                               │    ├── columns: "?column?":11
+                               │    ├── values
+                               │    │    └── tuple
+                               │    └── projections
+                               │         └── plus [as="?column?":11]
+                               │              ├── variable: x:9
+                               │              └── variable: y:10
+                               └── const: 1
 
 exec-ddl
 CREATE FUNCTION fetch_b(a_arg INT) RETURNS INT LANGUAGE SQL AS $$
@@ -314,16 +378,19 @@ project
            ├── input
            │    └── const: 1
            └── body
-                └── project
+                └── limit
                      ├── columns: b:3
-                     └── select
-                          ├── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                          ├── scan abc
-                          │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                          └── filters
-                               └── eq
-                                    ├── variable: a:2
-                                    └── variable: a_arg:1
+                     ├── project
+                     │    ├── columns: b:3
+                     │    └── select
+                     │         ├── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │         ├── scan abc
+                     │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │         └── filters
+                     │              └── eq
+                     │                   ├── variable: a:2
+                     │                   └── variable: a_arg:1
+                     └── const: 1
 
 build format=show-scalars
 SELECT fetch_b(add(1, 2))
@@ -342,25 +409,31 @@ project
            │         │    ├── const: 1
            │         │    └── const: 2
            │         └── body
-           │              └── project
+           │              └── limit
            │                   ├── columns: "?column?":3
-           │                   ├── values
-           │                   │    └── tuple
-           │                   └── projections
-           │                        └── plus [as="?column?":3]
-           │                             ├── variable: x:1
-           │                             └── variable: y:2
+           │                   ├── project
+           │                   │    ├── columns: "?column?":3
+           │                   │    ├── values
+           │                   │    │    └── tuple
+           │                   │    └── projections
+           │                   │         └── plus [as="?column?":3]
+           │                   │              ├── variable: x:1
+           │                   │              └── variable: y:2
+           │                   └── const: 1
            └── body
-                └── project
+                └── limit
                      ├── columns: b:6
-                     └── select
-                          ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
-                          ├── scan abc
-                          │    └── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
-                          └── filters
-                               └── eq
-                                    ├── variable: a:5
-                                    └── variable: a_arg:4
+                     ├── project
+                     │    ├── columns: b:6
+                     │    └── select
+                     │         ├── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │         ├── scan abc
+                     │         │    └── columns: a:5!null b:6 c:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+                     │         └── filters
+                     │              └── eq
+                     │                   ├── variable: a:5
+                     │                   └── variable: a_arg:4
+                     └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE b = fetch_b(a)
@@ -379,16 +452,19 @@ project
                      ├── input
                      │    └── variable: a:1
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: b:8
-                               └── select
-                                    ├── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
-                                    ├── scan abc
-                                    │    └── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
-                                    └── filters
-                                         └── eq
-                                              ├── variable: a:7
-                                              └── variable: a_arg:6
+                               ├── project
+                               │    ├── columns: b:8
+                               │    └── select
+                               │         ├── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+                               │         ├── scan abc
+                               │         │    └── columns: a:7!null b:8 c:9 crdb_internal_mvcc_timestamp:10 tableoid:11
+                               │         └── filters
+                               │              └── eq
+                               │                   ├── variable: a:7
+                               │                   └── variable: a_arg:6
+                               └── const: 1
 
 exec-ddl
 CREATE FUNCTION shadowed_a(a INT) RETURNS INT LANGUAGE SQL AS $$
@@ -410,16 +486,19 @@ project
            ├── input
            │    └── const: 1
            └── body
-                └── project
+                └── limit
                      ├── columns: c:4
-                     └── select
-                          ├── columns: abc.a:2!null b:3!null c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                          ├── scan abc
-                          │    └── columns: abc.a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
-                          └── filters
-                               └── eq
-                                    ├── variable: b:3
-                                    └── variable: abc.a:2
+                     ├── project
+                     │    ├── columns: c:4
+                     │    └── select
+                     │         ├── columns: abc.a:2!null b:3!null c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │         ├── scan abc
+                     │         │    └── columns: abc.a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │         └── filters
+                     │              └── eq
+                     │                   ├── variable: b:3
+                     │                   └── variable: abc.a:2
+                     └── const: 1
 
 exec-ddl
 CREATE FUNCTION add_num_args(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$
@@ -441,14 +520,17 @@ project
            │    ├── const: 1
            │    └── const: 2
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":3
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":3]
-                               ├── variable: x:1
-                               └── variable: y:2
+                     ├── project
+                     │    ├── columns: "?column?":3
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":3]
+                     │              ├── variable: x:1
+                     │              └── variable: y:2
+                     └── const: 1
 
 build format=show-scalars
 SELECT add_num_args(add_num_args(1, 2), 3)
@@ -467,24 +549,30 @@ project
            │    │    │    ├── const: 1
            │    │    │    └── const: 2
            │    │    └── body
-           │    │         └── project
+           │    │         └── limit
            │    │              ├── columns: "?column?":3
-           │    │              ├── values
-           │    │              │    └── tuple
-           │    │              └── projections
-           │    │                   └── plus [as="?column?":3]
-           │    │                        ├── variable: x:1
-           │    │                        └── variable: y:2
+           │    │              ├── project
+           │    │              │    ├── columns: "?column?":3
+           │    │              │    ├── values
+           │    │              │    │    └── tuple
+           │    │              │    └── projections
+           │    │              │         └── plus [as="?column?":3]
+           │    │              │              ├── variable: x:1
+           │    │              │              └── variable: y:2
+           │    │              └── const: 1
            │    └── const: 3
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":6
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":6]
-                               ├── variable: x:4
-                               └── variable: y:5
+                     ├── project
+                     │    ├── columns: "?column?":6
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":6]
+                     │              ├── variable: x:4
+                     │              └── variable: y:5
+                     └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE a = add_num_args(add_num_args(b, c), 3)
@@ -507,24 +595,30 @@ project
                      │    │    │    ├── variable: b:2
                      │    │    │    └── variable: c:3
                      │    │    └── body
-                     │    │         └── project
+                     │    │         └── limit
                      │    │              ├── columns: "?column?":8
-                     │    │              ├── values
-                     │    │              │    └── tuple
-                     │    │              └── projections
-                     │    │                   └── plus [as="?column?":8]
-                     │    │                        ├── variable: x:6
-                     │    │                        └── variable: y:7
+                     │    │              ├── project
+                     │    │              │    ├── columns: "?column?":8
+                     │    │              │    ├── values
+                     │    │              │    │    └── tuple
+                     │    │              │    └── projections
+                     │    │              │         └── plus [as="?column?":8]
+                     │    │              │              ├── variable: x:6
+                     │    │              │              └── variable: y:7
+                     │    │              └── const: 1
                      │    └── const: 3
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":11
-                               ├── values
-                               │    └── tuple
-                               └── projections
-                                    └── plus [as="?column?":11]
-                                         ├── variable: x:9
-                                         └── variable: y:10
+                               ├── project
+                               │    ├── columns: "?column?":11
+                               │    ├── values
+                               │    │    └── tuple
+                               │    └── projections
+                               │         └── plus [as="?column?":11]
+                               │              ├── variable: x:9
+                               │              └── variable: y:10
+                               └── const: 1
 
 assign-placeholders-build query-args=(33) format=show-scalars
 SELECT add_num_args(1, $1) FROM abc WHERE a = add_num_args($1, 2)
@@ -544,14 +638,17 @@ project
  │                   │    ├── const: 33
  │                   │    └── const: 2
  │                   └── body
- │                        └── project
+ │                        └── limit
  │                             ├── columns: "?column?":8
- │                             ├── values
- │                             │    └── tuple
- │                             └── projections
- │                                  └── plus [as="?column?":8]
- │                                       ├── variable: x:6
- │                                       └── variable: y:7
+ │                             ├── project
+ │                             │    ├── columns: "?column?":8
+ │                             │    ├── values
+ │                             │    │    └── tuple
+ │                             │    └── projections
+ │                             │         └── plus [as="?column?":8]
+ │                             │              ├── variable: x:6
+ │                             │              └── variable: y:7
+ │                             └── const: 1
  └── projections
       └── udf: add_num_args [as=add_num_args:12]
            ├── args: x:9 y:10
@@ -559,14 +656,17 @@ project
            │    ├── const: 1
            │    └── const: 33
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":11
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":11]
-                               ├── variable: x:9
-                               └── variable: y:10
+                     ├── project
+                     │    ├── columns: "?column?":11
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":11]
+                     │              ├── variable: x:9
+                     │              └── variable: y:10
+                     └── const: 1
 
 # --------------------------------------------------
 # UDFs with anonymous arguments.
@@ -592,14 +692,17 @@ project
            │    ├── const: 1
            │    └── const: 2
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":3
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":3]
-                               ├── variable: arg1:1
-                               └── variable: arg2:2
+                     ├── project
+                     │    ├── columns: "?column?":3
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":3]
+                     │              ├── variable: arg1:1
+                     │              └── variable: arg2:2
+                     └── const: 1
 
 build format=show-scalars
 SELECT add_anon(add_anon(1, 2), 3)
@@ -618,24 +721,30 @@ project
            │    │    │    ├── const: 1
            │    │    │    └── const: 2
            │    │    └── body
-           │    │         └── project
+           │    │         └── limit
            │    │              ├── columns: "?column?":3
-           │    │              ├── values
-           │    │              │    └── tuple
-           │    │              └── projections
-           │    │                   └── plus [as="?column?":3]
-           │    │                        ├── variable: arg1:1
-           │    │                        └── variable: arg2:2
+           │    │              ├── project
+           │    │              │    ├── columns: "?column?":3
+           │    │              │    ├── values
+           │    │              │    │    └── tuple
+           │    │              │    └── projections
+           │    │              │         └── plus [as="?column?":3]
+           │    │              │              ├── variable: arg1:1
+           │    │              │              └── variable: arg2:2
+           │    │              └── const: 1
            │    └── const: 3
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":6
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":6]
-                               ├── variable: arg1:4
-                               └── variable: arg2:5
+                     ├── project
+                     │    ├── columns: "?column?":6
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":6]
+                     │              ├── variable: arg1:4
+                     │              └── variable: arg2:5
+                     └── const: 1
 
 build format=show-scalars
 SELECT * FROM abc WHERE a = add_anon(add_anon(b, c), 3)
@@ -658,24 +767,30 @@ project
                      │    │    │    ├── variable: b:2
                      │    │    │    └── variable: c:3
                      │    │    └── body
-                     │    │         └── project
+                     │    │         └── limit
                      │    │              ├── columns: "?column?":8
-                     │    │              ├── values
-                     │    │              │    └── tuple
-                     │    │              └── projections
-                     │    │                   └── plus [as="?column?":8]
-                     │    │                        ├── variable: arg1:6
-                     │    │                        └── variable: arg2:7
+                     │    │              ├── project
+                     │    │              │    ├── columns: "?column?":8
+                     │    │              │    ├── values
+                     │    │              │    │    └── tuple
+                     │    │              │    └── projections
+                     │    │              │         └── plus [as="?column?":8]
+                     │    │              │              ├── variable: arg1:6
+                     │    │              │              └── variable: arg2:7
+                     │    │              └── const: 1
                      │    └── const: 3
                      └── body
-                          └── project
+                          └── limit
                                ├── columns: "?column?":11
-                               ├── values
-                               │    └── tuple
-                               └── projections
-                                    └── plus [as="?column?":11]
-                                         ├── variable: arg1:9
-                                         └── variable: arg2:10
+                               ├── project
+                               │    ├── columns: "?column?":11
+                               │    ├── values
+                               │    │    └── tuple
+                               │    └── projections
+                               │         └── plus [as="?column?":11]
+                               │              ├── variable: arg1:9
+                               │              └── variable: arg2:10
+                               └── const: 1
 
 assign-placeholders-build query-args=(33) format=show-scalars
 SELECT add_anon(1, $1) FROM abc WHERE a = add_anon($1, 2)
@@ -695,14 +810,17 @@ project
  │                   │    ├── const: 33
  │                   │    └── const: 2
  │                   └── body
- │                        └── project
+ │                        └── limit
  │                             ├── columns: "?column?":8
- │                             ├── values
- │                             │    └── tuple
- │                             └── projections
- │                                  └── plus [as="?column?":8]
- │                                       ├── variable: arg1:6
- │                                       └── variable: arg2:7
+ │                             ├── project
+ │                             │    ├── columns: "?column?":8
+ │                             │    ├── values
+ │                             │    │    └── tuple
+ │                             │    └── projections
+ │                             │         └── plus [as="?column?":8]
+ │                             │              ├── variable: arg1:6
+ │                             │              └── variable: arg2:7
+ │                             └── const: 1
  └── projections
       └── udf: add_anon [as=add_anon:12]
            ├── args: arg1:9 arg2:10
@@ -710,11 +828,14 @@ project
            │    ├── const: 1
            │    └── const: 33
            └── body
-                └── project
+                └── limit
                      ├── columns: "?column?":11
-                     ├── values
-                     │    └── tuple
-                     └── projections
-                          └── plus [as="?column?":11]
-                               ├── variable: arg1:9
-                               └── variable: arg2:10
+                     ├── project
+                     │    ├── columns: "?column?":11
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── plus [as="?column?":11]
+                     │              ├── variable: arg1:9
+                     │              └── variable: arg2:10
+                     └── const: 1

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -839,3 +839,124 @@ project
                      │              ├── variable: arg1:9
                      │              └── variable: arg2:10
                      └── const: 1
+
+
+# --------------------------------------------------
+# UDFs with implicit record types.
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION get_abc(i INT) RETURNS abc LANGUAGE SQL AS $$
+  SELECT a, b, c FROM abc WHERE c > i ORDER BY b DESC
+$$;
+----
+
+build format=show-scalars
+SELECT get_abc(3)
+----
+project
+ ├── columns: get_abc:8
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: get_abc [as=get_abc:8]
+           ├── args: i:1
+           ├── input
+           │    └── const: 3
+           └── body
+                └── project
+                     ├── columns: column7:7
+                     ├── limit
+                     │    ├── columns: a:2!null b:3 c:4!null
+                     │    ├── internal-ordering: -3
+                     │    ├── project
+                     │    │    ├── columns: a:2!null b:3 c:4!null
+                     │    │    └── select
+                     │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │         ├── scan abc
+                     │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │         └── filters
+                     │    │              └── gt
+                     │    │                   ├── variable: c:4
+                     │    │                   └── variable: i:1
+                     │    └── const: 1
+                     └── projections
+                          └── tuple [as=column7:7]
+                               ├── variable: a:2
+                               ├── variable: b:3
+                               └── variable: c:4
+
+exec-ddl
+CREATE FUNCTION get_abc_star(i INT) RETURNS abc LANGUAGE SQL AS $$
+  SELECT * FROM abc WHERE c > i ORDER BY b DESC
+$$;
+----
+
+build format=show-scalars
+SELECT get_abc_star(3)
+----
+project
+ ├── columns: get_abc_star:8
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: get_abc_star [as=get_abc_star:8]
+           ├── args: i:1
+           ├── input
+           │    └── const: 3
+           └── body
+                └── project
+                     ├── columns: column7:7
+                     ├── limit
+                     │    ├── columns: a:2!null b:3 c:4!null
+                     │    ├── internal-ordering: -3
+                     │    ├── project
+                     │    │    ├── columns: a:2!null b:3 c:4!null
+                     │    │    └── select
+                     │    │         ├── columns: a:2!null b:3 c:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │         ├── scan abc
+                     │    │         │    └── columns: a:2!null b:3 c:4 crdb_internal_mvcc_timestamp:5 tableoid:6
+                     │    │         └── filters
+                     │    │              └── gt
+                     │    │                   ├── variable: c:4
+                     │    │                   └── variable: i:1
+                     │    └── const: 1
+                     └── projections
+                          └── tuple [as=column7:7]
+                               ├── variable: a:2
+                               ├── variable: b:3
+                               └── variable: c:4
+
+exec-ddl
+CREATE FUNCTION abc_b(i abc) RETURNS INT LANGUAGE SQL AS $$
+  SELECT (i).b
+$$;
+----
+
+build format=show-scalars
+SELECT abc_b((1,2,3)::abc)
+----
+project
+ ├── columns: abc_b:3
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: abc_b [as=abc_b:3]
+           ├── args: i:1
+           ├── input
+           │    └── cast: RECORD
+           │         └── tuple
+           │              ├── const: 1
+           │              ├── const: 2
+           │              └── const: 3
+           └── body
+                └── limit
+                     ├── columns: b:2
+                     ├── project
+                     │    ├── columns: b:2
+                     │    ├── values
+                     │    │    └── tuple
+                     │    └── projections
+                     │         └── column-access: 1 [as=b:2]
+                     │              └── variable: i:1
+                     └── const: 1

--- a/pkg/sql/opt/testutils/testcat/testdata/table
+++ b/pkg/sql/opt/testutils/testcat/testdata/table
@@ -387,6 +387,40 @@ TABLE virtpk
       ├── v int not null as (a + 10) stored
       └── a int not null
 
+# Tables are implicit record types.
+exec-ddl
+CREATE TABLE typ1 (
+  a INT PRIMARY KEY,
+  b STRING
+)
+----
+
+exec-ddl
+CREATE TABLE typ2 (
+  a INT PRIMARY KEY
+)
+----
+
+exec-ddl
+CREATE TABLE tab_with_types (
+  k INT PRIMARY KEY,
+  t1 typ1,
+  t2 typ2
+)
+----
+
+exec-ddl
+SHOW CREATE tab_with_types
+----
+TABLE tab_with_types
+ ├── k int not null
+ ├── t1 tuple{int AS a, string AS b}
+ ├── t2 tuple{int AS a}
+ ├── crdb_internal_mvcc_timestamp decimal [hidden] [system]
+ ├── tableoid oid [hidden] [system]
+ └── PRIMARY INDEX tab_with_types_pkey
+      └── k int not null
+
 # Regression test for #76994. Only unique constraints with the same columns and
 # predicates should be deduplicated.
 exec-ddl

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -94,13 +94,6 @@ func (p *planner) EvalRoutineExpr(
 
 	// Fetch the first row from the row container and return the first
 	// datum.
-	// TODO(mgartner): Consider adding an assertion error if more than one
-	// row exists in the row container. This would require the optimizer to
-	// automatically add LIMIT 1 expressions on the last statement in a
-	// routine to avoid errors when a statement returns more than one row.
-	// Adding the limit would be valid because any other rows after the
-	// first can simply be ignored. The limit could also be beneficial
-	// because it could allow additional query plan optimizations.
 	rightRowsIterator := newRowContainerIterator(ctx, rch, retTypes)
 	defer rightRowsIterator.Close()
 	res, err := rightRowsIterator.Next()


### PR DESCRIPTION
#### opt: wrap last statement in a UDF with LIMIT 1

A UDF always returns a single row from the last statement in the UDF
(unless it is a set returning UDF, but we do not currently support
those). So, we can wrap the last statement in a `LIMIT 1` expression
which may allow additional optimizations to trigger.

Release justification: This is a minor change to a new feature.

Release note: None

#### opt: add implicit record types to opt test catalog

Release justification: This is a test-only change.

Release note: None

#### sql: support implicit record arg and return types in UDFs

Implicit record types are now supported as argument types and return
types of user-defined functions. For example:

    CREATE TABLE t (a INT PRIMARY KEY, b INT);
    CREATE FUNCTION ret_t() RETURNS t LANGUAGE SQL AS $$
      SELECT * FROM t
    $$;
    CREATE FUNCTION t_a(some_t t) RETURNS INT LANGUAGE SQL AS $$
      SELECT (some_t).a
    $$;

Fixes #86393

Release justification: This fixes a limitation of a newly added feature.

Release note: None

#### sql: propagate UDF errors correctly

This commit fixes a bug where an error that occurred during evaluation
of a UDF was not correctly propagated.

Release justification: This fixes a critical bug with a new feature.

Release note: None

#### sql: cast UDF result to function return type

The last statement of a UDF may have a resulting type, `R`, that does
not match the function's given return type, `F`. This is allowed if a
cast from `R` to `F` is valid in an implicit or assignment context.

This commit adds an assignment cast operator to the output column of the
final statement in the function body, if necessary.

Release justification: This fixes a minor bug with a new feature.

Release Note: None
