### PR TITLE
rowexec: make sure to close generator builtin with error in Start

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/sql_keys
+++ b/pkg/sql/logictest/testdata/logic_test/sql_keys
@@ -66,3 +66,8 @@ query II
 SELECT count(key), count(DISTINCT key) FROM crdb_internal.scan(crdb_internal.table_span($tableid))
 ----
 4096 4096
+
+# Regression test for not closing the generator builtin if it encounters an
+# error in Start() (#87248).
+statement error failed to verify keys for Scan
+SELECT crdb_internal.scan('\xff':::BYTES, '\x3f5918':::BYTES);

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -179,10 +179,12 @@ func (ps *projectSetProcessor) nextInputRow() (
 					return nil, nil, err
 				}
 			}
+			// Store the generator before Start so that it'll be closed even if
+			// Start returns an error.
+			ps.gens[i] = gen
 			if err := gen.Start(ps.Ctx, ps.FlowCtx.Txn); err != nil {
 				return nil, nil, err
 			}
-			ps.gens[i] = gen
 		}
 		ps.done[i] = false
 	}


### PR DESCRIPTION
Previously, if an error is returned by `Start` method of the generator
builtin, we would never close it which could lead to leaking of
resources. This is now fixed.

Fixes: #87248.

Release justification: bug fix.

Release note: None