### PR TITLE
roachtests/awsdms: remove unrequired session setting

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -281,7 +281,6 @@ func setupCockroachDBCluster(ctx context.Context, t test.Test, c cluster.Cluster
 		for _, stmt := range []string{
 			fmt.Sprintf("CREATE USER %s", awsdmsCRDBUser),
 			fmt.Sprintf("GRANT admin TO %s", awsdmsCRDBUser),
-			fmt.Sprintf("ALTER USER %s SET expect_and_ignore_not_visible_columns_in_copy = true", awsdmsCRDBUser),
 		} {
 			if _, err := db.Exec(stmt); err != nil {
 				return err


### PR DESCRIPTION
Now that schema changer removes the rowid column, we can no longer test
with the expect and ignore hidden columns setting.

Release note: None

Release justification: test only change