### PR TITLE
workload/schemachange: propagate worker ID to log

### DIFF
--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -331,7 +331,7 @@ func (w *schemaChangeWorker) getErrorState() string {
 }
 
 func (w *schemaChangeWorker) runInTxn(ctx context.Context, tx pgx.Tx) error {
-	w.logger.startLog()
+	w.logger.startLog(w.id)
 	w.logger.writeLog("BEGIN")
 	opsNum := 1 + w.opGen.randIntn(w.maxOpsPerWorker)
 
@@ -534,13 +534,14 @@ func (w *schemaChangeWorker) releaseLocksIfHeld() {
 
 // startLog initializes the currentLogEntry of the schemaChangeWorker. It is a noop
 // if l.verbose < 1.
-func (l *logger) startLog() {
+func (l *logger) startLog(workerID int) {
 	if l.verbose < 1 {
 		return
 	}
 	l.currentLogEntry.mu.Lock()
 	defer l.currentLogEntry.mu.Unlock()
 	l.currentLogEntry.mu.entry = &LogEntry{
+		WorkerID:        workerID,
 		ClientTimestamp: timeutil.Now().Format("15:04:05.999999"),
 	}
 }


### PR DESCRIPTION
The schemachange workload can run with concurrency. It logs what workers do. It was hard to understand what different workers are doing because we never populated the worker ID.

Release note: None