### PR TITLE
allocator: increase log verbosity

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2204,7 +2204,7 @@ func loadBasedLeaseRebalanceScore(
 	underfullScore := underfullLeaseThreshold - remoteStore.Capacity.LeaseCount
 	totalScore := overfullScore + underfullScore
 
-	log.KvDistribution.VEventf(ctx, 1,
+	log.KvDistribution.Infof(ctx,
 		"node: %d, sourceWeight: %.2f, remoteWeight: %.2f, remoteLatency: %v, "+
 			"rebalanceThreshold: %.2f, meanLeases: %.2f, sourceLeaseCount: %d, overfullThreshold: %d, "+
 			"remoteLeaseCount: %d, underfullThreshold: %d, totalScore: %d",

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -1142,14 +1142,14 @@ func (rq *replicateQueue) addOrReplaceVoters(
 		ops = roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, newVoter)
 	}
 	if removeIdx < 0 {
-		log.KvDistribution.VEventf(ctx, 1, "adding voter %+v: %s",
+		log.KvDistribution.Infof(ctx, "adding voter %+v: %s",
 			newVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	} else {
 		if !dryRun {
 			rq.metrics.trackRemoveMetric(allocatorimpl.VoterTarget, replicaStatus)
 		}
 		removeVoter := existingVoters[removeIdx]
-		log.KvDistribution.VEventf(ctx, 1, "replacing voter %s with %+v: %s",
+		log.KvDistribution.Infof(ctx, "replacing voter %s with %+v: %s",
 			removeVoter, newVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 		// NB: We may have performed a promotion of a non-voter above, but we will
 		// not perform a demotion here and instead just remove the existing replica
@@ -1206,14 +1206,14 @@ func (rq *replicateQueue) addOrReplaceNonVoters(
 
 	ops := roachpb.MakeReplicationChanges(roachpb.ADD_NON_VOTER, newNonVoter)
 	if removeIdx < 0 {
-		log.KvDistribution.VEventf(ctx, 1, "adding non-voter %+v: %s",
+		log.KvDistribution.Infof(ctx, "adding non-voter %+v: %s",
 			newNonVoter, rangeRaftProgress(repl.RaftStatus(), existingNonVoters))
 	} else {
 		if !dryRun {
 			rq.metrics.trackRemoveMetric(allocatorimpl.NonVoterTarget, replicaStatus)
 		}
 		removeNonVoter := existingNonVoters[removeIdx]
-		log.KvDistribution.VEventf(ctx, 1, "replacing non-voter %s with %+v: %s",
+		log.KvDistribution.Infof(ctx, "replacing non-voter %s with %+v: %s",
 			removeNonVoter, newNonVoter, rangeRaftProgress(repl.RaftStatus(), existingNonVoters))
 		ops = append(ops,
 			roachpb.MakeReplicationChanges(roachpb.REMOVE_NON_VOTER, roachpb.ReplicationTarget{
@@ -1403,7 +1403,7 @@ func (rq *replicateQueue) removeVoter(
 		rq.metrics.trackRemoveMetric(allocatorimpl.VoterTarget, allocatorimpl.Alive)
 	}
 
-	log.KvDistribution.VEventf(ctx, 1, "removing voting replica %+v due to over-replication: %s",
+	log.KvDistribution.Infof(ctx, "removing voting replica %+v due to over-replication: %s",
 		removeVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	desc := repl.Desc()
 	// TODO(aayush): Directly removing the voter here is a bit of a missed
@@ -1449,7 +1449,7 @@ func (rq *replicateQueue) removeNonVoter(
 	if !dryRun {
 		rq.metrics.trackRemoveMetric(allocatorimpl.NonVoterTarget, allocatorimpl.Alive)
 	}
-	log.KvDistribution.VEventf(ctx, 1, "removing non-voting replica %+v due to over-replication: %s",
+	log.KvDistribution.Infof(ctx, "removing non-voting replica %+v due to over-replication: %s",
 		removeNonVoter, rangeRaftProgress(repl.RaftStatus(), existingVoters))
 	target := roachpb.ReplicationTarget{
 		NodeID:  removeNonVoter.NodeID,
@@ -1491,7 +1491,7 @@ func (rq *replicateQueue) removeDecommissioning(
 	}
 
 	if len(decommissioningReplicas) == 0 {
-		log.KvDistribution.VEventf(ctx, 1, "range of %[1]ss %[2]s was identified as having decommissioning %[1]ss, "+
+		log.KvDistribution.Infof(ctx, "range of %[1]ss %[2]s was identified as having decommissioning %[1]ss, "+
 			"but no decommissioning %[1]ss were found", targetType, repl)
 		return true, nil
 	}
@@ -1511,7 +1511,7 @@ func (rq *replicateQueue) removeDecommissioning(
 	if !dryRun {
 		rq.metrics.trackRemoveMetric(targetType, allocatorimpl.Decommissioning)
 	}
-	log.KvDistribution.VEventf(ctx, 1, "removing decommissioning %s %+v from store", targetType, decommissioningReplica)
+	log.KvDistribution.Infof(ctx, "removing decommissioning %s %+v from store", targetType, decommissioningReplica)
 	target := roachpb.ReplicationTarget{
 		NodeID:  decommissioningReplica.NodeID,
 		StoreID: decommissioningReplica.StoreID,
@@ -1540,9 +1540,8 @@ func (rq *replicateQueue) removeDead(
 ) (requeue bool, _ error) {
 	desc := repl.Desc()
 	if len(deadReplicas) == 0 {
-		log.KvDistribution.VEventf(
+		log.KvDistribution.Infof(
 			ctx,
-			1,
 			"range of %[1]s %[2]s was identified as having dead %[1]ss, but no dead %[1]ss were found",
 			targetType,
 			repl,
@@ -1553,7 +1552,7 @@ func (rq *replicateQueue) removeDead(
 	if !dryRun {
 		rq.metrics.trackRemoveMetric(targetType, allocatorimpl.Dead)
 	}
-	log.KvDistribution.VEventf(ctx, 1, "removing dead %s %+v from store", targetType, deadReplica)
+	log.KvDistribution.Infof(ctx, "removing dead %s %+v from store", targetType, deadReplica)
 	target := roachpb.ReplicationTarget{
 		NodeID:  deadReplica.NodeID,
 		StoreID: deadReplica.StoreID,
@@ -1609,7 +1608,7 @@ func (rq *replicateQueue) considerRebalance(
 		if !ok {
 			// If there was nothing to do for the set of voting replicas on this
 			// range, attempt to rebalance non-voters.
-			log.KvDistribution.VEventf(ctx, 1, "no suitable rebalance target for voters")
+			log.KvDistribution.Infof(ctx, "no suitable rebalance target for voters")
 			addTarget, removeTarget, details, ok = rq.allocator.RebalanceNonVoter(
 				ctx,
 				conf,
@@ -1629,12 +1628,12 @@ func (rq *replicateQueue) considerRebalance(
 		lhBeingRemoved := removeTarget.StoreID == repl.store.StoreID()
 
 		if !ok {
-			log.KvDistribution.VEventf(ctx, 1, "no suitable rebalance target for non-voters")
+			log.KvDistribution.Infof(ctx, "no suitable rebalance target for non-voters")
 		} else if !lhRemovalAllowed {
 			if done, err := rq.maybeTransferLeaseAway(
 				ctx, repl, removeTarget.StoreID, dryRun, canTransferLeaseFrom,
 			); err != nil {
-				log.KvDistribution.VEventf(ctx, 1, "want to remove self, but failed to transfer lease away: %s", err)
+				log.KvDistribution.Infof(ctx, "want to remove self, but failed to transfer lease away: %s", err)
 				ok = false
 			} else if done {
 				// Lease is now elsewhere, so we're not in charge any more.
@@ -1656,8 +1655,7 @@ func (rq *replicateQueue) considerRebalance(
 					rq.metrics.NonVoterPromotionsCount.Inc(1)
 				}
 			}
-			log.KvDistribution.VEventf(ctx,
-				1,
+			log.KvDistribution.Infof(ctx,
 				"rebalancing %s %+v to %+v: %s",
 				rebalanceTargetType,
 				removeTarget,
@@ -1724,7 +1722,7 @@ func replicationChangesForRebalance(
 		chgs = []roachpb.ReplicationChange{
 			{ChangeType: roachpb.ADD_VOTER, Target: addTarget},
 		}
-		log.KvDistribution.VEventf(ctx, 1, "can't swap replica due to lease; falling back to add")
+		log.KvDistribution.Infof(ctx, "can't swap replica due to lease; falling back to add")
 		return chgs, false, err
 	}
 
@@ -1810,7 +1808,7 @@ func (rq *replicateQueue) shedLease(
 	}
 
 	if opts.DryRun {
-		log.KvDistribution.VEventf(ctx, 1, "transferring lease to s%d", target.StoreID)
+		log.KvDistribution.Infof(ctx, "transferring lease to s%d", target.StoreID)
 		return allocator.NoTransferDryRun, nil
 	}
 
@@ -1859,7 +1857,7 @@ func (rq *replicateQueue) TransferLease(
 	ctx context.Context, rlm ReplicaLeaseMover, source, target roachpb.StoreID, rangeQPS float64,
 ) error {
 	rq.metrics.TransferLeaseCount.Inc(1)
-	log.KvDistribution.VEventf(ctx, 1, "transferring lease to s%d", target)
+	log.KvDistribution.Infof(ctx, "transferring lease to s%d", target)
 	if err := rlm.AdminTransferLease(ctx, target); err != nil {
 		return errors.Wrapf(err, "%s: unable to transfer lease to s%d", rlm, target)
 	}

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -312,9 +312,8 @@ func (sr *StoreRebalancer) rebalanceStore(
 		}
 
 		descBeforeRebalance := replWithStats.repl.Desc()
-		log.KvDistribution.VEventf(
+		log.KvDistribution.Infof(
 			ctx,
-			1,
 			"rebalancing r%d (%.2f qps) to better balance load: voters from %v to %v; non-voters from %v to %v",
 			replWithStats.repl.RangeID,
 			replWithStats.qps,
@@ -408,7 +407,7 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		}
 
 		desc, conf := replWithStats.repl.DescAndSpanConfig()
-		log.KvDistribution.VEventf(ctx, 3, "considering lease transfer for r%d with %.2f qps",
+		log.KvDistribution.Infof(ctx, "considering lease transfer for r%d with %.2f qps",
 			desc.RangeID, replWithStats.qps)
 
 		// Check all the other voting replicas in order of increasing qps.
@@ -436,9 +435,8 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 		)
 
 		if candidate == (roachpb.ReplicaDescriptor{}) {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"could not find a better lease transfer target for r%d; considering replica rebalance instead",
 				desc.RangeID,
 			)
@@ -455,17 +453,16 @@ func (sr *StoreRebalancer) chooseLeaseToTransfer(
 			candidates,
 			replWithStats.repl.loadStats.batchRequests,
 		) {
-			log.KvDistribution.VEventf(
-				ctx, 3, "r%d is on s%d due to follow-the-workload; considering replica rebalance instead",
+			log.KvDistribution.Infof(
+				ctx, "r%d is on s%d due to follow-the-workload; considering replica rebalance instead",
 				desc.RangeID, localDesc.StoreID,
 			)
 			considerForRebalance = append(considerForRebalance, replWithStats)
 			continue
 		}
 		if targetStore, ok := storeMap[candidate.StoreID]; ok {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				1,
 				"transferring lease for r%d (qps=%.2f) to store s%d (qps=%.2f) from local store s%d (qps=%.2f)",
 				desc.RangeID,
 				replWithStats.qps,
@@ -529,9 +526,8 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		numDesiredVoters := allocatorimpl.GetNeededVoters(conf.GetNumVoters(), clusterNodes)
 		numDesiredNonVoters := allocatorimpl.GetNeededNonVoters(numDesiredVoters, int(conf.GetNumNonVoters()), clusterNodes)
 		if expected, actual := numDesiredVoters, len(rangeDesc.Replicas().VoterDescriptors()); expected != actual {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"r%d is either over or under replicated (expected %d voters, found %d); ignoring",
 				rangeDesc.RangeID,
 				expected,
@@ -540,9 +536,8 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 		if expected, actual := numDesiredNonVoters, len(rangeDesc.Replicas().NonVoterDescriptors()); expected != actual {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"r%d is either over or under replicated (expected %d non-voters, found %d); ignoring",
 				rangeDesc.RangeID,
 				expected,
@@ -576,9 +571,8 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			continue
 		}
 
-		log.KvDistribution.VEventf(
+		log.KvDistribution.Infof(
 			ctx,
-			3,
 			"considering replica rebalance for r%d with %.2f qps",
 			replWithStats.repl.GetRangeID(),
 			replWithStats.qps,
@@ -594,7 +588,7 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 			// Bail if there are no stores that are better for the existing replicas.
 			// If the range needs a lease transfer to enable better load distribution,
 			// it will be handled by the logic in `chooseLeaseToTransfer()`.
-			log.KvDistribution.VEventf(ctx, 3, "could not find rebalance opportunities for r%d", replWithStats.repl.RangeID)
+			log.KvDistribution.Infof(ctx, "could not find rebalance opportunities for r%d", replWithStats.repl.RangeID)
 			continue
 		}
 
@@ -626,9 +620,8 @@ func (sr *StoreRebalancer) chooseRangeToRebalance(
 		// being on dead stores, ignore this rebalance option. The lease for
 		// this range post-rebalance would have no suitable location.
 		if len(validTargets) == 0 {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"could not find rebalance opportunities for r%d, no replica found to hold lease",
 				replWithStats.repl.RangeID,
 			)
@@ -694,9 +687,8 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 			options,
 		)
 		if !shouldRebalance {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"no more rebalancing opportunities for r%d voters that improve QPS balance",
 				rbCtx.rangeDesc.RangeID,
 			)
@@ -705,9 +697,8 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 			// Record the fact that we found at least one rebalance opportunity.
 			foundRebalance = true
 		}
-		log.KvDistribution.VEventf(
+		log.KvDistribution.Infof(
 			ctx,
-			3,
 			"rebalancing voter (qps=%.2f) for r%d on %v to %v in order to improve QPS balance",
 			rbCtx.replWithStats.qps,
 			rbCtx.rangeDesc.RangeID,
@@ -758,9 +749,8 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 			options,
 		)
 		if !shouldRebalance {
-			log.KvDistribution.VEventf(
+			log.KvDistribution.Infof(
 				ctx,
-				3,
 				"no more rebalancing opportunities for r%d non-voters that improve QPS balance",
 				rbCtx.rangeDesc.RangeID,
 			)
@@ -769,9 +759,8 @@ func (sr *StoreRebalancer) getRebalanceTargetsBasedOnQPS(
 			// Record the fact that we found at least one rebalance opportunity.
 			foundRebalance = true
 		}
-		log.KvDistribution.VEventf(
+		log.KvDistribution.Infof(
 			ctx,
-			3,
 			"rebalancing non-voter (qps=%.2f) for r%d on %v to %v in order to improve QPS balance",
 			rbCtx.replWithStats.qps,
 			rbCtx.rangeDesc.RangeID,


### PR DESCRIPTION
Now that we log distribution logs to a separate log file (#85688), we can
enable more logging by default (without setting vmodule).

This PR enables most log messages in the store rebalancer, and some in the
replicate queue. The rational is that the store rebalancer iterates over
128 replicas every minute and therefore we can allow logging per replica.
We roughly expect:
200 bytes per log message x 128 x 10 messages = 250K per minute,
or 15MB per hour. The replicate queue tries to avoid per replica logging
(e.g in functions such as shouldEnqueue), instead it will log when an
action such as adding a replica is executed.

In a roachtest, running drain and decommission when adding a new node we
see only a few MBs per hour in the kv-distribution log file.

Release justification: low risk, will help debugging.
Release note: None