### PR TITLE
colbuilder: fix invalid sharing of a memory account by the columnarizer

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -69,7 +69,6 @@ func wrapRowSources(
 	flowCtx *execinfra.FlowCtx,
 	inputs []colexecargs.OpWithMetaInfo,
 	inputTypes [][]*types.T,
-	streamingMemAcc *mon.BoundAccount,
 	monitorRegistry *colexecargs.MonitorRegistry,
 	processorID int32,
 	newToWrap func([]execinfra.RowSource) (execinfra.RowSource, error),
@@ -121,7 +120,7 @@ func wrapRowSources(
 	if !isProcessor {
 		return nil, nil, errors.AssertionFailedf("unexpectedly %T is not an execinfra.Processor", toWrap)
 	}
-	batchAllocator := colmem.NewAllocator(ctx, streamingMemAcc, factory)
+	batchAllocator := colmem.NewAllocator(ctx, monitorRegistry.NewStreamingMemAccount(flowCtx), factory)
 	metadataAllocator := colmem.NewAllocator(ctx, monitorRegistry.NewStreamingMemAccount(flowCtx), factory)
 	var c *colexec.Columnarizer
 	if proc.MustBeStreaming() {
@@ -548,7 +547,6 @@ func (r opResult) createAndWrapRowSource(
 		flowCtx,
 		inputs,
 		inputTypes,
-		args.StreamingMemAccount,
 		args.MonitorRegistry,
 		processorID,
 		func(inputs []execinfra.RowSource) (execinfra.RowSource, error) {


### PR DESCRIPTION
We recently merged a couple of changes to the memory accounting in the columnarizer which relied on its memory account not being shared with any other component. This, however, wasn't true since we passed the "streaming" memory account that many components can use. This commit fixes that oversight by always creating a separate account.

The previous behavior could result in the columnarizer clearing the account when another user of that account attempts to shrink it (in production builds this would only trigger a sentry report with no panic). For example, this situation could occur when we plan a vectorized ordered aggregator that uses a default aggregate function and then we handle the rendering with a wrapped row-by-row processor which requires a creation of the columnarizer.

Fixes: #87016.

Release justification: bug fix.

Release note: None (no release with this bug)