### PR TITLE
kvserver,storage: calculate GCBytesAge in AddSSTable for points

### DIFF
--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -174,8 +174,8 @@ func BenchmarkUpdateSSTTimestamps(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := UpdateSSTTimestamps(
-			ctx, st, sstFile.Bytes(), sstTimestamp, requestTimestamp, concurrency)
+		_, _, err := UpdateSSTTimestamps(
+			ctx, st, sstFile.Bytes(), sstTimestamp, requestTimestamp, concurrency, nil /* stats */)
 		require.NoError(b, err)
 	}
 }


### PR DESCRIPTION
Currently, the stats calculations in `AddSSTable` and `CheckSSTConflicts`
does not adjust for any GCBytesAge differences that arise from sst keys
deleting or shadowing engine keys. This results in mismatching GCBytesAge
values if we were to run the existing TestEvalAddSSTable test with
sufficiently-large "now" timestamps to accrue GCBytesAge.

This change updates TestEvalAddSSTable to multiply each timestamp
with 1e9 so that it operates in full-second increments to see more
interesting GCBytesAge behaviour. It also updates the code path
where we mass-update SST timestamps to make the corresponding
GCBytesAge adjustment. Finally, it ensures that GCBytesAge
is accrued from the right timestamps in cases of sst keys
/ tombstones shadowing engine keys / tombstones.

Note that this change only fixes GCBytesAge for point keys;
a fix for range keys will come in a follow-up.

Fixes #82920.

Release note: None.