### PR TITLE
xform: avoid locality-optimized scans which must always read remote rows

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_locality_optimized_search_query_behavior
@@ -1,0 +1,151 @@
+# tenant-cluster-setting-override-opt: allow-multi-region-abstractions-for-secondary-tenants
+# LogicTest: multiregion-9node-3region-3azs
+# TODO(#75864): enable multiregion-9node-3region-3azs-tenant.
+
+# Set the closed timestamp interval to be short to shorten the amount of time
+# we need to wait for the system config to propagate.
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
+
+############################################
+# Regression tests for support issue #1780 #
+############################################
+statement ok
+CREATE DATABASE test_db
+
+statement ok
+USE test_db
+
+statement ok
+SET experimental_enable_unique_without_index_constraints = true
+
+statement ok
+CREATE TABLE users (
+        account_id UUID NOT NULL,
+        home_region STRING NOT NULL,
+        address STRING NOT NULL,
+        CONSTRAINT users_pkey PRIMARY KEY (home_region ASC, account_id ASC),
+        UNIQUE INDEX home_region_and_address (home_region ASC, address ASC) PARTITION BY LIST (home_region) (
+                PARTITION ca VALUES IN (('ca')),
+                PARTITION us VALUES IN (('us')),
+                PARTITION ap VALUES IN (('ap'))
+        ),
+        CONSTRAINT check_home_region CHECK (home_region IN ('ap':::STRING, 'us':::STRING, 'ca':::STRING))
+) PARTITION BY LIST (home_region) (
+        PARTITION ca VALUES IN (('ca')),
+        PARTITION us VALUES IN (('us')),
+        PARTITION ap VALUES IN (('ap'))
+);
+
+statement ok
+ALTER PARTITION "ca" OF INDEX users@* CONFIGURE ZONE USING
+  constraints = '[+region=ca-central-1]';
+
+statement ok
+ALTER PARTITION "us" OF INDEX users@* CONFIGURE ZONE USING
+  constraints = '[+region=us-east-1]';
+
+statement ok
+ALTER PARTITION "ap" OF INDEX users@* CONFIGURE ZONE USING
+  constraints = '[+region=ap-southeast-2]';
+
+# Locality-optimized scan should not be used when rows from other regions
+# might exist and need to be returned.
+query T retry
+EXPLAIN SELECT 1 FROM users@home_region_and_address
+WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
+  AND address = '221B Baker Street';
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • scan
+      missing stats
+      table: users@home_region_and_address
+      spans: [/'ap'/'221B Baker Street' - /'ap'/'221B Baker Street'] [/'ca'/'221B Baker Street' - /'ca'/'221B Baker Street'] [/'us'/'221B Baker Street' - /'us'/'221B Baker Street']
+
+# With a hard limit <= the max cardinality of the local scan, we should choose
+# locality-optimized scan.
+query T retry
+EXPLAIN SELECT 1 FROM users@home_region_and_address
+WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
+  AND address = '221B Baker Street' LIMIT 1;
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • union all
+    │ limit: 1
+    │
+    ├── • scan
+    │     missing stats
+    │     table: users@home_region_and_address
+    │     spans: [/'ap'/'221B Baker Street' - /'ap'/'221B Baker Street']
+    │     limit: 1
+    │
+    └── • scan
+          missing stats
+          table: users@home_region_and_address
+          spans: [/'ca'/'221B Baker Street' - /'ca'/'221B Baker Street'] [/'us'/'221B Baker Street' - /'us'/'221B Baker Street']
+          limit: 1
+
+# With a hard limit > the max cardinality of the local scan, we should not
+# choose locality-optimized scan.
+query T retry
+EXPLAIN SELECT 1 FROM users@home_region_and_address
+WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
+  AND address = '221B Baker Street' LIMIT 2;
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • scan
+      missing stats
+      table: users@home_region_and_address
+      spans: [/'ap'/'221B Baker Street' - /'ap'/'221B Baker Street'] [/'ca'/'221B Baker Street' - /'ca'/'221B Baker Street'] [/'us'/'221B Baker Street' - /'us'/'221B Baker Street']
+      limit: 2
+
+statement ok
+ALTER TABLE users ADD UNIQUE WITHOUT INDEX (address)
+
+# With a unique constraint on the non-partitioning index key columns, a
+# non-limited scan can avoid reading remote regions by picking
+# locality-optimized scan.
+query T retry
+EXPLAIN SELECT 1 FROM users@home_region_and_address
+WHERE home_region IN ('ap':::STRING, 'ca':::STRING, 'us':::STRING)
+  AND address = '221B Baker Street';
+----
+distribution: local
+vectorized: true
+·
+• render
+│
+└── • union all
+    │ limit: 1
+    │
+    ├── • scan
+    │     missing stats
+    │     table: users@home_region_and_address
+    │     spans: [/'ap'/'221B Baker Street' - /'ap'/'221B Baker Street']
+    │
+    └── • scan
+          missing stats
+          table: users@home_region_and_address
+          spans: [/'ca'/'221B Baker Street' - /'ca'/'221B Baker Street'] [/'us'/'221B Baker Street' - /'us'/'221B Baker Street']
+
+statement ok
+RESET experimental_enable_unique_without_index_constraints
+
+################################################
+# End regression tests for support issue #1780 #
+################################################

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -122,6 +122,13 @@ func TestCCLLogic_multi_region_import_export(
 	runCCLLogicTest(t, "multi_region_import_export")
 }
 
+func TestCCLLogic_multi_region_locality_optimized_search_query_behavior(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "multi_region_locality_optimized_search_query_behavior")
+}
+
 func TestCCLLogic_multi_region_privileges(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Previously, for tables with old-style partitioning, which don't use the
new multiregion abstractions, there were no guardrails in place to
prevent 2 cases where locality-optimized scan must always read ranges in
remote regions:

1. When a scan with no hard limit has a non-unique index constraint
   (could return more than one row per matched index key, not including
   the partitioning key column)
2. When the max cardinality of a constrained scan is less than the hard
   limit placed on the scan via a LIMIT clause

This was inadequate because locality-optimized scan is usually slower
than distributed scans when reading from remote regions is required. If
we can statically determine reading from remote regions is required,
locality-optimized scan should not even be costed and considered by the
optimizer. Multiregion tables, such as REGIONAL BY ROW tables, don't
encounter this issue because the internal `crdb_region` partitioning
column is not part of the UNIQUE constraint in that case, for example:
```
CREATE TABLE regional_by_row_table (
  col1 int,
  col2 bool NOT NULL,
  UNIQUE INDEX idx(col1) -- crdb_region is implicitly the 1st idx col
) LOCALITY REGIONAL BY ROW;

SELECT * FROM regional_by_row_table WHERE col1 = 1;
```
In the above, we could use LOS and split this into a local scan:
`SELECT * FROM regional_by_row_table WHERE crdb_region = 'us' AND col1 = 1;`
... and remote scans:
```
SELECT * FROM regional_by_row_table WHERE crdb_region IN ('ca', 'ap')
          AND col1 = 1;
```
The max cardinality of the local scan is 1, and the max cardinality of
the original scan is 1, so we know it's possible to fulfill the request
solely with the local scan.

To address this, this patch avoids planning locality-optimized scan for
the two cases listed at the top of the description. The first case is
detected by the local scan of the UNION ALL having a lower max
cardinality than the max cardinality including all constraint spans
(for example, given a pair of columns (part_col, col1), if col1 is a
unique key, then max_cardinality(col1) will equal 
max_cardinality(part_col, col1). The second case is detected by a
direct comparison of the hard limit with the max cardinality of the
local scan.

Release note (bug fix): This patch fixes a misused query optimization
involving tables with one or more PARTITION BY clauses and partition
zone constraints which assign region locality to those partitions.
In some cases the optimizer picks a `locality-optimized search` query
plan which is not truly locality-optimized, and has higher latency than
competing query plans which use distributed scan. Locality-optimized
search is now avoided in cases which are known not to benefit from this
optimization.

Release justification: Low risk fix for suboptimal locality-optimized scan