### PR TITLE
changefeedccl: default to bare envelope for cdc expressions

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -420,6 +420,8 @@ func createChangefeedJobRecord(
 		// that support it.
 		details.Select = cdceval.AsStringUnredacted(normalized.Clause())
 
+		opts.SetDefaultEnvelope(changefeedbase.OptEnvelopeBare)
+
 		// TODO(#85143): do not enforce schema_change_policy='stop' for changefeed expressions.
 		schemachangeOptions, err := opts.GetSchemaChangeHandlingOptions()
 		if err != nil {

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -138,6 +138,7 @@ const (
 	OptEnvelopeRow           EnvelopeType = `row`
 	OptEnvelopeDeprecatedRow EnvelopeType = `deprecated_row`
 	OptEnvelopeWrapped       EnvelopeType = `wrapped`
+	OptEnvelopeBare          EnvelopeType = `bare`
 
 	OptFormatJSON FormatType = `json`
 	OptFormatAvro FormatType = `avro`
@@ -286,7 +287,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptConfluentSchemaRegistry:  stringOption,
 	OptCursor:                   timestampOption,
 	OptEndTime:                  timestampOption,
-	OptEnvelope:                 enum("row", "key_only", "wrapped", "deprecated_row"),
+	OptEnvelope:                 enum("row", "key_only", "wrapped", "deprecated_row", "bare"),
 	OptFormat:                   enum("json", "avro", "csv", "experimental_avro"),
 	OptFullTableName:            flagOption,
 	OptKeyInValue:               flagOption,

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -399,7 +399,7 @@ func makeCloudStorageSink(
 	}
 
 	switch encodingOpts.Envelope {
-	case changefeedbase.OptEnvelopeWrapped:
+	case changefeedbase.OptEnvelopeWrapped, changefeedbase.OptEnvelopeBare:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -196,7 +196,7 @@ func MakePubsubSink(
 	}
 
 	switch encodingOpts.Envelope {
-	case changefeedbase.OptEnvelopeWrapped:
+	case changefeedbase.OptEnvelopeWrapped, changefeedbase.OptEnvelopeBare:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -289,7 +289,7 @@ func makeWebhookSink(
 	}
 
 	switch encodingOpts.Envelope {
-	case changefeedbase.OptEnvelopeWrapped:
+	case changefeedbase.OptEnvelopeWrapped, changefeedbase.OptEnvelopeBare:
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1639,7 +1639,12 @@ type webhookSinkTestfeedPayload struct {
 
 // extractValueFromJSONMessage extracts the value of the first element of
 // the payload array from an webhook sink JSON message.
-func extractValueFromJSONMessage(message []byte) ([]byte, error) {
+func extractValueFromJSONMessage(message []byte) (val []byte, err error) {
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "message was '%s'", message)
+		}
+	}()
 	var parsed webhookSinkTestfeedPayload
 	if err := gojson.Unmarshal(message, &parsed); err != nil {
 		return nil, err
@@ -1649,7 +1654,6 @@ func extractValueFromJSONMessage(message []byte) ([]byte, error) {
 		return nil, fmt.Errorf("payload value in json message contains no elements")
 	}
 
-	var err error
 	var value []byte
 	if value, err = reformatJSON(keyParsed[0]); err != nil {
 		return nil, err


### PR DESCRIPTION
Changes the default json encoding when using an expression to omit the `after` key and store any metadata in a crdb field. Avro encoding changes "after" to "record".

This is meant as a quick fix to the defaults and validations that inappropriately insist on a metadata-friendly envelope when cdc expressions are meant to provide their own metadata as part of the projection.

Release justification: Change to new functionality.
Release note (bug fix): Improved the default output when using a SELECT clause with a CHANGEFEED.