### PR TITLE
ui: hide non-tenant columns on the txn details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -451,7 +451,7 @@ export class TransactionDetails extends React.Component<
                         "transactionDetails",
                         isTenant,
                         hasViewActivityRedactedRole,
-                      )}
+                      ).filter(c => !(isTenant && c.hideIfTenant))}
                       className={cx("statements-table")}
                       sortSetting={sortSetting}
                       onChangeSortSetting={this.onChangeSortSetting}


### PR DESCRIPTION
Fixes #85248.

Despite passing `isTenant` to `makeStatementsColumns`, it seems the contract is to [also filter its results][1].

[1]: https://github.com/cockroachdb/cockroach/blob/018e180dc367c82fc5fbe7eb95a447f500cb90ff/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx#L577-L594

Release justification: bug fixes and low-risk updates to new functionality
Release note: None