### PR TITLE
storage: tighten `MVCCDeleteRangeUsingTombstone` key span checks

### DIFF
--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -482,6 +482,7 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 	defer eng.Close()
 
 	rng, _ := randutil.NewTestRand()
+	localMax, maxKey := keys.LocalMax, keys.MaxKey
 
 	var keys []roachpb.Key
 	fillDataForStats := func(rw storage.ReadWriter, keyCount, valCount int) (enginepb.MVCCStats, hlc.Timestamp) {
@@ -505,7 +506,7 @@ func TestFullRangeDeleteHeuristic(t *testing.T) {
 
 	deleteWithTombstone := func(rw storage.ReadWriter, delTime hlc.Timestamp, ms *enginepb.MVCCStats) {
 		require.NoError(t, storage.MVCCDeleteRangeUsingTombstone(
-			ctx, rw, ms, []byte{0}, []byte{0xff}, delTime, hlc.ClockTimestamp{}, nil, nil, false, 1, nil))
+			ctx, rw, ms, localMax, maxKey, delTime, hlc.ClockTimestamp{}, nil, nil, false, 1, nil))
 	}
 	deleteWithPoints := func(rw storage.ReadWriter, delTime hlc.Timestamp, ms *enginepb.MVCCStats) {
 		for _, key := range keys {

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -169,7 +169,7 @@ var intentInterleavingIterPool = sync.Pool{
 }
 
 func isLocal(k roachpb.Key) bool {
-	return len(k) == 0 || keys.IsLocal(k)
+	return k.Compare(keys.LocalMax) < 0
 }
 
 func newIntentInterleavingIterator(reader Reader, opts IterOptions) MVCCIterator {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -3187,7 +3187,7 @@ func MVCCDeleteRangeUsingTombstone(
 
 	// We currently don't allow MVCC range tombstones across the local keyspace,
 	// to be safe. This wouldn't handle MVCC stats (SysBytes) correctly either.
-	if keys.IsLocal(startKey) || keys.IsLocal(endKey) {
+	if startKey.Compare(keys.LocalMax) < 0 {
 		return errors.AssertionFailedf("can't write MVCC range tombstone across local keyspan %s",
 			rangeKey)
 	}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1099,8 +1099,9 @@ func cmdDeleteRangeTombstone(e *evalCtx) error {
 	var msCovered *enginepb.MVCCStats
 	if cmdDeleteRangeTombstoneKnownStats && !e.hasArg("noCoveredStats") {
 		// Some tests will submit invalid MVCC range keys, where e.g. the end key is
-		// before the start key -- ignore them to avoid iterator panics.
-		if key.Compare(endKey) < 0 {
+		// before the start key -- don't attempt to compute covered stats for these
+		// to avoid iterator panics.
+		if key.Compare(endKey) < 0 && key.Compare(keys.LocalMax) >= 0 {
 			ms, err := ComputeStats(e.engine, key, endKey, ts.WallTime)
 			if err != nil {
 				return err

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -418,7 +418,7 @@ meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline me
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 
-# Writing across the local keyspace should error.
+# Writing across the local keyspace should error, as should writing from \x00.
 run error
 del_range_ts k=%a end=%b ts=1
 ----
@@ -439,3 +439,24 @@ meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline me
 meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 error: (*assert.withAssertionFailure:) can't write MVCC range tombstone across local keyspan /Local/Range/"{a"-b"}/1.000000000,0
+
+run error
+del_range_ts k=+ end=z ts=1
+----
+>> at end:
+rangekey: {a-b}/[10.000000000,0=/<empty>]
+rangekey: {b-d}/[4.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+meta: "d"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "d"/7.000000000,0 -> /BYTES/d7
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+meta: "h"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
+meta: "i"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+error: (*assert.withAssertionFailure:) can't write MVCC range tombstone across local keyspan {\x00-z}/1.000000000,0


### PR DESCRIPTION
**storage: tighten `MVCCDeleteRangeUsingTombstone` key span checks**

We've previously disallowed writing MVCC range tombstones across local
keyspace. However, this check used `keys.IsLocal()`, which simply checks
whether the key has the local prefix (`\x01`), so it was possible for
callers to use e.g. `\x00` as a start key and span the local keyspace
anyway.

This patch changes the check to ensure the start key is at or after
`keys.LocalMax`.

Release justification: bug fixes and low-risk updates to new functionality

Release note: None

**storage: fix `intentInterleavingIter` local key detection**

`intentInterleavingIter` will error if given bounds that span from the
local to the global keyspace. However, it only checked whether the start
key satisfied `keys.IsLocal()`, i.e. that the key began with `\x01`.
This meant that it was possible to give a start key with a `\x00` prefix
that spanned across the local and global keyspaces, without triggering
the error. This could cause the iterator to be incorrectly positioned in
the lock table keyspace.

This patch fixes the check by comparing the start key with
`keys.LocalMax` instead. This does not appear to have a measurable
impact on performance:

```
name                                                                old time/op    new time/op    delta
MVCCGet_Pebble/batch=true/versions=1/valueSize=8/numRangeKeys=0-24    2.39µs ± 1%    2.39µs ± 1%   ~     (p=0.810 n=10+10)
```

Resolves #87489.

Release justification: low risk, high benefit changes to existing functionality
Release note: None