### PR TITLE
storage: fix `NextKey()` for prefix iterators

### DIFF
--- a/pkg/storage/testdata/intent_interleaving_iter/basic
+++ b/pkg/storage/testdata/intent_interleaving_iter/basic
@@ -156,8 +156,7 @@ seek-ge "f"/0,0: output: .
 seek-ge "c"/0,0: output: meta k=c
 next: output: .
 
-# Prefix iteration and NextKey. What we will see after the prefix is
-# exhausted is undefined.
+# Prefix iterators will be exhausted on NextKey().
 iter prefix=true
 seek-ge k=d
 next-key
@@ -170,10 +169,10 @@ next-key
 seek-ge "d"/0,0: output: value k=d ts=25.000000000,0 v=d25
 next-key: output: .
 seek-ge "a"/0,0: output: meta k=a ts=20.000000000,0 txn=1
-next-key: output: meta k=b ts=30.000000000,0 txn=2
+next-key: output: .
 seek-ge "a"/0,0: output: meta k=a ts=20.000000000,0 txn=1
 next: output: value k=a ts=20.000000000,0 v=a20
-next-key: output: meta k=b ts=30.000000000,0 txn=2
+next-key: output: .
 
 # Seek to particular timestamp.
 iter lower=a upper=f

--- a/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
+++ b/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
@@ -1,0 +1,279 @@
+# Tests NextKey() handling for prefix iterators.
+#
+#  7     [b7]    [d7]
+#  6          o-------o
+#  5  a5  b5  c5  d5
+#  4  a4  b4  c4  d4
+#  3  a3  b3  c3  d3
+#  2  a2  b2  c2  d2
+#  1  a1  b1  c1  d1  e1
+#     a   b   c   d   e
+#
+run ok
+put k=a ts=1 v=a1
+put k=a ts=2 v=a2
+put k=a ts=3 v=a3
+put k=a ts=4 v=a4
+put k=a ts=5 v=a5
+put k=b ts=1 v=b1
+put k=b ts=2 v=b2
+put k=b ts=3 v=b3
+put k=b ts=4 v=b4
+put k=b ts=5 v=b5
+put k=c ts=1 v=c1
+put k=c ts=2 v=c2
+put k=c ts=3 v=c3
+put k=c ts=4 v=c4
+put k=c ts=5 v=c5
+put k=d ts=1 v=d1
+put k=d ts=2 v=d2
+put k=d ts=3 v=d3
+put k=d ts=4 v=d4
+put k=d ts=5 v=d5
+put k=e ts=1 v=e1
+del_range_ts k=c end=e ts=6
+with t=A
+  txn_begin ts=7
+  put k=b v=b7
+  put k=d v=d7
+----
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+rangekey: {c-e}/[6.000000000,0=/<empty>]
+data: "a"/5.000000000,0 -> /BYTES/a5
+data: "a"/4.000000000,0 -> /BYTES/a4
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "a"/1.000000000,0 -> /BYTES/a1
+meta: "b"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "b"/7.000000000,0 -> /BYTES/b7
+data: "b"/5.000000000,0 -> /BYTES/b5
+data: "b"/4.000000000,0 -> /BYTES/b4
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "b"/2.000000000,0 -> /BYTES/b2
+data: "b"/1.000000000,0 -> /BYTES/b1
+data: "c"/5.000000000,0 -> /BYTES/c5
+data: "c"/4.000000000,0 -> /BYTES/c4
+data: "c"/3.000000000,0 -> /BYTES/c3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "c"/1.000000000,0 -> /BYTES/c1
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "d"/7.000000000,0 -> /BYTES/d7
+data: "d"/5.000000000,0 -> /BYTES/d5
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/1.000000000,0 -> /BYTES/e1
+
+# Make sure that stepping backwards on a prefix iterator will error. We thus
+# don't have to test switching directions after a NextKey().
+run error
+iter_new prefix kind=keys type=pointsAndRanges
+iter_seek_ge k=a ts=3
+iter_next
+iter_prev
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next: "a"/2.000000000,0=/BYTES/a2
+iter_prev: err=pebble: unsupported reverse prefix iteration
+error: (*withstack.withStack:) pebble: unsupported reverse prefix iteration
+
+run error
+iter_new prefix kind=keysAndIntents type=pointsAndRanges
+iter_seek_ge k=a ts=3
+iter_next
+iter_prev
+----
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next: "a"/2.000000000,0=/BYTES/a2
+iter_prev: err=intentIter should not be after iter
+error: (*withstack.withStack:) intentIter should not be after iter
+
+# Complete iterator with intents and range keys.
+run ok
+iter_new prefix types=pointsAndRanges
+iter_seek_ge k=a
+iter_next_key
+iter_seek_ge k=a ts=3
+iter_next_key
+iter_seek_ge k=a ts=1
+iter_next_key
+iter_seek_ge k=b
+iter_next_key
+iter_seek_ge k=b ts=3
+iter_next_key
+iter_seek_ge k=b ts=1
+iter_next_key
+iter_seek_ge k=c
+iter_next_key
+iter_seek_ge k=c ts=3
+iter_next_key
+iter_seek_ge k=c ts=1
+iter_next_key
+iter_seek_ge k=d
+iter_next_key
+iter_seek_ge k=d ts=3
+iter_next_key
+iter_seek_ge k=d ts=1
+iter_next_key
+----
+iter_seek_ge: "a"/5.000000000,0=/BYTES/a5
+iter_next_key: .
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: .
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_next_key: .
+iter_seek_ge: "b"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+iter_seek_ge: "b"/3.000000000,0=/BYTES/b3
+iter_next_key: .
+iter_seek_ge: "b"/1.000000000,0=/BYTES/b1
+iter_next_key: .
+iter_seek_ge: c{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: "c"/3.000000000,0=/BYTES/c3 c{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: "c"/1.000000000,0=/BYTES/c1 c{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true d{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: "d"/3.000000000,0=/BYTES/d3 d{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: "d"/1.000000000,0=/BYTES/d1 d{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+
+# Non-intent point keys only.
+run ok
+iter_new prefix kind=keys types=pointsOnly
+iter_seek_ge k=a
+iter_next_key
+iter_seek_ge k=a ts=3
+iter_next_key
+iter_seek_ge k=a ts=1
+iter_next_key
+iter_seek_ge k=b
+iter_next_key
+iter_seek_ge k=b ts=3
+iter_next_key
+iter_seek_ge k=b ts=1
+iter_next_key
+iter_seek_ge k=c
+iter_next_key
+iter_seek_ge k=c ts=3
+iter_next_key
+iter_seek_ge k=c ts=1
+iter_next_key
+iter_seek_ge k=d
+iter_next_key
+iter_seek_ge k=d ts=3
+iter_next_key
+iter_seek_ge k=d ts=1
+iter_next_key
+----
+iter_seek_ge: "a"/5.000000000,0=/BYTES/a5
+iter_next_key: .
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: .
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_next_key: .
+iter_seek_ge: "b"/7.000000000,0=/BYTES/b7
+iter_next_key: .
+iter_seek_ge: "b"/3.000000000,0=/BYTES/b3
+iter_next_key: .
+iter_seek_ge: "b"/1.000000000,0=/BYTES/b1
+iter_next_key: .
+iter_seek_ge: "c"/5.000000000,0=/BYTES/c5
+iter_next_key: .
+iter_seek_ge: "c"/3.000000000,0=/BYTES/c3
+iter_next_key: .
+iter_seek_ge: "c"/1.000000000,0=/BYTES/c1
+iter_next_key: .
+iter_seek_ge: "d"/7.000000000,0=/BYTES/d7
+iter_next_key: .
+iter_seek_ge: "d"/3.000000000,0=/BYTES/d3
+iter_next_key: .
+iter_seek_ge: "d"/1.000000000,0=/BYTES/d1
+iter_next_key: .
+
+# Range keys only.
+run ok
+iter_new prefix types=rangesOnly
+iter_seek_ge k=a
+iter_next_key
+iter_seek_ge k=b
+iter_next_key
+iter_seek_ge k=c
+iter_next_key
+iter_seek_ge k=c ts=1
+iter_next_key
+iter_seek_ge k=d
+iter_next_key
+iter_seek_ge k=d ts=1
+iter_next_key
+----
+iter_seek_ge: .
+iter_next_key: .
+iter_seek_ge: .
+iter_next_key: .
+iter_seek_ge: c{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: c{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: d{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+iter_seek_ge: d{-\x00}/[6.000000000,0=/<empty>] !
+iter_next_key: .
+
+# Point synthesis.
+run ok
+iter_new prefix types=pointsAndRanges pointSynthesis
+iter_seek_ge k=a
+iter_next_key
+iter_seek_ge k=a ts=3
+iter_next_key
+iter_seek_ge k=a ts=1
+iter_next_key
+iter_seek_ge k=b
+iter_next_key
+iter_seek_ge k=b ts=3
+iter_next_key
+iter_seek_ge k=b ts=1
+iter_next_key
+iter_seek_ge k=c
+iter_next_key
+iter_seek_ge k=c ts=3
+iter_next_key
+iter_seek_ge k=c ts=1
+iter_next_key
+iter_seek_ge k=d
+iter_next_key
+iter_seek_ge k=d ts=3
+iter_next_key
+iter_seek_ge k=d ts=1
+iter_next_key
+----
+iter_seek_ge: "a"/5.000000000,0=/BYTES/a5
+iter_next_key: .
+iter_seek_ge: "a"/3.000000000,0=/BYTES/a3
+iter_next_key: .
+iter_seek_ge: "a"/1.000000000,0=/BYTES/a1
+iter_next_key: .
+iter_seek_ge: "b"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+iter_seek_ge: "b"/3.000000000,0=/BYTES/b3
+iter_next_key: .
+iter_seek_ge: "b"/1.000000000,0=/BYTES/b1
+iter_next_key: .
+iter_seek_ge: "c"/6.000000000,0=/<empty>
+iter_next_key: .
+iter_seek_ge: "c"/3.000000000,0=/BYTES/c3
+iter_next_key: .
+iter_seek_ge: "c"/1.000000000,0=/BYTES/c1
+iter_next_key: .
+iter_seek_ge: "d"/0,0=txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+iter_next_key: .
+iter_seek_ge: "d"/3.000000000,0=/BYTES/d3
+iter_next_key: .
+iter_seek_ge: "d"/1.000000000,0=/BYTES/d1
+iter_next_key: .


### PR DESCRIPTION
Previously, calling `NextKey()` on a prefix iterator could incorrectly
switch the iterator to non-prefix mode and step onto a different key
prefix. This patch instead exhausts the iterator in this case.

There are no existing prefix `NextKey()` callers that would be affected.
This was verified by adding a panic if `NextKey()` was called on a
prefix iterator and running the entire test suite.

Resolves #87355.

Release justification: fixes for high-priority or high-severity bugs in
existing functionality

Release note: None