### PR TITLE
release-22.1: sql: add schema_name to index usage stat telemetry, add descriptions to proto fields, sql: add created_at to index usage stat telemetry

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2365,14 +2365,6 @@ An event of type `captured_index_usage_stats`
 | `LastRead` | LastRead is the timestamp at which the index was last read. | no |
 | `TableID` | TableID is the ID of the table on which the index was created. This is same as descpb.TableID and is unique within the cluster. | no |
 | `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
-<<<<<<< HEAD
-| `DatabaseName` |  | no |
-| `TableName` |  | no |
-| `IndexName` |  | no |
-| `IndexType` |  | no |
-| `IsUnique` |  | no |
-| `IsInverted` |  | no |
-=======
 | `DatabaseName` | DatabaseName is the name of the database in which the index was created. | no |
 | `TableName` | TableName is the name of the table on which the index was created. | no |
 | `IndexName` | IndexName is the name of the index within the scope of the given table. | no |
@@ -2380,11 +2372,7 @@ An event of type `captured_index_usage_stats`
 | `IsUnique` | IsUnique indicates if the index has a UNIQUE constraint. | no |
 | `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
 | `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
-<<<<<<< HEAD
->>>>>>> b224354ea1 (sql: add descriptions to idx usage telemetry fields)
-=======
 | `SchemaName` | SchemaName is the name of the schema in which the index was created. | no |
->>>>>>> d6dfdede40 (sql: add schema_name to index usage stat telemetry)
 
 
 #### Common fields

--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2361,16 +2361,26 @@ An event of type `captured_index_usage_stats`
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `TotalReadCount` | TotalReadCount is the number of times this index has been read from. | no |
-| `LastRead` | LastRead is the timestamp that this index was last being read from. | no |
-| `TableID` | TableID is the ID of the table this index is created on. This is same as descpb.TableID and is unique within the cluster. | no |
+| `TotalReadCount` | TotalReadCount is the number of times the index has been read. | no |
+| `LastRead` | LastRead is the timestamp at which the index was last read. | no |
+| `TableID` | TableID is the ID of the table on which the index was created. This is same as descpb.TableID and is unique within the cluster. | no |
 | `IndexID` | IndexID is the ID of the index within the scope of the given table. | no |
+<<<<<<< HEAD
 | `DatabaseName` |  | no |
 | `TableName` |  | no |
 | `IndexName` |  | no |
 | `IndexType` |  | no |
 | `IsUnique` |  | no |
 | `IsInverted` |  | no |
+=======
+| `DatabaseName` | DatabaseName is the name of the database in which the index was created. | no |
+| `TableName` | TableName is the name of the table on which the index was created. | no |
+| `IndexName` | IndexName is the name of the index within the scope of the given table. | no |
+| `IndexType` | IndexType is the type of the index. Index types include "primary" and "secondary". | no |
+| `IsUnique` | IsUnique indicates if the index has a UNIQUE constraint. | no |
+| `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
+| `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
+>>>>>>> b224354ea1 (sql: add descriptions to idx usage telemetry fields)
 
 
 #### Common fields

--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2380,7 +2380,11 @@ An event of type `captured_index_usage_stats`
 | `IsUnique` | IsUnique indicates if the index has a UNIQUE constraint. | no |
 | `IsInverted` | IsInverted indicates if the index is an inverted index. | no |
 | `CreatedAt` | CreatedAt is the timestamp at which the index was created. | no |
+<<<<<<< HEAD
 >>>>>>> b224354ea1 (sql: add descriptions to idx usage telemetry fields)
+=======
+| `SchemaName` | SchemaName is the name of the schema in which the index was created. | no |
+>>>>>>> d6dfdede40 (sql: add schema_name to index usage stat telemetry)
 
 
 #### Common fields

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -170,7 +170,7 @@ func captureIndexUsageStats(
 
 	// Capture index usage statistics for each database.
 	var ok bool
-	expectedNumDatums := 9
+	expectedNumDatums := 11
 	var allCapturedIndexUsageStats []eventpb.EventPayload
 	for _, databaseName := range allDatabaseNames {
 		// Omit index usage statistics on the default databases 'system',
@@ -188,13 +188,17 @@ func captureIndexUsageStats(
 		 ti.is_unique,
 		 ti.is_inverted,
 		 total_reads,
-		 last_read
+		 last_read,
+		 ti.created_at,
+     t.schema_name
 		FROM %s.crdb_internal.index_usage_statistics AS us
 		JOIN %s.crdb_internal.table_indexes ti
 		ON us.index_id = ti.index_id
 		 AND us.table_id = ti.descriptor_id
+    JOIN %s.crdb_internal.tables t 
+    ON ti.descriptor_id = t.table_id
 		ORDER BY total_reads ASC;
-	`, databaseName, databaseName)
+	`, databaseName, databaseName, databaseName)
 
 		it, err := ie.QueryIteratorEx(
 			ctx,
@@ -232,6 +236,11 @@ func captureIndexUsageStats(
 			if row[8] != tree.DNull {
 				lastRead = tree.MustBeDTimestampTZ(row[8]).Time
 			}
+			createdAt := time.Time{}
+			if row[9] != tree.DNull {
+				createdAt = tree.MustBeDTimestamp(row[9]).Time
+			}
+			schemaName := tree.MustBeDString(row[10])
 
 			capturedIndexStats := &eventpb.CapturedIndexUsageStats{
 				TableID:        uint32(roachpb.TableID(tableID)),
@@ -244,6 +253,8 @@ func captureIndexUsageStats(
 				IndexType:      string(indexType),
 				IsUnique:       bool(isUnique),
 				IsInverted:     bool(isInverted),
+				CreatedAt:      createdAt.String(),
+				SchemaName:     string(schemaName),
 			}
 
 			allCapturedIndexUsageStats = append(allCapturedIndexUsageStats, capturedIndexStats)

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -660,6 +660,26 @@ func (m *CapturedIndexUsageStats) AppendJSONFields(printComma bool, b redact.Red
 		b = append(b, "\"IsInverted\":true"...)
 	}
 
+	if m.CreatedAt != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"CreatedAt\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.CreatedAt)))
+		b = append(b, '"')
+	}
+
+	if m.SchemaName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"SchemaName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.SchemaName)))
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -177,6 +177,9 @@ message CapturedIndexUsageStats {
 
   // CreatedAt is the timestamp at which the index was created.
   string created_at = 12 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // SchemaName is the name of the schema in which the index was created.
+  string schema_name = 13 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -144,25 +144,39 @@ message CapturedIndexUsageStats {
 
   // Couldn't use roachpb.CollectedIndexUsageStatistics due to circular dependency.
 
-  // TotalReadCount is the number of times this index has been read from.
+  // TotalReadCount is the number of times the index has been read.
   uint64 total_read_count = 2;
 
-  // LastRead is the timestamp that this index was last being read from.
+  // LastRead is the timestamp at which the index was last read.
   string last_read = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // TableID is the ID of the table this index is created on. This is same as
+  // TableID is the ID of the table on which the index was created. This is same as
   // descpb.TableID and is unique within the cluster.
   uint32 table_id = 4 [(gogoproto.customname) = "TableID"];
 
   // IndexID is the ID of the index within the scope of the given table.
   uint32 index_id = 5 [(gogoproto.customname) = "IndexID"];
 
+  // DatabaseName is the name of the database in which the index was created.
   string database_name = 6 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // TableName is the name of the table on which the index was created.
   string table_name = 7 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IndexName is the name of the index within the scope of the given table.
   string index_name = 8 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IndexType is the type of the index. Index types include "primary" and "secondary".
   string index_type = 9 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+
+  // IsUnique indicates if the index has a UNIQUE constraint.
   bool is_unique = 10 [(gogoproto.jsontag) = ",omitempty"];
+
+  // IsInverted indicates if the index is an inverted index.
   bool is_inverted = 11 [(gogoproto.jsontag) = ",omitempty"];
+
+  // CreatedAt is the timestamp at which the index was created.
+  string created_at = 12 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
 // CreateChangefeed is an event for any CREATE CHANGEFEED query that


### PR DESCRIPTION
Backport:
  * 2/2 commits from "sql: add schema_name to index usage stat telemetry, add descriptions to proto fields" (#87504)
  * 1/1 commits from "sql: add created_at to index usage stat telemetry" (#87448)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: low risk, high benefit changes to existing functionality