### PR TITLE
bazel: detect go standard library deprecation errors

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -24,6 +24,10 @@ def go_deps():
         name = "co_honnef_go_tools",
         build_file_proto_mode = "disable_global",
         importpath = "honnef.co/go/tools",
+        patch_args = ["-p1"],
+        patches = [
+            "@com_github_cockroachdb_cockroach//build/patches:co_honnef_go_tools.patch",
+        ],
         sha256 = "9cc6be802987a1ad579e7a1d90bde4c50b9832ce9213eab302bf8916ab3dc2b7",
         strip_prefix = "honnef.co/go/tools@v0.3.2",
         urls = [

--- a/build/patches/co_honnef_go_tools.patch
+++ b/build/patches/co_honnef_go_tools.patch
@@ -1,0 +1,46 @@
+diff --git a/staticcheck/lint.go b/staticcheck/lint.go
+index 85bcb21..e91e81c 100644
+--- a/staticcheck/lint.go
++++ b/staticcheck/lint.go
+@@ -3080,6 +3080,9 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
+ 	}
+ 
+ 	handleDeprecation := func(depr *deprecated.IsDeprecated, node ast.Node, deprecatedObjName string, pkgPath string, tfn types.Object) {
++		if depr == nil && !isStdlibPath(pkgPath) {
++			panic(`Cannot pass nil "depr" object if the deprecated object is not from the standard library`)
++		}
+ 		// Note: gopls doesn't correctly run analyzers on
+ 		// dependencies, so we'll never be able to find deprecated
+ 		// objects in imported code. We've experimented with
+@@ -3136,16 +3139,16 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
+ 			switch std.AlternativeAvailableSince {
+ 			case knowledge.DeprecatedNeverUse:
+ 				report.Report(pass, node,
+-					fmt.Sprintf("%s has been deprecated since Go 1.%d because it shouldn't be used: %s",
+-						report.Render(pass, node), std.DeprecatedSince, depr.Msg))
++					fmt.Sprintf("%s has been deprecated since Go 1.%d because it shouldn't be used",
++						report.Render(pass, node), std.DeprecatedSince))
+ 			case std.DeprecatedSince, knowledge.DeprecatedUseNoLonger:
+ 				report.Report(pass, node,
+-					fmt.Sprintf("%s has been deprecated since Go 1.%d: %s",
+-						report.Render(pass, node), std.DeprecatedSince, depr.Msg))
++					fmt.Sprintf("%s has been deprecated since Go 1.%d",
++						report.Render(pass, node), std.DeprecatedSince))
+ 			default:
+ 				report.Report(pass, node,
+-					fmt.Sprintf("%s has been deprecated since Go 1.%d and an alternative has been available since Go 1.%d: %s",
+-						report.Render(pass, node), std.DeprecatedSince, std.AlternativeAvailableSince, depr.Msg))
++					fmt.Sprintf("%s has been deprecated since Go 1.%d and an alternative has been available since Go 1.%d",
++						report.Render(pass, node), std.DeprecatedSince, std.AlternativeAvailableSince))
+ 			}
+ 		} else {
+ 			report.Report(pass, node, fmt.Sprintf("%s is deprecated: %s", report.Render(pass, node), depr.Msg))
+@@ -3185,6 +3188,8 @@ func CheckDeprecated(pass *analysis.Pass) (interface{}, error) {
+ 
+ 		if depr, ok := deprs.Objects[obj]; ok {
+ 			handleDeprecation(depr, sel, code.SelectorName(pass, sel), obj.Pkg().Path(), tfn)
++		} else if _, ok := knowledge.StdlibDeprecations[code.SelectorName(pass, sel)]; ok {
++			handleDeprecation(nil, sel, code.SelectorName(pass, sel), obj.Pkg().Path(), tfn)
+ 		}
+ 		return true
+ 	}

--- a/pkg/security/tls.go
+++ b/pkg/security/tls.go
@@ -48,9 +48,6 @@ func newServerTLSConfig(
 		cfg.ClientCAs = certPool
 	}
 
-	// Use the default cipher suite from golang (RC4 is going away in 1.5).
-	// Prefer the server-specified suite.
-	cfg.PreferServerCipherSuites = true
 	// Should we disable session resumption? This may break forward secrecy.
 	// cfg.SessionTicketsDisabled = true
 	return cfg, nil
@@ -67,9 +64,6 @@ func newUIServerTLSConfig(settings TLSSettings, certPEM, keyPEM []byte) (*tls.Co
 		return nil, err
 	}
 
-	// Use the default cipher suite from golang (RC4 is going away in 1.5).
-	// Prefer the server-specified suite.
-	cfg.PreferServerCipherSuites = true
 	// Should we disable session resumption? This may break forward secrecy.
 	// cfg.SessionTicketsDisabled = true
 	return cfg, nil


### PR DESCRIPTION
Previously, `staticcheck` only raised deprecation errors
from non-stdlib packages because the analysis pass used
by the deprecation analyzer is created by `nogo` which doesn't
analyze the standard library packages.

This code change patches `staticcheck` to let it detect deprecation
errors from the standard library and raise them. It also removes two
uses of `tls.Config.PreferServerCipherSuites` because it's deprecated
since Go 1.18 and is a legacy field that is ignored and has no effect.

Closes #84877

Release justification: Non-production code change
Release note: None