### PR TITLE
ui: fix transaction insights elapsed time and active description

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/transactionInsightDetails.tsx
@@ -20,7 +20,6 @@ import { Button } from "src/button";
 import { Loading } from "src/loading";
 import { SqlBox, SqlBoxSize } from "src/sql";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
-import { Duration } from "src/util";
 import { DATE_FORMAT_24_UTC } from "src/util/format";
 import { getMatchParamByName } from "src/util/query";
 import {
@@ -144,10 +143,6 @@ export class TransactionInsightDetails extends React.Component<TransactionInsigh
                 <SummaryCardItem
                   label="Start Time"
                   value={insightDetails.startTime.format(DATE_FORMAT_24_UTC)}
-                />
-                <SummaryCardItem
-                  label="Elapsed Time"
-                  value={Duration(insightDetails.elapsedTime * 1e6)}
                 />
               </SummaryCard>
             </Col>

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageRoot.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPageRoot.tsx
@@ -51,8 +51,8 @@ export const TransactionsPageRoot = ({
       label: "Active Executions",
       description: (
         <span>
-          Active executions represent individual statement executions in
-          progress. Use active statement execution details, such as the
+          Active executions represent individual transactions executions in
+          progress. Use active transaction execution details, such as the
           application or elapsed time, to understand and tune workload
           performance.
           {/* TODO (xinhaoz) #78379 add 'Learn More' link to documentation page*/}


### PR DESCRIPTION
closes #87496, closes #87456

<img width="1951" alt="Screen Shot 2022-09-07 at 1 00 13 PM" src="https://user-images.githubusercontent.com/8868107/188937392-457b7ace-4292-4c6f-b800-5f3a89e71887.png">

<img width="1814" alt="Screen Shot 2022-09-07 at 12 59 45 PM" src="https://user-images.githubusercontent.com/8868107/188937366-1c8b6dd5-2930-467a-b958-cef7d373c775.png">

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: (ui change): Fixed the active
transaction description.Removed transaction
insights details elapsed time because it is
not available and was the contention time.