### PR TITLE
release-22.1: sql/sqlstats: record QuerySummary when merging stats, sql: fix prepared statement query summary

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -456,6 +456,7 @@ func (ex *connExecutor) execStmtInOpenState(
 		stmt.Prepared = ps
 		stmt.ExpectedTypes = ps.Columns
 		stmt.StmtNoConstants = ps.StatementNoConstants
+		stmt.StmtSummary = ps.StatementSummary
 		res.ResetStmtType(ps.AST)
 
 		if e.DiscardRows {

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -403,3 +403,19 @@ SELECT * FROM txn_fingerprint_view
 
 statement ok
 COMMIT
+
+statement ok
+BEGIN; SELECT count(1) AS wombat1; COMMIT
+
+query T
+SELECT metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE '%wombat1%'
+----
+SELECT count(_) AS wom...
+
+statement ok
+SELECT count(1) AS wombat2
+
+query T
+SELECT metadata->>'querySummary' FROM crdb_internal.statement_statistics WHERE metadata->>'query' LIKE '%wombat2%'
+----
+SELECT count(_) AS wom...

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -67,8 +67,7 @@ type PreparedStatement struct {
 	createdAt time.Time
 	// origin is the protocol in which this prepare statement was created.
 	// Used for reporting on `pg_prepared_statements`.
-	origin           PreparedStatementOrigin
-	StatementSummary string
+	origin PreparedStatementOrigin
 }
 
 // MemoryEstimate returns a rough estimate of the PreparedStatement's memory

--- a/pkg/sql/querycache/prepared_statement.go
+++ b/pkg/sql/querycache/prepared_statement.go
@@ -30,6 +30,9 @@ type PrepareMetadata struct {
 	// suitable for recording in statement statistics.
 	StatementNoConstants string
 
+	// StatementSummary is a summarized version of the query.
+	StatementSummary string
+
 	// Provides TypeHints and Types fields which contain placeholder typing
 	// information.
 	tree.PlaceholderTypesInfo

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -465,6 +465,7 @@ func (s *stmtStats) mergeStatsLocked(statistics *roachpb.CollectedStatementStati
 	s.mu.distSQLUsed = statistics.Key.DistSQL
 	s.mu.fullScan = statistics.Key.FullScan
 	s.mu.database = statistics.Key.Database
+	s.mu.querySummary = statistics.Key.QuerySummary
 }
 
 // getStatsForStmt retrieves the per-stmt stat object. Regardless of if a valid


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql/sqlstats: record QuerySummary when merging stats" (#84170)
  * 1/1 commits from "sql: fix prepared statement query summary" (#83673)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk, high benefit change to existing functionality