### PR TITLE
ui: showing ALTER index recommendations

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -98,6 +98,9 @@ function createIndexRecommendationsToSchemaInsight(
         case "drop":
           idxType = "DropIndex";
           break;
+        case "alteration":
+          idxType = "AlterIndex";
+          break;
       }
 
       results.push({

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -13,7 +13,12 @@ import { Modal } from "../modal";
 import { Text, TextTypes } from "../text";
 import { Button } from "../button";
 import { executeIndexRecAction, IndexActionResponse } from "../api";
-import { createIndex, dropIndex, onlineSchemaChanges } from "../util";
+import {
+  alterIndex,
+  createIndex,
+  dropIndex,
+  onlineSchemaChanges,
+} from "../util";
 import { Anchor } from "../anchor";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import classNames from "classnames/bind";
@@ -107,6 +112,19 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
             DROP INDEX
           </Anchor>
           {" statements"}
+        </>
+      );
+      break;
+    case "AlterIndex":
+      title = "alter the index";
+      btnLAbel = "Alter Index";
+      descriptionDocs = (
+        <>
+          {"an "}
+          <Anchor href={alterIndex} target="_blank">
+            ALTER INDEX
+          </Anchor>
+          {" statement"}
         </>
       );
       break;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -224,6 +224,7 @@ export type InsightType =
   | "DropIndex"
   | "CreateIndex"
   | "ReplaceIndex"
+  | "AlterIndex"
   | "HighContention"
   | "HighRetryCount"
   | "SuboptimalPlan"

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -214,11 +214,13 @@ export const filterSchemaInsights = (
 export function insightType(type: InsightType): string {
   switch (type) {
     case "CreateIndex":
-      return "Create New Index";
+      return "Create Index";
     case "DropIndex":
       return "Drop Unused Index";
     case "ReplaceIndex":
       return "Replace Index";
+    case "AlterIndex":
+      return "Alter Index";
     case "HighContention":
       return "High Contention";
     case "HighRetryCount":

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -74,6 +74,7 @@ function descriptionCell(
   switch (insightRec.type) {
     case "CreateIndex":
     case "ReplaceIndex":
+    case "AlterIndex":
       return (
         <>
           <div className={cx("description-item")}>
@@ -206,6 +207,7 @@ function actionCell(
     case "CreateIndex":
     case "ReplaceIndex":
     case "DropIndex":
+    case "AlterIndex":
       return (
         <IdxRecAction
           actionQuery={insightRec.query}
@@ -224,6 +226,8 @@ function actionCell(
           actionType={
             query.toLowerCase().includes("drop ")
               ? "ReplaceIndex"
+              : query.toLowerCase().includes("alter ")
+              ? "AlterIndex"
               : "CreateIndex"
           }
           database={insightRec.database}

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -170,6 +170,9 @@ function formatIdxRecommendations(
       case "drop":
         idxType = "DropIndex";
         break;
+      case "alteration":
+        idxType = "AlterIndex";
+        break;
     }
     const idxRec: InsightRecommendation = {
       type: idxType,

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -114,6 +114,7 @@ export const secondaryIndex = docsURL("schema-design-indexes.html");
 export const onlineSchemaChanges = docsURL("online-schema-changes.html");
 export const createIndex = docsURL("create-index.html");
 export const dropIndex = docsURL("drop-index.html");
+export const alterIndex = docsURL("alter-index.html");
 export const lockingStrength = docsURL(
   "explain.html#find-out-if-a-statement-is-using-select-for-update-locking",
 );


### PR DESCRIPTION
With the new index recommendation type introduced
on #87174, this commit does the proper handle of
the alter option and show the recommendation with
its proper docs accordingly.

Fixes #87414

Rename "Create new index" to "Create Index"

Release justification: low risk change
Release note (ui change): Showing index recommendation
of `ALTER index` type (both in Statement Details
page and on Insights page).