### PR TITLE
upgrades: skip TestRoleIDMigration15000Users under race

### DIFF
--- a/pkg/upgrade/upgrades/role_id_migration_test.go
+++ b/pkg/upgrade/upgrades/role_id_migration_test.go
@@ -205,6 +205,7 @@ func TestRoleIDMigration100User(t *testing.T) {
 
 func TestRoleIDMigration15000Users(t *testing.T) {
 	skip.UnderStress(t)
+	skip.UnderRace(t)
 	// 15000 is 1.5x the batch size used in the migration.
 	runTestRoleIDMigration(t, 15000)
 }

--- a/pkg/upgrade/upgrades/role_options_migration_test.go
+++ b/pkg/upgrade/upgrades/role_options_migration_test.go
@@ -214,6 +214,7 @@ func TestRoleOptionsMigration100User(t *testing.T) {
 
 func TestRoleOptionsMigration15000User(t *testing.T) {
 	skip.UnderStress(t)
+	skip.UnderRace(t)
 	runTestRoleOptionsMigration(t, 15000)
 }
 


### PR DESCRIPTION
It consistently times out under race.

Release note: none.