### PR TITLE
sql: disable agg funcs in costfuzz and unoptimized query oracle

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -182,6 +182,9 @@ func runOneRoundQueryComparison(
 		sqlsmith.UnlikelyRandomNulls(), sqlsmith.DisableCrossJoins(),
 		sqlsmith.DisableIndexHints(), sqlsmith.DisableWith(),
 		sqlsmith.LowProbabilityWhereClauseWithJoinTables(),
+		// TODO(mgartner): Re-enable aggregate functions when we can guarantee
+		// they are deterministic.
+		sqlsmith.DisableAggregateFuncs(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),
 	)

--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -61,6 +61,7 @@ var (
 		"DisableLimits":                           sqlsmith.DisableLimits(),
 		"AvoidConsts":                             sqlsmith.AvoidConsts(),
 		"DisableWindowFuncs":                      sqlsmith.DisableWindowFuncs(),
+		"DisableAggregateFuncs":                   sqlsmith.DisableAggregateFuncs(),
 		"OutputSort":                              sqlsmith.OutputSort(),
 		"UnlikelyConstantPredicate":               sqlsmith.UnlikelyConstantPredicate(),
 		"FavorCommonData":                         sqlsmith.FavorCommonData(),

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -437,6 +437,10 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		return nil, false
 	}
 
+	if fn.def.Class == tree.AggregateClass && s.disableAggregateFuncs {
+		return nil, false
+	}
+
 	var window *tree.WindowDef
 	// Use a window function if:
 	// - we chose an aggregate function, then 1/6 chance, but not if we're in a HAVING (noWindow == true)

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -82,6 +82,7 @@ type Smither struct {
 	disableNondeterministicFns bool
 	disableLimits              bool
 	disableWindowFuncs         bool
+	disableAggregateFuncs      bool
 	simpleDatums               bool
 	avoidConsts                bool
 	outputSort                 bool
@@ -376,6 +377,11 @@ var AvoidConsts = simpleOption("avoid consts", func(s *Smither) {
 // DisableWindowFuncs disables window functions.
 var DisableWindowFuncs = simpleOption("disable window funcs", func(s *Smither) {
 	s.disableWindowFuncs = true
+})
+
+// DisableAggregateFuncs disables window functions.
+var DisableAggregateFuncs = simpleOption("disable aggregate funcs", func(s *Smither) {
+	s.disableAggregateFuncs = true
 })
 
 // OutputSort adds a top-level ORDER BY on all columns.


### PR DESCRIPTION
The false-positives of costfuzz and unoptimized-query-oracle caused by
aggregate functions are overwhelming. This commit prevents aggregate
functions from being generated for these tests.

Informs #87353

Release justification: This is a test-only change.

Release note: None