### PR TITLE
cli: fix default certs-dir

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -13,6 +13,7 @@ package base
 import (
 	"context"
 	"net/url"
+	"os"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -48,9 +49,6 @@ const (
 
 	// NetworkTimeout is the timeout used for network operations.
 	NetworkTimeout = 3 * time.Second
-
-	// DefaultCertsDirectory is the default value for the cert directory flag.
-	DefaultCertsDirectory = "${HOME}/.cockroach-certs"
 
 	// defaultRaftTickInterval is the default resolution of the Raft timer.
 	defaultRaftTickInterval = 200 * time.Millisecond
@@ -100,6 +98,9 @@ const (
 	// before a lease expires when acquisition to renew the lease begins.
 	DefaultDescriptorLeaseRenewalTimeout = time.Minute
 )
+
+// DefaultCertsDirectory is the default value for the cert directory flag.
+var DefaultCertsDirectory = os.ExpandEnv("${HOME}/.cockroach-certs")
 
 // DefaultHistogramWindowInterval returns the default rotation window for
 // histograms.

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -139,6 +139,26 @@ end_test
 send "\\q\r"
 eexpect eof
 
+start_test "Check that default certs dir is respected"
+
+set ::env(HOME) "."
+system "mkdir -p ./.cockroach-certs"
+system "cp $certs_dir/* ./.cockroach-certs/"
+
+spawn $argv sql
+eexpect root@
+eexpect "/defaultdb>"
+send "\\c\r"
+eexpect "Connection string:"
+eexpect "sslrootcert=.cockroach-certs"
+eexpect "You are connected to database \"defaultdb\" as user \"root\""
+eexpect root@
+
+end_test
+
+send "\\q\r"
+eexpect eof
+
 start_test "Check that extra URL params are preserved when changing database"
 
 spawn $argv sql --certs-dir=$certs_dir --url=postgres://root@localhost:26257/defaultdb?options=--search_path%3Dcustom_path&statement_timeout=1234


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/87191

https://github.com/cockroachdb/cockroach/pull/82020 accidentally broke
the logic for the certs-dir defaulting to ${HOME}/.cockroach-certs/

No release note since this bug was not released.

Release note: None

Release justification: low risk bug fix to new functionality.