### PR TITLE
scbuildstmt: fallback if adding a virtual column with NOT NULL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2649,20 +2649,8 @@ ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL:::I
 statement error pgcode 23502 null value in column "j" violates not-null constraint
 ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL UNIQUE;
 
-# Note that this should absolutely not succeed, but it does because of #81675.
-# We'll rely on that in order to test that the subsequent index build fails.
-# When addressing #81675, this portion of this test will need to be removed.
-skipif config local-legacy-schema-changer
-statement ok
-ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL;
-
-onlyif config local-legacy-schema-changer
 statement error validation of NOT NULL constraint failed: validation of CHECK "j IS NOT NULL" failed on row: i=1, j=NULL
 ALTER TABLE t_add_column_not_null ADD COLUMN j INT GENERATED ALWAYS AS (NULL::INT) VIRTUAL NOT NULL;
-
-skipif config local-legacy-schema-changer
-statement error pgcode 23502 null value in column "j" violates not-null constraint
-CREATE INDEX idx_j ON t_add_column_not_null (j);
 
 statement ok
 DROP TABLE t_add_column_not_null

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -44,6 +44,7 @@ func alterTableAddColumn(
 	// We don't support handling zone config related properties for tables, so
 	// throw an unsupported error.
 	fallBackIfZoneConfigExists(b, d, tbl.TableID)
+	fallBackIfVirtualColumnWithNotNullConstraint(t)
 	// Check column non-existence.
 	{
 		elts := b.ResolveColumn(tbl.TableID, d.Name, ResolveParams{

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -665,3 +665,17 @@ func fallBackIfZoneConfigExists(b BuildCtx, n tree.NodeFormatter, id catid.DescI
 		}
 	}
 }
+
+// fallBackIfVirtualColumnWithNotNullConstraint throws an unimplemented error
+// if the to-be-added column `d` is a virtual column with not null constraint.
+// This is a quick, temporary fix for the following troubled stmt in the
+// declarative schema changer:
+// `ALTER TABLE t ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;` succeeded
+// but expectedly failed in the legacy schema changer.
+func fallBackIfVirtualColumnWithNotNullConstraint(t *tree.AlterTableAddColumn) {
+	d := t.ColumnDef
+	if d.IsVirtual() && d.Nullable.Nullability == tree.NotNull {
+		panic(scerrors.NotImplementedErrorf(t,
+			"virtual column with NOT NULL constraint is not supported"))
+	}
+}


### PR DESCRIPTION
We found a regression in the new schema changer for the following stmt: `ALTER TABLE t ADD COLUMN j INT AS (NULL::INT) VIRTUAL NOT NULL;` incorrectly succeeded. This PR made `ADD COLUMN` fall back if the to-be-added column is a virtual column with NOT NULL constraint.

Surprisingly, we actually have logic tests in place for this case but it has incorrect expected output so we also changed the exsiting tests.

Fix: #87457

Release justification: bug fix for GA blocker.

Release note: None