### PR TITLE
release-22.1: rowexec,colfetcher: introduce cluster settings for batch sizes

### DIFF
--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//pkg/sql/rowinfra",
         "//pkg/sql/scrub",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
         "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/encoding",

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3209,6 +3209,14 @@ func (m *sessionDataMutator) SetJoinReaderOrderingStrategyBatchSize(val int64) {
 	m.data.JoinReaderOrderingStrategyBatchSize = val
 }
 
+func (m *sessionDataMutator) SetJoinReaderNoOrderingStrategyBatchSize(val int64) {
+	m.data.JoinReaderNoOrderingStrategyBatchSize = val
+}
+
+func (m *sessionDataMutator) SetJoinReaderIndexJoinStrategyBatchSize(val int64) {
+	m.data.JoinReaderIndexJoinStrategyBatchSize = val
+}
+
 func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsEnabled(val bool) {
 	m.data.ParallelizeMultiKeyLookupJoinsEnabled = val
 }

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/nodedialer",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4752,6 +4752,8 @@ integer_datetimes                                     on
 intervalstyle                                         postgres
 intervalstyle_enabled                                 on
 is_superuser                                          on
+join_reader_index_join_strategy_batch_size            4.0 MiB
+join_reader_no_ordering_strategy_batch_size           2.0 MiB
 join_reader_ordering_strategy_batch_size              10 KiB
 large_full_scan_rows                                  1000
 lc_collate                                            C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4179,6 +4179,8 @@ integer_datetimes                                     on                  NULL  
 intervalstyle                                         postgres            NULL      NULL        NULL        string
 intervalstyle_enabled                                 on                  NULL      NULL        NULL        string
 is_superuser                                          on                  NULL      NULL        NULL        string
+join_reader_index_join_strategy_batch_size            4.0 MiB             NULL      NULL        NULL        string
+join_reader_no_ordering_strategy_batch_size           2.0 MiB             NULL      NULL        NULL        string
 join_reader_ordering_strategy_batch_size              10 KiB              NULL      NULL        NULL        string
 large_full_scan_rows                                  1000                NULL      NULL        NULL        string
 lc_collate                                            C.UTF-8             NULL      NULL        NULL        string
@@ -4303,6 +4305,8 @@ integer_datetimes                                     on                  NULL  
 intervalstyle                                         postgres            NULL  user     NULL      postgres            postgres
 intervalstyle_enabled                                 on                  NULL  user     NULL      on                  on
 is_superuser                                          on                  NULL  user     NULL      on                  on
+join_reader_index_join_strategy_batch_size            4.0 MiB             NULL  user     NULL      4.0 MiB             4.0 MiB
+join_reader_no_ordering_strategy_batch_size           2.0 MiB             NULL  user     NULL      2.0 MiB             2.0 MiB
 join_reader_ordering_strategy_batch_size              10 KiB              NULL  user     NULL      10 KiB              10 KiB
 large_full_scan_rows                                  1000                NULL  user     NULL      1000                1000
 lc_collate                                            C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
@@ -4422,6 +4426,8 @@ integer_datetimes                                     NULL    NULL     NULL     
 intervalstyle                                         NULL    NULL     NULL     NULL        NULL
 intervalstyle_enabled                                 NULL    NULL     NULL     NULL        NULL
 is_superuser                                          NULL    NULL     NULL     NULL        NULL
+join_reader_index_join_strategy_batch_size            NULL    NULL     NULL     NULL        NULL
+join_reader_no_ordering_strategy_batch_size           NULL    NULL     NULL     NULL        NULL
 join_reader_ordering_strategy_batch_size              NULL    NULL     NULL     NULL        NULL
 large_full_scan_rows                                  NULL    NULL     NULL     NULL        NULL
 lc_collate                                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -82,6 +82,8 @@ integer_datetimes                                     on
 intervalstyle                                         postgres
 intervalstyle_enabled                                 on
 is_superuser                                          on
+join_reader_index_join_strategy_batch_size            4.0 MiB
+join_reader_no_ordering_strategy_batch_size           2.0 MiB
 join_reader_ordering_strategy_batch_size              10 KiB
 large_full_scan_rows                                  1000
 lc_collate                                            C.UTF-8

--- a/pkg/sql/rowexec/joinreader_strategies.go
+++ b/pkg/sql/rowexec/joinreader_strategies.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/memsize"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowcontainer"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -156,13 +157,31 @@ type joinReaderNoOrderingStrategy struct {
 	strategyMemAcc *mon.BoundAccount
 }
 
-// getLookupRowsBatchSizeHint returns the batch size for the join reader no
-// ordering strategy. This number was chosen by running TPCH queries 7, 9, 10,
-// and 11 with varying batch sizes and choosing the smallest batch size that
-// offered a significant performance improvement. Larger batch sizes offered
-// small to no marginal improvements.
-func (s *joinReaderNoOrderingStrategy) getLookupRowsBatchSizeHint(*sessiondata.SessionData) int64 {
-	return 2 << 20 /* 2 MiB */
+// This number was chosen by running TPCH queries 7, 9, 10, and 11 with varying
+// batch sizes and choosing the smallest batch size that offered a significant
+// performance improvement. Larger batch sizes offered small to no marginal
+// improvements.
+const joinReaderNoOrderingStrategyBatchSizeDefault = 2 << 20 /* 2 MiB */
+
+// JoinReaderNoOrderingStrategyBatchSize determines the size of input batches
+// used to construct a single lookup KV batch by joinReaderNoOrderingStrategy.
+var JoinReaderNoOrderingStrategyBatchSize = settings.RegisterByteSizeSetting(
+	settings.TenantWritable,
+	"sql.distsql.join_reader_no_ordering_strategy.batch_size",
+	"size limit on the input rows to construct a single lookup KV batch",
+	joinReaderNoOrderingStrategyBatchSizeDefault,
+	settings.PositiveInt,
+)
+
+func (s *joinReaderNoOrderingStrategy) getLookupRowsBatchSizeHint(
+	sd *sessiondata.SessionData,
+) int64 {
+	if sd.JoinReaderNoOrderingStrategyBatchSize == 0 {
+		// In some tests the session data might not be set - use the default
+		// value then.
+		return joinReaderNoOrderingStrategyBatchSizeDefault
+	}
+	return sd.JoinReaderNoOrderingStrategyBatchSize
 }
 
 func (s *joinReaderNoOrderingStrategy) getMaxLookupKeyCols() int {
@@ -375,13 +394,10 @@ type joinReaderIndexJoinStrategy struct {
 	strategyMemAcc *mon.BoundAccount
 }
 
-// getLookupRowsBatchSizeHint returns the batch size for the join reader index
-// join strategy. This number was chosen by running TPCH queries 3, 4, 5, 9,
-// and 19 with varying batch sizes and choosing the smallest batch size that
-// offered a significant performance improvement. Larger batch sizes offered
-// small to no marginal improvements.
-func (s *joinReaderIndexJoinStrategy) getLookupRowsBatchSizeHint(*sessiondata.SessionData) int64 {
-	return 4 << 20 /* 4 MB */
+func (s *joinReaderIndexJoinStrategy) getLookupRowsBatchSizeHint(
+	sd *sessiondata.SessionData,
+) int64 {
+	return execinfra.GetIndexJoinBatchSize(sd)
 }
 
 func (s *joinReaderIndexJoinStrategy) getMaxLookupKeyCols() int {

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -89,11 +89,18 @@ message SessionData {
   // increase the speed of lookup joins when each input row might get multiple
   // looked up rows at the cost of increased memory usage.
   bool parallelize_multi_key_lookup_joins_enabled = 19;
-
   // Troubleshooting mode determines whether we refuse to do additional work with
   // the query (i.e. collect & emit telemetry data). Troubleshooting mode is
   // disabled by default.
   bool troubleshooting_mode = 21;
+  // JoinReaderNoOrderingStrategyBatchSize is the size limit on the input rows
+  // to the joinReader processor (when ordering is **not** required to be
+  // maintained) to construct a single lookup KV batch.
+  int64 join_reader_no_ordering_strategy_batch_size = 22;
+  // JoinReaderIndexJoinStrategyBatchSize is the size limit on the input rows
+  // to the joinReader processor (when performing index joins) to construct a
+  // single lookup KV batch.
+  int64 join_reader_index_join_strategy_batch_size = 23;
 }
 
 // DataConversionConfig contains the parameters that influence the output

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/delegate"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -1911,6 +1912,48 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(rowexec.JoinReaderOrderingStrategyBatchSize.Get(sv)))
+		},
+	},
+
+	// CockroachDB extension.
+	`join_reader_no_ordering_strategy_batch_size`: {
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			size, err := humanizeutil.ParseBytes(s)
+			if err != nil {
+				return err
+			}
+			if size <= 0 {
+				return errors.New("join_reader_no_ordering_strategy_batch_size can only be set to a positive value")
+			}
+			m.SetJoinReaderNoOrderingStrategyBatchSize(size)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return string(humanizeutil.IBytes(evalCtx.SessionData().JoinReaderNoOrderingStrategyBatchSize)), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return string(humanizeutil.IBytes(rowexec.JoinReaderNoOrderingStrategyBatchSize.Get(sv)))
+		},
+	},
+
+	// CockroachDB extension.
+	`join_reader_index_join_strategy_batch_size`: {
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			size, err := humanizeutil.ParseBytes(s)
+			if err != nil {
+				return err
+			}
+			if size <= 0 {
+				return errors.New("join_reader_index_join_strategy_batch_size can only be set to a positive value")
+			}
+			m.SetJoinReaderIndexJoinStrategyBatchSize(size)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext) (string, error) {
+			return string(humanizeutil.IBytes(evalCtx.SessionData().JoinReaderIndexJoinStrategyBatchSize)), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return string(humanizeutil.IBytes(execinfra.JoinReaderIndexJoinStrategyBatchSize.Get(sv)))
 		},
 	},
 


### PR DESCRIPTION
Backport 1/1 commits from #87398.

/cc @cockroachdb/release

---

This commit introduces several cluster settings as well as the
corresponding session variables to control the batch sizes of the
NoOrdering and IndexJoin join reader strategies as well as the
batch size of the ColIndexJoin operator. We already have these
things for the Ordering strategy of the join reader, so it seems
reasonable to have them for the other strategies.

Release justification: low-risk improvement.

Release note: None
