### PR TITLE
sql: add query level execution stats to sampled query log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2605,6 +2605,12 @@ contains common SQL event/execution details.
 | `ZigZagJoinCount` | The number of zig zag joins in the query plan. | no |
 | `ContentionNanos` | The duration of time in nanoseconds that the query experienced contention. | no |
 | `Regions` | The regions of the nodes where SQL processors ran. | no |
+| `NetworkBytesSent` | The number of network bytes sent by nodes for this query. | no |
+| `MaxMemUsage` | The maximum amount of memory usage by nodes for this query. | no |
+| `MaxDiskUsage` | The maximum amount of disk usage by nodes for this query. | no |
+| `KVBytesRead` | The number of bytes read at the KV layer for this query. | no |
+| `KVRowsRead` | The number of rows read at the KV layer for this query. | no |
+| `NetworkMessages` | The number of network messages sent by nodes for this query. | no |
 
 
 #### Common fields

--- a/pkg/sql/telemetry_logging.go
+++ b/pkg/sql/telemetry_logging.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -54,10 +55,8 @@ type TelemetryLoggingTestingKnobs struct {
 	// getTimeNow allows tests to override the timeutil.Now() function used
 	// when updating rolling query counts.
 	getTimeNow func() time.Time
-	// getContentionNanos allows tests to override the recorded contention time
-	// for the query. Used to stub non-zero values to populate the log's contention
-	// time field.
-	getContentionNanos func() int64
+	// getQueryLevelMetrics allows tests to override the recorded query level stats.
+	getQueryLevelStats func() execstats.QueryLevelStats
 	// getTracingStatus allows tests to override whether the current query has tracing
 	// enabled or not. Queries with tracing enabled are always sampled to telemetry.
 	getTracingStatus func() bool
@@ -91,11 +90,13 @@ func (t *TelemetryLoggingMetrics) maybeUpdateLastEmittedTime(
 	return false
 }
 
-func (t *TelemetryLoggingMetrics) getContentionTime(contentionTimeInNanoseconds int64) int64 {
-	if t.Knobs != nil && t.Knobs.getContentionNanos != nil {
-		return t.Knobs.getContentionNanos()
+func (t *TelemetryLoggingMetrics) getQueryLevelStats(
+	queryLevelStats execstats.QueryLevelStats,
+) execstats.QueryLevelStats {
+	if t.Knobs != nil && t.Knobs.getQueryLevelStats != nil {
+		return t.Knobs.getQueryLevelStats()
 	}
-	return contentionTimeInNanoseconds
+	return queryLevelStats
 }
 
 func (t *TelemetryLoggingMetrics) isTracing(_ *tracing.Span, tracingEnabled bool) bool {

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3884,6 +3884,60 @@ func (m *SampledQuery) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = append(b, ']')
 	}
 
+	if m.NetworkBytesSent != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NetworkBytesSent\":"...)
+		b = strconv.AppendInt(b, int64(m.NetworkBytesSent), 10)
+	}
+
+	if m.MaxMemUsage != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MaxMemUsage\":"...)
+		b = strconv.AppendInt(b, int64(m.MaxMemUsage), 10)
+	}
+
+	if m.MaxDiskUsage != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"MaxDiskUsage\":"...)
+		b = strconv.AppendInt(b, int64(m.MaxDiskUsage), 10)
+	}
+
+	if m.KVBytesRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KVBytesRead\":"...)
+		b = strconv.AppendInt(b, int64(m.KVBytesRead), 10)
+	}
+
+	if m.KVRowsRead != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"KVRowsRead\":"...)
+		b = strconv.AppendInt(b, int64(m.KVRowsRead), 10)
+	}
+
+	if m.NetworkMessages != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NetworkMessages\":"...)
+		b = strconv.AppendInt(b, int64(m.NetworkMessages), 10)
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -143,6 +143,24 @@ message SampledQuery {
   // The regions of the nodes where SQL processors ran.
   repeated string regions = 38 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
+  // The number of network bytes sent by nodes for this query.
+  int64 network_bytes_sent = 39 [(gogoproto.jsontag) = ',omitempty'];
+
+  // The maximum amount of memory usage by nodes for this query.
+  int64 max_mem_usage = 40 [(gogoproto.jsontag) = ',omitempty'];
+
+  // The maximum amount of disk usage by nodes for this query.
+  int64 max_disk_usage = 41 [(gogoproto.jsontag) = ',omitempty'];
+
+  // The number of bytes read at the KV layer for this query.
+  int64 kv_bytes_read = 42 [(gogoproto.customname) = "KVBytesRead", (gogoproto.jsontag) = ',omitempty'];
+
+  // The number of rows read at the KV layer for this query.
+  int64 kv_rows_read = 43 [(gogoproto.customname) = "KVRowsRead", (gogoproto.jsontag) = ',omitempty'];
+
+  // The number of network messages sent by nodes for this query.
+  int64 network_messages = 44 [(gogoproto.jsontag) = ',omitempty'];
+
   reserved 12;
 }
 

--- a/pkg/util/log/logtestutils/BUILD.bazel
+++ b/pkg/util/log/logtestutils/BUILD.bazel
@@ -3,13 +3,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "logtestutils",
-    srcs = ["log_test_utils.go"],
+    srcs = [
+        "log_test_utils.go",
+        "telemetry_logging_test_utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/log/logtestutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/execstats",
         "//pkg/util/log",
         "//pkg/util/log/channel",
         "//pkg/util/log/logconfig",
+        "//pkg/util/syncutil",
     ],
 )
 

--- a/pkg/util/log/logtestutils/telemetry_logging_test_utils.go
+++ b/pkg/util/log/logtestutils/telemetry_logging_test_utils.go
@@ -1,0 +1,79 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package logtestutils
+
+import (
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// StubTime is a helper struct to stub the current time.
+type StubTime struct {
+	syncutil.RWMutex
+	t time.Time
+}
+
+// SetTime sets the current time.
+func (s *StubTime) SetTime(t time.Time) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.t = t
+}
+
+// TimeNow returns the current stubbed time.
+func (s *StubTime) TimeNow() time.Time {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.t
+}
+
+// StubQueryStats is a helper struct to stub query level stats.
+type StubQueryStats struct {
+	syncutil.RWMutex
+	stats execstats.QueryLevelStats
+}
+
+// SetQueryLevelStats sets the stubbed query level stats.
+func (s *StubQueryStats) SetQueryLevelStats(stats execstats.QueryLevelStats) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.stats = stats
+}
+
+// QueryLevelStats returns the current stubbed query level stats.
+func (s *StubQueryStats) QueryLevelStats() execstats.QueryLevelStats {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.stats
+}
+
+// StubTracingStatus is a helper struct to stub whether a query is being
+// traced.
+type StubTracingStatus struct {
+	syncutil.RWMutex
+	isTracing bool
+}
+
+// SetTracingStatus sets the stubbed status for tracing (true/false).
+func (s *StubTracingStatus) SetTracingStatus(t bool) {
+	s.RWMutex.Lock()
+	defer s.RWMutex.Unlock()
+	s.isTracing = t
+}
+
+// TracingStatus returns the stubbed status for tracing.
+func (s *StubTracingStatus) TracingStatus() bool {
+	s.RWMutex.RLock()
+	defer s.RWMutex.RUnlock()
+	return s.isTracing
+}


### PR DESCRIPTION
Partially addresses: #84729

This change adds:
- network bytes sent
- maximum memory usage
- maximum disk usage
- KV bytes read
- KV rows read
- network messages

fields to the `SampledQuery` telemetry log.

Release justification: low risk, high benefit changes to existing functionality

Release note (sql change): This change adds::
- network bytes sent
- maximum memory usage
- maximum disk usage
- KV bytes read
- KV rows read
- network messages fields to the `SampledQuery` telemetry log.