### PR TITLE
dev: if specified, dev generate bazel before other targets

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=54
+DEV_VERSION=55
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/generate.go
+++ b/pkg/cmd/dev/generate.go
@@ -95,6 +95,13 @@ func (d *dev) generate(cmd *cobra.Command, targets []string) error {
 	for _, target := range targets {
 		targetsMap[target] = struct{}{}
 	}
+	// NB: We have to run the bazel generator first if it's specified.
+	if _, ok := targetsMap["bazel"]; ok {
+		delete(targetsMap, "bazel")
+		if err := generatorTargetMapping["bazel"](cmd); err != nil {
+			return err
+		}
+	}
 	{
 		// In this case, generating both go and cgo would duplicate work.
 		// Generate go_nocgo instead.


### PR DESCRIPTION
The results of this generation can impact most of the other generation
targets, so it should be done first.

Release justification: Non-production code changes
Release note: None