### PR TITLE
backupccl: parallelize loading of manifests from External Storage

### DIFF
--- a/pkg/ccl/backupccl/backup_job.go
+++ b/pkg/ccl/backupccl/backup_job.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"net/url"
 	"path"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -116,10 +118,10 @@ func clusterNodeCount(gw gossip.OptionalGossip) (int, error) {
 // backup exports a snapshot of every kv entry into ranged sstables.
 //
 // The output is an sstable per range with files in the following locations:
-// - <dir>/<unique_int>.sst
-// - <dir> is given by the user and may be cloud storage
-// - Each file contains data for a key range that doesn't overlap with any other
-//   file.
+//   - <dir>/<unique_int>.sst
+//   - <dir> is given by the user and may be cloud storage
+//   - Each file contains data for a key range that doesn't overlap with any other
+//     file.
 func backup(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
@@ -788,6 +790,122 @@ func (b *backupResumer) ReportResults(ctx context.Context, resultsCh chan<- tree
 	}:
 		return nil
 	}
+}
+
+func getBackupDetailAndManifest(
+	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
+	txn *kv.Txn,
+	initialDetails jobspb.BackupDetails,
+	user username.SQLUsername,
+	backupDestination backupdest.ResolvedDestination,
+) (jobspb.BackupDetails, backuppb.BackupManifest, error) {
+	makeCloudStorage := execCfg.DistSQLSrv.ExternalStorageFromURI
+
+	kmsEnv := backupencryption.MakeBackupKMSEnv(execCfg.Settings, &execCfg.ExternalIODirConfig,
+		execCfg.DB, user, execCfg.InternalExecutor)
+
+	mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
+	defer mem.Close(ctx)
+
+	prevBackups, encryptionOptions, memSize, err := backupinfo.FetchPreviousBackups(ctx, &mem, user,
+		makeCloudStorage, backupDestination.PrevBackupURIs, *initialDetails.EncryptionOptions, &kmsEnv)
+
+	if err != nil {
+		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+	}
+	defer func() {
+		mem.Shrink(ctx, memSize)
+	}()
+
+	if len(prevBackups) > 0 {
+		baseManifest := prevBackups[0]
+		if baseManifest.DescriptorCoverage == tree.AllDescriptors &&
+			!initialDetails.FullCluster {
+			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
+		}
+
+		if err := requireEnterprise(execCfg, "incremental"); err != nil {
+			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+		}
+		lastEndTime := prevBackups[len(prevBackups)-1].EndTime
+		if lastEndTime.Compare(initialDetails.EndTime) > 0 {
+			return jobspb.BackupDetails{}, backuppb.BackupManifest{},
+				errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
+					"the previous backup's end time of %s.",
+					initialDetails.EndTime.GoTime(), lastEndTime.GoTime())
+		}
+	}
+
+	localityKVs := make([]string, len(backupDestination.URIsByLocalityKV))
+	i := 0
+	for k := range backupDestination.URIsByLocalityKV {
+		localityKVs[i] = k
+		i++
+	}
+
+	for i := range prevBackups {
+		prevBackup := prevBackups[i]
+		// IDs are how we identify tables, and those are only meaningful in the
+		// context of their own cluster, so we need to ensure we only allow
+		// incremental previous backups that we created.
+		if fromCluster := prevBackup.ClusterID; !fromCluster.Equal(execCfg.NodeInfo.LogicalClusterID()) {
+			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf("previous BACKUP belongs to cluster %s", fromCluster.String())
+		}
+
+		prevLocalityKVs := prevBackup.LocalityKVs
+
+		// Checks that each layer in the backup uses the same localities
+		// Does NOT check that each locality/layer combination is actually at the
+		// expected locations.
+		// This is complex right now, but should be easier shortly.
+		// TODO(benbardin): Support verifying actual existence of localities for
+		// each layer after deprecating TO-syntax in 22.2
+		sort.Strings(localityKVs)
+		sort.Strings(prevLocalityKVs)
+		if !(len(localityKVs) == 0 && len(prevLocalityKVs) == 0) && !reflect.DeepEqual(localityKVs,
+			prevLocalityKVs) {
+			// Note that this won't verify the default locality. That's not
+			// necessary, because the default locality defines the backup manifest
+			// location. If that URI isn't right, the backup chain will fail to
+			// load.
+			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf(
+				"Requested backup has localities %s, but a previous backup layer in this collection has localities %s. "+
+					"Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an "+
+					"incremental backup with matching localities.",
+				localityKVs, prevLocalityKVs,
+			)
+		}
+	}
+
+	// updatedDetails and backupManifest should be treated as read-only after
+	// they're returned from their respective functions. Future changes to those
+	// objects should be made within those functions.
+	updatedDetails, err := updateBackupDetails(
+		ctx,
+		initialDetails,
+		backupDestination.CollectionURI,
+		backupDestination.DefaultURI,
+		backupDestination.ChosenSubdir,
+		backupDestination.URIsByLocalityKV,
+		prevBackups,
+		encryptionOptions,
+		&kmsEnv)
+	if err != nil {
+		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+	}
+
+	backupManifest, err := createBackupManifest(
+		ctx,
+		execCfg,
+		txn,
+		updatedDetails,
+		prevBackups)
+	if err != nil {
+		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
+	}
+
+	return updatedDetails, backupManifest, nil
 }
 
 func (b *backupResumer) readManifestOnResume(

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -11,15 +11,12 @@ package backupccl
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase"
-	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupdest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupencryption"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupinfo"
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
@@ -37,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -1215,122 +1211,6 @@ func checkForNewTables(
 		return errors.Errorf("previous backup does not contain table %q", t.GetName())
 	}
 	return nil
-}
-
-func getBackupDetailAndManifest(
-	ctx context.Context,
-	execCfg *sql.ExecutorConfig,
-	txn *kv.Txn,
-	initialDetails jobspb.BackupDetails,
-	user username.SQLUsername,
-	backupDestination backupdest.ResolvedDestination,
-) (jobspb.BackupDetails, backuppb.BackupManifest, error) {
-	makeCloudStorage := execCfg.DistSQLSrv.ExternalStorageFromURI
-
-	kmsEnv := backupencryption.MakeBackupKMSEnv(execCfg.Settings, &execCfg.ExternalIODirConfig,
-		execCfg.DB, user, execCfg.InternalExecutor)
-
-	mem := execCfg.RootMemoryMonitor.MakeBoundAccount()
-	defer mem.Close(ctx)
-
-	prevBackups, encryptionOptions, memSize, err := backupinfo.FetchPreviousBackups(ctx, &mem, user,
-		makeCloudStorage, backupDestination.PrevBackupURIs, *initialDetails.EncryptionOptions, &kmsEnv)
-
-	if err != nil {
-		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
-	}
-	defer func() {
-		mem.Shrink(ctx, memSize)
-	}()
-
-	if len(prevBackups) > 0 {
-		baseManifest := prevBackups[0]
-		if baseManifest.DescriptorCoverage == tree.AllDescriptors &&
-			!initialDetails.FullCluster {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Errorf("cannot append a backup of specific tables or databases to a cluster backup")
-		}
-
-		if err := requireEnterprise(execCfg, "incremental"); err != nil {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
-		}
-		lastEndTime := prevBackups[len(prevBackups)-1].EndTime
-		if lastEndTime.Compare(initialDetails.EndTime) > 0 {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{},
-				errors.Newf("`AS OF SYSTEM TIME` %s must be greater than "+
-					"the previous backup's end time of %s.",
-					initialDetails.EndTime.GoTime(), lastEndTime.GoTime())
-		}
-	}
-
-	localityKVs := make([]string, len(backupDestination.URIsByLocalityKV))
-	i := 0
-	for k := range backupDestination.URIsByLocalityKV {
-		localityKVs[i] = k
-		i++
-	}
-
-	for i := range prevBackups {
-		prevBackup := prevBackups[i]
-		// IDs are how we identify tables, and those are only meaningful in the
-		// context of their own cluster, so we need to ensure we only allow
-		// incremental previous backups that we created.
-		if fromCluster := prevBackup.ClusterID; !fromCluster.Equal(execCfg.NodeInfo.LogicalClusterID()) {
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf("previous BACKUP belongs to cluster %s", fromCluster.String())
-		}
-
-		prevLocalityKVs := prevBackup.LocalityKVs
-
-		// Checks that each layer in the backup uses the same localities
-		// Does NOT check that each locality/layer combination is actually at the
-		// expected locations.
-		// This is complex right now, but should be easier shortly.
-		// TODO(benbardin): Support verifying actual existence of localities for
-		// each layer after deprecating TO-syntax in 22.2
-		sort.Strings(localityKVs)
-		sort.Strings(prevLocalityKVs)
-		if !(len(localityKVs) == 0 && len(prevLocalityKVs) == 0) && !reflect.DeepEqual(localityKVs,
-			prevLocalityKVs) {
-			// Note that this won't verify the default locality. That's not
-			// necessary, because the default locality defines the backup manifest
-			// location. If that URI isn't right, the backup chain will fail to
-			// load.
-			return jobspb.BackupDetails{}, backuppb.BackupManifest{}, errors.Newf(
-				"Requested backup has localities %s, but a previous backup layer in this collection has localities %s. "+
-					"Mismatched backup layers are not supported. Please take a new full backup with the new localities, or an "+
-					"incremental backup with matching localities.",
-				localityKVs, prevLocalityKVs,
-			)
-		}
-	}
-
-	// updatedDetails and backupManifest should be treated as read-only after
-	// they're returned from their respective functions. Future changes to those
-	// objects should be made within those functions.
-	updatedDetails, err := updateBackupDetails(
-		ctx,
-		initialDetails,
-		backupDestination.CollectionURI,
-		backupDestination.DefaultURI,
-		backupDestination.ChosenSubdir,
-		backupDestination.URIsByLocalityKV,
-		prevBackups,
-		encryptionOptions,
-		&kmsEnv)
-	if err != nil {
-		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
-	}
-
-	backupManifest, err := createBackupManifest(
-		ctx,
-		execCfg,
-		txn,
-		updatedDetails,
-		prevBackups)
-	if err != nil {
-		return jobspb.BackupDetails{}, backuppb.BackupManifest{}, err
-	}
-
-	return updatedDetails, backupManifest, nil
 }
 
 func getTenantInfo(

--- a/pkg/ccl/backupccl/backupdest/BUILD.bazel
+++ b/pkg/ccl/backupccl/backupdest/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/util/ioctx",
         "//pkg/util/mon",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/backupccl/backupinfo/manifest_handling.go
+++ b/pkg/ccl/backupccl/backupinfo/manifest_handling.go
@@ -146,6 +146,8 @@ func ReadBackupManifestFromStore(
 	encryption *jobspb.BackupEncryptionOptions,
 	kmsEnv cloud.KMSEnv,
 ) (backuppb.BackupManifest, int64, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.ReadBackupManifestFromStore")
+	defer sp.Finish()
 	backupManifest, memSize, err := ReadBackupManifest(ctx, mem, exportStore, backupbase.BackupManifestName,
 		encryption, kmsEnv)
 	if err != nil {
@@ -697,8 +699,8 @@ func LoadBackupManifests(
 var ErrLocalityDescriptor = errors.New(`Locality Descriptor not found`)
 
 // GetLocalityInfo takes a list of stores and their URIs, along with the main
-// backup manifest searches each for the locality pieces listed in the the
-// main manifest, returning the mapping.
+// backup manifest searches each for the locality pieces listed in the main
+// manifest, returning the mapping.
 func GetLocalityInfo(
 	ctx context.Context,
 	stores []cloud.ExternalStorage,
@@ -1259,6 +1261,7 @@ func FetchPreviousBackups(
 }
 
 // getBackupManifests fetches the backup manifest from a list of backup URIs.
+// The manifests are loaded from External Storage in parallel.
 func getBackupManifests(
 	ctx context.Context,
 	mem *mon.BoundAccount,


### PR DESCRIPTION
This change is a targetted change to parallelize the loading
of backup manifests for each incremental layer of a backup.
This method is shared by both restore as well as `SHOW BACKUP`.

Fixes: https://github.com/cockroachdb/cockroach/issues/87183

Release note: None

Release justification: low risk performance improvement required
for making `SHOW BACKUP` in the presence of many incremental layers
more performant