### PR TITLE
builtins: add pg_get_functiondef

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3441,6 +3441,12 @@ A write probe will effectively probe reads as well.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_column_size"></a><code>pg_column_size(anyelement...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Return size in bytes of the column provided as an argument</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="pg_get_function_identity_arguments"></a><code>pg_get_function_identity_arguments(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the argument list (without defaults) necessary to identify a function, in the form it would need to appear in within ALTER FUNCTION, for instance.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_function_result"></a><code>pg_get_function_result(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the types of the result of the specified function.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="pg_get_functiondef"></a><code>pg_get_functiondef(func_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>For user-defined functions, returns the definition of the specified function. For builtin functions, returns the name of the function.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_serial_sequence"></a><code>pg_get_serial_sequence(table_name: <a href="string.html">string</a>, column_name: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the name of the sequence used by the given column_name in the table table_name.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="pg_get_viewdef"></a><code>pg_get_viewdef(view_oid: oid) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns the CREATE statement for an existing view.</p>

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4663,7 +4663,7 @@ FROM pg_proc p
 JOIN pg_type t ON t.typinput = p.oid
 WHERE t.typname = '_int4'
 ----
-2017  array_in  array_in
+2018  array_in  array_in
 
 ## #16285
 ## int2vectors should be 0-indexed
@@ -4701,7 +4701,7 @@ SELECT cur_max_builtin_oid FROM [SELECT max(oid) as cur_max_builtin_oid FROM pg_
 query TT
 SELECT proname, oid FROM pg_catalog.pg_proc WHERE oid = $cur_max_builtin_oid
 ----
-to_regtype  2037
+to_regtype  2038
 
 ## Ensure that unnest works with oid wrapper arrays
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1522,6 +1522,36 @@ CREATE FUNCTION int_identity_v(i INT) RETURNS INT VOLATILE LANGUAGE SQL AS $$
 SELECT i;
 $$;
 
+query T
+SELECT pg_get_functiondef('get_l'::regproc::oid)
+----
+CREATE FUNCTION public.get_l(IN i INT8)
+    RETURNS INT8
+    IMMUTABLE
+    LEAKPROOF
+    CALLED ON NULL INPUT
+    LANGUAGE SQL
+    AS $$
+    SELECT v FROM test.public.kv WHERE k = i;
+$$
+
+query T
+SELECT pg_get_functiondef(NULL)
+----
+NULL
+
+query T
+SELECT pg_get_functiondef(123456)
+----
+NULL
+
+# Postgres behaves differently for builtin functions, but we don't yet support
+# the syntax for defining non-SQL functions.
+query T
+SELECT pg_get_functiondef('soundex'::regproc::oid)
+----
+soundex
+
 # Only the volatile functions should see the changes made by the UPDATE in the
 # CTE.
 query IIIIIIII colnames

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
@@ -639,11 +640,48 @@ var pgBuiltins = map[string]builtinDefinition{
 		},
 	),
 
-	// pg_get_function_result returns the types of the result of an builtin
+	"pg_get_functiondef": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.Overload{
+			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
+			ReturnType: tree.FixedReturnType(types.String),
+			Fn: func(ctx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				idToQuery := catid.DescID(tree.MustBeDOid(args[0]).Oid)
+				getFuncQuery := `SELECT prosrc FROM pg_proc WHERE oid=$1`
+				if catid.IsOIDUserDefined(oid.Oid(idToQuery)) {
+					getFuncQuery = `SELECT create_statement FROM crdb_internal.create_function_statements WHERE function_id=$1`
+					var err error
+					idToQuery, err = catid.UserDefinedOIDToID(oid.Oid(idToQuery))
+					if err != nil {
+						return nil, err
+					}
+				}
+				results, err := ctx.Planner.QueryRowEx(
+					ctx.Ctx(), "pg_get_functiondef",
+					sessiondata.NoSessionDataOverride,
+					getFuncQuery,
+					idToQuery,
+				)
+				if err != nil {
+					return nil, err
+				}
+				if len(results) == 0 {
+					return tree.DNull, nil
+				}
+				return results[0], nil
+			},
+			Info: "For user-defined functions, returns the definition of the specified function. " +
+				"For builtin functions, returns the name of the function.",
+			Volatility: volatility.Stable,
+		},
+	),
+
+	// pg_get_function_result returns the types of the result of a builtin
 	// function. Multi-return builtins currently are returned as anyelement, which
 	// is a known incompatibility with Postgres.
 	// https://www.postgresql.org/docs/11/functions-info.html
-	"pg_get_function_result": makeBuiltin(defProps(),
+	"pg_get_function_result": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
@@ -661,7 +699,7 @@ var pgBuiltins = map[string]builtinDefinition{
 				}
 				return t[0], nil
 			},
-			Info:       notUsableInfo,
+			Info:       "Returns the types of the result of the specified function.",
 			Volatility: volatility.Stable,
 		},
 	),
@@ -670,7 +708,8 @@ var pgBuiltins = map[string]builtinDefinition{
 	// identify a function, in the form it would need to appear in within ALTER
 	// FUNCTION, for instance. This form omits default values.
 	// https://www.postgresql.org/docs/11/functions-info.html
-	"pg_get_function_identity_arguments": makeBuiltin(defProps(),
+	"pg_get_function_identity_arguments": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"func_oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.String),
@@ -707,21 +746,24 @@ var pgBuiltins = map[string]builtinDefinition{
 				}
 				return tree.NewDString(sb.String()), nil
 			},
-			Info:       notUsableInfo,
+			Info: "Returns the argument list (without defaults) necessary to identify a function, " +
+				"in the form it would need to appear in within ALTER FUNCTION, for instance.",
 			Volatility: volatility.Stable,
 		},
 	),
 
 	// pg_get_indexdef functions like SHOW CREATE INDEX would if we supported that
 	// statement.
-	"pg_get_indexdef": makeBuiltin(tree.FunctionProperties{DistsqlBlocklist: true},
+	"pg_get_indexdef": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo, DistsqlBlocklist: true},
 		makePGGetIndexDef(tree.ArgTypes{{"index_oid", types.Oid}}),
 		makePGGetIndexDef(tree.ArgTypes{{"index_oid", types.Oid}, {"column_no", types.Int}, {"pretty_bool", types.Bool}}),
 	),
 
 	// pg_get_viewdef functions like SHOW CREATE VIEW but returns the same format as
 	// PostgreSQL leaving out the actual 'CREATE VIEW table_name AS' portion of the statement.
-	"pg_get_viewdef": makeBuiltin(tree.FunctionProperties{DistsqlBlocklist: true},
+	"pg_get_viewdef": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo, DistsqlBlocklist: true},
 		makePGGetViewDef(tree.ArgTypes{{"view_oid", types.Oid}}),
 		makePGGetViewDef(tree.ArgTypes{{"view_oid", types.Oid}, {"pretty_bool", types.Bool}}),
 	),
@@ -758,7 +800,8 @@ var pgBuiltins = map[string]builtinDefinition{
 	// pg_my_temp_schema returns the OID of session's temporary schema, or 0 if
 	// none.
 	// https://www.postgresql.org/docs/11/functions-info.html
-	"pg_my_temp_schema": makeBuiltin(defProps(),
+	"pg_my_temp_schema": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ArgTypes{},
 			ReturnType: tree.FixedReturnType(types.Oid),
@@ -790,7 +833,8 @@ var pgBuiltins = map[string]builtinDefinition{
 	// pg_is_other_temp_schema returns true if the given OID is the OID of another
 	// session's temporary schema.
 	// https://www.postgresql.org/docs/11/functions-info.html
-	"pg_is_other_temp_schema": makeBuiltin(defProps(),
+	"pg_is_other_temp_schema": makeBuiltin(
+		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
 		tree.Overload{
 			Types:      tree.ArgTypes{{"oid", types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),


### PR DESCRIPTION
refs https://github.com/hasura/graphql-engine/issues/8821

This also cleans up the docs for other function introspectio builtins.

Release note (sql change): Added the pg_get_functiondef builtin
function, which returns the CREATE statement that can be used to create
the given user-defined function. For builtin functions, it only returns
the name of the function.

Release justification: low risk enhancement for compatibility.