### PR TITLE
backupccl: add mutex to TestReintroduceOfflineSpans

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -922,10 +923,13 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 	restoreBlockEntiresThreshold := 4
 	entriesCount := 0
 	params := base.TestClusterArgs{}
+	var mu syncutil.Mutex
 	knobs := base.TestingKnobs{
 		DistSQL: &execinfra.TestingKnobs{
 			BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
 				RunAfterProcessingRestoreSpanEntry: func(_ context.Context) {
+					mu.Lock()
+					defer mu.Unlock()
 					if entriesCount == 0 {
 						close(dbRestoreStarted)
 					}


### PR DESCRIPTION
We saw one instance of a close of closed channel - https://teamcity.cockroachdb.com/viewLog.html?buildId=6352806&buildTypeId=Cockroach_BazelEssentialCi
This is not reproducible but its likely because concurrent
restore data workers processed restore span entries concurrently.
This change wraps the variables in a mutex.

Release note: None

Release justification: test only change