### PR TITLE
release-22.1: admin: tenant support jobs endpoints

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -34,6 +34,7 @@ ALL_TESTS = [
     "//pkg/ccl/oidcccl:oidcccl_test",
     "//pkg/ccl/partitionccl:partitionccl_test",
     "//pkg/ccl/schemachangerccl:schemachangerccl_test",
+    "//pkg/ccl/serverccl/adminccl:adminccl_test",
     "//pkg/ccl/serverccl/diagnosticsccl:diagnosticsccl_test",
     "//pkg/ccl/serverccl/statusccl:statusccl_test",
     "//pkg/ccl/serverccl:serverccl_test",

--- a/pkg/ccl/serverccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/BUILD.bazel
@@ -2,9 +2,29 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "serverccl",
-    srcs = ["doc.go"],
+    srcs = [
+        "doc.go",
+        "tenant_test_utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/serverccl",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/base",
+        "//pkg/roachpb",
+        "//pkg/rpc",
+        "//pkg/security",
+        "//pkg/server/serverpb",
+        "//pkg/sql",
+        "//pkg/sql/contention",
+        "//pkg/sql/pgwire",
+        "//pkg/sql/sqlstats/persistedsqlstats",
+        "//pkg/sql/tests",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/sqlutils",
+        "//pkg/util/httputil",
+        "//pkg/util/protoutil",
+        "@com_github_stretchr_testify//require",
+    ],
 )
 
 go_test(

--- a/pkg/ccl/serverccl/adminccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/adminccl/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "adminccl_test",
+    srcs = [
+        "main_test.go",
+        "tenant_admin_test.go",
+    ],
+    deps = [
+        "//pkg/ccl",
+        "//pkg/ccl/serverccl",
+        "//pkg/ccl/utilccl",
+        "//pkg/security",
+        "//pkg/security/securitytest",
+        "//pkg/server",
+        "//pkg/server/serverpb",
+        "//pkg/spanconfig",
+        "//pkg/sql/tests",
+        "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
+        "//pkg/testutils/testcluster",
+        "//pkg/util/leaktest",
+        "//pkg/util/log",
+        "//pkg/util/randutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/ccl/serverccl/adminccl/main_test.go
+++ b/pkg/ccl/serverccl/adminccl/main_test.go
@@ -1,0 +1,34 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package adminccl
+
+import (
+	"os"
+	"testing"
+
+	_ "github.com/cockroachdb/cockroach/pkg/ccl"
+	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
+	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func TestMain(m *testing.M) {
+	defer utilccl.TestingEnableEnterprise()()
+	security.SetAssetLoader(securitytest.EmbeddedAssets)
+	randutil.SeedForTests()
+	serverutils.InitTestServerFactory(server.TestServerFactory)
+	serverutils.InitTestClusterFactory(testcluster.TestClusterFactory)
+	os.Exit(m.Run())
+}
+
+//go:generate ../../../util/leaktest/add-leaktest.sh *_test.go

--- a/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
+++ b/pkg/ccl/serverccl/adminccl/tenant_admin_test.go
@@ -1,0 +1,65 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package adminccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/serverccl"
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
+	"github.com/cockroachdb/cockroach/pkg/sql/tests"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTenantAdminAPI(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// The liveness session might expire before the stress race can finish.
+	skip.UnderStressRace(t, "expensive tests")
+
+	ctx := context.Background()
+
+	knobs := tests.CreateTestingKnobs()
+	knobs.SpanConfig = &spanconfig.TestingKnobs{
+		// Some of these subtests expect multiple (uncoalesced) tenant ranges.
+		StoreDisableCoalesceAdjacent: true,
+	}
+
+	testHelper := serverccl.NewTestTenantHelper(t, 3 /* tenantClusterSize */, knobs)
+	defer testHelper.Cleanup(ctx, t)
+
+	t.Run("tenant_jobs", func(t *testing.T) {
+		testJobsRPCs(ctx, t, testHelper)
+	})
+}
+
+func testJobsRPCs(ctx context.Context, t *testing.T, helper serverccl.TenantTestHelper) {
+	http := helper.TestCluster().TenantAdminHTTPClient(t, 1)
+	defer http.Close()
+
+	_ = helper.TestCluster().TenantConn(1).Exec(t, "CREATE TABLE test (id INT)")
+	_ = helper.TestCluster().TenantConn(1).Exec(t, "ALTER TABLE test ADD COLUMN name STRING")
+
+	jobsResp := serverpb.JobsResponse{}
+	http.GetJSON("/_admin/v1/jobs", &jobsResp)
+	require.NotEmpty(t, jobsResp.Jobs)
+
+	jobResp := serverpb.JobResponse{}
+	job := jobsResp.Jobs[0]
+	http.GetJSON(fmt.Sprintf("/_admin/v1/jobs/%d", job.ID), &jobResp)
+
+	require.Equal(t, jobResp.ID, job.ID)
+}

--- a/pkg/ccl/serverccl/statusccl/BUILD.bazel
+++ b/pkg/ccl/serverccl/statusccl/BUILD.bazel
@@ -1,27 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
-
-go_library(
-    name = "statusccl",
-    srcs = ["tenant_test_utils.go"],
-    importpath = "github.com/cockroachdb/cockroach/pkg/ccl/serverccl/statusccl",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/base",
-        "//pkg/roachpb",
-        "//pkg/security",
-        "//pkg/server/serverpb",
-        "//pkg/sql",
-        "//pkg/sql/contention",
-        "//pkg/sql/pgwire",
-        "//pkg/sql/sqlstats/persistedsqlstats",
-        "//pkg/sql/tests",
-        "//pkg/testutils/serverutils",
-        "//pkg/testutils/sqlutils",
-        "//pkg/util/httputil",
-        "//pkg/util/protoutil",
-        "@com_github_stretchr_testify//require",
-    ],
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "statusccl_test",
@@ -30,11 +7,11 @@ go_test(
         "tenant_grpc_test.go",
         "tenant_status_test.go",
     ],
-    embed = [":statusccl"],
     deps = [
         "//pkg/base",
         "//pkg/ccl",
         "//pkg/ccl/kvccl",
+        "//pkg/ccl/serverccl",
         "//pkg/ccl/utilccl",
         "//pkg/keys",
         "//pkg/roachpb",

--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -6,7 +6,7 @@
 //
 //     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
 
-package statusccl
+package serverccl
 
 import (
 	"context"
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -36,7 +37,9 @@ import (
 // a server from the test cluster.
 type serverIdx int
 
-const randomServer serverIdx = -1
+// RandomServer is a magic value, that when passed to the Tenant() method of
+// TenantClusterHelper picks a random tenant.
+const RandomServer serverIdx = -1
 
 type testTenant struct {
 	tenant                   serverutils.TestTenantInterface
@@ -47,13 +50,55 @@ type testTenant struct {
 	tenantContentionRegistry *contention.Registry
 }
 
+func (h *testTenant) GetRPCContext() *rpc.Context {
+	return h.tenant.RPCContext()
+}
+
+func (h *testTenant) GetTenantConn() *sqlutils.SQLRunner {
+	return h.tenantDB
+}
+
+func (h *testTenant) TenantSQLStats() *persistedsqlstats.PersistedSQLStats {
+	return h.tenantSQLStats
+}
+
+func (h *testTenant) TenantStatusSrv() serverpb.SQLStatusServer {
+	return h.tenantStatus
+}
+
+func (h *testTenant) TenantContentionRegistry() *contention.Registry {
+	return h.tenantContentionRegistry
+}
+
+func (h *testTenant) GetTenant() serverutils.TestTenantInterface {
+	return h.tenant
+}
+
+func (h *testTenant) GetTenantDB() *gosql.DB {
+	return h.tenantConn
+}
+
+// TestTenant exposes an interface for testing an individual tenant
+type TestTenant interface {
+	GetTenant() serverutils.TestTenantInterface
+	GetTenantDB() *gosql.DB
+	GetTenantConn() *sqlutils.SQLRunner
+	TenantSQLStats() *persistedsqlstats.PersistedSQLStats
+	TenantStatusSrv() serverpb.SQLStatusServer
+	TenantContentionRegistry() *contention.Registry
+	GetRPCContext() *rpc.Context
+	Cleanup(t *testing.T)
+}
+
+var _ TestTenant = &testTenant{}
+
 func newTestTenant(
 	t *testing.T,
 	server serverutils.TestServerInterface,
 	existing bool,
 	tenantID roachpb.TenantID,
 	knobs base.TestingKnobs,
-) *testTenant {
+) TestTenant {
 	t.Helper()
 
 	tenantParams := tests.CreateTestTenantParams(tenantID)
@@ -77,7 +122,7 @@ func newTestTenant(
 	}
 }
 
-func (h *testTenant) cleanup(t *testing.T) {
+func (h *testTenant) Cleanup(t *testing.T) {
 	require.NoError(t, h.tenantConn.Close())
 }
 
@@ -86,13 +131,26 @@ type tenantTestHelper struct {
 
 	// Creating two separate tenant clusters. This allows unit tests to test
 	// the isolation between different tenants are properly enforced.
-	tenantTestCluster    tenantCluster
-	tenantControlCluster tenantCluster
+	tenantTestCluster    TenantClusterHelper
+	tenantControlCluster TenantClusterHelper
 }
 
-func newTestTenantHelper(
+// TenantTestHelper is an interface that provides a helpful structure for tests
+// involving a tenant where we have a test target tenant and a separate control
+// tenant operating on the same host.
+type TenantTestHelper interface {
+	TestCluster() TenantClusterHelper
+	ControlCluster() TenantClusterHelper
+	HostCluster() serverutils.TestClusterInterface
+	Cleanup(ctx context.Context, t *testing.T)
+}
+
+var _ TenantTestHelper = &tenantTestHelper{}
+
+// NewTestTenantHelper constructs a TenantTestHelper instance.
+func NewTestTenantHelper(
 	t *testing.T, tenantClusterSize int, knobs base.TestingKnobs,
-) *tenantTestHelper {
+) TenantTestHelper {
 	t.Helper()
 
 	params, _ := tests.CreateTestServerParams()
@@ -104,7 +162,7 @@ func newTestTenantHelper(
 
 	return &tenantTestHelper{
 		hostCluster: testCluster,
-		tenantTestCluster: newTenantCluster(
+		tenantTestCluster: newTenantClusterHelper(
 			t,
 			server,
 			tenantClusterSize,
@@ -113,7 +171,7 @@ func newTestTenantHelper(
 		),
 		// Spin up a small tenant cluster under a different tenant ID to test
 		// tenant isolation.
-		tenantControlCluster: newTenantCluster(
+		tenantControlCluster: newTenantClusterHelper(
 			t,
 			server,
 			1, /* tenantClusterSize */
@@ -123,33 +181,53 @@ func newTestTenantHelper(
 	}
 }
 
-func (h *tenantTestHelper) testCluster() tenantCluster {
+func (h *tenantTestHelper) HostCluster() serverutils.TestClusterInterface {
+	return h.hostCluster
+}
+
+func (h *tenantTestHelper) TestCluster() TenantClusterHelper {
 	return h.tenantTestCluster
 }
 
-func (h *tenantTestHelper) controlCluster() tenantCluster {
+func (h *tenantTestHelper) ControlCluster() TenantClusterHelper {
 	return h.tenantControlCluster
 }
 
-func (h *tenantTestHelper) cleanup(ctx context.Context, t *testing.T) {
+func (h *tenantTestHelper) Cleanup(ctx context.Context, t *testing.T) {
 	t.Helper()
 	h.hostCluster.Stopper().Stop(ctx)
-	h.tenantTestCluster.cleanup(t)
-	h.tenantControlCluster.cleanup(t)
+	h.tenantTestCluster.Cleanup(t)
+	h.tenantControlCluster.Cleanup(t)
 }
 
-type tenantCluster []*testTenant
+type tenantCluster []TestTenant
 
-func newTenantCluster(
+// TenantClusterHelper is an interface that provides access to a set of tenants
+// on a host cluster under test.
+type TenantClusterHelper interface {
+	Tenant(idx serverIdx) TestTenant
+	TenantConn(idx serverIdx) *sqlutils.SQLRunner
+	TenantDB(idx serverIdx) *gosql.DB
+	TenantHTTPClient(t *testing.T, idx serverIdx, isAdmin bool) *httpClient
+	TenantAdminHTTPClient(t *testing.T, idx serverIdx) *httpClient
+	TenantSQLStats(idx serverIdx) *persistedsqlstats.PersistedSQLStats
+	TenantStatusSrv(idx serverIdx) serverpb.SQLStatusServer
+	TenantContentionRegistry(idx serverIdx) *contention.Registry
+	Cleanup(t *testing.T)
+}
+
+var _ TenantClusterHelper = tenantCluster{}
+
+func newTenantClusterHelper(
 	t *testing.T,
 	server serverutils.TestServerInterface,
 	tenantClusterSize int,
 	tenantID uint64,
 	knobs base.TestingKnobs,
-) tenantCluster {
+) TenantClusterHelper {
 	t.Helper()
 
-	cluster := make([]*testTenant, tenantClusterSize)
+	var cluster tenantCluster = make([]TestTenant, tenantClusterSize)
 	existing := false
 	for i := 0; i < tenantClusterSize; i++ {
 		cluster[i] =
@@ -160,42 +238,52 @@ func newTenantCluster(
 	return cluster
 }
 
-func (c tenantCluster) tenantConn(idx serverIdx) *sqlutils.SQLRunner {
-	return c.tenant(idx).tenantDB
+func (c tenantCluster) TenantDB(idx serverIdx) *gosql.DB {
+	return c.Tenant(idx).GetTenantDB()
 }
 
-func (c tenantCluster) tenantHTTPClient(t *testing.T, idx serverIdx, isAdmin bool) *httpClient {
-	client, err := c.tenant(idx).tenant.GetAuthenticatedHTTPClient(isAdmin)
+func (c tenantCluster) TenantConn(idx serverIdx) *sqlutils.SQLRunner {
+	return c.Tenant(idx).GetTenantConn()
+}
+
+func (c tenantCluster) TenantHTTPClient(t *testing.T, idx serverIdx, isAdmin bool) *httpClient {
+	var client http.Client
+	var err error
+	if isAdmin {
+		client, err = c.Tenant(idx).GetTenant().GetAdminAuthenticatedHTTPClient()
+	} else {
+		client, err = c.Tenant(idx).GetTenant().GetAuthenticatedHTTPClient(false)
+	}
 	require.NoError(t, err)
-	return &httpClient{t: t, client: client, baseURL: c[idx].tenant.AdminURL()}
+	return &httpClient{t: t, client: client, baseURL: c[idx].GetTenant().AdminURL()}
 }
 
-func (c tenantCluster) tenantAdminHTTPClient(t *testing.T, idx serverIdx) *httpClient {
-	return c.tenantHTTPClient(t, idx, true /* isAdmin */)
+func (c tenantCluster) TenantAdminHTTPClient(t *testing.T, idx serverIdx) *httpClient {
+	return c.TenantHTTPClient(t, idx, true /* isAdmin */)
 }
 
-func (c tenantCluster) tenantSQLStats(idx serverIdx) *persistedsqlstats.PersistedSQLStats {
-	return c.tenant(idx).tenantSQLStats
+func (c tenantCluster) TenantSQLStats(idx serverIdx) *persistedsqlstats.PersistedSQLStats {
+	return c.Tenant(idx).TenantSQLStats()
 }
 
-func (c tenantCluster) tenantStatusSrv(idx serverIdx) serverpb.SQLStatusServer {
-	return c.tenant(idx).tenantStatus
+func (c tenantCluster) TenantStatusSrv(idx serverIdx) serverpb.SQLStatusServer {
+	return c.Tenant(idx).TenantStatusSrv()
 }
 
-func (c tenantCluster) tenantContentionRegistry(idx serverIdx) *contention.Registry {
-	return c.tenant(idx).tenantContentionRegistry
+func (c tenantCluster) TenantContentionRegistry(idx serverIdx) *contention.Registry {
+	return c.Tenant(idx).TenantContentionRegistry()
 }
 
-func (c tenantCluster) cleanup(t *testing.T) {
+func (c tenantCluster) Cleanup(t *testing.T) {
 	for _, tenant := range c {
-		tenant.cleanup(t)
+		tenant.Cleanup(t)
 	}
 }
 
-// tenant selects a tenant node from the tenant cluster. If randomServer
+// Tenant selects a tenant node from the tenant cluster. If randomServer
 // is passed in, then a random node is selected.
-func (c tenantCluster) tenant(idx serverIdx) *testTenant {
-	if idx == randomServer {
+func (c tenantCluster) Tenant(idx serverIdx) TestTenant {
+	if idx == RandomServer {
 		return c[rand.Intn(len(c))]
 	}
 

--- a/pkg/server/tenant_admin.go
+++ b/pkg/server/tenant_admin.go
@@ -148,3 +148,41 @@ func (t *tenantAdminServer) Drain(
 
 	return t.drain.handleDrain(ctx, req, stream)
 }
+
+func (t *tenantAdminServer) Jobs(
+	ctx context.Context, req *serverpb.JobsRequest,
+) (_ *serverpb.JobsResponse, retErr error) {
+	ctx = t.AnnotateCtx(ctx)
+
+	userName, err := userFromContext(ctx)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+
+	j, err := jobsHelper(
+		ctx,
+		req,
+		userName,
+		t.sqlServer,
+	)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return j, nil
+}
+
+func (t *tenantAdminServer) Job(
+	ctx context.Context, request *serverpb.JobRequest,
+) (_ *serverpb.JobResponse, retErr error) {
+	ctx = t.AnnotateCtx(ctx)
+
+	userName, err := userFromContext(ctx)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	r, err := jobHelper(ctx, request, userName, t.sqlServer)
+	if err != nil {
+		return nil, serverError(ctx, err)
+	}
+	return r, nil
+}


### PR DESCRIPTION
Release note: None

Release justification: non-production code changeBackport 2/2 commits from #84620.

/cc @cockroachdb/release

---

Previously, the Job() and Jobs() endpoints were not implemented on the
tenant admin server as there was not a need and we had split the
implementation into a tenant-only server.

Now that we want to ship the jobs page into CC Console and support it
for multi-tenant, the endpoints for the UI should work as expected.

This PR edits the `jobHelper` and `jobsHelper` helpers to be functions
instead of methods in `adminServer` which allows the implementation to
be shared between the two servers.

Fixes #84621.

Release note: None

Release justification: low risk, high benefit addition to multi-tenant
