### PR TITLE
ci: do not run `ui-test` as part of non-Bazel CI suite

### DIFF
--- a/build/teamcity-check-genfiles.sh
+++ b/build/teamcity-check-genfiles.sh
@@ -52,10 +52,3 @@ cd ..
 
 end_check_generated_code_tests
 tc_end_block "Ensure dependencies are up-to-date"
-
-tc_start_block "Test web UI"
-# Run the UI tests. This logically belongs in teamcity-test.sh, but we do it
-# here to minimize total build time since this build has already generated the
-# UI.
-run build/builder.sh make -C pkg/ui
-tc_end_block "Test web UI"


### PR DESCRIPTION
This is broken due to an apparent race condition/non-determinism.
We have coverage of the same tests in Bazel CI so we can just skip this.

Release justification: Non-production code changes
Release note: None