### PR TITLE
sql/schemachanger: add creation time to indexes

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_index
@@ -24,6 +24,7 @@ upsert descriptor #104
   +  mutations:
   +  - direction: ADD
   +    index:
+  +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -261,7 +262,8 @@ upsert descriptor #104
   -  modificationTime:
   -    wallTime: "1640995200000000008"
   +  indexes:
-  +  - createdExplicitly: true
+  +  - createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
   +    id: 2
@@ -294,6 +296,7 @@ upsert descriptor #104
   -  - direction: ADD
   +  - direction: DROP
        index:
+  -      createdAtNanos: "1640998800000000000"
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -91,6 +91,9 @@ func addNewIndexMutation(
 		UseDeletePreservingEncoding: isDeletePreserving,
 		StoreColumnNames:            []string{},
 	}
+	if isSecondary && !isDeletePreserving {
+		idx.CreatedAtNanos = m.clock.ApproximateTime().UnixNano()
+	}
 	if opIndex.Sharding != nil {
 		idx.Sharded = *opIndex.Sharding
 	}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla
@@ -78,6 +78,7 @@ upsert descriptor #104
   +  - direction: ADD
   +    index:
   +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -327,6 +328,7 @@ upsert descriptor #104
   -    wallTime: "1640995200000000008"
   +  indexes:
   +  - constraintId: 4
+  +    createdAtNanos: "1640998800000000000"
   +    createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
@@ -388,6 +390,7 @@ upsert descriptor #104
   +  - direction: DROP
        index:
   -      constraintId: 4
+  -      createdAtNanos: "1640998800000000000"
   +      constraintId: 5
          createdExplicitly: true
          foreignKey: {}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_index
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_index
@@ -24,6 +24,7 @@ upsert descriptor #106
   +  mutations:
   +  - direction: ADD
   +    index:
+  +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -239,7 +240,8 @@ upsert descriptor #106
   -  modificationTime:
   -    wallTime: "1640995200000000008"
   +  indexes:
-  +  - createdExplicitly: true
+  +  - createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
   +    id: 2
@@ -262,6 +264,7 @@ upsert descriptor #106
   -  - direction: ADD
   +  - direction: DROP
        index:
+  -      createdAtNanos: "1640998800000000000"
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements
@@ -449,6 +449,7 @@ upsert descriptor #104
   +  - direction: ADD
   +    index:
   +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -662,6 +663,7 @@ upsert descriptor #104
   -    wallTime: "1640995200000000016"
   +  indexes:
   +  - constraintId: 4
+  +    createdAtNanos: "1640998800000000000"
   +    createdExplicitly: true
   +    foreignKey: {}
   +    geoConfig: {}
@@ -723,7 +725,8 @@ upsert descriptor #104
   +  - direction: DROP
        index:
          constraintId: 4
-  ...
+  -      createdAtNanos: "1640998800000000000"
+         createdExplicitly: true
          foreignKey: {}
          geoConfig: {}
   -      id: 5


### PR DESCRIPTION
This fixes a gap in the declarative schema changer whereby it did not
previously populate the `CreatedAtNanos` field of new secondary indexes. The
declarative schema changer is not used to create many secondary indexes, so it
was not a huge deal, but, nevertheless, the oversight has been fixed.

Fixes #86196

Release justification: Low risk change to new functionality

Release note: None