### PR TITLE
kvserver: rm transient fields from CheckConsistencyRequest

### DIFF
--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1737,10 +1737,7 @@ func checkConsistencyArgs(desc *roachpb.RangeDescriptor) *roachpb.CheckConsisten
 			Key:    desc.StartKey.AsRawKey(),
 			EndKey: desc.EndKey.AsRawKey(),
 		},
-		WithDiff:   false,
-		Mode:       1,
-		Checkpoint: false,
-		Terminate:  nil,
+		Mode: roachpb.ChecksumMode_CHECK_FULL,
 	}
 }
 

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -84,7 +84,7 @@ message ComputeChecksum {
   // inconsistency and we want to preserve as much state as possible.
   bool checkpoint = 4;
   // Replicas processing this command which find themselves in this slice will
-  // terminate. See `CheckConsistencyRequest.Terminate`.
+  // terminate. See `ComputeChecksumRequest.Terminate`.
   repeated roachpb.ReplicaDescriptor terminate = 6 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -89,28 +89,26 @@ type replicaChecksum struct {
 // which is then printed before calling `log.Fatal`. This behavior should be
 // lifted to the consistency checker queue in the future.
 func (r *Replica) CheckConsistency(
-	ctx context.Context, args roachpb.CheckConsistencyRequest,
+	ctx context.Context, req roachpb.CheckConsistencyRequest,
 ) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
-	startKey := r.Desc().StartKey.AsRawKey()
-
-	checkArgs := roachpb.ComputeChecksumRequest{
-		RequestHeader: roachpb.RequestHeader{Key: startKey},
+	return r.checkConsistencyImpl(ctx, roachpb.ComputeChecksumRequest{
+		RequestHeader: roachpb.RequestHeader{Key: r.Desc().StartKey.AsRawKey()},
 		Version:       batcheval.ReplicaChecksumVersion,
-		Snapshot:      args.WithDiff,
-		Mode:          args.Mode,
-		Checkpoint:    args.Checkpoint,
-		Terminate:     args.Terminate,
-	}
+		Mode:          req.Mode,
+	})
+}
 
+func (r *Replica) checkConsistencyImpl(
+	ctx context.Context, args roachpb.ComputeChecksumRequest,
+) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
 	isQueue := args.Mode == roachpb.ChecksumMode_CHECK_VIA_QUEUE
 
-	results, err := r.RunConsistencyCheck(ctx, checkArgs)
+	results, err := r.RunConsistencyCheck(ctx, args)
 	if err != nil {
 		return roachpb.CheckConsistencyResponse{}, roachpb.NewError(err)
 	}
 
-	res := roachpb.CheckConsistencyResponse_Result{}
-	res.RangeID = r.RangeID
+	res := roachpb.CheckConsistencyResponse_Result{RangeID: r.RangeID}
 
 	shaToIdxs := map[string][]int{}
 	var missing []ConsistencyCheckResult
@@ -187,7 +185,7 @@ func (r *Replica) CheckConsistency(
 		haveDelta = d2 != enginepb.MVCCStats{}
 	}
 
-	res.StartKey = []byte(startKey)
+	res.StartKey = []byte(args.Key)
 	res.Status = roachpb.CheckConsistencyResponse_RANGE_CONSISTENT
 	if minoritySHA != "" {
 		res.Status = roachpb.CheckConsistencyResponse_RANGE_INCONSISTENT
@@ -267,7 +265,7 @@ func (r *Replica) CheckConsistency(
 		log.Infof(ctx, "triggering stats recomputation to resolve delta of %+v", results[0].Response.Delta)
 
 		req := roachpb.RecomputeStatsRequest{
-			RequestHeader: roachpb.RequestHeader{Key: startKey},
+			RequestHeader: roachpb.RequestHeader{Key: args.Key},
 		}
 
 		var b kv.Batch
@@ -277,7 +275,7 @@ func (r *Replica) CheckConsistency(
 		return resp, roachpb.NewError(err)
 	}
 
-	if args.WithDiff {
+	if args.Snapshot {
 		// A diff was already printed. Return because all the code below will do
 		// is request another consistency check, with a diff and with
 		// instructions to terminate the minority nodes.
@@ -285,10 +283,10 @@ func (r *Replica) CheckConsistency(
 		return resp, nil
 	}
 
-	// No diff was printed, so we want to re-run with diff.
-	// Note that this recursive call will be terminated in the `args.WithDiff`
-	// branch above.
-	args.WithDiff = true
+	// No diff was printed, so we want to re-run the check with snapshots
+	// requested, to build the diff. Note that this recursive call will be
+	// terminated in the `args.Snapshot` branch above.
+	args.Snapshot = true
 	args.Checkpoint = true
 	for _, idxs := range shaToIdxs[minoritySHA] {
 		args.Terminate = append(args.Terminate, results[idxs].Replica)
@@ -312,7 +310,7 @@ func (r *Replica) CheckConsistency(
 	// https://github.com/cockroachdb/cockroach/issues/36861
 	defer log.TemporarilyDisableFileGCForMainLogger()()
 
-	if _, pErr := r.CheckConsistency(ctx, args); pErr != nil {
+	if _, pErr := r.checkConsistencyImpl(ctx, args); pErr != nil {
 		log.Errorf(ctx, "replica inconsistency detected; could not obtain actual diff: %s", pErr)
 	}
 

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -103,7 +103,7 @@ func (r *Replica) checkConsistencyImpl(
 ) (roachpb.CheckConsistencyResponse, *roachpb.Error) {
 	isQueue := args.Mode == roachpb.ChecksumMode_CHECK_VIA_QUEUE
 
-	results, err := r.RunConsistencyCheck(ctx, args)
+	results, err := r.runConsistencyCheck(ctx, args)
 	if err != nil {
 		return roachpb.CheckConsistencyResponse{}, roachpb.NewError(err)
 	}
@@ -346,11 +346,11 @@ func (r *Replica) collectChecksumFromReplica(
 	return *resp, nil
 }
 
-// RunConsistencyCheck carries out a round of CheckConsistency/CollectChecksum
+// runConsistencyCheck carries out a round of ComputeChecksum/CollectChecksum
 // for the members of this range, returning the results (which it does not act
 // upon). The first result will belong to the local replica, and in particular
 // there is a first result when no error is returned.
-func (r *Replica) RunConsistencyCheck(
+func (r *Replica) runConsistencyCheck(
 	ctx context.Context, req roachpb.ComputeChecksumRequest,
 ) ([]ConsistencyCheckResult, error) {
 	// Send a ComputeChecksum which will trigger computation of the checksum on

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -641,22 +641,8 @@ enum ChecksumMode {
 // running a ComputeChecksum on the range followed by a storage.CollectChecksum.
 message CheckConsistencyRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
-  // log a diff of inconsistencies if such inconsistencies are found. This is only
-  // valid if mode == FROM_QUEUE
-  bool with_diff = 2;
   ChecksumMode mode = 3;
-  // Whether to create a RocksDB checkpoint on each replica at the log position
-  // at which the SHA is computed. The checkpoint is essentially a cheap point-
-  // in-time backup of the database. It will be put into the engines' auxiliary
-  // directory and needs to be removed manually to avoid leaking disk space.
-  bool checkpoint = 4;
-  // A list of nodes that the consistency check wants to terminate. This is
-  // typically set when Checkpoint above is also set, as part of a second round
-  // after a first consistency check that did find a divergence. The second
-  // round is concerned with damage control and wants the nodes it suspects hold
-  // anomalous data to be shut down, so that this data isn't served to clients
-  // (or worse, spread to other replicas).
-  repeated ReplicaDescriptor terminate = 5 [(gogoproto.nullable) = false];
+  reserved 2, 4, 5;
 }
 
 // A CheckConsistencyResponse is the return value from the CheckConsistency() method.
@@ -1447,15 +1433,18 @@ message ComputeChecksumRequest {
   bool snapshot = 4;
   // The type of checksum to compute. See ChecksumMode.
   ChecksumMode mode = 5;
-  // If set, a checkpoint (i.e. cheap backup) of the engine will be taken. This
-  // is expected to be set only if we already know that there is a problem and
-  // we want to preserve as much state as possible. The checkpoint will be stored
-  // in the engine's auxiliary directory.
+  // If set, a checkpoint (i.e. cheap backup) of the storage engine will be
+  // taken. This is expected to be set only if we already know that there is a
+  // problem, and we want to preserve as much state as possible. The checkpoint
+  // will be stored in the engine's auxiliary directory, and needs to be removed
+  // manually to avoid leaking disk space.
   bool checkpoint = 6;
-  // If non-empty, specifies the replicas which are the most likely source of the
-  // inconsistency. After evaluating the command, these replicas will terminate.
-  //
-  // See the field of the same name in CheckConsistencyRequest for details.
+  // If non-empty, specifies the replicas which are the most likely source of
+  // the inconsistency. After evaluating the command, they will terminate. This
+  // is used together with the Checkpoint field, as part of a second round, when
+  // the first round found a divergence. The second round is concerned with
+  // damage control, and shuts down the nodes with suspected anomalous data, so
+  // that this data isn't served to clients or spread to other replicas.
   repeated ReplicaDescriptor terminate = 7 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/sql/consistencychecker/consistency_checker.go
+++ b/pkg/sql/consistencychecker/consistency_checker.go
@@ -41,7 +41,6 @@ func (s *ConsistencyChecker) CheckConsistency(
 			EndKey: to,
 		},
 		Mode: mode,
-		// NB: we're never requesting a diff since we couldn't render it anyway.
 	})
 
 	// NB: DistSender has special code to avoid parallelizing the request if


### PR DESCRIPTION
A few fields in CheckConsistencyRequest are used solely to support the
"recursive" CheckConsistency flow which sends another request if the first one
did not compute the diff. This is an implementation detail that should not leak
into the proto API. Having it in the proto increases the possibility of bugs,
as it's hard to reason about this API, and the caller has too much control and
possibility to misconfigure.

Release justification: small fix
Release note: None