### PR TITLE
sql: parse sequence name instead of using name identifier directly

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1211,6 +1211,31 @@ CREATE FUNCTION public.f_test_cor(IN a INT8, IN b INT8)
   SELECT 3;
 $$
 
+subtest seq_qualified_name
+
+statement ok
+CREATE SCHEMA sc_seq_qualified_name;
+CREATE SEQUENCE sc_seq_qualified_name.sq;
+
+statement error pq: relation "sc_seq_qualified_name.sq" does not exist
+CREATE FUNCTION f_seq_qualified_name() RETURNS INT LANGUAGE SQL AS $$ SELECT * FROM nextval('"sc_seq_qualified_name.sq"') $$;
+
+statement ok
+CREATE FUNCTION f_seq_qualified_name() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('sc_seq_qualified_name.sq') $$;
+
+query I
+SELECT f_seq_qualified_name()
+----
+1
+
+statement ok
+CREATE FUNCTION f_seq_qualified_name_quoted() RETURNS INT LANGUAGE SQL AS $$ SELECT nextval('"sc_seq_qualified_name"."sq"') $$;
+
+query I
+SELECT f_seq_qualified_name_quoted()
+----
+2
+
 subtest execution
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1336,3 +1336,28 @@ a      INT8    true   NULL            ·  {materialized_view_with_null_pkey}  fa
 b      STRING  true   NULL            ·  {materialized_view_with_null_pkey}  false
 c      INT8    true   NULL            ·  {materialized_view_with_null_pkey}  false
 rowid  INT8    false  unique_rowid()  ·  {materialized_view_with_null_pkey}  true
+
+subtest seq_qualified_name
+
+statement ok
+CREATE SCHEMA sc_seq_qualified_name;
+CREATE SEQUENCE sc_seq_qualified_name.sq;
+
+statement error pq: relation "sc_seq_qualified_name.sq" does not exist
+CREATE VIEW v_seq_rewrite_quoted AS SELECT nextval('"sc_seq_qualified_name.sq"');
+
+statement ok
+CREATE VIEW v_seq_rewrite AS SELECT nextval('sc_seq_qualified_name.sq');
+
+query I
+SELECT * FROM v_seq_rewrite
+----
+1
+
+statement ok
+CREATE VIEW v_seq_rewrite_quoted AS SELECT nextval('"sc_seq_qualified_name"."sq"');
+
+query I
+SELECT * FROM v_seq_rewrite_quoted
+----
+2

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -582,8 +582,11 @@ func (b *Builder) buildFunction(
 					panic(err)
 				}
 			} else {
-				tn := tree.MakeUnqualifiedTableName(tree.Name(seqIdentifier.SeqName))
-				ds, _, _ = b.resolveDataSource(&tn, privilege.SELECT)
+				tn, err := parser.ParseQualifiedTableName(seqIdentifier.SeqName)
+				if err != nil {
+					panic(err)
+				}
+				ds, _, _ = b.resolveDataSource(tn, privilege.SELECT)
 			}
 			b.schemaDeps = append(b.schemaDeps, opt.SchemaDep{
 				DataSource: ds,


### PR DESCRIPTION
Previously, we use the sequence name identifier directly when building
a function in optbuilder if a function expression use any sequences.
This does work when sequence name string is qualifed because sequence
name cannot be found. We need to parse the name string into a table
name instead.

Release note: None.
Release justification: low risk bug fix.