### PR TITLE
generate-logictest: add test timeout to BUILD files template

### DIFF
--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -249,6 +249,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "{{ .TestRuleName }}_test",
     size = "enormous",
+    args = ["-test.timeout=3595s"],
     srcs = ["generated_test.go"],
     data = [
         "//c-deps:libgeos",  # keep{{ if .SqliteLogicTest }}


### PR DESCRIPTION
In #86363, we added a test.timeout arg to all go_test targets.
When generate-logictest runs out of `bazel-generate.sh`,
logic tests build files are re-created based on the template
that was missing the `test.timeout` arg and since the timeout
script doesn't run, the timeouts get deleted. This patch updates
the template to include a test timeout.

Release justification: Non-production code changes
Release note: None