### PR TITLE
backupccl: elide spans from backups that were subsequently reintroduced

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -275,6 +275,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/span",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1305,7 +1305,7 @@ func createBackupManifest(
 		}
 	}
 
-	var newSpans roachpb.Spans
+	var newSpans, reintroducedSpans roachpb.Spans
 	var priorIDs map[descpb.ID]descpb.ID
 
 	var revs []backuppb.BackupManifest_DescriptorRevision
@@ -1361,11 +1361,11 @@ func createBackupManifest(
 
 		newSpans = filterSpans(spans, prevBackups[len(prevBackups)-1].Spans)
 
-		tableSpans, err := getReintroducedSpans(ctx, execCfg, prevBackups, tables, revs, endTime)
+		reintroducedSpans, err = getReintroducedSpans(ctx, execCfg, prevBackups, tables, revs, endTime)
 		if err != nil {
 			return backuppb.BackupManifest{}, err
 		}
-		newSpans = append(newSpans, tableSpans...)
+		newSpans = append(newSpans, reintroducedSpans...)
 	}
 
 	// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion

--- a/pkg/ccl/backupccl/backuppb/backup.proto
+++ b/pkg/ccl/backupccl/backuppb/backup.proto
@@ -81,6 +81,12 @@ message BackupManifest {
   // here are covered in the interval (0, startTime], which, in conjunction with
   // the coverage from (startTime, endTime] implied for all spans in Spans,
   // results in coverage from [0, endTime] for these spans.
+  //
+  // The first set of spans in this field are new spans that did not
+  // exist in the previous backup (a new index, for example), while the remaining
+  // spans are re-introduced spans, which need to be backed up again from (0,
+  // startTime] because a non-mvcc operation may have occurred on this span. See
+  // the getReintroducedSpans() for more information.
   repeated roachpb.Span introduced_spans = 15 [(gogoproto.nullable) = false];
 
   repeated DescriptorRevision descriptor_changes = 16  [(gogoproto.nullable) = false];

--- a/pkg/ccl/backupccl/restoration_data.go
+++ b/pkg/ccl/backupccl/restoration_data.go
@@ -66,10 +66,13 @@ func (*mainRestorationData) isMainBundle() bool { return true }
 type restorationDataBase struct {
 	// spans is the spans included in this bundle.
 	spans []roachpb.Span
+
 	// rekeys maps old table IDs to their new table descriptor.
 	tableRekeys []execinfrapb.TableRekey
+
 	// tenantRekeys maps tenants being restored to their new ID.
 	tenantRekeys []execinfrapb.TenantRekey
+
 	// pkIDs stores the ID of the primary keys for all of the tables that we're
 	// restoring for RowCount calculation.
 	pkIDs map[uint64]bool

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -267,6 +267,11 @@ func restore(
 		return emptyRowCount, errors.Wrap(err, "resolving locality locations")
 	}
 
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backupManifests, endTime)
+	if err != nil {
+		return emptyRowCount, err
+	}
+
 	if err := checkCoverage(restoreCtx, dataToRestore.getSpans(), backupManifests); err != nil {
 		return emptyRowCount, err
 	}
@@ -275,8 +280,8 @@ func restore(
 	// which are grouped by keyrange.
 	highWaterMark := job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater
 
-	importSpans := makeSimpleImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityMap,
-		highWaterMark, targetRestoreSpanSize.Get(execCtx.ExecCfg().SV()))
+	importSpans := makeSimpleImportSpans(dataToRestore.getSpans(), backupManifests,
+		backupLocalityMap, introducedSpanFrontier, highWaterMark, targetRestoreSpanSize.Get(execCtx.ExecCfg().SV()))
 
 	if len(importSpans) == 0 {
 		// There are no files to restore.
@@ -741,11 +746,7 @@ func createImportingDescriptors(
 		// -  An offline table undergoing an IMPORT INTO has all importing data
 		//    elided in the restore processor and is restored online to its pre import
 		//    state.
-		//
-		// TODO (msbutler) remove the schema_change condition once the online schema changer
-		// doesn't rely on OFFLINE state (#86626, #86691)
-		if desc.Offline() && desc.GetDeclarativeSchemaChangerState() == nil {
-
+		if desc.Offline() {
 			if schema, ok := desc.(catalog.SchemaDescriptor); ok {
 				offlineSchemas[schema.GetID()] = struct{}{}
 			}
@@ -1465,9 +1466,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err != nil {
 		return err
 	}
-
-	preData, preValidateData, mainData, err := createImportingDescriptors(ctx, p, backupCodec,
-		sqlDescs, r)
+	preData, preValidateData, mainData, err := createImportingDescriptors(ctx, p, backupCodec, sqlDescs, r)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -16,33 +16,64 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuppb"
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	spanUtils "github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 // MockBackupChain returns a chain of mock backup manifests that have spans and
 // file spans suitable for checking coverage computations. Every 3rd inc backup
-// introduces a span and drops a span. Incremental backups have half as many
-// files as the base. Files spans are ordered by start key but may overlap.
+// reintroduces a span. On a random backup, one random span is dropped and
+// another is added. Incremental backups have half as many files as the base.
+// Files spans are ordered by start key but may overlap.
 func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.BackupManifest {
 	backups := make([]backuppb.BackupManifest, length)
 	ts := hlc.Timestamp{WallTime: time.Second.Nanoseconds()}
+
+	// spanIdxToDrop represents that span that will get dropped during this mock backup chain.
+	spanIdxToDrop := r.Intn(spans)
+
+	// backupWithDroppedSpan represents the first backup that will observe the dropped span.
+	backupWithDroppedSpan := r.Intn(len(backups))
+
+	genTableID := func(j int) uint32 {
+		return uint32(10 + j*2)
+	}
+
 	for i := range backups {
 		backups[i].Spans = make(roachpb.Spans, spans)
+		backups[i].IntroducedSpans = make(roachpb.Spans, 0)
 		for j := range backups[i].Spans {
-			backups[i].Spans[j] = makeTableSpan(uint32(100 + j + (i / 3)))
+			tableID := genTableID(j)
+			backups[i].Spans[j] = makeTableSpan(tableID)
 		}
 		backups[i].EndTime = ts.Add(time.Minute.Nanoseconds()*int64(i), 0)
 		if i > 0 {
 			backups[i].StartTime = backups[i-1].EndTime
+
+			if i >= backupWithDroppedSpan {
+				// At and after the backupWithDroppedSpan, drop the span at
+				// span[spanIdxToDrop], present in the first i backups, and add a new
+				// one.
+				newTableID := genTableID(spanIdxToDrop) + 1
+				backups[i].Spans[spanIdxToDrop] = makeTableSpan(newTableID)
+				backups[i].IntroducedSpans = append(backups[i].IntroducedSpans, backups[i].Spans[spanIdxToDrop])
+			}
+
 			if i%3 == 0 {
-				backups[i].IntroducedSpans = roachpb.Spans{backups[i].Spans[spans-1]}
+				// Reintroduce an existing span
+				spanIdx := r.Intn(spans)
+				backups[i].IntroducedSpans = append(backups[i].IntroducedSpans, backups[i].Spans[spanIdx])
 			}
 		}
 
@@ -82,6 +113,8 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 // length to the number of files a file's end key was greater than any prior end
 // key when walking files in order by start key in the backups. This check is
 // thus sensitive to ordering; the coverage correctness check however is not.
+//
+// The function also verifies that a cover does not cross a span boundary.
 func checkRestoreCovering(
 	backups []backuppb.BackupManifest,
 	spans roachpb.Spans,
@@ -90,11 +123,33 @@ func checkRestoreCovering(
 ) error {
 	var expectedPartitions int
 	required := make(map[string]*roachpb.SpanGroup)
-	for _, s := range spans {
+
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	if err != nil {
+		return err
+	}
+
+	for _, span := range spans {
 		var last roachpb.Key
 		for _, b := range backups {
+			var coveredLater bool
+			introducedSpanFrontier.Entries(func(s roachpb.Span,
+				ts hlc.Timestamp) (done spanUtils.OpResult) {
+				if span.Overlaps(s) {
+					if b.EndTime.Less(ts) {
+						coveredLater = true
+					}
+					return spanUtils.StopMatch
+				}
+				return spanUtils.ContinueMatch
+			})
+			if coveredLater {
+				// Skip spans that were later re-introduced. See makeSimpleImportSpans
+				// for explanation.
+				continue
+			}
 			for _, f := range b.Files {
-				if sp := s.Intersect(f.Span); sp.Valid() {
+				if sp := span.Intersect(f.Span); sp.Valid() {
 					if required[f.Path] == nil {
 						required[f.Path] = &roachpb.SpanGroup{}
 					}
@@ -107,10 +162,21 @@ func checkRestoreCovering(
 			}
 		}
 	}
+	var spanIdx int
 	for _, c := range cov {
 		for _, f := range c.Files {
 			required[f.Path].Sub(c.Span)
 		}
+		for spans[spanIdx].EndKey.Compare(c.Span.Key) < 0 {
+			spanIdx++
+		}
+		// Assert that every cover is contained by a required span.
+		requiredSpan := spans[spanIdx]
+		if requiredSpan.Overlaps(c.Span) && !requiredSpan.Contains(c.Span) {
+			return errors.Errorf("cover with requiredSpan %v is not contained by required requiredSpan"+
+				" %v", c.Span, requiredSpan)
+		}
+
 	}
 	for name, uncovered := range required {
 		for _, missing := range uncovered.Slice() {
@@ -128,8 +194,20 @@ const noSpanTargetSize = 0
 func TestRestoreEntryCoverExample(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
+	mockTenantID := roachpb.MakeTenantID(10)
+	mockTenantPrefix := keys.MakeTenantPrefix(mockTenantID)
+
 	sp := func(start, end string) roachpb.Span {
-		return roachpb.Span{Key: roachpb.Key(start), EndKey: roachpb.Key(end)}
+		// During makeSimpleImportSpans, a reIntroducedTableID is extracted from each passed in
+		// span, unless the span contains a tenantPrefix. If the span contains
+		// neither a tenant prefix nor a table prefix, makeSimpleImportSpans will
+		// return an error. Since the input spans in this test do not contain a
+		// table prefix, add a mock tenant prefix to each span to prevent spurious
+		// errors in makeSimpleImportSpans.
+		sp, err := keys.RewriteSpanToTenantPrefix(roachpb.Span{Key: roachpb.Key(start),
+			EndKey: roachpb.Key(end)}, mockTenantPrefix)
+		require.NoError(t, err)
+		return sp
 	}
 	f := func(start, end, path string) backuppb.BackupManifest_File {
 		return backuppb.BackupManifest_File{Span: sp(start, end), Path: path}
@@ -142,7 +220,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		return r
 	}
 
-	// Setup and test the example in the comnent on makeSimpleImportSpans.
+	// Setup and test the example in the comment of makeSimpleImportSpans.
 	spans := []roachpb.Span{sp("a", "f"), sp("f", "i"), sp("l", "m")}
 	backups := []backuppb.BackupManifest{
 		{Files: []backuppb.BackupManifest_File{f("a", "c", "1"), f("c", "e", "2"), f("h", "i", "3")}},
@@ -151,14 +229,20 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Files: []backuppb.BackupManifest_File{f("h", "i", "8"), f("l", "m", "9")}},
 	}
 
-	// Pretend every span has 1MB.
 	for i := range backups {
+		backups[i].StartTime = hlc.Timestamp{WallTime: int64(i)}
+		backups[i].EndTime = hlc.Timestamp{WallTime: int64(i + 1)}
+
 		for j := range backups[i].Files {
+			// Pretend every span has 1MB.
 			backups[i].Files[j].EntryCounts.DataSize = 1 << 20
 		}
 	}
 
-	cover := makeSimpleImportSpans(spans, backups, nil, nil, noSpanTargetSize)
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	require.NoError(t, err)
+
+	cover := makeSimpleImportSpans(spans, backups, nil, introducedSpanFrontier, nil, noSpanTargetSize)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "c"), Files: paths("1", "4", "6")},
 		{Span: sp("c", "e"), Files: paths("2", "4", "6")},
@@ -167,29 +251,251 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, cover)
 
-	coverSized := makeSimpleImportSpans(spans, backups, nil, nil, 2<<20)
+	coverSized := makeSimpleImportSpans(spans, backups, nil, introducedSpanFrontier, nil, 2<<20)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "f"), Files: paths("1", "2", "4", "6")},
 		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, coverSized)
+}
 
+type mockBackupInfo struct {
+	// tableIDs identifies the tables included in the backup.
+	tableIDs []int
+
+	// indexIDs defines a map from tableID to tableIndexes included in the backup.
+	indexIDs map[int][]int
+
+	// reintroducedTableIDs identifies a set of TableIDs to reintroduce in the backup.
+	reintroducedTableIDs map[int]struct{}
+
+	// expectedBackupSpanCount defines the number of backup spans created by spansForAllTableIndexes.
+	expectedBackupSpanCount int
+}
+
+func createMockTables(
+	info mockBackupInfo,
+) (tables []catalog.TableDescriptor, reIntroducedTables []catalog.TableDescriptor) {
+	tables = make([]catalog.TableDescriptor, 0)
+	reIntroducedTables = make([]catalog.TableDescriptor, 0)
+	for _, tableID := range info.tableIDs {
+		indexes := make([]descpb.IndexDescriptor, 0)
+		for _, indexID := range info.indexIDs[tableID] {
+			indexes = append(indexes, getMockIndexDesc(descpb.IndexID(indexID)))
+		}
+		table := getMockTableDesc(descpb.ID(tableID), indexes[0], indexes, nil, nil)
+		tables = append(tables, table)
+		if _, ok := info.reintroducedTableIDs[tableID]; ok {
+			reIntroducedTables = append(reIntroducedTables, table)
+		}
+	}
+	return tables, reIntroducedTables
+}
+
+func createMockManifest(
+	t *testing.T,
+	execCfg *sql.ExecutorConfig,
+	info mockBackupInfo,
+	endTime hlc.Timestamp,
+	path string,
+) backuppb.BackupManifest {
+	tables, _ := createMockTables(info)
+
+	spans, err := spansForAllTableIndexes(execCfg, tables,
+		nil /* revs */)
+	require.NoError(t, err)
+	require.Equal(t, info.expectedBackupSpanCount, len(spans))
+
+	files := make([]backuppb.BackupManifest_File, len(spans))
+	for _, sp := range spans {
+		files = append(files, backuppb.BackupManifest_File{Span: sp, Path: path})
+	}
+
+	return backuppb.BackupManifest{Spans: spans,
+		EndTime: endTime, Files: files}
+}
+
+// TestRestoreEntryCoverReIntroducedSpans checks that all reintroduced spans are
+// covered in RESTORE by files in the incremental backup that reintroduced the
+// spans. The test also checks the invariants required during RESTORE to elide
+// files from the full backup that are later reintroduced. These include:
+//
+//   - During BackupManifest creation, spansForAllTableIndexes will merge
+//     adjacent indexes within a table, but not indexes across tables.
+//
+//   - During spansForAllRestoreTableIndexes, each restored index will have its
+//     own span.
+func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	codec := keys.SystemSQLCodec
+	execCfg := &sql.ExecutorConfig{
+		Codec: codec,
+	}
+
+	testCases := []struct {
+		name string
+		full mockBackupInfo
+		inc  mockBackupInfo
+
+		// expectedRestoreSpanCount defines the number of required spans passed to
+		// makeSimpleImportSpans.
+		expectedRestoreSpanCount int
+	}{
+		{
+			name: "adjacent indexes",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "non-adjacent indexes",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 3,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "dropped non-adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 2,
+		},
+		{
+			name: "new non-adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 3,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "new adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "new in-between index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 4,
+		},
+	}
+
+	fullBackupPath := "full"
+	incBackupPath := "inc"
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			backups := []backuppb.BackupManifest{
+				createMockManifest(t, execCfg, test.full, hlc.Timestamp{WallTime: int64(1)}, fullBackupPath),
+				createMockManifest(t, execCfg, test.inc, hlc.Timestamp{WallTime: int64(2)}, incBackupPath),
+			}
+
+			// Create the IntroducedSpans field for incremental backup.
+			incTables, reIntroducedTables := createMockTables(test.inc)
+
+			newSpans := filterSpans(backups[1].Spans, backups[0].Spans)
+			reIntroducedSpans, err := spansForAllTableIndexes(execCfg, reIntroducedTables, nil)
+			require.NoError(t, err)
+			backups[1].IntroducedSpans = append(newSpans, reIntroducedSpans...)
+
+			restoreSpans := spansForAllRestoreTableIndexes(codec, incTables, nil, false)
+			require.Equal(t, test.expectedRestoreSpanCount, len(restoreSpans))
+
+			introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+			require.NoError(t, err)
+
+			cover := makeSimpleImportSpans(restoreSpans, backups, nil, introducedSpanFrontier, nil, 0)
+
+			for _, reIntroTable := range reIntroducedTables {
+				var coveredReIntroducedGroup roachpb.SpanGroup
+				for _, entry := range cover {
+					// If a restoreSpanEntry overlaps with re-introduced table span,
+					// assert the entry only contains files from the incremental backup.
+					if reIntroTable.TableSpan(codec).Overlaps(entry.Span) {
+						coveredReIntroducedGroup.Add(entry.Span)
+						for _, files := range entry.Files {
+							require.Equal(t, incBackupPath, files.Path)
+						}
+					}
+				}
+				// Assert that all re-introduced indexes are included in the restore
+				for _, reIntroIndexSpan := range reIntroTable.AllIndexSpans(codec) {
+					require.Equal(t, true, coveredReIntroducedGroup.Encloses(reIntroIndexSpan))
+				}
+			}
+		})
+	}
 }
 
 func TestRestoreEntryCover(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	r, _ := randutil.NewTestRand()
 	for _, numBackups := range []int{1, 2, 3, 5, 9, 10, 11, 12} {
 		for _, spans := range []int{1, 2, 3, 5, 9, 11, 12} {
 			for _, files := range []int{0, 1, 2, 3, 4, 10, 12, 50} {
 				backups := MockBackupChain(numBackups, spans, files, r)
+
 				for _, target := range []int64{0, 1, 4, 100, 1000} {
 					t.Run(fmt.Sprintf("numBackups=%d, numSpans=%d, numFiles=%d, merge=%d", numBackups, spans, files, target), func(t *testing.T) {
-						cover := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, nil, target<<20)
-						if err := checkRestoreCovering(backups, backups[numBackups-1].Spans, cover, target != noSpanTargetSize); err != nil {
-							t.Fatal(err)
-						}
+						introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+						require.NoError(t, err)
+						cover := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil,
+							introducedSpanFrontier, nil,
+							target<<20)
+						require.NoError(t, checkRestoreCovering(backups, backups[numBackups-1].Spans, cover, target != noSpanTargetSize))
 					})
 				}
 			}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -492,14 +492,19 @@ func MakeBackupTableEntry(
 		return BackupTableEntry{}, errors.Wrapf(err, "making spans for table %s", fullyQualifiedTableName)
 	}
 
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backupManifests, hlc.Timestamp{})
+	if err != nil {
+		return BackupTableEntry{}, err
+	}
+
 	entry := makeSimpleImportSpans(
 		[]roachpb.Span{tablePrimaryIndexSpan},
 		backupManifests,
-		nil,           /*backupLocalityInfo*/
+		nil, /*backupLocalityInfo*/
+		introducedSpanFrontier,
 		roachpb.Key{}, /*lowWaterMark*/
 		0,             /* disable merging */
 	)
-
 	lastSchemaChangeTime := findLastSchemaChangeTime(backupManifests, tbDesc, endTime)
 
 	backupTableEntry := BackupTableEntry{

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -1,0 +1,392 @@
+# test that we properly fully backup an offline span when it can be non-mvcc
+#
+# TODO(msbutler): waiting for https://github.com/cockroachdb/cockroach/pull/86689 to land
+# Part 1 - ensure clear range induces full reintroduction of spans
+# - begin import jobs and pause it
+# - run inc backup - verify inc has captured the data
+# - roll it back it back non-mvcc
+# - run an inc backup and ensure we reintroduce the table spans
+
+new-server name=s1
+----
+
+###########
+# Case 1: an incremental backup captures a non-mvcc rollback
+###########
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE INDEX foo_idx ON foo (s);
+CREATE INDEX foo_to_drop_idx ON foo (s);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+exec-sql
+SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = false;
+----
+
+
+exec-sql
+SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = false;
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz;
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+----
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/' with revision_history;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job cancel=a
+----
+
+job cancel=aa
+----
+
+job tag=a wait-for-state=cancelled
+----
+
+
+job tag=aa wait-for-state=cancelled
+----
+
+# Verify proper rollback
+query-sql
+SELECT count(*) FROM d.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d.foofoo;
+----
+1
+
+
+# Even though the full table will get backed up from ts=0 during the next round of incremental
+# backups, only active indexes (foo_idx and foo_new_idx) should appear in the restored cluster.
+exec-sql
+DROP INDEX foo_to_drop_idx;
+----
+NOTICE: the data for dropped indexes is reclaimed asynchronously
+HINT: The reclamation delay can be customized in the zone configuration for the table.
+
+exec-sql
+CREATE INDEX foo_new_idx ON foo (s);
+----
+
+
+# Ensure incremental backups backup the newly online spans from ts=0, as the
+# import was rolled back via non-mvcc clear range. So, backup 0 rows from foo
+# (it was empty pre-import), and 1 row from foo (had 1 row pre-import);
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' with revision_history;
+----
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 3 full
+d foofoo table 4 full
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 3 full
+d foofoo table 4 full
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 3 full
+d foofoo table 4 full
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+
+# To verify the incremental backed up the pre-import state table, restore d and ensure all tables
+# are in their pre-import state.
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name=d2;
+----
+
+
+query-sql
+SELECT count(*) FROM d2.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d2.foofoo;
+----
+1
+
+
+query-sql
+select DISTINCT index_name FROM [SHOW INDEXES FROM d.foo];
+----
+foo_pkey
+foo_idx
+foo_new_idx
+
+###########
+# Case 2: an incremental backup captures an mvcc rollback
+###########
+
+exec-sql
+DROP DATABASE d2;
+CREATE TABLE foo2 (i INT PRIMARY KEY, s STRING);
+CREATE INDEX foo2_idx ON foo2 (s);
+CREATE INDEX foo2_to_drop_idx ON foo2 (s);
+CREATE TABLE foofoo2 (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo2 VALUES (10, 'x0');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true;
+----
+
+exec-sql
+SET CLUSTER SETTING kv.bulkio.write_metadata_sst.enabled = false;
+----
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=b
+IMPORT INTO foo2 (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=bb
+IMPORT INTO foofoo2 (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/';
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/';
+----
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/';
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job cancel=b
+----
+
+job cancel=bb
+----
+
+job tag=b wait-for-state=cancelled
+----
+
+
+job tag=bb wait-for-state=cancelled
+----
+
+# Even though the full table will get backed up from ts=0 during the next round of incremental
+# backups, only active indexes (foo2_idx and foo2_new_idx) should appear in the restored cluster.
+exec-sql
+DROP INDEX foo2_to_drop_idx;
+----
+NOTICE: the data for dropped indexes is reclaimed asynchronously
+HINT: The reclamation delay can be customized in the zone configuration for the table.
+
+exec-sql
+CREATE INDEX foo2_new_idx ON foo2 (s);
+----
+
+
+# These incremental backups will back up all mvcc history from foo2 and foofoo2 because the
+# tables returned online. For each table, this means:
+# - foofoo2 will have 7 rows:
+#    - 1 row from before the import
+#    - 3 rows from the import
+#    - 3 delete tombstones from the import rollback
+# - foo2: will have 3 rows:
+#    - 3 rows from the import
+#    - Note because foo2 had no data pre import, an mvcc range tombstone will delete the imported data.
+#      The incremental backup will capture this range tombstone, however, SHOW BACKUP currently will
+#      not record this range as a "row" in the backup.
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/';
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/';
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/';
+----
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo2' or object_name = 'foofoo2'
+ORDER BY
+  start_time, database_name;
+----
+d foo2 table 3 full
+d foofoo2 table 4 full
+d foo2 table 3 incremental
+d foofoo2 table 7 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo2' or object_name = 'foofoo2'
+ORDER BY
+  start_time, database_name;
+----
+d foo2 table 3 full
+d foofoo2 table 4 full
+d foo2 table 3 incremental
+d foofoo2 table 7 incremental
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+WHERE
+  object_name = 'foo2' or object_name = 'foofoo2'
+ORDER BY
+  start_time, database_name;
+----
+d foo2 table 3 full
+d foofoo2 table 4 full
+d foo2 table 3 incremental
+d foofoo2 table 7 incremental
+
+# To verify the incremental backup captured the tombstones, restore d and ensure all tables
+# are in their pre-import state.
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name=d2;
+----
+
+
+query-sql
+SELECT count(*) FROM d2.foo2;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d2.foofoo2;
+----
+1
+
+query-sql
+select DISTINCT index_name FROM [SHOW INDEXES FROM d2.foo2];
+----
+foo2_pkey
+foo2_idx
+foo2_new_idx


### PR DESCRIPTION
Currently RESTORE may restore invalid backup data from a backed up table that
underwent an IMPORT rollback. See https://github.com/cockroachdb/cockroach/issues/87305 for a detailed explanation.

This patch ensures that RESTORE elides older backup data that were deleted via
a non-MVCC operation. Because incremental backups always reintroduce spans
(i.e. backs them up from timestamp 0) that may have undergone a non-mvcc
operation, restore can identify restoring spans with potentially corrupt data
in the backup chain and only ingest the spans' reintroduced data to any system
time, without the corrupt data.

Here's the basic impliemenation in Restore:
- For each span we want to restore
   - identify the last time, l, the span was introduced, using the manifests
   - dont restore the span using a backup if backup.EndTime < l

This implementation rests on the following assumption: the input spans for each
restoration flow (created in createImportingDescriptors) and the
restoreSpanEntries (created by makeSimpleImportSpans) do not span across
multiple tables. Given this assumption, makeSimpleImportSpans skips adding
files from a backups for a given input span that was reintroduced in a
subsequent backup.

It's worth noting that all significant refactoring occurs on code run by
the restore coordinator; therefore, no special care needs to be taken for
mixed / cross version backups. In other words, if the coordinator has updated,
the cluster restores properly; else, the bug will exist on the restored cluster.
It's also worth noting that other forms of this bug are apparent on older
cluster versions (https://github.com/cockroachdb/cockroach/issues/88042, https://github.com/cockroachdb/cockroach/issues/88043) and has not been noticed by customers; thus,
there is no need to fail a mixed version restore to protect the customer from
this already existing bug.

Informs https://github.com/cockroachdb/cockroach/issues/87305

Release justification: bug fix

Release note: fix for TA advisory
https://cockroachlabs.atlassian.net/browse/TSE-198