### PR TITLE
sql: fix unused duration formatting for index recommendations

### DIFF
--- a/pkg/sql/idxusage/index_usage_stats_rec.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec.go
@@ -12,6 +12,7 @@ package idxusage
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -42,7 +43,7 @@ var DropUnusedIndexDuration = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
-const indexExceedUsageDurationReasonPlaceholder = "This index has not been used in over %s and can be removed for better write performance."
+const indexExceedUsageDurationReasonPlaceholder = "This index has not been used in over %sand can be removed for better write performance."
 const indexNeverUsedReason = "This index has not been used and can be removed for better write performance."
 
 // UnusedIndexRecommendationTestingKnobs provides hooks and knobs for unit tests.
@@ -124,9 +125,32 @@ func (i IndexStatsRow) recommendDropUnusedIndex(
 }
 
 func formatDuration(d time.Duration) string {
-	days := d / (24 * time.Hour)
-	hours := d % (24 * time.Hour)
-	minutes := hours % time.Hour
+	const numHoursInDay = 24
+	const numMinutesInHour = 60
+	const numSecondsInMinute = 60
 
-	return fmt.Sprintf("%dd%dh%dm", days, hours/time.Hour, minutes)
+	days := int64(d.Hours()) / (numHoursInDay)
+	hours := int64(math.Floor(d.Hours())) % numHoursInDay
+	minutes := int64(math.Floor(d.Minutes())) % numMinutesInHour
+	seconds := int64(math.Floor(d.Seconds())) % numSecondsInMinute
+
+	var daysSubstring string
+	var hoursSubstring string
+	var minutesSubstring string
+	var secondsSubstring string
+
+	if days > 0 {
+		daysSubstring = fmt.Sprintf("%d days, ", days)
+	}
+	if hours > 0 {
+		hoursSubstring = fmt.Sprintf("%d hours, ", hours)
+	}
+	if minutes > 0 {
+		minutesSubstring = fmt.Sprintf("%d minutes, ", minutes)
+	}
+	if seconds > 0 {
+		secondsSubstring = fmt.Sprintf("%d seconds, ", seconds)
+	}
+
+	return fmt.Sprintf("%s%s%s%s", daysSubstring, hoursSubstring, minutesSubstring, secondsSubstring)
 }

--- a/pkg/sql/idxusage/index_usage_stats_rec_test.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec_test.go
@@ -89,7 +89,7 @@ func TestGetRecommendationsFromIndexStats(t *testing.T) {
 					TableID: 1,
 					IndexID: 2,
 					Type:    serverpb.IndexRecommendation_DROP_UNUSED,
-					Reason:  "This index has not been used in over 0d1h0m and can be removed for better write performance.",
+					Reason:  "This index has not been used in over 1 hours, and can be removed for better write performance.",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes: #85222 for DB Console

Previously, the index details page would not display unused index durations correctly for short durations (<1 hour).  This change corrects the formatting logic to display these durations correctly, and in a more readable format.

Screenshot of new formatting:
![Screen Shot 2022-09-07 at 3 19 13 PM](https://user-images.githubusercontent.com/15315413/188960473-1014f827-be2f-423d-ac84-12bc5f6999de.png)

Release justification: low risk, high benefit changes to existing functionality

Release note: None