### PR TITLE
release-22.1: cli: don't show password in \c metacommand

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -1422,7 +1422,7 @@ func (c *cliState) handleConnectInternal(cmd []string) error {
 		if dbName == "" {
 			dbName = currURL.GetDatabase()
 		}
-		fmt.Fprintf(c.iCtx.stdout, "Connection string: %s\n", currURL.ToPQ())
+		fmt.Fprintf(c.iCtx.stdout, "Connection string: %s\n", currURL.ToPQRedacted())
 		fmt.Fprintf(c.iCtx.stdout, "You are connected to database %q as user %q.\n", dbName, currURL.GetUsername())
 		return nil
 

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -32,6 +32,7 @@ send "create user foo with password 'abc';\r"
 eexpect "CREATE ROLE"
 eexpect root@
 eexpect "/t>"
+end_test
 
 start_test "Check that the client-side connect cmd prints the current conn details"
 send "\\c\r"
@@ -39,6 +40,7 @@ eexpect "Connection string:"
 eexpect "You are connected to database \"t\" as user \"root\""
 eexpect root@
 eexpect "/t>"
+end_test
 
 start_test "Check that the client-side connect cmd can change databases"
 send "\\c postgres\r"
@@ -165,6 +167,20 @@ eexpect "custom_path"
 send "SHOW statement_timeout;\r"
 eexpect "1234"
 
+end_test
+
+send "\\q\r"
+eexpect eof
+
+start_test "Check that the client-side connect cmd prints the current conn details with password redacted"
+
+spawn $argv sql --certs-dir=$certs_dir --url=postgres://foo:abc@localhost:26257/defaultdb
+eexpect foo@
+send "\\c\r"
+eexpect "Connection string: postgresql://foo:~~~~~~@"
+eexpect "You are connected to database \"defaultdb\" as user \"foo\""
+eexpect foo@
+eexpect "/defaultdb>"
 end_test
 
 send "\\q\r"

--- a/pkg/server/pgurl/generate.go
+++ b/pkg/server/pgurl/generate.go
@@ -103,6 +103,26 @@ func (u *URL) ToPQ() *url.URL {
 	return nu
 }
 
+// ToPQRedacted converts the URL to a connection string supported
+// by drivers using libpq or compatible, with the password redacted.
+func (u *URL) ToPQRedacted() *url.URL {
+	nu, opts := u.baseURL()
+
+	if u.username != "" {
+		nu.User = url.User(u.username)
+	}
+	switch u.authn {
+	case authnPassword, authnPasswordWithClientCert:
+		if u.hasPassword {
+			// Use '~' since it does not need to be escaped.
+			nu.User = url.UserPassword(u.username, "~~~~~~")
+		}
+	}
+
+	nu.RawQuery = opts.Encode()
+	return nu
+}
+
 // String makes URL printable.
 func (u *URL) String() string { return u.ToPQ().String() }
 


### PR DESCRIPTION
Backport 1/1 commits from #87298.

/cc @cockroachdb/release

---

fixes https://github.com/cockroachdb/cockroach/issues/87294

Release note (cli change): The \c metacommand no longer shows the
password in plaintext.

Release justification: low risk change
