### PR TITLE
ci: add some extra environment variables for sqllogic corpus nightly

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly.sh
@@ -8,6 +8,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run SQL Logic Test with Declarative Corpus Generation"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e GOOGLE_EPHEMERAL_CREDENTIALS -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e GOOGLE_EPHEMERAL_CREDENTIALS -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" \
   run_bazel build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
 tc_end_block "Run SQL Logic Test High VModule"


### PR DESCRIPTION
Without these extra environment variables, GitHub posting doesn't work correctly.

Release justification: Non-production code changes
Release note: None