### PR TITLE
server: mark testDrainContext assertion methods as test helpers

### DIFF
--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -246,18 +246,21 @@ func (t *testDrainContext) sendShutdown() *serverpb.DrainResponse {
 }
 
 func (t *testDrainContext) assertDraining(resp *serverpb.DrainResponse, drain bool) {
+	t.Helper()
 	if resp.IsDraining != drain {
 		t.Fatalf("expected draining %v, got %v", drain, resp.IsDraining)
 	}
 }
 
 func (t *testDrainContext) assertRemaining(resp *serverpb.DrainResponse, remaining bool) {
+	t.Helper()
 	if actualRemaining := (resp.DrainRemainingIndicator > 0); remaining != actualRemaining {
 		t.Fatalf("expected remaining %v, got %v", remaining, actualRemaining)
 	}
 }
 
 func (t *testDrainContext) assertEqual(expected int, actual int) {
+	t.Helper()
 	if expected == actual {
 		return
 	}


### PR DESCRIPTION
The error messages in cases like #86974 are not useful otherwise. This change allows us to see where the assertion method was called from.

Release justification: testing only.