### PR TITLE
sql/importer: add hints on null value import failure for CSV files

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -722,6 +722,24 @@ ORDER BY table_name
 			err:      "error parsing row 1: expected 2 fields, got 3",
 			rejected: "dog,{some,thing}\n",
 		},
+		{
+			name:     "hint for quoted string matching nullif when allow_quoted_null is not set",
+			create:   `a string, b bool`,
+			with:     `WITH nullif = 'NULL'`,
+			typ:      "CSV",
+			data:     `dog,"NULL"`,
+			err:      "null value is quoted but allow_quoted_null option is not set",
+			rejected: "dog,\"NULL\"\n",
+		},
+		{
+			name:     "hint for extra leading whitespace in string matching nullif",
+			create:   `a string, b bool`,
+			with:     `WITH nullif = 'NULL'`,
+			typ:      "CSV",
+			data:     `dog, NULL`,
+			err:      "null value must not have extra whitespace",
+			rejected: "dog, NULL\n",
+		},
 
 		// PG COPY
 		{


### PR DESCRIPTION
This patch adds hints notifying the user when an `IMPORT INTO ... CSV DATA`
command fails due to null values in the CSV file having leading or trailing
whitespace or being quoted when the `allow_quoted_null` option is not set.

Fixes https://github.com/cockroachdb/cockroach/issues/83723

Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): A hint is now provided when importing from a CSV file fails because a null value has leading or trailing whitespace or because a value is quoted when the `allow_quoted_null` option is not set.