### PR TITLE
roachtest/sqlsmith: skip some known errors

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -252,10 +252,12 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 				es := err.Error()
 				if strings.Contains(es, "internal error") {
 					// TODO(yuzefovich): we temporarily ignore internal errors
-					// that are because of #40929.
+					// that are because of #40929 and #86009.
 					var expectedError bool
 					for _, exp := range []string{
 						"could not parse \"0E-2019\" as type decimal",
+						"unable to vectorize execution plan: localtimestamp",
+						"unable to vectorize execution plan: overlaps",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)
 					}


### PR DESCRIPTION
This commit makes it so that sqlsmith no longer fails on duplicates
of #86009.

Informs: #86009.

Release justification: test-only change.

Release note: None