### PR TITLE
sql: add idx recs to sampled query telemetry

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2613,6 +2613,7 @@ contains common SQL event/execution details.
 | `KVBytesRead` | The number of bytes read at the KV layer for this query. | no |
 | `KVRowsRead` | The number of rows read at the KV layer for this query. | no |
 | `NetworkMessages` | The number of network messages sent by nodes for this query. | no |
+| `IndexRecommendations` | Generated index recommendations for this query. | no |
 
 
 #### Common fields

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -402,6 +402,10 @@ func (p *planner) maybeLogStatementInternal(
 			}
 
 			stats = telemetryMetrics.getQueryLevelStats(stats)
+			indexRecs := make([]string, 0, len(p.curPlan.instrumentation.indexRecs))
+			for _, rec := range p.curPlan.instrumentation.indexRecs {
+				indexRecs = append(indexRecs, rec.SQL)
+			}
 
 			skippedQueries := telemetryMetrics.resetSkippedQueryCount()
 			sampledQuery := eventpb.SampledQuery{
@@ -446,6 +450,7 @@ func (p *planner) maybeLogStatementInternal(
 				KVBytesRead:              stats.KVBytesRead,
 				KVRowsRead:               stats.KVRowsRead,
 				NetworkMessages:          stats.NetworkMessages,
+				IndexRecommendations:     indexRecs,
 			}
 			p.logOperationalEventsOnlyExternally(ctx, &sampledQuery)
 		} else {

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3958,6 +3958,23 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendInt(b, int64(m.NetworkMessages), 10)
 	}
 
+	if len(m.IndexRecommendations) > 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"IndexRecommendations\":["...)
+		for i, v := range m.IndexRecommendations {
+			if i > 0 {
+				b = append(b, ',')
+			}
+			b = append(b, '"')
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
+			b = append(b, '"')
+		}
+		b = append(b, ']')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -161,6 +161,9 @@ message SampledQuery {
   // The number of network messages sent by nodes for this query.
   int64 network_messages = 44 [(gogoproto.jsontag) = ',omitempty'];
 
+  // Generated index recommendations for this query.
+  repeated string index_recommendations = 45 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
   reserved 12;
 }
 


### PR DESCRIPTION
Closes #86177

This commit adds index recommendations to the sampled query log.

Release justification: low risk update to existing functionality Release note (sql change): index recs now appear in sampled query log