### PR TITLE
backupccl: add checks for a dropped full schedule

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -115,6 +115,17 @@ func doAlterBackupSchedules(
 		return err
 	}
 
+	if s.fullJob == nil {
+		// This can happen if a user calls DROP SCHEDULE on the full schedule.
+		// TODO(benbardin): Resolve https://github.com/cockroachdb/cockroach/issues/87435.
+		// Note that this will only prevent this state going forward. It will not
+		// repair this state where it already exists.
+		return errors.Newf(
+			"incremental backup schedule %d has no corresponding full backup schedule; drop schedule %d and recreate",
+			s.incJob.ScheduleID(),
+			s.incJob.ScheduleID())
+	}
+
 	// Note that even ADMIN is subject to these restrictions. We expect to
 	// add a finer-grained permissions model soon.
 	if s.fullJob.Owner() != p.User() {

--- a/pkg/ccl/backupccl/schedule_exec.go
+++ b/pkg/ccl/backupccl/schedule_exec.go
@@ -439,7 +439,9 @@ func unlinkDependentSchedule(
 
 	// Clear the DependentID field since we are dropping the record associated
 	// with it.
+	// TODO(benbardin): Resolve https://github.com/cockroachdb/cockroach/issues/87435 as well.
 	dependentArgs.DependentScheduleID = 0
+	dependentArgs.UnpauseOnSuccess = 0
 	any, err := pbtypes.MarshalAny(dependentArgs)
 	if err != nil {
 		return err

--- a/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/missing-schedule
+++ b/pkg/ccl/backupccl/testdata/backup-restore/alter-schedule/missing-schedule
@@ -1,0 +1,74 @@
+new-server name=s1 allow-implicit-access
+----
+
+# Test that dropping the full backup causes a graceful failure on ALTER.
+
+exec-sql
+create schedule datatest for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+exec-sql
+drop schedule $fullID
+----
+
+# The schedule is now in an invalid state.
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true}
+
+exec-sql expect-error-regex=(pq: incremental backup schedule \d* has no corresponding full backup schedule; drop schedule \d* and recreate)
+alter backup schedule $incID set recurring '@hourly';
+----
+regex matches error
+
+exec-sql
+drop schedule $incID
+----
+
+# Test that dropping the incremental backup is not an issue.
+
+exec-sql
+create schedule datatest for backup into 'nodelocal://1/example-schedule' recurring '@daily' full backup '@weekly';
+----
+
+let $fullID $incID
+with schedules as (show schedules) select id from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true, "dependent_schedule_id": $incID, "unpause_on_success": $incID}
+$incID Waiting for initial backup to complete @daily root {"backup_statement": "BACKUP INTO LATEST IN 'nodelocal://1/example-schedule' WITH detached", "backup_type": 1, "chain_protected_timestamp_records": true, "dependent_schedule_id": $fullID}
+
+exec-sql
+drop schedule $incID
+----
+
+# The schedule remains in a valid state.
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @weekly root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}
+
+exec-sql
+alter backup schedule $fullID set recurring '@daily';
+----
+
+query-sql
+with schedules as (show schedules) select id, state, recurrence, owner, command from schedules where label='datatest' order by command->>'backup_type' asc;
+----
+$fullID <nil> @daily root {"backup_statement": "BACKUP INTO 'nodelocal://1/example-schedule' WITH detached", "chain_protected_timestamp_records": true}


### PR DESCRIPTION
Release justification: High-impact bugfix (NPE).

Release note (enterprise change): Fixes NPE when ALTER BACKUP SCHEDULE
was called after a dependent schedule was dropped.