### PR TITLE
colmem: fix some issues with the memory limiting

### DIFF
--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -122,7 +122,7 @@ func NewAllocator(
 ) *Allocator {
 	if buildutil.CrdbTestBuild {
 		if unlimitedAcc != nil {
-			if l := unlimitedAcc.Monitor().Limit(); l != math.MaxInt64 {
+			if l := unlimitedAcc.Monitor().Limit(); l != noMemLimit {
 				colexecerror.InternalError(errors.AssertionFailedf(
 					"unexpectedly NewAllocator is called with an account with limit of %d bytes", l,
 				))
@@ -188,6 +188,46 @@ func (a *Allocator) ResetBatch(batch coldata.Batch) {
 	a.ReleaseMemory(batch.ResetInternalBatch())
 }
 
+// truncateToMemoryLimit returns the largest batch capacity that is still within
+// the memory limit for the given type schema. The returned value is at most
+// minDesiredCapacity and at least 1.
+func truncateToMemoryLimit(minDesiredCapacity int, maxBatchMemSize int64, typs []*types.T) int {
+	if maxBatchMemSize == noMemLimit {
+		// If there is no memory limit, then we don't reduce the ask.
+		return minDesiredCapacity
+	}
+	// If we have a memory limit, then make sure that it is sufficient for the
+	// desired capacity, if not, reduce the ask.
+	estimatedMemoryUsage := SelVectorSize(minDesiredCapacity) + EstimateBatchSizeBytes(typs, minDesiredCapacity)
+	if estimatedMemoryUsage > maxBatchMemSize {
+		// Perform the binary search to find the maximum allowed capacity.
+		l, r := 1, minDesiredCapacity // [l, r)
+		for l+1 < r {
+			m := (l + r) / 2
+			if SelVectorSize(m)+EstimateBatchSizeBytes(typs, m) > maxBatchMemSize {
+				r = m
+			} else {
+				l = m
+			}
+		}
+		minDesiredCapacity = l
+	}
+	return minDesiredCapacity
+}
+
+// growCapacity grows the capacity exponentially or up to minDesiredCapacity
+// (whichever is larger) without exceeding coldata.BatchSize().
+func growCapacity(oldCapacity int, minDesiredCapacity int) int {
+	newCapacity := oldCapacity * 2
+	if newCapacity < minDesiredCapacity {
+		newCapacity = minDesiredCapacity
+	}
+	if newCapacity > coldata.BatchSize() {
+		newCapacity = coldata.BatchSize()
+	}
+	return newCapacity
+}
+
 // resetMaybeReallocate returns a batch that is guaranteed to be in a "reset"
 // state (meaning it is ready to be used) and to have the capacity of at least
 // 1. minDesiredCapacity is a hint about the capacity of the returned batch
@@ -227,23 +267,47 @@ func (a *Allocator) resetMaybeReallocate(
 	}
 	reallocated = true
 	if oldBatch == nil {
+		minDesiredCapacity = truncateToMemoryLimit(minDesiredCapacity, maxBatchMemSize, typs)
 		newBatch = a.NewMemBatchWithFixedCapacity(typs, minDesiredCapacity)
 	} else {
-		// If old batch is already of the largest capacity, we will reuse it.
-		useOldBatch := oldBatch.Capacity() == coldata.BatchSize()
-		// If the old batch already satisfies the desired capacity which is
-		// sufficient, we will reuse it too.
-		if desiredCapacitySufficient && oldBatch.Capacity() >= minDesiredCapacity {
-			useOldBatch = true
-		}
+		oldCapacity := oldBatch.Capacity()
+		var useOldBatch bool
 		// Avoid calculating the memory footprint if possible.
 		var oldBatchMemSize int64
-		if !useOldBatch {
-			// Check if the old batch already reached the maximum memory size,
-			// and use it if so.
-			oldBatchMemSize = GetBatchMemSize(oldBatch)
-			oldBatchReachedMemSize = oldBatchMemSize >= maxBatchMemSize
-			useOldBatch = oldBatchReachedMemSize
+		if oldCapacity == coldata.BatchSize() {
+			// If old batch is already of the largest capacity, we will reuse
+			// it.
+			useOldBatch = true
+		} else {
+			// Check that if we were to grow the capacity and allocate a new
+			// batch, the new batch would still not exceed the limit.
+			if estimatedMaxCapacity := truncateToMemoryLimit(
+				growCapacity(oldCapacity, minDesiredCapacity), maxBatchMemSize, typs,
+			); estimatedMaxCapacity < minDesiredCapacity {
+				// Reduce the ask according to the estimated maximum. Note that
+				// we do not set desiredCapacitySufficient to false since this
+				// is the largest capacity we can allocate, so it doesn't matter
+				// that the caller wanted more (similar to what we do with
+				// clamping at coldata.BatchSize() above).
+				minDesiredCapacity = estimatedMaxCapacity
+				if estimatedMaxCapacity < int(float64(oldCapacity)*1.1) {
+					// If we cannot grow the capacity of the old batch by more
+					// than 10%, we might as well just reuse the old batch.
+					minDesiredCapacity = oldCapacity
+					desiredCapacitySufficient = true
+				}
+			}
+			if desiredCapacitySufficient && oldCapacity >= minDesiredCapacity {
+				// If the old batch already satisfies the desired capacity which
+				// is sufficient, we will reuse it.
+				useOldBatch = true
+			} else {
+				// Check if the old batch already reached the maximum memory
+				// size, and use it if so.
+				oldBatchMemSize = GetBatchMemSize(oldBatch)
+				oldBatchReachedMemSize = oldBatchMemSize >= maxBatchMemSize
+				useOldBatch = oldBatchReachedMemSize
+			}
 		}
 		if useOldBatch {
 			reallocated = false
@@ -251,18 +315,15 @@ func (a *Allocator) resetMaybeReallocate(
 			newBatch = oldBatch
 		} else {
 			a.ReleaseMemory(oldBatchMemSize)
-			newCapacity := oldBatch.Capacity() * 2
-			if newCapacity < minDesiredCapacity {
-				newCapacity = minDesiredCapacity
-			}
-			if newCapacity > coldata.BatchSize() {
-				newCapacity = coldata.BatchSize()
-			}
+			newCapacity := growCapacity(oldCapacity, minDesiredCapacity)
+			newCapacity = truncateToMemoryLimit(newCapacity, maxBatchMemSize, typs)
 			newBatch = a.NewMemBatchWithFixedCapacity(typs, newCapacity)
 		}
 	}
 	return newBatch, reallocated, oldBatchReachedMemSize
 }
+
+const noMemLimit = math.MaxInt64
 
 // ResetMaybeReallocateNoMemLimit is the same as resetMaybeReallocate when
 // MaxInt64 is used as the maxBatchMemSize argument and the desired capacity is
@@ -273,7 +334,7 @@ func (a *Allocator) resetMaybeReallocate(
 func (a *Allocator) ResetMaybeReallocateNoMemLimit(
 	typs []*types.T, oldBatch coldata.Batch, requiredCapacity int,
 ) (newBatch coldata.Batch, reallocated bool) {
-	newBatch, reallocated, _ = a.resetMaybeReallocate(typs, oldBatch, requiredCapacity, math.MaxInt64, true /* desiredCapacitySufficient */)
+	newBatch, reallocated, _ = a.resetMaybeReallocate(typs, oldBatch, requiredCapacity, noMemLimit, true /* desiredCapacitySufficient */)
 	return newBatch, reallocated
 }
 
@@ -703,9 +764,9 @@ func (h *AccountingHelper) ResetMaybeReallocate(
 	// batches.
 	minDesiredCapacity := tuplesToBeSet
 	desiredCapacitySufficient := tuplesToBeSet > 0
-	if h.maxCapacity > 0 && (h.maxCapacity < tuplesToBeSet || tuplesToBeSet == 0) {
+	if h.maxCapacity > 0 && (h.maxCapacity <= tuplesToBeSet || tuplesToBeSet == 0) {
 		// If we have already exceeded the max capacity, and
-		// - that capacity is lower then the number of tuples to be set, or
+		// - that capacity doesn't exceed the number of tuples to be set, or
 		// - the number of tuples to be set is unknown,
 		// then we'll use that max capacity and tell the allocator to not try
 		// allocating larger batch.
@@ -724,6 +785,20 @@ func (h *AccountingHelper) ResetMaybeReallocate(
 		// allows us to avoid computing the memory size of the batch on each
 		// call.
 		h.maxCapacity = oldBatch.Capacity()
+	} else if reallocated && GetBatchMemSize(newBatch) >= h.memoryLimit {
+		// A new batch has just been allocated and it exceeds the memory limit,
+		// so we memorize its capacity to use from now on. Notably, this will
+		// also ensure that the SetAccountingHelper will use the full capacity
+		// of this batch when variable-width types are present.
+		if buildutil.CrdbTestBuild {
+			if batchMemSize := GetBatchMemSize(newBatch); h.discardBatch(batchMemSize) && newBatch.Capacity() > 1 {
+				colexecerror.InternalError(errors.AssertionFailedf(
+					"newly-allocated batch of capacity %d should be discarded right away: "+
+						"memory limit %d, batch mem size %d", newBatch.Capacity(), h.memoryLimit, batchMemSize,
+				))
+			}
+		}
+		h.maxCapacity = newBatch.Capacity()
 	}
 	return newBatch, reallocated
 }
@@ -928,10 +1003,11 @@ func (h *SetAccountingHelper) AccountForSet(rowIdx int) (batchDone bool) {
 	return batchDone
 }
 
-// TestingUpdateMemoryLimit sets the new memory limit. It should only be used in
-// tests.
+// TestingUpdateMemoryLimit sets the new memory limit as well as resets the
+// memorized max capacity. It should only be used in tests.
 func (h *SetAccountingHelper) TestingUpdateMemoryLimit(memoryLimit int64) {
 	h.helper.memoryLimit = memoryLimit
+	h.helper.maxCapacity = 0
 }
 
 // ReleaseMemory releases all of the memory that is currently registered with

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -23,11 +23,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -40,20 +40,33 @@ func init() {
 	randutil.SeedForTests()
 }
 
+const increment = -1
+
+func getAllocator(increment int64) (_ *colmem.Allocator, _ *mon.BoundAccount, cleanup func()) {
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := mon.NewMonitor(
+		"test-mem" /* name */, mon.MemoryResource, nil, /* curCount */
+		nil /* maxHist */, increment, math.MaxInt64 /* noteworthy */, st,
+	)
+	testMemMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
+	memAcc := testMemMonitor.MakeBoundAccount()
+	evalCtx := eval.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	cleanup = func() {
+		memAcc.Close(ctx)
+		testMemMonitor.Stop(ctx)
+	}
+	return testAllocator, &memAcc, cleanup
+}
+
 func TestMaybeAppendColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 	t.Run("VectorAlreadyPresent", func(t *testing.T) {
 		b := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Int})
 		b.SetLength(coldata.BatchSize())
@@ -109,16 +122,9 @@ func TestPerformAppend(t *testing.T) {
 	const nullOk = false
 	const resetChance = 0.5
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 
 	batch1 := colexecutils.NewAppendOnlyBufferedBatch(testAllocator, typs, nil /* colsToStore */)
 	batch2 := colexecutils.NewAppendOnlyBufferedBatch(testAllocator, typs, nil /* colsToStore */)
@@ -192,25 +198,9 @@ func TestAccountingHelper(t *testing.T) {
 		require.NoError(t, coldata.SetBatchSizeForTests(oldBatchSize))
 	}()
 
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
 	// Use increment of 1 so that no allocations are "reserved".
-	testMemMonitor := mon.NewMonitor(
-		"test-mem",
-		mon.MemoryResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		1,             /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-	testMemMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, _, cleanup := getAllocator(1 /* increment */)
+	defer cleanup()
 
 	// Allocate a scratch bytes value that exceeds the target size in all
 	// scenarios.
@@ -384,17 +374,9 @@ func TestSetAccountingHelper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 	numCols := rng.Intn(10) + 1
 	typs := make([]*types.T, numCols)
 	for i := range typs {
@@ -460,6 +442,78 @@ func TestSetAccountingHelper(t *testing.T) {
 	}
 }
 
+// TestSetAccountingHelperMemoryLimit verifies that colmem.SetAccountingHelper
+// reasonably uses the capacity of already allocated batches.
+func TestSetAccountingHelperMemoryLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if coldata.BatchSize() < 4 {
+		skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 4")
+	}
+
+	// Use increment of 1 so that no allocations are "reserved".
+	testAllocator, _, cleanup := getAllocator(1 /* increment */)
+	defer cleanup()
+
+	// We need to use at least one type of variable width in order to trigger
+	// more interesting path in AccountForSet.
+	typs := []*types.T{types.Bytes}
+
+	// We will ask the helper for batches of different sizes ("small" doesn't
+	// exceed the memory limit, and "large" exceeds it by too much so it is not
+	// actually allocated according to the ask - instead a "medium" batch is
+	// allocated).
+	largeCap := coldata.BatchSize()
+	smallCap := largeCap / 4
+	mediumCap := smallCap * 2
+	// Use memory limit that is exactly the footprint of the medium batch.
+	memoryLimit := colmem.GetBatchMemSize(testAllocator.NewMemBatchWithFixedCapacity(typs, mediumCap))
+	testAllocator.ReleaseAll()
+
+	var helper colmem.SetAccountingHelper
+	helper.Init(testAllocator, memoryLimit, typs)
+
+	// Allocate the small batch and ensure that we use all tuples inside of it.
+	b, _ := helper.ResetMaybeReallocate(typs, nil /* oldBatch */, smallCap)
+	var rowIdx int
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, smallCap, rowIdx)
+
+	// Attempt to allocate a batch with too large of a capacity.
+	b, reallocated := helper.ResetMaybeReallocate(typs, b, largeCap)
+	require.True(t, reallocated)
+	// We expect that the ask of largeCap is not satisfied and that the batch
+	// of exactly mediumCap is allocated.
+	require.Equal(t, b.Capacity(), mediumCap)
+	// Ensure that the helper still uses the whole capacity.
+	rowIdx = 0
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, b.Capacity(), rowIdx)
+
+	// Increase the limit by a little so that the previously allocated batch is
+	// below the new limit. This also unsets the memorized max capacity so that
+	// the helper considers allocating a new batch.
+	helper.TestingUpdateMemoryLimit(memoryLimit + 1)
+	// Now try to allocate a batch of medium capacity plus one, but a new batch
+	// won't be allocated because the helper will estimate that it would exceed
+	// the (newly-updated) memory limit.
+	b, reallocated = helper.ResetMaybeReallocate(typs, b, mediumCap+1)
+	require.False(t, reallocated)
+	rowIdx = 0
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, b.Capacity(), rowIdx)
+}
+
 // TestEstimateBatchSizeBytes verifies that EstimateBatchSizeBytes returns such
 // an estimate that it equals the actual footprint of the newly-created batch
 // with no values set.
@@ -467,16 +521,9 @@ func TestEstimateBatchSizeBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := eval.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, memAcc, cleanup := getAllocator(increment)
+	defer cleanup()
 
 	numCols := rng.Intn(10) + 1
 	typs := make([]*types.T, numCols)
@@ -485,7 +532,7 @@ func TestEstimateBatchSizeBytes(t *testing.T) {
 	}
 	const numRuns = 10
 	for run := 0; run < numRuns; run++ {
-		memAcc.Clear(ctx)
+		memAcc.Clear(context.Background())
 		numRows := rng.Intn(coldata.BatchSize()) + 1
 		batch := testAllocator.NewMemBatchWithFixedCapacity(typs, numRows)
 		expected := memAcc.Used()


### PR DESCRIPTION
**colexec: some fixes of the external sort**

This commit fixes some of the relatively benign issues in the external
sort:
- previously we forgot to unset the partition info for all partitions
that are being merged as part of the repeated merging process (we would
only reset the first one because it is overwritten by the newly created
"merged" partition)
- we incorrectly estimated "min output batch size" for the repeated
merging (the calculation was as if all current partitions were being
merged rather than `n`)
- we incorrectly computed the memory size of the enqueued batch. It is
possible that the batch is a "window" or doesn't use the whole capacity,
and previously we were using the total memory footprint.  However, we
need to only include the "proportional" size according to the length of
the batch.

The issues are relatively benign since they would mostly make the verbose
logging incorrect as well as over-estimate the "max batch mem size"
(which would mean that we'd merge the partitions sooner or with
a smaller output batch size).

Release justification: low-risk bug fix.

Release note: None

**colmem: fix some issues with the memory limiting**

This commit fixes a couple of issues with how we do memory-limiting of
batches by the footprint. In particular, the allocator will now estimate
the memory footprint of a batch before allocating a new one and will
clamp the capacity so that the batch stays under the limit. Previously,
we could allocate a batch that would exceed the limit even when all
types are fixed length. This behavior has been present since long time
ago.

Additionally, this commit fixes a recent regression in how
`SetAccountingHelper` uses the capacity of the batch. Previously, if
a new batch is allocated (when variable-width types are present) and
exceeds the memory limit, then the first call to `AccountForSet` would
artificially clamp the used capacity at 1, so the batch might have a lot
of unused capacity. Now the helper will memorize the full capacity right
after the batch is allocated. This regression was introduced in a recent
refactor of the `SetAccountingHelper`. In particular, it could lead to
the external sort (which uses the ordered synchronizer internally which
uses the `SetAccountingHelper`) becoming excruciatingly slow with
"unlucky" low memory limits. The limit would be "unlucky" if it is such
that a batch with capacity `c` doesn't exceed it, but the batch with
capacity `2 * c` would exceed the limit by less than a factor of two. In
such a scenario previously we would allocate the batch of capacity
`2 * c` yet would always use only a single row (because in
`AccountForSet` we would set the max capacity at 1).

Addresses: #87510.

Release justification: bug fix.

Release note: None