### PR TITLE
sql: fix `is_generated` in `information_schema.column` table

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -173,8 +173,10 @@ var (
 	// STRINGs. The BOOLEAN data type should NEVER be used in information_schema
 	// tables. Instead, define columns as STRINGs and map bools to STRINGs using
 	// yesOrNoDatum.
-	yesString = tree.NewDString("YES")
-	noString  = tree.NewDString("NO")
+	yesString    = tree.NewDString("YES")
+	noString     = tree.NewDString("NO")
+	alwaysString = tree.NewDString("ALWAYS")
+	neverString  = tree.NewDString("NEVER")
 )
 
 func yesOrNoDatum(b bool) tree.Datum {
@@ -182,6 +184,13 @@ func yesOrNoDatum(b bool) tree.Datum {
 		return yesString
 	}
 	return noString
+}
+
+func alwaysOrNeverDatum(b bool) tree.Datum {
+	if b {
+		return alwaysString
+	}
+	return neverString
 }
 
 func dNameOrNull(s string) tree.Datum {
@@ -543,9 +552,9 @@ https://www.postgresql.org/docs/9.5/infoschema-columns.html`,
 					identityMin,                                  // identity_minimum
 					// TODO(janexing): we don't support CYCLE syntax for sequences yet.
 					// https://github.com/cockroachdb/cockroach/issues/20961
-					tree.DNull,                        // identity_cycle
-					yesOrNoDatum(column.IsComputed()), // is_generated
-					colComputed,                       // generation_expression
+					tree.DNull,                              // identity_cycle
+					alwaysOrNeverDatum(column.IsComputed()), // is_generated
+					colComputed,                             // generation_expression
 					yesOrNoDatum(table.IsTable() &&
 						!table.IsVirtualTable() &&
 						!column.IsComputed(),

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -2430,9 +2430,9 @@ FROM information_schema.columns
 WHERE table_schema = 'public' AND table_name = 'computed'
 ----
 column_name  is_generated  generation_expression  is_updatable
-a            NO            ·                      YES
-b            YES           a + 1                  NO
-rowid        NO            ·                      YES
+a            NEVER         ·                      YES
+b            ALWAYS        a + 1                  NO
+rowid        NEVER         ·                      YES
 
 statement ok
 CREATE TABLE generated_as_identity (
@@ -5122,3 +5122,19 @@ query TTTTT
 select identity_start, identity_increment, identity_maximum, identity_minimum, identity_cycle from information_schema.columns where table_name = 't' and column_name='id1';
 ----
 10  1  9223372036854775807  1  NULL
+
+subtest generated_as_cols
+
+statement ok
+DROP TABLE IF EXISTS t
+
+statement ok
+CREATE TABLE t (i INTEGER PRIMARY KEY, x VARCHAR, y VARCHAR, z VARCHAR GENERATED ALWAYS AS (x || ' ' || y) STORED);
+
+query TT
+SELECT column_name, is_generated FROM information_schema.columns WHERE table_name = 't';
+----
+i  NEVER
+x  NEVER
+y  NEVER
+z  ALWAYS

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2791,9 +2791,9 @@ func (og *operationGenerator) randChildColumnForFkRelation(
 	`, typ))
 
 	if isNotComputed {
-		query.WriteString(`AND is_generated = 'NO'`)
+		query.WriteString(`AND is_generated = 'NEVER'`)
 	} else {
-		query.WriteString(`AND is_generated = 'YES'`)
+		query.WriteString(`AND is_generated = 'ALWAYS'`)
 	}
 
 	var tableSchema string


### PR DESCRIPTION
Previously, the `is_generated` column returns the string `YES` or `NO`, depending on whether the column is computed. While postgres returns `ALWAYS` and `NEVER`. This commit is to fix it.

fixes #87481

Release note (bug fix): fix `is_generated` in `information_schema.column` table