### PR TITLE
storage: gc range tombstone - fix mvcc stat update on merge

### DIFF
--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5132,6 +5132,11 @@ func MVCCGarbageCollectRangeKeys(
 
 			// If there's nothing to GC, keep moving.
 			if !rangeKeys.Oldest().LessEq(gcKey.Timestamp) {
+				// Even if we don't GC anything for this range fragment, we might have
+				// changed previous and it might become mergable as a result.
+				if ms != nil && lhs.CanMergeRight(rangeKeys) {
+					ms.Add(updateStatsOnRangeKeyMerge(rangeKeys.Bounds.Key, rangeKeys.Versions))
+				}
 				rangeKeys.CloneInto(&lhs)
 				continue
 			}


### PR DESCRIPTION
Previously if range tombstone fragment was not eligible for GC
it was not checked if it can merge with previous range tombstone
fragments stack. This was causing MVCC stats discrepancy.
This commit adds a check merge eligibility check for skipped
fragments.

Release justification: bugfix for upcoming functionality
Release note: None

Fixes: #87406