### PR TITLE
sql: fix recording db names with hyphen for idx usage stats

### DIFF
--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -116,6 +116,9 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	db.Exec(t, "CREATE DATABASE test")
 	db.Exec(t, "CREATE DATABASE test2")
 
+	// Test fix for #85577.
+	db.Exec(t, `CREATE DATABASE "test-hyphen"`)
+
 	// Create a table for each database.
 	db.Exec(t, "CREATE TABLE test.test_table (num INT PRIMARY KEY, letter char)")
 	db.Exec(t, "CREATE TABLE test2.test2_table (num INT PRIMARY KEY, letter char)")


### PR DESCRIPTION
Fixes #85577

This commit fixes a bug where the query constructed during
index usage stats recording failed for db names containing
a hyphen. The db name placeholder is now converted to string
from the `tree.Name`, which should properly escape hyphen
characters for the query.

Release justification: bug fix

Release note (bug fix): index usage stats are properly captured for database names with hyphens