### PR TITLE
tree: fix population of function properties

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -252,12 +252,10 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 				es := err.Error()
 				if strings.Contains(es, "internal error") {
 					// TODO(yuzefovich): we temporarily ignore internal errors
-					// that are because of #40929 and #86009.
+					// that are because of #40929.
 					var expectedError bool
 					for _, exp := range []string{
 						"could not parse \"0E-2019\" as type decimal",
-						"unable to vectorize execution plan: localtimestamp",
-						"unable to vectorize execution plan: overlaps",
 					} {
 						expectedError = expectedError || strings.Contains(es, exp)
 					}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_builtin
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_builtin
@@ -1,0 +1,16 @@
+# LogicTest: 5node-default-configs
+
+statement ok
+CREATE TABLE t (c INT);
+
+statement ok
+ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 2)
+
+# Regression test for not propagating the type annotation on the builtin
+# function with multiple overloads when serializing the expression for DistSQL
+# (#86009).
+statement ok
+SELECT c FROM t
+WHERE
+	localtimestamp(7::INT8):::TIMESTAMPTZ
+	IN ('1975-04-24 08:08:35.000071+00:00':::TIMESTAMPTZ, '1980-10-15 12:17:59.000616+00:00':::TIMESTAMPTZ);

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    shard_count = 13,
+    shard_count = 14,
     tags = ["cpu:3"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/sql/logictest/tests/5node-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/5node-disk/generated_test.go
@@ -93,6 +93,13 @@ func TestLogic_distsql_agg(
 	runLogicTest(t, "distsql_agg")
 }
 
+func TestLogic_distsql_builtin(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_builtin")
+}
+
 func TestLogic_distsql_crdb_internal(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -93,6 +93,13 @@ func TestLogic_distsql_agg(
 	runLogicTest(t, "distsql_agg")
 }
 
+func TestLogic_distsql_builtin(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_builtin")
+}
+
 func TestLogic_distsql_crdb_internal(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -189,8 +189,11 @@ func NewFunctionDefinition(
 		if def[i].PreferredOverload {
 			// Builtins with a preferred overload are always ambiguous.
 			props.AmbiguousReturnType = true
+			break
 		}
+	}
 
+	for i := range def {
 		def[i].FunctionProperties = *props
 		overloads[i] = &def[i]
 	}


### PR DESCRIPTION
In 6da18dc4404e6be9c018f82414e54526d83e8a7e we introduced a regression where `AmbiguousReturnType` would be incorrectly populated for builtin overloads if the first overloads in the list have `PreferredOverload` set to `false`, but later ones have it set to `true`. Before that change we had a single instance of the properties, and that change gave each overload its own copy, but without correctly making that copy.

Fixes: #86009.

Release justification: bug fix.

Release note: None (no stable release with this bug)