### PR TITLE
backupccl: backup/restore with user-defined functions

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -82,6 +82,7 @@ go_library(
         "//pkg/sql/catalog/descidgen",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/ingesting",
         "//pkg/sql/catalog/multiregion",
         "//pkg/sql/catalog/nstree",

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -467,6 +467,10 @@ func checkPrivilegesForBackup(
 			if err := p.CheckPrivilege(ctx, desc, privilege.USAGE); err != nil {
 				return errors.WithHint(err, notice)
 			}
+		case catalog.FunctionDescriptor:
+			if err := p.CheckPrivilege(ctx, desc, privilege.EXECUTE); err != nil {
+				return errors.WithHint(err, notice)
+			}
 		}
 	}
 

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -71,6 +71,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -78,6 +79,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -10302,4 +10304,294 @@ func TestBackupDBWithViewOnAdjacentDBRange(t *testing.T) {
 	// This statement should succeed as we are not backing up the span for dbview,
 	// but would fail if it was backed up.
 	sqlDB.Exec(t, `BACKUP database db into latest in 'userfile:///a' with revision_history;`)
+}
+
+func TestBackupRestoreDBWithUDFs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tempDir, tempDirCleanupFn := testutils.TempDir(t)
+	defer tempDirCleanupFn()
+
+	srcCluster, sqlDB, srcClusterCleanupFn := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
+	srcServer := srcCluster.Server(0)
+	defer srcClusterCleanupFn()
+
+	sqlDB.Exec(t, `
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE TYPE sc1.enum1 AS ENUM('Good');
+CREATE SEQUENCE sc1.sq1;
+CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sc1.tbl1;
+  SELECT nextval('sc1.sq1');
+$$;
+`)
+
+	rows := sqlDB.QueryStr(t, `SELECT function_id FROM crdb_internal.create_function_statements WHERE function_name = 'f1'`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	udfID, err := strconv.Atoi(rows[0][0])
+	require.NoError(t, err)
+	err = sql.TestingDescsTxn(ctx, srcServer, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		dbDesc, err := col.GetImmutableDatabaseByName(ctx, txn, "db1", tree.DatabaseLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 104, int(dbDesc.GetID()))
+
+		scDesc, err := col.GetImmutableSchemaByName(ctx, txn, dbDesc, "sc1", tree.SchemaLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 106, int(scDesc.GetID()))
+
+		tbName := tree.MakeTableNameWithSchema("db1", "sc1", "tbl1")
+		_, tbDesc, err := col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 107, int(tbDesc.GetID()))
+
+		typName := tree.MakeQualifiedTypeName("db1", "sc1", "enum1")
+		_, typDesc, err := col.GetImmutableTypeByName(ctx, txn, &typName, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 108, int(typDesc.GetID()))
+
+		tbName = tree.MakeTableNameWithSchema("db1", "sc1", "sq1")
+		_, tbDesc, err = col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 110, int(tbDesc.GetID()))
+
+		fnDesc, err := col.GetImmutableFunctionByID(ctx, txn, descpb.ID(udfID), tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 111, int(fnDesc.GetID()))
+		require.Equal(t, 104, int(fnDesc.GetParentID()))
+		require.Equal(t, 106, int(fnDesc.GetParentSchemaID()))
+		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, 100108, int(fnDesc.GetArgs()[0].Type.Oid()))
+		require.Equal(t, []descpb.ID{107, 110}, fnDesc.GetDependsOn())
+		require.Equal(t, []descpb.ID{108, 109}, fnDesc.GetDependsOnTypes())
+
+		fnDef, _ := scDesc.GetFunction("f1")
+		require.Equal(t, 111, int(fnDef.Overloads[0].ID))
+		require.Equal(t, 100108, int(fnDef.Overloads[0].ArgTypes[0].Oid()))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Bakcup and restore into a new db name.
+	sqlDB.Exec(t, `BACKUP DATABASE db1 INTO $1`, localFoo)
+	sqlDB.Exec(t, `RESTORE DATABASE db1 FROM LATEST IN $1 WITH new_db_name = db1_new`, localFoo)
+	sqlDB.Exec(t, `USE db1_new`)
+
+	// Verify that all IDs are correctly rewritten.
+	rows = sqlDB.QueryStr(t, `SELECT function_id FROM crdb_internal.create_function_statements WHERE function_name = 'f1'`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	udfID, err = strconv.Atoi(rows[0][0])
+	require.NoError(t, err)
+	err = sql.TestingDescsTxn(ctx, srcServer, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		dbDesc, err := col.GetImmutableDatabaseByName(ctx, txn, "db1_new", tree.DatabaseLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 112, int(dbDesc.GetID()))
+
+		scDesc, err := col.GetImmutableSchemaByName(ctx, txn, dbDesc, "sc1", tree.SchemaLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 114, int(scDesc.GetID()))
+
+		tbName := tree.MakeTableNameWithSchema("db1_new", "sc1", "tbl1")
+		_, tbDesc, err := col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 115, int(tbDesc.GetID()))
+
+		typName := tree.MakeQualifiedTypeName("db1_new", "sc1", "enum1")
+		_, typDesc, err := col.GetImmutableTypeByName(ctx, txn, &typName, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 116, int(typDesc.GetID()))
+
+		tbName = tree.MakeTableNameWithSchema("db1_new", "sc1", "sq1")
+		_, tbDesc, err = col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 118, int(tbDesc.GetID()))
+
+		fnDesc, err := col.GetImmutableFunctionByID(ctx, txn, descpb.ID(udfID), tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 119, int(fnDesc.GetID()))
+		require.Equal(t, 112, int(fnDesc.GetParentID()))
+		require.Equal(t, 114, int(fnDesc.GetParentSchemaID()))
+		// Make sure db name and IDs are rewritten in function body.
+		require.Equal(t, "SELECT a FROM db1_new.sc1.tbl1;\nSELECT nextval(118:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, 100116, int(fnDesc.GetArgs()[0].Type.Oid()))
+		require.Equal(t, []descpb.ID{115, 118}, fnDesc.GetDependsOn())
+		require.Equal(t, []descpb.ID{116, 117}, fnDesc.GetDependsOnTypes())
+
+		fnDef, _ := scDesc.GetFunction("f1")
+		require.Equal(t, 119, int(fnDef.Overloads[0].ID))
+		require.Equal(t, 100116, int(fnDef.Overloads[0].ArgTypes[0].Oid()))
+		return nil
+	})
+
+	// Make sure function actually works.
+	rows = sqlDB.QueryStr(t, `SELECT sc1.f1('Good'::sc1.enum1)`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	require.Equal(t, "1", rows[0][0])
+	require.NoError(t, err)
+}
+
+func TestBackupRestoreClusterWithUDFs(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tempDir, tempDirCleanupFn := testutils.TempDir(t)
+	defer tempDirCleanupFn()
+
+	srcCluster, srcSQLDB, srcClusterCleanupFn := backupRestoreTestSetupEmpty(
+		t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{},
+	)
+	srcServer := srcCluster.Server(0)
+	defer srcClusterCleanupFn()
+
+	tgtCluster, tgtSQLDB, tgtClusterCleanupFn := backupRestoreTestSetupEmpty(
+		t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{},
+	)
+	tgtServer := tgtCluster.Server(0)
+	defer tgtClusterCleanupFn()
+
+	srcSQLDB.Exec(t, `
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE TYPE sc1.enum1 AS ENUM('Good');
+CREATE SEQUENCE sc1.sq1;
+CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sc1.tbl1;
+  SELECT nextval('sc1.sq1');
+$$;
+`)
+
+	rows := srcSQLDB.QueryStr(t, `SELECT function_id FROM crdb_internal.create_function_statements WHERE function_name = 'f1'`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	udfID, err := strconv.Atoi(rows[0][0])
+	require.NoError(t, err)
+	err = sql.TestingDescsTxn(ctx, srcServer, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		dbDesc, err := col.GetImmutableDatabaseByName(ctx, txn, "db1", tree.DatabaseLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 104, int(dbDesc.GetID()))
+
+		scDesc, err := col.GetImmutableSchemaByName(ctx, txn, dbDesc, "sc1", tree.SchemaLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 106, int(scDesc.GetID()))
+
+		tbName := tree.MakeTableNameWithSchema("db1", "sc1", "tbl1")
+		_, tbDesc, err := col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 107, int(tbDesc.GetID()))
+
+		typName := tree.MakeQualifiedTypeName("db1", "sc1", "enum1")
+		_, typDesc, err := col.GetImmutableTypeByName(ctx, txn, &typName, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 108, int(typDesc.GetID()))
+
+		tbName = tree.MakeTableNameWithSchema("db1", "sc1", "sq1")
+		_, tbDesc, err = col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 110, int(tbDesc.GetID()))
+
+		fnDesc, err := col.GetImmutableFunctionByID(ctx, txn, descpb.ID(udfID), tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 111, int(fnDesc.GetID()))
+		require.Equal(t, 104, int(fnDesc.GetParentID()))
+		require.Equal(t, 106, int(fnDesc.GetParentSchemaID()))
+		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(110:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, 100108, int(fnDesc.GetArgs()[0].Type.Oid()))
+		require.Equal(t, []descpb.ID{107, 110}, fnDesc.GetDependsOn())
+		require.Equal(t, []descpb.ID{108, 109}, fnDesc.GetDependsOnTypes())
+
+		fnDef, _ := scDesc.GetFunction("f1")
+		require.Equal(t, 111, int(fnDef.Overloads[0].ID))
+		require.Equal(t, 100108, int(fnDef.Overloads[0].ArgTypes[0].Oid()))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Bakcup the whole src cluster.
+	srcSQLDB.Exec(t, `BACKUP INTO $1`, localFoo)
+
+	// Restore into target cluster.
+	tgtSQLDB.Exec(t, `RESTORE FROM LATEST IN $1`, localFoo)
+	tgtSQLDB.Exec(t, `USE db1`)
+
+	// Verify that all IDs are correctly rewritten.
+	rows = tgtSQLDB.QueryStr(t, `SELECT function_id FROM crdb_internal.create_function_statements WHERE function_name = 'f1'`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	udfID, err = strconv.Atoi(rows[0][0])
+	require.NoError(t, err)
+	err = sql.TestingDescsTxn(ctx, tgtServer, func(ctx context.Context, txn *kv.Txn, col *descs.Collection) error {
+		dbDesc, err := col.GetImmutableDatabaseByName(ctx, txn, "db1", tree.DatabaseLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 107, int(dbDesc.GetID()))
+
+		scDesc, err := col.GetImmutableSchemaByName(ctx, txn, dbDesc, "sc1", tree.SchemaLookupFlags{Required: true})
+		require.NoError(t, err)
+		require.Equal(t, 125, int(scDesc.GetID()))
+
+		tbName := tree.MakeTableNameWithSchema("db1", "sc1", "tbl1")
+		_, tbDesc, err := col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 126, int(tbDesc.GetID()))
+
+		typName := tree.MakeQualifiedTypeName("db1", "sc1", "enum1")
+		_, typDesc, err := col.GetImmutableTypeByName(ctx, txn, &typName, tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 127, int(typDesc.GetID()))
+
+		tbName = tree.MakeTableNameWithSchema("db1", "sc1", "sq1")
+		_, tbDesc, err = col.GetImmutableTableByName(
+			ctx, txn, &tbName, tree.ObjectLookupFlagsWithRequired(),
+		)
+		require.NoError(t, err)
+		require.Equal(t, 129, int(tbDesc.GetID()))
+
+		fnDesc, err := col.GetImmutableFunctionByID(ctx, txn, descpb.ID(udfID), tree.ObjectLookupFlagsWithRequired())
+		require.NoError(t, err)
+		require.Equal(t, 130, int(fnDesc.GetID()))
+		require.Equal(t, 107, int(fnDesc.GetParentID()))
+		require.Equal(t, 125, int(fnDesc.GetParentSchemaID()))
+		// Make sure db name and IDs are rewritten in function body.
+		require.Equal(t, "SELECT a FROM db1.sc1.tbl1;\nSELECT nextval(129:::REGCLASS);", fnDesc.GetFunctionBody())
+		require.Equal(t, 100127, int(fnDesc.GetArgs()[0].Type.Oid()))
+		require.Equal(t, []descpb.ID{126, 129}, fnDesc.GetDependsOn())
+		require.Equal(t, []descpb.ID{127, 128}, fnDesc.GetDependsOnTypes())
+
+		fnDef, _ := scDesc.GetFunction("f1")
+		require.Equal(t, 130, int(fnDef.Overloads[0].ID))
+		require.Equal(t, 100127, int(fnDef.Overloads[0].ArgTypes[0].Oid()))
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Make sure function actually works on the target cluster.
+	rows = tgtSQLDB.QueryStr(t, `SELECT sc1.f1('Good'::sc1.enum1)`)
+	require.Equal(t, 1, len(rows))
+	require.Equal(t, 1, len(rows[0]))
+	require.Equal(t, "1", rows[0][0])
+	require.NoError(t, err)
+
 }

--- a/pkg/ccl/backupccl/backupinfo/backup_metadata.go
+++ b/pkg/ccl/backupccl/backupinfo/backup_metadata.go
@@ -510,6 +510,8 @@ func descID(in descpb.Descriptor) descpb.ID {
 		return i.Type.ID
 	case *descpb.Descriptor_Schema:
 		return i.Schema.ID
+	case *descpb.Descriptor_Function:
+		return i.Function.ID
 	default:
 		panic(fmt.Sprintf("unknown desc %T", in))
 	}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -40,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/ingesting"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
@@ -709,6 +710,8 @@ func createImportingDescriptors(
 	var writtenTypes []catalog.TypeDescriptor
 	var schemas []*schemadesc.Mutable
 	var types []*typedesc.Mutable
+	var functions []*funcdesc.Mutable
+
 	// Store the tables as both the concrete mutable structs and the interface
 	// to deal with the lack of slice covariance in go. We want the slice of
 	// mutable descriptors for rewriting but ultimately want to return the
@@ -780,6 +783,10 @@ func createImportingDescriptors(
 		case catalog.TypeDescriptor:
 			mut := typedesc.NewBuilder(desc.TypeDesc()).BuildCreatedMutableType()
 			types = append(types, mut)
+			allMutableDescs = append(allMutableDescs, mut)
+		case catalog.FunctionDescriptor:
+			mut := funcdesc.NewBuilder(desc.FuncDesc()).BuildCreatedMutableFunction()
+			functions = append(functions, mut)
 			allMutableDescs = append(allMutableDescs, mut)
 		}
 	}
@@ -882,6 +889,24 @@ func createImportingDescriptors(
 		return nil, nil, nil, err
 	}
 
+	// TODO(chengxiong): for now, we know that functions are not referenced by any
+	// other objects, so that function descriptors are only restored when
+	// restoring databases. This means that all function descriptors are not
+	// remaps. Which means that we don't need resolve collisions between functions
+	// being restored and existing functions in target DB However, this won't be
+	// true when we start supporting udf references from other objects. For
+	// example, we need extra logic to handle remaps for udfs used by a table when
+	// backup/restore is on table level.
+	functionsToWrite := make([]*funcdesc.Mutable, len(functions))
+	writtenFunctions := make([]catalog.FunctionDescriptor, len(functions))
+	for i, fn := range functions {
+		functionsToWrite[i] = fn
+		writtenFunctions[i] = fn
+	}
+	if err := rewrite.FunctionDescs(functions, details.DescriptorRewrites, details.OverrideDB); err != nil {
+		return nil, nil, nil, err
+	}
+
 	// Finally, clean up / update any schema changer state inside descriptors
 	// globally.
 	if err := rewrite.MaybeClearSchemaChangerStateInDescs(allMutableDescs); err != nil {
@@ -899,6 +924,9 @@ func createImportingDescriptors(
 		desc.SetOffline("restoring")
 	}
 	for _, desc := range mutableDatabases {
+		desc.SetOffline("restoring")
+	}
+	for _, desc := range functionsToWrite {
 		desc.SetOffline("restoring")
 	}
 
@@ -1007,7 +1035,8 @@ func createImportingDescriptors(
 
 			// Write the new descriptors which are set in the OFFLINE state.
 			if err := ingesting.WriteDescriptors(
-				ctx, p.ExecCfg().Codec, txn, p.User(), descsCol, databases, writtenSchemas, tables, writtenTypes,
+				ctx, p.ExecCfg().Codec, txn, p.User(), descsCol,
+				databases, writtenSchemas, tables, writtenTypes, writtenFunctions,
 				details.DescriptorCoverage, nil /* extra */, restoreTempSystemDB,
 			); err != nil {
 				return errors.Wrapf(err, "restoring %d TableDescriptors from %d databases", len(tables), len(databases))
@@ -1171,6 +1200,10 @@ func createImportingDescriptors(
 			details.SchemaDescs = make([]*descpb.SchemaDescriptor, len(schemasToWrite))
 			for i := range schemasToWrite {
 				details.SchemaDescs[i] = schemasToWrite[i].SchemaDesc()
+			}
+			details.FunctionDescs = make([]*descpb.FunctionDescriptor, len(functionsToWrite))
+			for i, fn := range functionsToWrite {
+				details.FunctionDescs[i] = fn.FuncDesc()
 			}
 
 			// Update the job once all descs have been prepared for ingestion.
@@ -1941,6 +1974,7 @@ func (r *restoreResumer) publishDescriptors(
 	newTypes := make([]*descpb.TypeDescriptor, 0, len(details.TypeDescs))
 	newSchemas := make([]*descpb.SchemaDescriptor, 0, len(details.SchemaDescs))
 	newDBs := make([]*descpb.DatabaseDescriptor, 0, len(details.DatabaseDescs))
+	newFunctions := make([]*descpb.FunctionDescriptor, 0, len(details.FunctionDescs))
 
 	// Go through the descriptors and find any declarative schema change jobs
 	// affecting them.
@@ -2027,6 +2061,10 @@ func (r *restoreResumer) publishDescriptors(
 		db := all.LookupDescriptorEntry(details.DatabaseDescs[i].GetID()).(catalog.DatabaseDescriptor)
 		newDBs = append(newDBs, db.DatabaseDesc())
 	}
+	for i := range details.FunctionDescs {
+		fn := all.LookupDescriptorEntry(details.FunctionDescs[i].GetID()).(catalog.FunctionDescriptor)
+		newFunctions = append(newFunctions, fn.FuncDesc())
+	}
 	b := txn.NewBatch()
 	if err := all.ForEachDescriptorEntry(func(desc catalog.Descriptor) error {
 		d := desc.(catalog.MutableDescriptor)
@@ -2053,6 +2091,7 @@ func (r *restoreResumer) publishDescriptors(
 	details.TypeDescs = newTypes
 	details.SchemaDescs = newSchemas
 	details.DatabaseDescs = newDBs
+	details.FunctionDescs = newFunctions
 	if err := r.job.SetDetails(ctx, txn, details); err != nil {
 		return errors.Wrap(err,
 			"updating job details after publishing tables")
@@ -2088,6 +2127,10 @@ func prefetchDescriptors(
 	for i := range details.DatabaseDescs {
 		expVersion[details.DatabaseDescs[i].GetID()] = details.DatabaseDescs[i].GetVersion()
 		allDescIDs.Add(details.DatabaseDescs[i].GetID())
+	}
+	for i := range details.FunctionDescs {
+		expVersion[details.FunctionDescs[i].GetID()] = details.FunctionDescs[i].GetVersion()
+		allDescIDs.Add(details.FunctionDescs[i].GetID())
 	}
 	// Note that no maximum size is put on the batch here because,
 	// in general, we assume that we can fit all of the descriptors

--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -738,6 +738,12 @@ func backupShowerDefault(
 						dbID = desc.GetParentID()
 						parentSchemaName = schemaIDToName[desc.GetParentSchemaID()]
 						parentSchemaID = desc.GetParentSchemaID()
+					case catalog.FunctionDescriptor:
+						descriptorType = "function"
+						dbName = dbIDToName[desc.GetParentID()]
+						dbID = desc.GetParentID()
+						parentSchemaName = schemaIDToName[desc.GetParentSchemaID()]
+						parentSchemaID = desc.GetParentSchemaID()
 					case catalog.TableDescriptor:
 						descriptorType = "table"
 						dbName = dbIDToName[desc.GetParentID()]

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -270,6 +270,8 @@ func fullClusterTargets(
 			fullClusterDescs = append(fullClusterDescs, desc)
 		case catalog.TypeDescriptor:
 			fullClusterDescs = append(fullClusterDescs, desc)
+		case catalog.FunctionDescriptor:
+			fullClusterDescs = append(fullClusterDescs, desc)
 		}
 	}
 	return fullClusterDescs, fullClusterDBs, nil
@@ -333,12 +335,12 @@ func fullClusterTargetsBackup(
 // filters the descriptors based on the targets specified in the restore, and
 // calculates the max descriptor ID in the backup.
 // Post filtering, the method returns:
-//   - A list of all descriptors (table, type, database, schema) along with their
-//     parent databases.
+//   - A list of all descriptors (table, type, database, schema, function) along with
+//     their parent databases.
 //   - A list of database descriptors IFF the user is restoring on the cluster or
 //     database level.
 //   - A map of table patterns to the resolved descriptor IFF the user is
-//     restoring on the table leve.
+//     restoring on the table level.
 //   - A list of tenants to restore, if applicable.
 func selectTargets(
 	ctx context.Context,

--- a/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/backup-permissions
@@ -249,3 +249,57 @@ select object_name from [show backup latest in 'nodelocal://1/test-nonroot-table
 pq: only users with the admin role or the EXTERNALIOIMPLICITACCESS system privilege are allowed to access the specified nodelocal URI
 
 subtest end
+
+subtest udf-permission
+
+exec-sql
+CREATE DATABASE d_test_fn;
+USE d_test_fn;
+CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
+USE d;
+----
+
+# Cluster backup should succeed as a root user.
+exec-sql
+BACKUP INTO 'userfile:///test-root/'
+----
+
+# Backups should succeed as a non-root user with admin role.
+exec-sql
+GRANT ADMIN TO testuser;
+----
+
+exec-sql user=testuser
+BACKUP INTO 'userfile:///test-nonroot-cluster';
+----
+
+exec-sql user=testuser
+BACKUP DATABASE d_test_fn INTO 'userfile:///test-nonroot-db';
+----
+
+exec-sql
+REVOKE ADMIN FROM testuser
+----
+
+# Grant system backup privilege and re-run the backup.
+exec-sql
+GRANT SYSTEM BACKUP TO testuser;
+----
+
+exec-sql user=testuser
+BACKUP INTO 'userfile:///test-nonroot-cluster';
+----
+
+# System privilege BACKUP does not allow a user to run database/table backups by
+# default.
+exec-sql user=testuser
+BACKUP DATABASE d_test_fn INTO 'userfile:///test-nonroot-db';
+----
+pq: user testuser does not have EXECUTE privilege on function f
+HINT: The existing privileges are being deprecated in favour of a fine-grained privilege model explained here <link>. In a future release, to run BACKUP DATABASE, user testuser will exclusively require the BACKUP privilege on database d_test_fn.
+
+exec-sql
+REVOKE SYSTEM BACKUP FROM testuser;
+----
+
+subtest end

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -1,0 +1,312 @@
+# Test backing up and restoring a database with user defined functions.
+new-server name=s
+----
+
+exec-sql
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE TYPE sc1.enum1 AS ENUM('Good');
+CREATE SEQUENCE sc1.sq1;
+CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sc1.tbl1;
+  SELECT nextval('sc1.sq1');
+$$;
+CREATE SCHEMA sc2;
+CREATE TABLE sc2.tbl2(a INT PRIMARY KEY);
+CREATE FUNCTION sc2.f2() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc2.tbl2 LIMIT 1 $$;
+----
+
+exec-sql
+INSERT INTO sc2.tbl2 VALUES (123)
+----
+
+query-sql
+SELECT sc2.f2()
+----
+123
+
+exec-sql
+BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> db1 database false
+db1 <nil> public schema false
+db1 <nil> sc1 schema false
+db1 sc1 tbl1 table false
+db1 sc1 enum1 type false
+db1 sc1 _enum1 type false
+db1 sc1 sq1 table false
+db1 sc1 f1 function false
+db1 <nil> sc2 schema false
+db1 sc2 tbl2 table false
+db1 sc2 f2 function false
+
+query-sql
+SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f1]
+----
+CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
+	RETURNS INT8
+	VOLATILE
+	NOT LEAKPROOF
+	CALLED ON NULL INPUT
+	LANGUAGE SQL
+	AS $$
+	SELECT a FROM db1.sc1.tbl1;
+	SELECT nextval('sc1.sq1'::REGCLASS);
+$$
+
+query-sql
+SELECT sc1.f1('Good'::sc1.enum1)
+----
+1
+
+exec-sql
+DROP DATABASE db1
+----
+
+exec-sql
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+----
+
+exec-sql
+USE db1_new
+----
+
+# Make sure function ids in signature and body are rewritten.
+# 1. argument type id is rewritten so that type name is deserialized correctly.
+# 2. db name in qualified name is rewritten.
+# 3. sequence id is rewritten so that sequence name is deserialized correctly.
+query-sql
+SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f1]
+----
+CREATE FUNCTION sc1.f1(IN a db1_new.sc1.enum1)
+	RETURNS INT8
+	VOLATILE
+	NOT LEAKPROOF
+	CALLED ON NULL INPUT
+	LANGUAGE SQL
+	AS $$
+	SELECT a FROM db1_new.sc1.tbl1;
+	SELECT nextval('sc1.sq1'::REGCLASS);
+$$
+
+# Make sure function signature is rewritten in schema descriptor so that
+# function can be resolved and executed.
+query-sql
+SELECT sc1.f1('Good'::db1_new.sc1.enum1)
+----
+1
+
+# Make sure function still queries from correct table.
+query-sql
+SELECT db1_new.sc2.f2()
+----
+123
+
+# Make sure dependency IDs are rewritten.
+# Note that technically this only tests forward-reference IDs in depended-on
+# objects are rewritten. But since we have cross-references validation, so this
+# also means back-references in UDF descriptor are good.
+exec-sql
+DROP SEQUENCE sc1.sq1
+----
+pq: cannot drop sequence sq1 because other objects depend on it
+
+exec-sql
+DROP TABLE sc1.tbl1
+----
+pq: cannot drop relation "tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
+----
+pq: cannot rename relation "sc1.tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
+----
+pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+DROP TYPE sc1.enum1
+----
+pq: cannot drop type "enum1" because other objects ([db1_new.sc1.f1]) still depend on it
+
+# Test backing up and restoring a full cluster with user defined function.
+new-server name=s1
+----
+
+exec-sql server=s1
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE TYPE sc1.enum1 AS ENUM('Good');
+CREATE SEQUENCE sc1.sq1;
+CREATE FUNCTION sc1.f1(a sc1.enum1) RETURNS INT LANGUAGE SQL AS $$
+  SELECT a FROM sc1.tbl1;
+  SELECT nextval('sc1.sq1');
+$$;
+CREATE SCHEMA sc2;
+CREATE TABLE sc2.tbl2(a INT PRIMARY KEY);
+CREATE FUNCTION sc2.f2() RETURNS INT LANGUAGE SQL AS $$ SELECT a FROM sc2.tbl2 LIMIT 1 $$;
+----
+
+exec-sql
+INSERT INTO sc2.tbl2 VALUES (123)
+----
+
+query-sql
+SELECT sc2.f2()
+----
+123
+
+exec-sql
+BACKUP INTO 'nodelocal://0/test/'
+----
+
+query-sql
+WITH descs AS (
+  SHOW BACKUP LATEST IN 'nodelocal://0/test/'
+)
+SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+----
+<nil> <nil> system database true
+system public users table true
+system public zones table true
+system public settings table true
+system public ui table true
+system public locations table true
+system public role_members table true
+system public comments table true
+system public role_options table true
+system public scheduled_jobs table true
+system public database_role_settings table true
+system public role_id_seq table true
+system public tenant_settings table true
+system public privileges table true
+system public external_connections table true
+<nil> <nil> defaultdb database true
+defaultdb <nil> public schema true
+<nil> <nil> postgres database true
+postgres <nil> public schema true
+<nil> <nil> data database true
+data <nil> public schema true
+data public bank table true
+<nil> <nil> db1 database true
+db1 <nil> public schema true
+db1 <nil> sc1 schema true
+db1 sc1 tbl1 table true
+db1 sc1 enum1 type true
+db1 sc1 _enum1 type true
+db1 sc1 sq1 table true
+db1 sc1 f1 function true
+db1 <nil> sc2 schema true
+db1 sc2 tbl2 table true
+db1 sc2 f2 function true
+
+query-sql
+SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f1]
+----
+CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
+	RETURNS INT8
+	VOLATILE
+	NOT LEAKPROOF
+	CALLED ON NULL INPUT
+	LANGUAGE SQL
+	AS $$
+	SELECT a FROM db1.sc1.tbl1;
+	SELECT nextval('sc1.sq1'::REGCLASS);
+$$
+
+query-sql
+SELECT sc1.f1('Good'::sc1.enum1)
+----
+1
+
+# Start a new cluster with the same IO dir.
+new-server name=s2 share-io-dir=s1
+----
+
+# Restore into the new cluster.
+exec-sql server=s2
+RESTORE FROM LATEST IN 'nodelocal://0/test/'
+----
+
+exec-sql
+USE db1
+----
+
+# Make sure function ids in signature and body are rewritten.
+# 1. argument type id is rewritten so that type name is deserialized correctly.
+# 2. db name in qualified name is rewritten.
+# 3. sequence id is rewritten so that sequence name is deserialized correctly.
+query-sql
+SELECT @2 FROM [SHOW CREATE FUNCTION sc1.f1]
+----
+CREATE FUNCTION sc1.f1(IN a db1.sc1.enum1)
+	RETURNS INT8
+	VOLATILE
+	NOT LEAKPROOF
+	CALLED ON NULL INPUT
+	LANGUAGE SQL
+	AS $$
+	SELECT a FROM db1.sc1.tbl1;
+	SELECT nextval('sc1.sq1'::REGCLASS);
+$$
+
+# Make sure function signature is rewritten in schema descriptor so that
+# function can be resolved and executed.
+query-sql
+SELECT sc1.f1('Good'::sc1.enum1)
+----
+1
+
+# Make sure function still queries from correct table.
+query-sql
+SELECT sc2.f2()
+----
+123
+
+# Make sure dependency IDs are rewritten.
+# Note that technically this only tests forward-reference IDs in depended-on
+# objects are rewritten. But since we have cross-references validation, so this
+# also means back-references in UDF descriptor are good.
+exec-sql
+DROP SEQUENCE sc1.sq1
+----
+pq: cannot drop sequence sq1 because other objects depend on it
+
+exec-sql
+DROP TABLE sc1.tbl1
+----
+pq: cannot drop relation "tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
+----
+pq: cannot rename relation "sc1.tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
+----
+pq: cannot set schema on relation "tbl1" because function "f1" depends on it
+HINT: you can drop f1 instead.
+
+exec-sql
+DROP TYPE sc1.enum1
+----
+pq: cannot drop type "enum1" because other objects ([db1.sc1.f1]) still depend on it

--- a/pkg/ccl/backupccl/testdata/backup-restore/views
+++ b/pkg/ccl/backupccl/testdata/backup-restore/views
@@ -1,0 +1,42 @@
+# Make sure that db names are rewritten in a view restored to a new db name.
+new-server name=s
+----
+
+exec-sql
+CREATE DATABASE db1;
+USE db1;
+CREATE SCHEMA sc1;
+CREATE TABLE sc1.tbl1(a INT PRIMARY KEY);
+CREATE VIEW sc1.v1 AS SELECT a FROM sc1.tbl1;
+----
+
+exec-sql
+INSERT INTO sc1.tbl1 VALUES (123);
+----
+
+query-sql
+SELECT * FROM sc1.v1;
+----
+123
+
+query-sql
+SHOW CREATE VIEW sc1.v1;
+----
+sc1.v1 CREATE VIEW sc1.v1 (
+	a
+) AS SELECT a FROM db1.sc1.tbl1
+
+exec-sql
+BACKUP DATABASE db1 INTO 'nodelocal://0/test/'
+----
+
+exec-sql
+RESTORE DATABASE db1 FROM LATEST IN 'nodelocal://0/test/' WITH new_db_name = db1_new
+----
+
+query-sql
+SHOW CREATE VIEW db1_new.sc1.v1;
+----
+db1_new.sc1.v1 CREATE VIEW sc1.v1 (
+	a
+) AS SELECT a FROM db1_new.sc1.tbl1

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -319,6 +319,9 @@ message RestoreDetails {
   // Like TypeDescs, it does not include existing schema descriptors in the
   // cluster that backed up schemas are remapped to.
   repeated sqlbase.SchemaDescriptor schema_descs = 15;
+  // FunctionDescs contains function descriptors written as part of this
+  // restore.
+  repeated sqlbase.FunctionDescriptor function_descs = 27;
   reserved 13;
   repeated sqlbase.TenantInfoWithUsage tenants = 21 [(gogoproto.nullable) = false];
 
@@ -387,7 +390,7 @@ message RestoreDetails {
 
   bool VerifyData = 26;
 
-  // NEXT ID: 27.
+  // NEXT ID: 28.
 }
 
 

--- a/pkg/sql/catalog/ingesting/BUILD.bazel
+++ b/pkg/sql/catalog/ingesting/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",

--- a/pkg/sql/catalog/ingesting/privileges.go
+++ b/pkg/sql/catalog/ingesting/privileges.go
@@ -85,6 +85,10 @@ func GetIngestingDescriptorPrivileges(
 		if descCoverage == tree.RequestedDescriptors {
 			updatedPrivileges = catpb.NewBaseDatabasePrivilegeDescriptor(user)
 		}
+	case catalog.FunctionDescriptor:
+		if descCoverage == tree.RequestedDescriptors {
+			updatedPrivileges = catpb.NewBasePrivilegeDescriptor(user)
+		}
 	}
 	return updatedPrivileges, nil
 }

--- a/pkg/sql/catalog/rewrite/BUILD.bazel
+++ b/pkg/sql/catalog/rewrite/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/drop_function_test.go
+++ b/pkg/sql/drop_function_test.go
@@ -276,6 +276,10 @@ USE defaultdb;
 			stmt:        "DROP DATABASE test_udf_db RESTRICT",
 			expectedErr: `pq: database "test_udf_db" is not empty and RESTRICT was specified`,
 		},
+		{
+			stmt:        "DROP TYPE notmyworkday",
+			expectedErr: `pq: cannot drop type "notmyworkday" because other objects ([defaultdb.test_sc.f]) still depend on it`,
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -587,9 +587,10 @@ func prepareNewTablesForIngestion(
 	// Write the new TableDescriptors and flip the namespace entries over to
 	// them. After this call, any queries on a table will be served by the newly
 	// imported data.
-	if err := ingesting.WriteDescriptors(ctx, p.ExecCfg().Codec, txn, p.User(), descsCol,
-		nil /* databases */, nil, /* schemas */
-		tableDescs, nil, tree.RequestedDescriptors, seqValKVs, "" /* inheritParentName */); err != nil {
+	if err := ingesting.WriteDescriptors(
+		ctx, p.ExecCfg().Codec, txn, p.User(), descsCol,
+		nil /* databases */, nil /* schemas */, tableDescs, nil /* types */, nil, /* functions */
+		tree.RequestedDescriptors, seqValKVs, "" /* inheritParentName */); err != nil {
 		return nil, errors.Wrapf(err, "creating importTables")
 	}
 


### PR DESCRIPTION
Fixes #84087
With user-defined functions introduced, backup/restore needs to work with the new function descriptors and schema descriptors containing function signatures. This commit adds logic into current backup/restore infrastructure to make sure function descriptors are properly backed up and restored.

Release note (enterprise change): backup/restore now can backup and restore user-defined function descriptors at database and cluster level.
Release justification: necessar fix to backup/restore to make sure it works with user-defined functions.