### PR TITLE
sql: add created_at to index usage stat telemetry

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2469,6 +2469,7 @@ An event of type `captured_index_usage_stats`
 | `IndexType` |  | no |
 | `IsUnique` |  | no |
 | `IsInverted` |  | no |
+| `CreatedAt` |  | no |
 
 
 #### Common fields

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -734,6 +734,16 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		b = append(b, "\"IsInverted\":true"...)
 	}
 
+	if m.CreatedAt != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"CreatedAt\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.CreatedAt)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -171,6 +171,7 @@ message CapturedIndexUsageStats {
   string index_type = 9 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   bool is_unique = 10 [(gogoproto.jsontag) = ",omitempty"];
   bool is_inverted = 11 [(gogoproto.jsontag) = ",omitempty"];
+  string created_at = 12 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that


### PR DESCRIPTION
This commit adds a creation timestamp to the index usage
statistics telemetry.

Fixes https://github.com/cockroachdb/cockroach/issues/84458.

Release justification: low-risk updates to new functionality
Release note(sql change): Added the creation timestamp to index usage statistics
telemetry.