### PR TITLE
release-22.1: rowexec: make sure to close generator builtin with error in Start

### DIFF
--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -162,10 +162,12 @@ func (ps *projectSetProcessor) nextInputRow() (
 			if gen == nil {
 				gen = builtins.EmptyGenerator()
 			}
+			// Store the generator before Start so that it'll be closed even if
+			// Start returns an error.
+			ps.gens[i] = gen
 			if err := gen.Start(ps.Ctx, ps.FlowCtx.Txn); err != nil {
 				return nil, nil, err
 			}
-			ps.gens[i] = gen
 		}
 		ps.done[i] = false
 	}


### PR DESCRIPTION
Backport 1/1 commits from #87286.

/cc @cockroachdb/release

---

Previously, if an error is returned by `Start` method of the generator
builtin, we would never close it which could lead to leaking of
resources. This is now fixed.

Fixes: #87248.

Release justification: bug fix.

Release note: None
