### PR TITLE
sql: fix `SHOW COMPLETIONS` length check panic

### DIFF
--- a/pkg/sql/delegate/show_completions.go
+++ b/pkg/sql/delegate/show_completions.go
@@ -56,7 +56,8 @@ func (d *delegator) delegateShowCompletions(n *tree.ShowCompletions) (tree.State
 // RunShowCompletions returns a list of completion keywords for the given
 // statement and offset.
 func RunShowCompletions(stmt string, offset int) ([]string, error) {
-	if offset <= 0 || offset > len(stmt) {
+	byteStmt := []byte(stmt)
+	if offset <= 0 || offset > len(byteStmt) {
 		return nil, nil
 	}
 
@@ -66,10 +67,9 @@ func RunShowCompletions(stmt string, offset int) ([]string, error) {
 	// Ie "SELECT ", will only return one token being "SELECT".
 	// If we're at the whitespace, we do not want to return completion
 	// recommendations for "SELECT".
-	if unicode.IsSpace([]rune(stmt)[offset-1]) {
+	if unicode.IsSpace(rune(byteStmt[offset-1])) {
 		return nil, nil
 	}
-
 	sqlTokens := parser.TokensIgnoreErrors(string([]rune(stmt)[:offset]))
 	if len(sqlTokens) == 0 {
 		return nil, nil

--- a/pkg/sql/delegate/show_completions_test.go
+++ b/pkg/sql/delegate/show_completions_test.go
@@ -87,6 +87,16 @@ func TestCompletions(t *testing.T) {
 			expectedCompletions: []string{"SELECT"},
 			offset:              12,
 		},
+		{
+			stmt:                "😋😋😋 😋😋😋",
+			expectedCompletions: []string{},
+			offset:              25,
+		},
+		{
+			stmt:                "Jalapeño",
+			expectedCompletions: []string{},
+			offset:              9,
+		},
 	}
 	for _, tc := range tests {
 		offset := tc.offset


### PR DESCRIPTION
fixes #84153

In cases where the offset was larger than the rune length of statements with special 
characters, `SHOW COMPLETIONS` would return a panic. We now apply the offset on a byte slice before casting to a rune to fix that issue.

Release justification: Bug fix for SHOW COMPLETIONS

Release note: None