### PR TITLE
util,changefeedccl: streaminger csv writes

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -148,6 +148,7 @@ go_test(
         "avro_test.go",
         "bench_test.go",
         "changefeed_test.go",
+        "csv_test.go",
         "encoder_test.go",
         "event_processing_test.go",
         "helpers_test.go",

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -525,6 +525,25 @@ func TestingMakeEventRow(
 	}
 }
 
+// TestingMakeEventRowFromDatums initializes a Row that will return the provided datums when
+// ForEachColumn is called. If anything else needs to be hydrated, use TestingMakeEventRow
+// instead.
+func TestingMakeEventRowFromDatums(datums tree.Datums) Row {
+	var desc EventDescriptor
+	var encRow rowenc.EncDatumRow
+	var alloc tree.DatumAlloc
+	for i, d := range datums {
+		desc.cols = append(desc.cols, ResultColumn{ord: i})
+		desc.valueCols = append(desc.valueCols, i)
+		encRow = append(encRow, rowenc.DatumToEncDatum(d.ResolvedType(), d))
+	}
+	return Row{
+		EventDescriptor: &desc,
+		datums:          encRow,
+		alloc:           &alloc,
+	}
+}
+
 // TestingGetFamilyIDFromKey returns family ID encoded in the specified roachpb.Key.
 // Exposed for testing.
 func TestingGetFamilyIDFromKey(

--- a/pkg/ccl/changefeedccl/csv_test.go
+++ b/pkg/ccl/changefeedccl/csv_test.go
@@ -1,0 +1,76 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package changefeedccl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkCSVEncodeWideRow(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	// 1024 columns of three runes each.
+	benchmarkEncodeCSV(b, 1024, 1024*3, 1024)
+}
+
+func BenchmarkCSVEncodeWideRowASCII(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	// 1024 columns of three runes each, all ASCII codepoints.
+	benchmarkEncodeCSV(b, 1024, 1024*3, 127)
+}
+
+func BenchmarkCSVEncodeWideColumnsASCII(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	// 3 columns of 1024 runes each, all ASCII codepoints.
+	benchmarkEncodeCSV(b, 3, 1024*3, 127)
+}
+
+func BenchmarkCSVEncodeWideColumns(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+
+	// 3 columns of 1024 runes each.
+	benchmarkEncodeCSV(b, 3, 1024*3, 1024)
+}
+
+func benchmarkEncodeCSV(b *testing.B, numCols int, numChars int, maxCodepoint int) {
+	encoder := newCSVEncoder(changefeedbase.EncodingOptions{Format: changefeedbase.OptFormatCSV})
+	ctx := context.Background()
+	vals := make([]string, numCols)
+	for i := 0; i < numChars; i++ {
+		vals[i%numCols] += fmt.Sprintf("%c", i%(maxCodepoint+1))
+	}
+	datums := tree.Datums{}
+	for _, str := range vals {
+		datums = append(datums, tree.NewDString(str))
+	}
+	row := cdcevent.TestingMakeEventRowFromDatums(datums)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := encoder.EncodeValue(ctx, eventContext{}, row, cdcevent.Row{})
+		require.NoError(b, err)
+	}
+}

--- a/pkg/util/encoding/csv/writer_test.go
+++ b/pkg/util/encoding/csv/writer_test.go
@@ -51,7 +51,10 @@ var writeTests = []struct {
 	{Input: [][]string{{"a", "a", ""}}, Output: "a,a,\n"},
 	{Input: [][]string{{"a", "a", "a"}}, Output: "a,a,a\n"},
 	{Input: [][]string{{`\.`}}, Output: "\"\\.\"\n"},
-	{Input: [][]string{{`"`, `,`, `x"`, `x`, `xx,`}}, Escape: 'x', Output: `"x"",",","xxx"",x,"xxxx,"` + "\n"},
+	{Input: [][]string{{`\.ab☃`}}, Output: "\\.ab☃\n"},
+	// Previous versions of csv.Writer didn't quote a string containing a custom escape character, which was
+	// probably a bug despite previously being asserted in this test. But also nothing actually used a custom escape character.
+	{Input: [][]string{{`"`, `,`, `x"`, `x`, `xx,`}}, Escape: 'x', Output: `"x"",",","xxx"","xx","xxxx,"` + "\n"},
 }
 
 func TestWrite(t *testing.T) {


### PR DESCRIPTION
The changefeed csv encoder was reading an entire row into memory before encoding it into CSV. There's no particular need to do so, and CSV is now being used at scale, so this PR modifies the CSV writer API slightly to allow for writing fields directly from an iterator.

Release justification: Performance tweak to new functionality.

Release note: None