### PR TITLE
opt: don't push limit with invalid ordering into window function

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -552,3 +552,24 @@ vectorized: true
 └── • virtual table
       table: pg_type@pg_type_oid_idx
       spans: [/1 - /1000]
+
+# Regression test for #69685 - a limit cannot be pushed below a window function
+# if its order-by references the window function.
+query T
+EXPLAIN SELECT * FROM generate_series(1, 10) ORDER BY row_number() OVER () LIMIT 1;
+----
+distribution: local
+vectorized: true
+·
+• top-k
+│ estimated row count: 1
+│ order: +row_number
+│ k: 1
+│
+└── • window
+    │ estimated row count: 10
+    │
+    └── • project set
+        │ estimated row count: 10
+        │
+        └── • emptyrow

--- a/pkg/sql/opt/norm/rules/window.opt
+++ b/pkg/sql/opt/norm/rules/window.opt
@@ -158,6 +158,10 @@ $input
     (Window $input:* $fns:* & (AllArePrefixSafe $fns) $private:*)
     $limit:*
     $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $inputCols:(OutputCols $input)
+        ) &
         (Let
             ($newOrdering $ok):(MakeSegmentedOrdering
                 $input
@@ -170,7 +174,14 @@ $input
 )
 =>
 (Window
-    (Limit $input $limit (DerefOrderingChoice $newOrdering))
+    (Limit
+        $input
+        $limit
+        (PruneOrdering
+            (DerefOrderingChoice $newOrdering)
+            $inputCols
+        )
+    )
     $fns
     $private
 )


### PR DESCRIPTION
This commit modifies the `PushLimitIntoWindow` normalization rule to
check whether the `Limit` ordering can be restricted to only reference
input columns, and to avoid matching if not. This prevents a panic that
would occur after pushing a `Limit` that references a window function
below that window function.

Fixes #69685

Release justification: low-risk fix for internal error

Release note (bug fix): Fixed a bug existing since before 21.1 that
could cause an internal error when executing a query with a limit
ordering on the output of a window function.