### PR TITLE
rpc: allow `IsSpanEmpty` requests from tenants

### DIFF
--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -172,6 +172,7 @@ var reqMethodAllowlist = [...]bool{
 	roachpb.AddSSTable:     true,
 	roachpb.Refresh:        true,
 	roachpb.RefreshRange:   true,
+	roachpb.IsSpanEmpty:    true,
 }
 
 func reqAllowed(r roachpb.Request) bool {


### PR DESCRIPTION
Resolves #87365.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None