### PR TITLE
streamingccl: ingestion processor internal subscription retry

### DIFF
--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -10,7 +10,6 @@ package streamingest
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -352,7 +351,6 @@ func (sip *streamIngestionProcessor) startPartitions(ctx context.Context) {
 		streamClient := sip.streamPartitionClients[partitionSpec.PartitionID]
 		g.GoCtx(func(ctx context.Context) error {
 			err := sip.partitionWorker(ctx, streamClient, partitionSpec, merged)
-			fmt.Printf("\x1b[33m worker err: %s \x1b[0m\n", err)
 			if err != nil {
 				errCh <- err
 			}
@@ -387,7 +385,6 @@ func (sip *streamIngestionProcessor) partitionWorker(
 	sip.mu.Lock()
 	startTime := frontierForSpans(sip.mu.frontier, spec.Spans...)
 	sip.mu.Unlock()
-	fmt.Printf("\x1b[36m subscribing from time %d \x1b[0m\n", startTime.WallTime)
 
 	if streamingKnobs, ok := sip.FlowCtx.TestingKnobs().StreamingTestingKnobs.(*sql.StreamingTestingKnobs); ok {
 		if streamingKnobs != nil && streamingKnobs.BeforeClientSubscribe != nil {
@@ -408,10 +405,8 @@ func (sip *streamIngestionProcessor) partitionWorker(
 		select {
 		case event, ok := <-sub.Events():
 			if !ok {
-				fmt.Printf("\x1b[31m partition worker done \x1b[0m\n")
 				return errors.Wrapf(sub.Err(), "partition %s subscription from %v", spec.PartitionID, addr)
 			}
-			fmt.Printf("\x1b[32m partition worker event %v \x1b[0m\n", event)
 
 			pe := partitionEvent{
 				Event:     event,
@@ -430,7 +425,6 @@ func (sip *streamIngestionProcessor) partitionWorker(
 
 // Next is part of the RowSource interface.
 func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
-	fmt.Printf("\x1b[31m calling next \x1b[0m\n")
 	if sip.State != execinfra.StateRunning {
 		return nil, sip.DrainHelper()
 	}
@@ -443,9 +437,7 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 		return nil, sip.DrainHelper()
 	}
 
-	fmt.Printf("\x1b[31m calling consumeEvents \x1b[0m\n")
 	progressUpdate, err := sip.consumeEvents()
-	fmt.Printf("\x1b[31m got consumeEvents (%+v) (%+v)\x1b[0m\n", progressUpdate, err)
 	if err != nil {
 		sip.MoveToDraining(err)
 		return nil, sip.DrainHelper()
@@ -465,7 +457,6 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 
 	sip.mu.Lock()
 	err = sip.mu.ingestionErr
-	fmt.Printf("\x1b[31m grabbing ingestionerr %s \x1b[0m\n", err)
 	sip.mu.Unlock()
 	if err != nil {
 		sip.MoveToDraining(err)
@@ -490,7 +481,6 @@ func (sip *streamIngestionProcessor) close() {
 	if sip.Closed {
 		return
 	}
-	fmt.Printf("\x1b[31m closing \x1b[0m\n")
 
 	for _, client := range sip.streamPartitionClients {
 		_ = client.Close(sip.Ctx)
@@ -580,8 +570,6 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 	for sip.State == execinfra.StateRunning {
 		select {
 		case err, ok := <-sip.partitionWorkerErr:
-			fmt.Printf("\x1b[32m partitionWorkerErr (%+v) \x1b[0m\n", ok)
-
 			// Clear partitionWorkerErr since we only want to handle the first event
 			// for a single set of workers.
 			sip.partitionWorkerErr = nil
@@ -620,7 +608,6 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 			}
 			continue
 		case event, ok := <-sip.eventCh:
-			fmt.Printf("\x1b[32m event from eventCh %v\x1b[0m\n", ok)
 			if !ok {
 				sip.internalDrained = true
 				flushResult, flushErr := sip.flush()
@@ -639,10 +626,8 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 				}
 			}
 
-			fmt.Printf("\x1b[32m %s emitting event \x1b[0m\n", event.partition)
 			switch event.Type() {
 			case streamingccl.KVEvent:
-				fmt.Printf("\x1b[32m kv event %v\x1b[0m\n", event.GetKV().Value.Timestamp)
 				if err := sip.bufferKV(event.GetKV()); err != nil {
 					return nil, err
 				}
@@ -655,7 +640,6 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 					return nil, err
 				}
 			case streamingccl.CheckpointEvent:
-				fmt.Printf("\x1b[32m checkpoint event %v\x1b[0m\n", event.GetResolvedSpans()[0].Timestamp)
 				if err := sip.bufferCheckpoint(event); err != nil {
 					return nil, err
 				}
@@ -717,10 +701,8 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
-	fmt.Printf("\x1b[32m rekey from %s \x1b[0m\n", key.String())
 	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
 	if !ok {
-		fmt.Printf("\x1b[35m rekey for %s, %v \x1b[0m\n", key.String(), ok)
 		return nil, errors.Wrapf(err, "key %s did not match tenant prefix")
 	}
 	if err != nil {

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor.go
@@ -10,6 +10,7 @@ package streamingest
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -140,14 +142,10 @@ type streamIngestionProcessor struct {
 	forceClientForTests streamclient.Client
 	// streamPartitionClients are a collection of streamclient.Client created for
 	// consuming multiple partitions from a stream.
-	streamPartitionClients []streamclient.Client
+	streamPartitionClients map[string]streamclient.Client
 
 	// cutoverProvider indicates when the cutover time has been reached.
 	cutoverProvider cutoverProvider
-
-	// frontier keeps track of the progress for the spans tracked by this processor
-	// and is used forward resolved spans
-	frontier *span.Frontier
 	// lastFlushTime keeps track of the last time that we flushed due to a
 	// checkpoint timestamp event.
 	lastFlushTime time.Time
@@ -176,12 +174,19 @@ type streamIngestionProcessor struct {
 	// cancelMergeAndWait cancels the merging goroutines and waits for them to
 	// finish. It cannot be called concurrently with Next(), as it consumes from
 	// the merged channel.
-	cancelMergeAndWait func()
+	cancelMergeAndWait func() error
+
+	// partitionWorkerErr is used to signal errors from partition workers.
+	partitionWorkerErr chan error
 
 	// mu is used to provide thread-safe read-write operations to ingestionErr
 	// and pollingErr.
 	mu struct {
 		syncutil.Mutex
+
+		// frontier keeps track of the progress for the spans tracked by this processor
+		// and is used to forward resolved spans.
+		frontier *span.Frontier
 
 		// ingestionErr stores any error that is returned from the worker goroutine so
 		// that it can be forwarded through the DistSQL flow.
@@ -242,7 +247,6 @@ func newStreamIngestionDataProcessor(
 		spec:              spec,
 		output:            output,
 		curKVBatch:        make([]storage.MVCCKeyValue, 0),
-		frontier:          frontier,
 		maxFlushRateTimer: timeutil.NewTimer(),
 		cutoverProvider: &cutoverFromJobProgress{
 			jobID:    jobspb.JobID(spec.JobID),
@@ -253,6 +257,8 @@ func newStreamIngestionDataProcessor(
 		rekeyer:          rekeyer,
 		rewriteToDiffKey: spec.TenantRekey.NewID != spec.TenantRekey.OldID,
 	}
+	sip.mu.frontier = frontier
+
 	if err := sip.Init(sip, post, streamIngestionResultTypes, flowCtx, processorID, output, nil, /* memMonitor */
 		execinfra.ProcStateOpts{
 			InputsToDrain: []execinfra.RowSource{},
@@ -303,49 +309,128 @@ func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 
 	log.Infof(ctx, "starting %d stream partitions", len(sip.spec.PartitionSpecs))
 
-	// Initialize the event streams.
-	subscriptions := make(map[string]streamclient.Subscription)
 	sip.cg = ctxgroup.WithContext(ctx)
-	sip.streamPartitionClients = make([]streamclient.Client, 0)
+
+	sip.streamPartitionClients = make(map[string]streamclient.Client)
 	for _, partitionSpec := range sip.spec.PartitionSpecs {
-		id := partitionSpec.PartitionID
-		token := streamclient.SubscriptionToken(partitionSpec.SubscriptionToken)
 		addr := partitionSpec.Address
 		var streamClient streamclient.Client
 		if sip.forceClientForTests != nil {
 			streamClient = sip.forceClientForTests
 			log.Infof(ctx, "using testing client")
 		} else {
+			var err error
 			streamClient, err = streamclient.NewStreamClient(ctx, streamingccl.StreamAddress(addr))
 			if err != nil {
-				sip.MoveToDraining(errors.Wrapf(err, "creating client for partition spec %q from %q", token, addr))
+				sip.MoveToDraining(err)
 				return
 			}
-			sip.streamPartitionClients = append(sip.streamPartitionClients, streamClient)
 		}
-
-		startTime := frontierForSpans(sip.frontier, partitionSpec.Spans...)
-
-		if streamingKnobs, ok := sip.FlowCtx.TestingKnobs().StreamingTestingKnobs.(*sql.StreamingTestingKnobs); ok {
-			if streamingKnobs != nil && streamingKnobs.BeforeClientSubscribe != nil {
-				streamingKnobs.BeforeClientSubscribe(addr, string(token), startTime)
-			}
-		}
-
-		sub, err := streamClient.Subscribe(ctx, streaming.StreamID(sip.spec.StreamID), token, startTime)
-
-		if err != nil {
-			sip.MoveToDraining(errors.Wrapf(err, "consuming partition %v", addr))
-			return
-		}
-		subscriptions[id] = sub
-		sip.cg.GoCtx(sub.Subscribe)
+		sip.streamPartitionClients[partitionSpec.PartitionID] = streamClient
 	}
-	sip.eventCh = sip.merge(ctx, subscriptions)
+	sip.startPartitions(ctx)
+}
+
+// startPartitions initializes the event-related properties of the ingestion
+// processor and spins up goroutines to connect to and read in events from each
+// producer partition and forward them to sip.eventCh.
+// When errors are encountered from the subscription to any partition, all
+// partitions are retried together as the shared batcher must be flushed prior
+// to repeating any events.
+func (sip *streamIngestionProcessor) startPartitions(ctx context.Context) {
+	// Initialize the event streams.
+	merged := make(chan partitionEvent)
+	ctx, cancel := context.WithCancel(ctx)
+	g := ctxgroup.WithContext(ctx)
+
+	// errCh is used to signal any worker errors for retry and is closed upon all
+	// workers completing.
+	errCh := make(chan error, len(sip.spec.PartitionSpecs))
+
+	for _, partitionSpec := range sip.spec.PartitionSpecs {
+		partitionSpec := partitionSpec
+		streamClient := sip.streamPartitionClients[partitionSpec.PartitionID]
+		g.GoCtx(func(ctx context.Context) error {
+			err := sip.partitionWorker(ctx, streamClient, partitionSpec, merged)
+			fmt.Printf("\x1b[33m worker err: %s \x1b[0m\n", err)
+			if err != nil {
+				errCh <- err
+			}
+			return err
+		})
+	}
+
+	sip.cancelMergeAndWait = func() error {
+		cancel()
+		return g.Wait()
+	}
+
+	go func() {
+		// Ignore err since non-nil error would have been sent to errCh already
+		_ = g.Wait()
+		close(errCh)
+	}()
+
+	sip.eventCh = merged
+	sip.partitionWorkerErr = errCh
+}
+
+func (sip *streamIngestionProcessor) partitionWorker(
+	ctx context.Context,
+	client streamclient.Client,
+	spec execinfrapb.StreamIngestionPartitionSpec,
+	out chan partitionEvent,
+) error {
+	token := streamclient.SubscriptionToken(spec.SubscriptionToken)
+	addr := spec.Address
+
+	sip.mu.Lock()
+	startTime := frontierForSpans(sip.mu.frontier, spec.Spans...)
+	sip.mu.Unlock()
+	fmt.Printf("\x1b[36m subscribing from time %d \x1b[0m\n", startTime.WallTime)
+
+	if streamingKnobs, ok := sip.FlowCtx.TestingKnobs().StreamingTestingKnobs.(*sql.StreamingTestingKnobs); ok {
+		if streamingKnobs != nil && streamingKnobs.BeforeClientSubscribe != nil {
+			streamingKnobs.BeforeClientSubscribe(addr, string(token), startTime)
+		}
+	}
+
+	var sub streamclient.Subscription
+	sub, err := client.Subscribe(ctx, streaming.StreamID(sip.spec.StreamID), token, startTime)
+	if err != nil {
+		return errors.Wrapf(err, "subscribing to partition %v", addr)
+	}
+
+	sip.cg.GoCtx(sub.Subscribe)
+	ctxDone := ctx.Done()
+
+	for {
+		select {
+		case event, ok := <-sub.Events():
+			if !ok {
+				fmt.Printf("\x1b[31m partition worker done \x1b[0m\n")
+				return errors.Wrapf(sub.Err(), "partition %s subscription from %v", spec.PartitionID, addr)
+			}
+			fmt.Printf("\x1b[32m partition worker event %v \x1b[0m\n", event)
+
+			pe := partitionEvent{
+				Event:     event,
+				partition: spec.PartitionID,
+			}
+			select {
+			case out <- pe:
+			case <-ctxDone:
+				return ctx.Err()
+			}
+		case <-ctxDone:
+			return ctx.Err()
+		}
+	}
 }
 
 // Next is part of the RowSource interface.
 func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetadata) {
+	fmt.Printf("\x1b[31m calling next \x1b[0m\n")
 	if sip.State != execinfra.StateRunning {
 		return nil, sip.DrainHelper()
 	}
@@ -358,13 +443,15 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 		return nil, sip.DrainHelper()
 	}
 
+	fmt.Printf("\x1b[31m calling consumeEvents \x1b[0m\n")
 	progressUpdate, err := sip.consumeEvents()
+	fmt.Printf("\x1b[31m got consumeEvents (%+v) (%+v)\x1b[0m\n", progressUpdate, err)
 	if err != nil {
 		sip.MoveToDraining(err)
 		return nil, sip.DrainHelper()
 	}
 
-	if progressUpdate != nil {
+	if progressUpdate != nil && len(progressUpdate.ResolvedSpans) > 0 {
 		progressBytes, err := protoutil.Marshal(progressUpdate)
 		if err != nil {
 			sip.MoveToDraining(err)
@@ -378,6 +465,7 @@ func (sip *streamIngestionProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Pr
 
 	sip.mu.Lock()
 	err = sip.mu.ingestionErr
+	fmt.Printf("\x1b[31m grabbing ingestionerr %s \x1b[0m\n", err)
 	sip.mu.Unlock()
 	if err != nil {
 		sip.MoveToDraining(err)
@@ -402,6 +490,7 @@ func (sip *streamIngestionProcessor) close() {
 	if sip.Closed {
 		return
 	}
+	fmt.Printf("\x1b[31m closing \x1b[0m\n")
 
 	for _, client := range sip.streamPartitionClients {
 		_ = client.Close(sip.Ctx)
@@ -418,7 +507,9 @@ func (sip *streamIngestionProcessor) close() {
 	sip.pollingWaitGroup.Wait()
 	// Wait for the merge goroutine.
 	if sip.cancelMergeAndWait != nil {
-		sip.cancelMergeAndWait()
+		if err := sip.cancelMergeAndWait(); err != nil {
+			sip.mu.ingestionErr = err
+		}
 	}
 	sip.InternalClose()
 }
@@ -450,62 +541,6 @@ func (sip *streamIngestionProcessor) checkForCutoverSignal(
 	}
 }
 
-// merge takes events from all the streams and merges them into a single
-// channel.
-func (sip *streamIngestionProcessor) merge(
-	ctx context.Context, subscriptions map[string]streamclient.Subscription,
-) chan partitionEvent {
-	merged := make(chan partitionEvent)
-
-	ctx, cancel := context.WithCancel(ctx)
-	g := ctxgroup.WithContext(ctx)
-
-	sip.cancelMergeAndWait = func() {
-		cancel()
-		// Wait until the merged channel is closed by the goroutine above.
-		for range merged {
-		}
-	}
-
-	for partition, sub := range subscriptions {
-		partition := partition
-		sub := sub
-		g.GoCtx(func(ctx context.Context) error {
-			ctxDone := ctx.Done()
-			for {
-				select {
-				case event, ok := <-sub.Events():
-					if !ok {
-						return sub.Err()
-					}
-
-					pe := partitionEvent{
-						Event:     event,
-						partition: partition,
-					}
-
-					select {
-					case merged <- pe:
-					case <-ctxDone:
-						return ctx.Err()
-					}
-				case <-ctxDone:
-					return ctx.Err()
-				}
-			}
-		})
-	}
-	go func() {
-		err := g.Wait()
-		sip.mu.Lock()
-		defer sip.mu.Unlock()
-		sip.mu.ingestionErr = err
-		close(merged)
-	}()
-
-	return merged
-}
-
 // consumeEvents handles processing events on the merged event queue and returns
 // once a checkpoint event has been emitted so that it can inform the downstream
 // frontier processor to consider updating the frontier.
@@ -514,6 +549,7 @@ func (sip *streamIngestionProcessor) merge(
 // increasing after it has flushed all KV events previously received by that
 // partition.
 func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, error) {
+	ctx := sip.Ctx
 	// This timer is used to batch up resolved timestamp events that occur within
 	// a given time interval, as to not flush too often and allow the buffer to
 	// accumulate data.
@@ -524,12 +560,71 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 		return nil, nil
 	}
 
+	ro := retry.Options{
+		InitialBackoff: 3 * time.Second,
+		Multiplier:     2,
+		MaxBackoff:     1 * time.Minute,
+		MaxRetries:     5,
+	}
+	if streamingKnobs, ok := sip.FlowCtx.TestingKnobs().StreamingTestingKnobs.(*sql.StreamingTestingKnobs); ok {
+		if streamingKnobs != nil && streamingKnobs.OverrideIngestionPartitionRetry != nil {
+			ro = streamingKnobs.OverrideIngestionPartitionRetry()
+		}
+	}
+	// The retry struct is created fresh for every call to consumeEvents(),
+	// meaning its backoff amount is effectively reset at least every flush
+	// interval.
+	r := retry.Start(ro)
+	retryCount := 0
+
 	for sip.State == execinfra.StateRunning {
 		select {
+		case err, ok := <-sip.partitionWorkerErr:
+			fmt.Printf("\x1b[32m partitionWorkerErr (%+v) \x1b[0m\n", ok)
+
+			// Clear partitionWorkerErr since we only want to handle the first event
+			// for a single set of workers.
+			sip.partitionWorkerErr = nil
+
+			// If the first event we observe is that channel was closed, the workers
+			// completed without error and we can signal termination of events.
+			if !ok {
+				close(sip.eventCh)
+				continue
+			}
+
+			// If out of retries, record the error and signal the termination of events.
+			if !r.Next() {
+				log.Errorf(ctx, "exiting after %d attempts with subscription error %s", retryCount, err.Error())
+				sip.mu.Lock()
+				sip.mu.ingestionErr = err
+				sip.mu.Unlock()
+				close(sip.eventCh)
+				continue
+			}
+
+			retryCount++
+			log.Infof(ctx, "ingestion processor retrying subscriptions (attempt %d) after error: %s", retryCount, err.Error())
+			_ = sip.cancelMergeAndWait()
+
+			// Must flush to avoid inserting old KVs into the same SST
+			log.Infof(ctx, "ingestion processor flushing existing batches before retry")
+			flushResult, flushErr := sip.flush()
+
+			log.Infof(ctx, "ingestion processor restarting subscriptions for retry")
+			sip.startPartitions(ctx)
+
+			// Only return if there was some progress made by the flush
+			if flushErr != nil || (flushResult != nil && len(flushResult.ResolvedSpans) > 0) {
+				return flushResult, flushErr
+			}
+			continue
 		case event, ok := <-sip.eventCh:
+			fmt.Printf("\x1b[32m event from eventCh %v\x1b[0m\n", ok)
 			if !ok {
 				sip.internalDrained = true
-				return sip.flush()
+				flushResult, flushErr := sip.flush()
+				return flushResult, flushErr
 			}
 			if event.Type() == streamingccl.KVEvent {
 				sip.metrics.AdmitLatency.RecordValue(
@@ -544,8 +639,10 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 				}
 			}
 
+			fmt.Printf("\x1b[32m %s emitting event \x1b[0m\n", event.partition)
 			switch event.Type() {
 			case streamingccl.KVEvent:
+				fmt.Printf("\x1b[32m kv event %v\x1b[0m\n", event.GetKV().Value.Timestamp)
 				if err := sip.bufferKV(event.GetKV()); err != nil {
 					return nil, err
 				}
@@ -558,6 +655,7 @@ func (sip *streamIngestionProcessor) consumeEvents() (*jobspb.ResolvedSpans, err
 					return nil, err
 				}
 			case streamingccl.CheckpointEvent:
+				fmt.Printf("\x1b[32m checkpoint event %v\x1b[0m\n", event.GetResolvedSpans()[0].Timestamp)
 				if err := sip.bufferCheckpoint(event); err != nil {
 					return nil, err
 				}
@@ -619,9 +717,11 @@ func (sip *streamIngestionProcessor) bufferSST(sst *roachpb.RangeFeedSSTable) er
 }
 
 func (sip *streamIngestionProcessor) rekey(key roachpb.Key) ([]byte, error) {
+	fmt.Printf("\x1b[32m rekey from %s \x1b[0m\n", key.String())
 	rekey, ok, err := sip.rekeyer.RewriteKey(key, 0 /*wallTime*/)
 	if !ok {
-		return nil, errors.New("every key is expected to match tenant prefix")
+		fmt.Printf("\x1b[35m rekey for %s, %v \x1b[0m\n", key.String(), ok)
+		return nil, errors.Wrapf(err, "key %s did not match tenant prefix")
 	}
 	if err != nil {
 		return nil, err
@@ -697,6 +797,8 @@ func (sip *streamIngestionProcessor) bufferKV(kv *roachpb.KeyValue) error {
 }
 
 func (sip *streamIngestionProcessor) bufferCheckpoint(event partitionEvent) error {
+	sip.mu.Lock()
+	defer sip.mu.Unlock()
 	resolvedSpans := event.GetResolvedSpans()
 	if resolvedSpans == nil {
 		return errors.New("checkpoint event expected to have resolved spans")
@@ -711,7 +813,7 @@ func (sip *streamIngestionProcessor) bufferCheckpoint(event partitionEvent) erro
 		if highestTimestamp.Less(resolvedSpan.Timestamp) {
 			highestTimestamp = resolvedSpan.Timestamp
 		}
-		_, err := sip.frontier.Forward(resolvedSpan.Span, resolvedSpan.Timestamp)
+		_, err := sip.mu.frontier.Forward(resolvedSpan.Span, resolvedSpan.Timestamp)
 		if err != nil {
 			return errors.Wrap(err, "unable to forward checkpoint frontier")
 		}
@@ -838,9 +940,12 @@ func (sip *streamIngestionProcessor) flush() (*jobspb.ResolvedSpans, error) {
 		}
 	}
 
+	sip.mu.Lock()
+	defer sip.mu.Unlock()
+
 	// Go through buffered checkpoint events, and put them on the channel to be
 	// emitted to the downstream frontier processor.
-	sip.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+	sip.mu.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
 		flushedCheckpoints.ResolvedSpans = append(flushedCheckpoints.ResolvedSpans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
 		return span.ContinueMatch
 	})

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -381,14 +381,11 @@ func TestStreamIngestionProcessor(t *testing.T) {
 		require.NoError(t, err)
 
 		emittedRows := readRows(out)
-		fmt.Printf("\x1b[34m EMITTED ROWS: (%+v) \x1b[0m\n", emittedRows)
 
 		require.Contains(t, emittedRows, "key_1{-\\x00} 0.000000007,0",
 			"partition 1 should advance to timestamp 7")
 		require.Contains(t, emittedRows, "key_2{-\\x00} 0.000000009,0",
 			"partition 2 should advance to timestamp 9")
-
-		fmt.Printf("\x1b[34m DONE TEST \x1b[0m\n")
 	})
 
 	// Two partitions, checkpoint for each, client start time for each should match

--- a/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
+++ b/pkg/ccl/streamingccl/streamingest/stream_ingestion_processor_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
@@ -54,8 +55,44 @@ import (
 // partition being consumed. Stream partitions are identified by unique
 // partition addresses.
 type mockStreamClient struct {
-	partitionEvents map[string][]streamingccl.Event
-	doneCh          chan struct{}
+	mu struct {
+		syncutil.Mutex
+		partitionEvents map[string][]mockClientEvent
+		doneCh          chan struct{}
+	}
+}
+
+type mockClientEvent struct {
+	err         error
+	errTs       hlc.Timestamp
+	errLifetime int
+	event       streamingccl.Event
+}
+
+func (e *mockClientEvent) Timestamp() hlc.Timestamp {
+	if e.err != nil {
+		return e.errTs
+	}
+
+	switch e.event.Type() {
+	case streamingccl.KVEvent:
+		return e.event.GetKV().Value.Timestamp
+	case streamingccl.SSTableEvent:
+		return e.event.GetSSTable().WriteTS
+	case streamingccl.DeleteRangeEvent:
+		return e.event.GetDeleteRange().Timestamp
+	case streamingccl.CheckpointEvent:
+		spans := e.event.GetResolvedSpans()
+		minTs := hlc.MaxTimestamp
+		for _, span := range spans {
+			if span.Timestamp.Less(minTs) {
+				minTs = span.Timestamp
+			}
+		}
+		return minTs
+	default:
+		panic("unknown event type")
+	}
 }
 
 var _ streamclient.Client = &mockStreamClient{}
@@ -88,6 +125,7 @@ func (m *mockStreamClient) Plan(
 
 type mockSubscription struct {
 	eventsCh chan streamingccl.Event
+	err      error
 }
 
 // Subscribe implements the Subscription interface.
@@ -102,7 +140,7 @@ func (m *mockSubscription) Events() <-chan streamingccl.Event {
 
 // Err implements the Subscription interface.
 func (m *mockSubscription) Err() error {
-	return nil
+	return m.err
 }
 
 // Subscribe implements the Client interface.
@@ -112,29 +150,65 @@ func (m *mockStreamClient) Subscribe(
 	token streamclient.SubscriptionToken,
 	startTime hlc.Timestamp,
 ) (streamclient.Subscription, error) {
-	var events []streamingccl.Event
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var ok bool
-	if events, ok = m.partitionEvents[string(token)]; !ok {
+	if _, ok = m.mu.partitionEvents[string(token)]; !ok {
 		return nil, errors.Newf("no events found for partition %s", string(token))
 	}
 	log.Infof(ctx, "%q beginning subscription from time %v ", string(token), startTime)
 
-	log.Infof(ctx, "%q emitting %d events", string(token), len(events))
-	eventCh := make(chan streamingccl.Event, len(events))
-	for _, event := range events {
-		log.Infof(ctx, "%q emitting event %v", string(token), event)
-		eventCh <- event
-	}
-	log.Infof(ctx, "%q done emitting %d events", string(token), len(events))
-	go func() {
-		if m.doneCh != nil {
-			log.Infof(ctx, "%q waiting for doneCh", string(token))
-			<-m.doneCh
-			log.Infof(ctx, "%q received event on doneCh", string(token))
+	// Only emit events after the start time until the first valid error
+	var events []mockClientEvent
+	for i := range m.mu.partitionEvents[string(token)] {
+		event := m.mu.partitionEvents[string(token)][i]
+		if !startTime.LessEq(event.Timestamp()) {
+			continue
 		}
-		close(eventCh)
-	}()
-	return &mockSubscription{eventsCh: eventCh}, nil
+		if event.err == nil {
+			events = append(events, event)
+		} else if event.errLifetime > 0 {
+			event.err = errors.Wrapf(event.err, "error with lifetime %d", event.errLifetime)
+			events = append(events, event)
+			m.mu.partitionEvents[string(token)][i].errLifetime--
+			break
+		}
+	}
+
+	log.Infof(ctx, "%q emitting %d events", string(token), len(events))
+	eventsCh := make(chan streamingccl.Event, len(events))
+	var subErr error
+	for _, event := range events {
+		if event.err == nil {
+			log.Infof(ctx, "%q emitting event %v", string(token), event.event)
+			if event.event.Type() == streamingccl.KVEvent {
+				// Need to clone the key since it is mutated inplace by the rekeyer
+				kv := event.event.GetKV()
+				eventsCh <- streamingccl.MakeKVEvent(roachpb.KeyValue{Key: kv.Key.Clone(), Value: kv.Value})
+			} else {
+				eventsCh <- event.event
+			}
+		} else {
+			log.Infof(ctx, "%q recording error %s", string(token), event.err.Error())
+			subErr = event.err
+		}
+	}
+	log.Infof(ctx, "%q done emitting %d events and set err %s", string(token), len(events), subErr)
+
+	if m.mu.doneCh == nil {
+		close(eventsCh)
+	} else {
+		go func() {
+			m.mu.Lock()
+			defer m.mu.Unlock()
+			log.Infof(ctx, "%q waiting for doneCh", string(token))
+			<-m.mu.doneCh
+			log.Infof(ctx, "%q received event on doneCh", string(token))
+			close(eventsCh)
+		}()
+	}
+
+	return &mockSubscription{eventsCh: eventsCh, err: subErr}, nil
 }
 
 // Close implements the Client interface.
@@ -196,14 +270,19 @@ func TestStreamIngestionProcessor(t *testing.T) {
 	p2Key := roachpb.Key("key_2")
 	p2Span := roachpb.Span{Key: p2Key, EndKey: p2Key.Next()}
 
-	sampleKV := func() roachpb.KeyValue {
+	sampleKV := func(wallTime int64) mockClientEvent {
 		key, err := keys.RewriteKeyToTenantPrefix(p1Key,
 			keys.MakeTenantPrefix(roachpb.MakeTenantID(tenantID)))
 		require.NoError(t, err)
-		return roachpb.KeyValue{Key: key, Value: v}
+		value := v
+		value.Timestamp = hlc.Timestamp{WallTime: wallTime}
+		return mockClientEvent{event: streamingccl.MakeKVEvent(roachpb.KeyValue{Key: key, Value: value})}
 	}
-	sampleCheckpoint := func(span roachpb.Span, ts int64) []jobspb.ResolvedSpan {
-		return []jobspb.ResolvedSpan{{Span: span, Timestamp: hlc.Timestamp{WallTime: ts}}}
+	sampleCheckpoint := func(span roachpb.Span, ts int64) mockClientEvent {
+		return mockClientEvent{event: streamingccl.MakeCheckpointEvent([]jobspb.ResolvedSpan{{Span: span, Timestamp: hlc.Timestamp{WallTime: ts}}})}
+	}
+	sampleError := func(msg string, ts int64, lifetime int) mockClientEvent {
+		return mockClientEvent{err: errors.Errorf("%s", msg), errTs: hlc.Timestamp{WallTime: ts}, errLifetime: lifetime}
 	}
 
 	readRows := func(streamOut *distsqlutils.RowBuffer) map[string]struct{} {
@@ -227,20 +306,19 @@ func TestStreamIngestionProcessor(t *testing.T) {
 	}
 
 	t.Run("finite stream client", func(t *testing.T) {
-		events := func() []streamingccl.Event {
-			return []streamingccl.Event{
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeCheckpointEvent(sampleCheckpoint(p1Span, 2)),
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeCheckpointEvent(sampleCheckpoint(p1Span, 4)),
-				streamingccl.MakeCheckpointEvent(sampleCheckpoint(p2Span, 5)),
+		events := func() []mockClientEvent {
+			return []mockClientEvent{
+				sampleKV(1),
+				sampleKV(1),
+				sampleCheckpoint(p1Span, 2),
+				sampleKV(3),
+				sampleKV(3),
+				sampleCheckpoint(p1Span, 4),
+				sampleCheckpoint(p2Span, 5),
 			}
 		}
-		mockClient := &mockStreamClient{
-			partitionEvents: map[string][]streamingccl.Event{string(p1): events(), string(p2): events()},
-		}
+		mockClient := &mockStreamClient{}
+		mockClient.mu.partitionEvents = map[string][]mockClientEvent{string(p1): events(), string(p2): events()}
 
 		startTime := hlc.Timestamp{WallTime: 1}
 		partitions := []streamclient.PartitionInfo{
@@ -263,19 +341,68 @@ func TestStreamIngestionProcessor(t *testing.T) {
 			"partition 2 should advance to timestamp 5")
 	})
 
-	// Two partitions, checkpoint for each, client start time for each should match
-	t.Run("resume from checkpoint", func(t *testing.T) {
-		events := func() []streamingccl.Event {
-			return []streamingccl.Event{
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeCheckpointEvent(sampleCheckpoint(p2Span, 2)),
-				streamingccl.MakeKVEvent(sampleKV()),
-				streamingccl.MakeCheckpointEvent(sampleCheckpoint(p1Span, 6)),
+	t.Run("retries on subscription errors", func(t *testing.T) {
+		events := func() []mockClientEvent {
+			return []mockClientEvent{
+				sampleKV(1),
+				sampleKV(2),
+				sampleKV(3),
+				sampleCheckpoint(p2Span, 2),
+				sampleCheckpoint(p1Span, 3),
+				sampleKV(4),
+				sampleError("injected err", 5, 4),
+				sampleKV(6),
+				sampleCheckpoint(p1Span, 7),
+				sampleKV(8),
+				sampleCheckpoint(p2Span, 9),
 			}
 		}
-		mockClient := &mockStreamClient{
-			partitionEvents: map[string][]streamingccl.Event{string(p1): events(), string(p2): events()},
+
+		mockClient := &mockStreamClient{}
+		mockClient.mu.partitionEvents = map[string][]mockClientEvent{string(p1): events(), string(p2): events()}
+
+		startTime := hlc.Timestamp{WallTime: 1}
+		partitions := []streamclient.PartitionInfo{
+			{ID: "1", SubscriptionToken: p1, Spans: []roachpb.Span{p1Span}},
+			{ID: "2", SubscriptionToken: p2, Spans: []roachpb.Span{p2Span}},
 		}
+
+		out, err := runStreamIngestionProcessor(ctx, t, registry, kvDB,
+			partitions, startTime, []jobspb.ResolvedSpan{}, tenantRekey,
+			mockClient, nil /* cutoverProvider */, &sql.StreamingTestingKnobs{
+				OverrideIngestionPartitionRetry: func() retry.Options {
+					return retry.Options{
+						InitialBackoff: 1 * time.Millisecond,
+						Multiplier:     1,
+						MaxRetries:     5,
+					}
+				},
+			})
+		require.NoError(t, err)
+
+		emittedRows := readRows(out)
+		fmt.Printf("\x1b[34m EMITTED ROWS: (%+v) \x1b[0m\n", emittedRows)
+
+		require.Contains(t, emittedRows, "key_1{-\\x00} 0.000000007,0",
+			"partition 1 should advance to timestamp 7")
+		require.Contains(t, emittedRows, "key_2{-\\x00} 0.000000009,0",
+			"partition 2 should advance to timestamp 9")
+
+		fmt.Printf("\x1b[34m DONE TEST \x1b[0m\n")
+	})
+
+	// Two partitions, checkpoint for each, client start time for each should match
+	t.Run("resume from checkpoint", func(t *testing.T) {
+		events := func() []mockClientEvent {
+			return []mockClientEvent{
+				sampleKV(1),
+				sampleCheckpoint(p2Span, 2),
+				sampleKV(3),
+				sampleCheckpoint(p1Span, 6),
+			}
+		}
+		mockClient := &mockStreamClient{}
+		mockClient.mu.partitionEvents = map[string][]mockClientEvent{string(p1): events(), string(p2): events()}
 
 		startTime := hlc.Timestamp{WallTime: 1}
 		partitions := []streamclient.PartitionInfo{
@@ -287,8 +414,11 @@ func TestStreamIngestionProcessor(t *testing.T) {
 			{Span: p2Span, Timestamp: hlc.Timestamp{WallTime: 5}},
 		}
 
+		var clientStartMu syncutil.Mutex
 		lastClientStart := make(map[string]hlc.Timestamp)
 		streamingTestingKnobs := &sql.StreamingTestingKnobs{BeforeClientSubscribe: func(addr string, token string, clientStartTime hlc.Timestamp) {
+			clientStartMu.Lock()
+			defer clientStartMu.Unlock()
 			lastClientStart[token] = clientStartTime
 		}}
 		out, err := runStreamIngestionProcessor(ctx, t, registry, kvDB,
@@ -298,15 +428,17 @@ func TestStreamIngestionProcessor(t *testing.T) {
 
 		emittedRows := readRows(out)
 
+		// Should've started from the latest frontier
+		require.Equal(t, hlc.Timestamp{WallTime: 4}, lastClientStart[string(p1)])
+		require.Equal(t, hlc.Timestamp{WallTime: 5}, lastClientStart[string(p2)])
+
 		// Only compare the latest advancement, since not all intermediary resolved
 		// timestamps might be flushed (due to the minimum flush interval setting in
 		// the ingestion processor).
-		require.Contains(t, emittedRows, "key_1{-\\x00} 0.000000004,0",
-			"partition 1 should advance to timestamp 4")
+		require.Contains(t, emittedRows, "key_1{-\\x00} 0.000000006,0",
+			"partition 1 should advance to timestamp 6")
 		require.Contains(t, emittedRows, "key_2{-\\x00} 0.000000005,0",
 			"partition 2 should advance to timestamp 5")
-		require.Equal(t, lastClientStart[string(p1)], hlc.Timestamp{WallTime: 4})
-		require.Equal(t, lastClientStart[string(p2)], hlc.Timestamp{WallTime: 5})
 	})
 
 	t.Run("error stream client", func(t *testing.T) {
@@ -317,12 +449,21 @@ func TestStreamIngestionProcessor(t *testing.T) {
 		}
 		out, err := runStreamIngestionProcessor(ctx, t, registry, kvDB,
 			partitions, startTime, []jobspb.ResolvedSpan{}, tenantRekey, &errorStreamClient{},
-			nil /* cutoverProvider */, nil /* streamingTestingKnobs */)
+			nil /* cutoverProvider */, &sql.StreamingTestingKnobs{
+				OverrideIngestionPartitionRetry: func() retry.Options {
+					return retry.Options{
+						InitialBackoff: 1 * time.Millisecond,
+						Multiplier:     1,
+						MaxRetries:     5,
+					}
+				},
+			})
 		require.NoError(t, err)
 
 		// Expect no rows, and just the error.
 		row, meta := out.Next()
 		require.Nil(t, row)
+		require.NotNil(t, meta)
 		testutils.IsError(meta.Err, "this client always returns an error")
 	})
 }

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -104,6 +104,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -1619,12 +1620,16 @@ type StreamingTestingKnobs struct {
 	RunAfterReceivingEvent func(ctx context.Context) error
 
 	// BeforeClientSubscribe allows observation of parameters about to be passed
-	// to a streaming client
+	// to a streaming client.
 	BeforeClientSubscribe func(addr string, token string, startTime hlc.Timestamp)
 
 	// BeforeIngestionStart allows blocking the stream ingestion job
 	// before a stream ingestion happens.
 	BeforeIngestionStart func(ctx context.Context) error
+
+	// OverrideIngestionPartitionRetry allows changing the internal retry options
+	// used by ingestion processors.
+	OverrideIngestionPartitionRetry func() retry.Options
 }
 
 var _ base.ModuleTestingKnobs = &StreamingTestingKnobs{}


### PR DESCRIPTION
Previously if a temporary blip resulted in an error on the subscription
to a node the entire replication job would have to restart.  This change
makes ingestion processors have multiple retry attempts if the call to
Subscribe errors or an error on the subscription occurs.

Release justification: Change to unreleased feature.
Release note (bug fix): replication stream destination cluster
processors now attempt to retry subscribing to a source node without
surfacing the error to the rest of the job.
