### PR TITLE
colfetcher: improve low memory budget usage of index joins

### DIFF
--- a/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/sqlitelogictestccl/tests/3node-tenant/generated_test.go
@@ -72,8 +72,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -91,8 +91,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/kv/kvclient/kvstreamer/budget.go
+++ b/pkg/kv/kvclient/kvstreamer/budget.go
@@ -90,10 +90,10 @@ func (b *budget) consume(ctx context.Context, bytes int64, allowDebt bool) error
 func (b *budget) consumeLocked(ctx context.Context, bytes int64, allowDebt bool) error {
 	b.mu.AssertHeld()
 	// If we're asked to not exceed the limit (and the limit is greater than
-	// eight bytes - limits of eight bytes or less are treated as a special case
-	// for "forced disk spilling" scenarios like in logic tests), we have to
-	// check whether we'll stay within the budget.
-	if !allowDebt && b.limitBytes > 8 {
+	// twenty bytes - limits of twenty bytes or less are treated as a special
+	// case for "forced disk spilling" scenarios like in logic tests), we have
+	// to check whether we'll stay within the budget.
+	if !allowDebt && b.limitBytes > 20 {
 		if b.mu.acc.Used()+bytes > b.limitBytes {
 			return errors.Wrap(
 				mon.MemoryResource.NewBudgetExceededError(bytes, b.mu.acc.Used(), b.limitBytes),

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -174,7 +174,8 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	acc := rootMemMonitor.MakeBoundAccount()
 	defer acc.Close(ctx)
 
-	getStreamer := func(limitBytes int64) *Streamer {
+	const limitBytes = 30
+	getStreamer := func() *Streamer {
 		acc.Clear(ctx)
 		s := getStreamer(ctx, s, limitBytes, &acc)
 		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
@@ -182,8 +183,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	}
 
 	t.Run("single key exceeds limit", func(t *testing.T) {
-		const limitBytes = 10
-		streamer := getStreamer(limitBytes)
+		streamer := getStreamer()
 		defer streamer.Close(ctx)
 
 		// A single request that exceeds the limit should be allowed.
@@ -193,8 +193,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	})
 
 	t.Run("single key exceeds root pool size", func(t *testing.T) {
-		const limitBytes = 10
-		streamer := getStreamer(limitBytes)
+		streamer := getStreamer()
 		defer streamer.Close(ctx)
 
 		// A single request that exceeds the limit as well as the root SQL pool
@@ -205,8 +204,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	})
 
 	t.Run("multiple keys exceed limit", func(t *testing.T) {
-		const limitBytes = 10
-		streamer := getStreamer(limitBytes)
+		streamer := getStreamer()
 		defer streamer.Close(ctx)
 
 		// Create two requests which exceed the limit when combined.

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -496,10 +496,12 @@ func NewColIndexJoin(
 		if spec.MaintainOrdering && diskMonitor == nil {
 			return nil, errors.AssertionFailedf("diskMonitor is nil when ordering needs to be maintained")
 		}
-		// Keep 1/8th of the memory limit for the output batch of the cFetcher,
-		// and we'll give the remaining memory to the streamer budget below.
-		cFetcherMemoryLimit = int64(math.Ceil(float64(totalMemoryLimit) / 8.0))
-		streamerBudgetLimit := 7 * cFetcherMemoryLimit
+		// Keep 1/16th of the memory limit for the output batch of the cFetcher,
+		// another 1/16th of the limit for the input tuples buffered by the index
+		// joiner, and we'll give the remaining memory to the streamer budget
+		// below.
+		cFetcherMemoryLimit = int64(math.Ceil(float64(totalMemoryLimit) / 16.0))
+		streamerBudgetLimit := 14 * cFetcherMemoryLimit
 		kvFetcher = row.NewStreamingKVFetcher(
 			flowCtx.Cfg.DistSender,
 			flowCtx.Stopper(),

--- a/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-disk/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist-vec-off/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/fakedist/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-legacy-schema-changer/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local-vec-off/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }

--- a/pkg/sql/sqlitelogictest/tests/local/generated_test.go
+++ b/pkg/sql/sqlitelogictest/tests/local/generated_test.go
@@ -71,8 +71,6 @@ func runSqliteLogicTest(t *testing.T, file string) {
 	// limit than other logic tests get.
 	serverArgs := logictest.TestServerArgs{
 		MaxSQLMemoryLimit: 512 << 20, // 512 MiB
-		// TODO(yuzefovich): remove this once the flake in #84022 is fixed.
-		DisableWorkmemRandomization: true,
 	}
 	logictest.RunLogicTest(t, serverArgs, configIdx, filepath.Join(sqliteLogicTestDir, file))
 }


### PR DESCRIPTION
This commit improves the way memory budget is utilized by the index
joins when the streamer API is used when that budget is low (presumably
in the test environment). Previously, we would give 1/8th of the limit
to the output batch, 7/8th to the streamer, and another 1/8th to the
buffered input rows. Obviously, this was wrong since we gave out 9/8th
of the budget, but also since we added more memory accounting in the
streamer, the factor of 7 of the streamer budget in comparison to the
buffered input rows might be insufficient (i.e. we would construct
lookup spans, but then the streamer would exceed its budget in `Enqueue`
due to the footprint of the keys plus the overhead of the `roachpb.Span`
objects). In order to improve things here we now divide the memory limit
as 1/16th to the output batch, 1/16 to the buffered input rows, and the
remaining 14/16th to the streamer. This change seems safe since it would
only take effect when the `distsql_workmem` is artificially low.

Fixes: #84022.

Release justification: low-risk fix.

Release note: None