### PR TITLE
descmetadata: do not use experimental setting

### DIFF
--- a/pkg/sql/descmetadata/BUILD.bazel
+++ b/pkg/sql/descmetadata/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessioninit",
         "//pkg/sql/sqlutil",
         "//pkg/util/protoutil",

--- a/pkg/sql/descmetadata/metadata_updater.go
+++ b/pkg/sql/descmetadata/metadata_updater.go
@@ -28,7 +28,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessioninit"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -56,17 +55,11 @@ func NewMetadataUpdater(
 	txn *kv.Txn,
 	sessionData *sessiondata.SessionData,
 ) scexec.DescriptorMetadataUpdater {
-	// Unfortunately, we can't use the session data unmodified, previously the
-	// code modifying this metadata would use a circular executor that would ignore
-	// any settings set later on. We will intentionally, unset problematic settings
-	// here.
-	modifiedSessionData := sessionData.Clone()
-	modifiedSessionData.ExperimentalDistSQLPlanningMode = sessiondatapb.ExperimentalDistSQLPlanningOn
 	return metadataUpdater{
 		ctx:          ctx,
 		txn:          txn,
 		ieFactory:    ieFactory,
-		sessionData:  modifiedSessionData,
+		sessionData:  sessionData,
 		descriptors:  descriptors,
 		cacheEnabled: sessioninit.CacheEnabled.Get(settings),
 	}


### PR DESCRIPTION
Release justification: low-risk cleanup.

Release note: None