### PR TITLE
cloud/amazon: add setting for buffered put-object uploads

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -11,6 +11,7 @@
 package amazon
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -137,6 +138,13 @@ var reuseSession = settings.RegisterBoolSetting(
 	"cloudstorage.s3.session_reuse.enabled",
 	"persist the last opened s3 session and re-use it when opening a new session with the same arguments",
 	true,
+)
+
+var usePutObject = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"cloudstorage.s3.buffer_and_put_uploads.enabled",
+	"construct files in memory before uploading via PutObject (may cause crashes due to memory usage)",
+	false,
 )
 
 // s3ClientConfig is the immutable config used to initialize an s3 session.
@@ -543,7 +551,45 @@ func (s *s3Storage) Settings() *cluster.Settings {
 	return s.settings
 }
 
+type putUploader struct {
+	b      *bytes.Buffer
+	client *s3.S3
+	input  *s3.PutObjectInput
+}
+
+func (u *putUploader) Write(p []byte) (int, error) {
+	return u.b.Write(p)
+}
+
+func (u *putUploader) Close() error {
+	u.input.Body = bytes.NewReader(u.b.Bytes())
+	_, err := u.client.PutObject(u.input)
+	return err
+}
+
+func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteCloser, error) {
+	client, err := s.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 4<<20))
+
+	return &putUploader{
+		b: buf,
+		input: &s3.PutObjectInput{
+			Bucket: s.bucket,
+			Key:    aws.String(path.Join(s.prefix, basename)),
+		},
+		client: client,
+	}, nil
+}
+
 func (s *s3Storage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
+	if usePutObject.Get(&s.settings.SV) {
+		return s.putUploader(ctx, basename)
+	}
+
 	uploader, err := s.getUploader(ctx)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See also https://github.com/cockroachdb/cockroach/pull/87349

Release note: none.

Release justification: none (off by default).