### PR TITLE
sql: add schema_name to index usage stat telemetry, add descriptions to proto fields

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2470,6 +2470,7 @@ An event of type `captured_index_usage_stats`
 | `IsUnique` | IsUnique indicates if the index has a UNIQUE constraint. | no |
 | `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
 | `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
+| `SchemaName` | SchemaName is the name of the schema in which the index was created. | no |
 
 
 #### Common fields

--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2459,17 +2459,17 @@ An event of type `captured_index_usage_stats`
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `TotalReadCount` | TotalReadCount is the number of times this index has been read from. | no |
-| `LastRead` | LastRead is the timestamp that this index was last being read from. | no |
-| `TableID` | TableID is the ID of the table this index is created on. This is same as descpb.TableID and is unique within the cluster. | no |
+| `TotalReadCount` | TotalReadCount is the number of times the index has been read. | no |
+| `LastRead` | LastRead is the timestamp at which the index was last read. | no |
+| `TableID` | TableID is the ID of the table on which the index was created. This is same as descpb.TableID and is unique within the cluster. | no |
 | `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
-| `DatabaseName` |  | no |
-| `TableName` |  | no |
-| `IndexName` |  | no |
-| `IndexType` |  | no |
-| `IsUnique` |  | no |
-| `IsInverted` |  | no |
-| `CreatedAt` |  | no |
+| `DatabaseName` | DatabaseName is the name of the database in which the index was created. | no |
+| `TableName` | TableName is the name of the table on which the index was created. | no |
+| `IndexName` | IndexName is the name of the index within the scope of the given table. | no |
+| `IndexType` | IndexType is the type of the index. Index types include "primary" and "secondary". | no |
+| `IsUnique` | IsUnique indicates if the index has a UNIQUE constraint. | no |
+| `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
+| `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
 
 
 #### Common fields

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -744,6 +744,16 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		b = append(b, '"')
 	}
 
+	if m.SchemaName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SchemaName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SchemaName)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -152,25 +152,38 @@ message CapturedIndexUsageStats {
 
   // Couldn't use roachpb.CollectedIndexUsageStatistics due to circular dependency.
 
-  // TotalReadCount is the number of times this index has been read from.
+  // TotalReadCount is the number of times the index has been read.
   uint64 total_read_count = 2;
 
-  // LastRead is the timestamp that this index was last being read from.
+  // LastRead is the timestamp at which the index was last read.
   string last_read = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // TableID is the ID of the table this index is created on. This is same as
+  // TableID is the ID of the table on which the index was created. This is same as
   // descpb.TableID and is unique within the cluster.
   uint32 table_id = 4 [(gogoproto.customname) = "TableID"];
 
   // IndexID is the ID of the index within the scope of the given table.
   uint32 index_id = 5 [(gogoproto.customname) = "IndexID"];
 
+  // DatabaseName is the name of the database in which the index was created.
   string database_name = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // TableName is the name of the table on which the index was created.
   string table_name = 7 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IndexName is the name of the index within the scope of the given table.
   string index_name = 8 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IndexType is the type of the index. Index types include "primary" and "secondary".
   string index_type = 9 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IsUnique indicates if the index has a UNIQUE constraint.
   bool is_unique = 10 [(gogoproto.jsontag) = ",omitempty"];
+
+  // IsInverted indicates if the index is an inverted index.
   bool is_inverted = 11 [(gogoproto.jsontag) = ",omitempty"];
+
+  // CreatedAt is the timestamp at which the index was created.
   string created_at = 12 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -185,6 +185,9 @@ message CapturedIndexUsageStats {
 
   // CreatedAt is the timestamp at which the index was created.
   string created_at = 12 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // SchemaName is the name of the schema in which the index was created.
+  string schema_name = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that


### PR DESCRIPTION
The first commit in this PR adds descriptions to the index usage telemetry
proto fields.

Fixes https://github.com/cockroachdb/cockroach/issues/85855.

Release justification: non-production code changes
Release note: None

 ----

The second commit in this PR adds the schema name to the index usage statistics
telemetry.

Fixes https://github.com/cockroachdb/cockroach/issues/85932.

Release justification: low risk, high benefit changes to existing functionality
Release note (sql change): Added the schema name to index usage statistics
telemetry.