### PR TITLE
cmd/generate-logictest: match the template with the output

### DIFF
--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -249,8 +249,8 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "{{ .TestRuleName }}_test",
     size = "enormous",
-    args = ["-test.timeout=3595s"],
     srcs = ["generated_test.go"],
+    args = ["-test.timeout=3595s"],
     data = [
         "//c-deps:libgeos",  # keep{{ if .SqliteLogicTest }}
         "@com_github_cockroachdb_sqllogictest//:testfiles",  # keep{{ end }}{{ if .CclLogicTest }}


### PR DESCRIPTION
This commit fixes spurious diffs that occur with the current version of
`dev` where the timeout argument is added before the source files
although the checked-in code does it in the opposite order.

Release justification: test-only change.

Release note: None