### PR TITLE
streamingest: unskip TestTenantStreamingDeleteRange

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_replication_e2e_test.go
@@ -874,7 +874,6 @@ func TestTenantStreamingCutoverOnSourceFailure(t *testing.T) {
 
 func TestTenantStreamingDeleteRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	skip.WithIssue(t, 85630, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	// TODO(casper): disabled due to error when setting a cluster setting


### PR DESCRIPTION
#85866 seems to have stabilized this test, 5+ mins of stressing led to no failures so it seems safe to unskip.

Release note: None

Release justification: low risk, test only change

Fixes: #85630