### PR TITLE
opt: account for the number of spans generated for lookup join costing

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -214,7 +214,7 @@ anti-join (lookup parent)
  ├── lookup columns are key
  ├── cardinality: [0 - 1]
  ├── stats: [rows=1e-10]
- ├── cost: 8.29105556
+ ├── cost: 9.35772222
  ├── key: ()
  ├── fd: ()-->(1,2)
  ├── distribution: ap-southeast-2
@@ -684,4 +684,3 @@ project
 
 statement ok
 RESET enforce_home_region
-

--- a/pkg/sql/opt/exec/explain/testdata/gists_tpce
+++ b/pkg/sql/opt/exec/explain/testdata/gists_tpce
@@ -21,8 +21,8 @@ WHERE tr_b_id = b_id
 GROUP BY b_name
 ORDER BY 2 DESC
 ----
-hash: 13421148216330463175
-plan-gist: AgGUAQQAPAAAAAGqAQQAAwIAABQAogEEAgAUAJgBBAIAFACsAQQCAAkAAgIAARQAhgEEAAEHBAsCBwQRBgQ=
+hash: 14732118561700026222
+plan-gist: AgGUAQQAPAAAAAGqAQQAAwIAABQAogEEAgAUAJgBBAIAFACsAQQCAAkAAgIAARQAhgECAgEHBAsCBwQRBgQ=
 explain(shape):
 • sort
 │ order: -sum
@@ -35,9 +35,10 @@ explain(shape):
         └── • render
             │
             └── • lookup join
-                │ table: broker@broker_b_name_idx
+                │ table: broker@broker_pkey
+                │ equality: (tr_b_id) = (b_id)
                 │ equality cols are key
-                │ lookup condition: (b_name IN _) AND (tr_b_id = b_id)
+                │ pred: b_name IN _
                 │
                 └── • hash join
                     │ equality: (tr_s_symb) = (s_symb)
@@ -74,7 +75,8 @@ explain(gist):
         └── • render
             │
             └── • lookup join
-                │ table: broker@broker_b_name_idx
+                │ table: broker@broker_pkey
+                │ equality: (tr_s_symb) = (b_id)
                 │ equality cols are key
                 │
                 └── • hash join

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -639,7 +639,9 @@ func (b *ConstraintBuilder) constructColEquality(leftCol, rightCol opt.ColumnID)
 }
 
 // isCanonicalFilter returns true for the limited set of expr's that are
-// supported by the lookup joiner at execution time.
+// supported by the lookup joiner at execution time. Note that
+// indexLookupJoinPerLookupCost in coster.go depends on the validation performed
+// by this function, so changes made here should be reflected there.
 func isCanonicalFilter(filter memo.FiltersItem) bool {
 	isVar := func(expr opt.Expr) bool {
 		_, ok := expr.(*memo.VariableExpr)

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -1053,3 +1053,65 @@ index-join e
       ├── cost: 15.0650104
       ├── key: (1)
       └── fd: ()-->(2)
+
+# The number of spans generated for each lookup should contribute to the cost
+# of the lookup join (see #79797).
+
+exec-ddl
+CREATE TABLE small (
+  k INT PRIMARY KEY,
+  a INT
+)
+----
+
+exec-ddl
+CREATE TABLE big (
+  k INT PRIMARY KEY,
+  a INT,
+  INDEX (a)
+)
+----
+
+opt format=(show-stats,show-cost)
+SELECT * FROM small INNER LOOKUP JOIN big ON small.k = big.k AND big.a = ANY ARRAY[1, 2, 3, 4, 5, 6]
+----
+inner-join (lookup big)
+ ├── columns: k:1!null a:2 k:5!null a:6!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [5]
+ ├── lookup columns are key
+ ├── stats: [rows=60, distinct(1)=60, null(1)=0, distinct(5)=60, null(5)=0]
+ ├── cost: 7114.45
+ ├── key: (5)
+ ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+ ├── scan small
+ │    ├── columns: small.k:1!null small.a:2
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── cost: 1064.42
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters
+      └── big.a:6 IN (1, 2, 3, 4, 5, 6) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5] [/6 - /6]; tight)]
+
+opt format=(show-stats,show-cost)
+SELECT * FROM small INNER LOOKUP JOIN big@big_a_idx ON small.k = big.k AND big.a = ANY ARRAY[1, 2, 3, 4, 5, 6]
+----
+inner-join (lookup big@big_a_idx)
+ ├── columns: k:1!null a:2 k:5!null a:6!null
+ ├── flags: force lookup join (into right side)
+ ├── lookup expression
+ │    └── filters
+ │         ├── big.a:6 IN (1, 2, 3, 4, 5, 6) [outer=(6), constraints=(/6: [/1 - /1] [/2 - /2] [/3 - /3] [/4 - /4] [/5 - /5] [/6 - /6]; tight)]
+ │         └── small.k:1 = big.k:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ ├── lookup columns are key
+ ├── stats: [rows=60, distinct(1)=60, null(1)=0, distinct(5)=60, null(5)=0]
+ ├── cost: 25209.44
+ ├── key: (5)
+ ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+ ├── scan small
+ │    ├── columns: small.k:1!null small.a:2
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── cost: 1064.42
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -80,17 +80,15 @@ sort
       │    │    │    │    │    │    ├── key columns: [41] = [21]
       │    │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    │    ├── fd: (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21)
-      │    │    │    │    │    │    ├── inner-join (lookup broker@broker_b_name_idx)
+      │    │    │    │    │    │    ├── inner-join (lookup broker)
       │    │    │    │    │    │    │    ├── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    │    │    │    │    ├── lookup expression
-      │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         ├── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
-      │    │    │    │    │    │    │    │         └── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
+      │    │    │    │    │    │    │    ├── key columns: [44] = [47]
       │    │    │    │    │    │    │    ├── lookup columns are key
       │    │    │    │    │    │    │    ├── fd: (47)-->(49), (44)==(47), (47)==(44)
       │    │    │    │    │    │    │    ├── scan trade_request@trade_request_tr_b_id_tr_s_symb_idx
       │    │    │    │    │    │    │    │    └── columns: tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null
-      │    │    │    │    │    │    │    └── filters (true)
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
       │    │    │    │    │    │    └── filters (true)
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -52,12 +52,9 @@ sort
       │    ├── project
       │    │    ├── columns: column54:54!null b_name:49!null
       │    │    ├── immutable
-      │    │    ├── inner-join (lookup broker@broker_b_name_idx)
+      │    │    ├── inner-join (lookup broker)
       │    │    │    ├── columns: sc_id:1!null sc_name:2!null in_id:5!null in_sc_id:7!null co_id:10!null co_in_id:13!null s_symb:21!null s_co_id:26!null tr_s_symb:41!null tr_qty:42!null tr_bid_price:43!null tr_b_id:44!null b_id:47!null b_name:49!null
-      │    │    │    ├── lookup expression
-      │    │    │    │    └── filters
-      │    │    │    │         ├── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
-      │    │    │    │         └── tr_b_id:44 = b_id:47 [outer=(44,47), constraints=(/44: (/NULL - ]; /47: (/NULL - ]), fd=(44)==(47), (47)==(44)]
+      │    │    │    ├── key columns: [44] = [47]
       │    │    │    ├── lookup columns are key
       │    │    │    ├── fd: ()-->(1,2,7), (10)-->(13), (21)-->(26), (47)-->(49), (44)==(47), (47)==(44), (21)==(41), (41)==(21), (10)==(26), (26)==(10), (5)==(13), (13)==(5), (1)==(7), (7)==(1)
       │    │    │    ├── inner-join (hash)
@@ -92,7 +89,8 @@ sort
       │    │    │    │    │    └── filters (true)
       │    │    │    │    └── filters
       │    │    │    │         └── s_symb:21 = tr_s_symb:41 [outer=(21,41), constraints=(/21: (/NULL - ]; /41: (/NULL - ]), fd=(21)==(41), (41)==(21)]
-      │    │    │    └── filters (true)
+      │    │    │    └── filters
+      │    │    │         └── b_name:49 IN ('Broker1', 'Broker10', 'Broker11', 'Broker12', 'Broker13', 'Broker14', 'Broker15', 'Broker16', 'Broker17', 'Broker18', 'Broker19', 'Broker2', 'Broker20', 'Broker21', 'Broker22', 'Broker23', 'Broker24', 'Broker25', 'Broker26', 'Broker27', 'Broker28', 'Broker29', 'Broker3', 'Broker30', 'Broker4', 'Broker5', 'Broker6', 'Broker7', 'Broker8', 'Broker9') [outer=(49), constraints=(/49: [/'Broker1' - /'Broker1'] [/'Broker10' - /'Broker10'] [/'Broker11' - /'Broker11'] [/'Broker12' - /'Broker12'] [/'Broker13' - /'Broker13'] [/'Broker14' - /'Broker14'] [/'Broker15' - /'Broker15'] [/'Broker16' - /'Broker16'] [/'Broker17' - /'Broker17'] [/'Broker18' - /'Broker18'] [/'Broker19' - /'Broker19'] [/'Broker2' - /'Broker2'] [/'Broker20' - /'Broker20'] [/'Broker21' - /'Broker21'] [/'Broker22' - /'Broker22'] [/'Broker23' - /'Broker23'] [/'Broker24' - /'Broker24'] [/'Broker25' - /'Broker25'] [/'Broker26' - /'Broker26'] [/'Broker27' - /'Broker27'] [/'Broker28' - /'Broker28'] [/'Broker29' - /'Broker29'] [/'Broker3' - /'Broker3'] [/'Broker30' - /'Broker30'] [/'Broker4' - /'Broker4'] [/'Broker5' - /'Broker5'] [/'Broker6' - /'Broker6'] [/'Broker7' - /'Broker7'] [/'Broker8' - /'Broker8'] [/'Broker9' - /'Broker9']; tight)]
       │    │    └── projections
       │    │         └── tr_qty:42 * tr_bid_price:43 [as=column54:54, outer=(42,43), immutable]
       │    └── aggregations


### PR DESCRIPTION
This commit modifies the lookup-join costing logic to increase the per-lookup
cost proportional to the number of spans that will be generated by the
lookup-expr (if there is one). This is necessary because the total number of
lookups performed is equal to the number of input rows times the number of
spans generated per input row (previously only the former was accounted for).

This prevents cases of undercosting, which could cause the optimizer to prefer
a more expensive secondary-index lookup over an efficient primary-index lookup.
The former should only be considered when the selectivity of the index offsets
the cost of any extra lookups that must be performed.

Fixes #79797

Release justification: change to avoid regressions due to new functionality.

Release note (performance improvement): The optimizer is now less likely to
choose an expensive lookup join with a complex `ON` condition over a less
selective join that is cheaper to perform.