### PR TITLE
cloud/amazon: add params in put-upload case

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -578,8 +578,11 @@ func (s *s3Storage) putUploader(ctx context.Context, basename string) (io.WriteC
 	return &putUploader{
 		b: buf,
 		input: &s3.PutObjectInput{
-			Bucket: s.bucket,
-			Key:    aws.String(path.Join(s.prefix, basename)),
+			Bucket:               s.bucket,
+			Key:                  aws.String(path.Join(s.prefix, basename)),
+			ServerSideEncryption: nilIfEmpty(s.conf.ServerEncMode),
+			SSEKMSKeyId:          nilIfEmpty(s.conf.ServerKMSID),
+			StorageClass:         nilIfEmpty(s.conf.StorageClass),
 		},
 		client: client,
 	}, nil


### PR DESCRIPTION
Previously the setting enabled this alternative write path, which exactly matched the write behavior of 21.1.
However, 21.1 did not have options for server-side encryption or storage class, while more recent versions
do, and thus this alternative write path should respect them if set.

Release note: none.
Release justification: none (off by default).