### PR TITLE
release-22.1: ui/cluster-ui: add context to inform ui if on cockroach cloud

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/contexts/cockroachCloudContext.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/contexts/cockroachCloudContext.tsx
@@ -1,0 +1,13 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { createContext } from "react";
+
+export const CockroachCloudContext = createContext<boolean>(true);

--- a/pkg/ui/workspaces/cluster-ui/src/contexts/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/contexts/index.ts
@@ -1,0 +1,11 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+export * from "./cockroachCloudContext";

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -47,3 +47,4 @@ export { util, api };
 export * from "./sessions";
 export * from "./timeScaleDropdown";
 export * from "./graphs";
+export * from "./contexts";

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -74,6 +74,7 @@ import { RedirectToStatementDetails } from "src/routes/RedirectToStatementDetail
 import HotRangesPage from "src/views/hotRanges/index";
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
+import { CockroachCloudContext } from "@cockroachlabs/cluster-ui";
 
 // NOTE: If you are adding a new path to the router, and that path contains any
 // components that are personally identifying information, you MUST update the
@@ -96,303 +97,313 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
   return (
     <Provider store={store}>
       <ConnectedRouter history={history}>
-        <Switch>
-          {/* login */}
-          {createLoginRoute()}
-          {createLogoutRoute(store)}
-          <Route path="/">
-            <Layout>
-              <Switch>
-                <Redirect exact from="/" to="/overview" />
-                {/* overview page */}
-                {visualizationRoutes()}
+        <CockroachCloudContext.Provider value={false}>
+          <Switch>
+            {/* login */}
+            {createLoginRoute()}
+            {createLogoutRoute(store)}
+            <Route path="/">
+              <Layout>
+                <Switch>
+                  <Redirect exact from="/" to="/overview" />
+                  {/* overview page */}
+                  {visualizationRoutes()}
 
-                {/* time series metrics */}
-                <Redirect
-                  exact
-                  from="/metrics"
-                  to="/metrics/overview/cluster"
-                />
-                <Redirect
-                  exact
-                  from={`/metrics/:${dashboardNameAttr}`}
-                  to={`/metrics/:${dashboardNameAttr}/cluster`}
-                />
-                <Route
-                  exact
-                  path={`/metrics/:${dashboardNameAttr}/cluster`}
-                  component={NodeGraphs}
-                />
-                <Redirect
-                  exact
-                  path={`/metrics/:${dashboardNameAttr}/node`}
-                  to={`/metrics/:${dashboardNameAttr}/cluster`}
-                />
-                <Route
-                  path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
-                  component={NodeGraphs}
-                />
+                  {/* time series metrics */}
+                  <Redirect
+                    exact
+                    from="/metrics"
+                    to="/metrics/overview/cluster"
+                  />
+                  <Redirect
+                    exact
+                    from={`/metrics/:${dashboardNameAttr}`}
+                    to={`/metrics/:${dashboardNameAttr}/cluster`}
+                  />
+                  <Route
+                    exact
+                    path={`/metrics/:${dashboardNameAttr}/cluster`}
+                    component={NodeGraphs}
+                  />
+                  <Redirect
+                    exact
+                    path={`/metrics/:${dashboardNameAttr}/node`}
+                    to={`/metrics/:${dashboardNameAttr}/cluster`}
+                  />
+                  <Route
+                    path={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
+                    component={NodeGraphs}
+                  />
 
-                {/* node details */}
-                <Redirect exact from="/node" to="/overview/list" />
-                <Route
-                  exact
-                  path={`/node/:${nodeIDAttr}`}
-                  component={NodeOverview}
-                />
-                <Route
-                  exact
-                  path={`/node/:${nodeIDAttr}/logs`}
-                  component={NodeLogs}
-                />
+                  {/* node details */}
+                  <Redirect exact from="/node" to="/overview/list" />
+                  <Route
+                    exact
+                    path={`/node/:${nodeIDAttr}`}
+                    component={NodeOverview}
+                  />
+                  <Route
+                    exact
+                    path={`/node/:${nodeIDAttr}/logs`}
+                    component={NodeLogs}
+                  />
 
-                {/* events & jobs */}
-                <Route path="/events" component={EventPage} />
-                <Route exact path="/jobs" component={JobsPage} />
-                <Route path="/jobs/:id" component={JobDetails} />
+                  {/* events & jobs */}
+                  <Route path="/events" component={EventPage} />
+                  <Route exact path="/jobs" component={JobsPage} />
+                  <Route path="/jobs/:id" component={JobDetails} />
 
-                {/* databases */}
-                <Route exact path="/databases" component={DatabasesPage} />
-                <Redirect exact from="/databases/tables" to="/databases" />
-                <Redirect exact from="/databases/grants" to="/databases" />
-                <Redirect
-                  from={`/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                  to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                />
+                  {/* databases */}
+                  <Route exact path="/databases" component={DatabasesPage} />
+                  <Redirect exact from="/databases/tables" to="/databases" />
+                  <Redirect exact from="/databases/grants" to="/databases" />
+                  <Redirect
+                    from={`/databases/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                    to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                  />
 
-                <Redirect exact from="/database" to="/databases" />
-                <Route
-                  exact
-                  path={`/database/:${databaseNameAttr}`}
-                  component={DatabaseDetailsPage}
-                />
-                <Redirect
-                  exact
-                  from={`/database/:${databaseNameAttr}/table`}
-                  to={`/database/:${databaseNameAttr}`}
-                />
-                <Route
-                  exact
-                  path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                  component={DatabaseTablePage}
-                />
-                <Route
-                  exact
-                  path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index/:${indexNameAttr}`}
-                  component={IndexDetailsPage}
-                />
-                <Redirect
-                  exact
-                  from={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index`}
-                  to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
-                />
+                  <Redirect exact from="/database" to="/databases" />
+                  <Route
+                    exact
+                    path={`/database/:${databaseNameAttr}`}
+                    component={DatabaseDetailsPage}
+                  />
+                  <Redirect
+                    exact
+                    from={`/database/:${databaseNameAttr}/table`}
+                    to={`/database/:${databaseNameAttr}`}
+                  />
+                  <Route
+                    exact
+                    path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                    component={DatabaseTablePage}
+                  />
+                  <Route
+                    exact
+                    path={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index/:${indexNameAttr}`}
+                    component={IndexDetailsPage}
+                  />
+                  <Redirect
+                    exact
+                    from={`/database/:${databaseNameAttr}/table/:${tableNameAttr}/index`}
+                    to={`/database/:${databaseNameAttr}/table/:${tableNameAttr}`}
+                  />
 
-                {/* data distribution */}
-                <Route
-                  exact
-                  path="/data-distribution"
-                  component={DataDistributionPage}
-                />
+                  {/* data distribution */}
+                  <Route
+                    exact
+                    path="/data-distribution"
+                    component={DataDistributionPage}
+                  />
 
-                {/* SQL activity */}
-                <Route exact path="/sql-activity" component={SQLActivityPage} />
+                  {/* SQL activity */}
+                  <Route
+                    exact
+                    path="/sql-activity"
+                    component={SQLActivityPage}
+                  />
 
-                {/* statement statistics */}
-                <Redirect
-                  exact
-                  from={`/statements`}
-                  to={`/sql-activity?${tabAttr}=Statements`}
-                />
-                <Redirect
-                  exact
-                  from={`/statements/:${appAttr}`}
-                  to={`/statements?${appAttr}=:${appAttr}`}
-                />
-                <Route
-                  exact
-                  path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
-                  component={StatementDetails}
-                />
-                <Route
-                  exact
-                  path={`/statements/:${appAttr}/:${statementAttr}`}
-                  render={RedirectToStatementDetails}
-                />
-                <Route
-                  exact
-                  path={`/statements/:${appAttr}/:${implicitTxnAttr}/:${statementAttr}`}
-                  render={RedirectToStatementDetails}
-                />
-                <Route
-                  exact
-                  path={`/statements/:${appAttr}/:${databaseAttr}/:${implicitTxnAttr}/:${statementAttr}`}
-                  render={RedirectToStatementDetails}
-                />
-                <Route
-                  exact
-                  path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
-                  render={RedirectToStatementDetails}
-                />
-                <Route
-                  exact
-                  path={`/statement/:${databaseAttr}/:${implicitTxnAttr}/:${statementAttr}`}
-                  render={RedirectToStatementDetails}
-                />
-                <Redirect
-                  exact
-                  from={`/statement`}
-                  to={`/sql-activity?${tabAttr}=Statements`}
-                />
+                  {/* statement statistics */}
+                  <Redirect
+                    exact
+                    from={`/statements`}
+                    to={`/sql-activity?${tabAttr}=Statements`}
+                  />
+                  <Redirect
+                    exact
+                    from={`/statements/:${appAttr}`}
+                    to={`/statements?${appAttr}=:${appAttr}`}
+                  />
+                  <Route
+                    exact
+                    path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
+                    component={StatementDetails}
+                  />
+                  <Route
+                    exact
+                    path={`/statements/:${appAttr}/:${statementAttr}`}
+                    render={RedirectToStatementDetails}
+                  />
+                  <Route
+                    exact
+                    path={`/statements/:${appAttr}/:${implicitTxnAttr}/:${statementAttr}`}
+                    render={RedirectToStatementDetails}
+                  />
+                  <Route
+                    exact
+                    path={`/statements/:${appAttr}/:${databaseAttr}/:${implicitTxnAttr}/:${statementAttr}`}
+                    render={RedirectToStatementDetails}
+                  />
+                  <Route
+                    exact
+                    path={`/statement/:${implicitTxnAttr}/:${statementAttr}`}
+                    render={RedirectToStatementDetails}
+                  />
+                  <Route
+                    exact
+                    path={`/statement/:${databaseAttr}/:${implicitTxnAttr}/:${statementAttr}`}
+                    render={RedirectToStatementDetails}
+                  />
+                  <Redirect
+                    exact
+                    from={`/statement`}
+                    to={`/sql-activity?${tabAttr}=Statements`}
+                  />
 
-                {/* sessions */}
-                <Redirect
-                  exact
-                  from={`/sessions`}
-                  to={`/sql-activity?${tabAttr}=Sessions`}
-                />
-                <Route
-                  exact
-                  path={`/session/:${sessionAttr}`}
-                  component={SessionDetails}
-                />
+                  {/* sessions */}
+                  <Redirect
+                    exact
+                    from={`/sessions`}
+                    to={`/sql-activity?${tabAttr}=Sessions`}
+                  />
+                  <Route
+                    exact
+                    path={`/session/:${sessionAttr}`}
+                    component={SessionDetails}
+                  />
 
-                {/* transactions */}
-                <Redirect
-                  exact
-                  from={`/transactions`}
-                  to={`/sql-activity?${tabAttr}=Transactions`}
-                />
-                <Route
-                  exact
-                  path={`/transaction/:${txnFingerprintIdAttr}`}
-                  component={TransactionDetails}
-                />
-                <Redirect
-                  exact
-                  from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
-                  to={`/transaction/:${txnFingerprintIdAttr}`}
-                />
+                  {/* transactions */}
+                  <Redirect
+                    exact
+                    from={`/transactions`}
+                    to={`/sql-activity?${tabAttr}=Transactions`}
+                  />
+                  <Route
+                    exact
+                    path={`/transaction/:${txnFingerprintIdAttr}`}
+                    component={TransactionDetails}
+                  />
+                  <Redirect
+                    exact
+                    from={`/transaction/:${aggregatedTsAttr}/:${txnFingerprintIdAttr}`}
+                    to={`/transaction/:${txnFingerprintIdAttr}`}
+                  />
 
-                {/* debug pages */}
-                <Route exact path="/debug" component={Debug} />
-                <Route exact path="/debug/tracez" component={Tracez} />
-                <Route exact path="/debug/redux" component={ReduxDebug} />
-                <Route exact path="/debug/chart" component={CustomChart} />
-                <Route
-                  exact
-                  path="/debug/enqueue_range"
-                  component={EnqueueRange}
-                />
-                <Route exact path="/debug/hotranges" component={HotRanges} />
-                <Route
-                  exact
-                  path="/debug/hotranges/:node_id"
-                  component={HotRanges}
-                />
+                  {/* debug pages */}
+                  <Route exact path="/debug" component={Debug} />
+                  <Route exact path="/debug/tracez" component={Tracez} />
+                  <Route exact path="/debug/redux" component={ReduxDebug} />
+                  <Route exact path="/debug/chart" component={CustomChart} />
+                  <Route
+                    exact
+                    path="/debug/enqueue_range"
+                    component={EnqueueRange}
+                  />
+                  <Route exact path="/debug/hotranges" component={HotRanges} />
+                  <Route
+                    exact
+                    path="/debug/hotranges/:node_id"
+                    component={HotRanges}
+                  />
 
-                <Route path="/raft">
-                  <Raft>
-                    <Switch>
-                      <Redirect exact from="/raft" to="/raft/ranges" />
-                      <Route exact path="/raft/ranges" component={RaftRanges} />
-                      <Route
-                        exact
-                        path="/raft/messages/all"
-                        component={RaftMessages}
-                      />
-                      <Route
-                        exact
-                        path={`/raft/messages/node/:${nodeIDAttr}`}
-                        component={RaftMessages}
-                      />
-                    </Switch>
-                  </Raft>
-                </Route>
+                  <Route path="/raft">
+                    <Raft>
+                      <Switch>
+                        <Redirect exact from="/raft" to="/raft/ranges" />
+                        <Route
+                          exact
+                          path="/raft/ranges"
+                          component={RaftRanges}
+                        />
+                        <Route
+                          exact
+                          path="/raft/messages/all"
+                          component={RaftMessages}
+                        />
+                        <Route
+                          exact
+                          path={`/raft/messages/node/:${nodeIDAttr}`}
+                          component={RaftMessages}
+                        />
+                      </Switch>
+                    </Raft>
+                  </Route>
 
-                <Route
-                  exact
-                  path="/reports/problemranges"
-                  component={ProblemRanges}
-                />
-                <Route
-                  exact
-                  path={`/reports/problemranges/:${nodeIDAttr}`}
-                  component={ProblemRanges}
-                />
-                <Route
-                  exact
-                  path="/reports/localities"
-                  component={Localities}
-                />
-                <Route
-                  exact
-                  path={`/reports/network/:${nodeIDAttr}`}
-                  component={Network}
-                />
-                <Route exact path="/reports/network" component={Network} />
-                <Route exact path="/reports/nodes" component={Nodes} />
-                <Route
-                  exact
-                  path="/reports/nodes/history"
-                  component={ConnectedDecommissionedNodeHistory}
-                />
-                <Route exact path="/reports/settings" component={Settings} />
-                <Route
-                  exact
-                  path={`/reports/certificates/:${nodeIDAttr}`}
-                  component={Certificates}
-                />
-                <Route
-                  exact
-                  path={`/reports/range/:${rangeIDAttr}`}
-                  component={Range}
-                />
-                <Route
-                  exact
-                  path={`/reports/stores/:${nodeIDAttr}`}
-                  component={Stores}
-                />
-                <Route
-                  exact
-                  path={`/reports/statements/diagnosticshistory`}
-                  component={StatementsDiagnosticsHistoryView}
-                />
-                {/* hot ranges */}
-                <Route exact path={`/hotranges`} component={HotRangesPage} />
-                {/* old route redirects */}
-                <Redirect
-                  exact
-                  from="/cluster"
-                  to="/metrics/overview/cluster"
-                />
-                <Redirect
-                  from={`/cluster/all/:${dashboardNameAttr}`}
-                  to={`/metrics/:${dashboardNameAttr}/cluster`}
-                />
-                <Redirect
-                  from={`/cluster/node/:${nodeIDAttr}/:${dashboardNameAttr}`}
-                  to={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
-                />
-                <Redirect exact from="/cluster/nodes" to="/overview/list" />
-                <Redirect
-                  exact
-                  from={`/cluster/nodes/:${nodeIDAttr}`}
-                  to={`/node/:${nodeIDAttr}`}
-                />
-                <Redirect
-                  from={`/cluster/nodes/:${nodeIDAttr}/logs`}
-                  to={`/node/:${nodeIDAttr}/logs`}
-                />
-                <Redirect from="/cluster/events" to="/events" />
+                  <Route
+                    exact
+                    path="/reports/problemranges"
+                    component={ProblemRanges}
+                  />
+                  <Route
+                    exact
+                    path={`/reports/problemranges/:${nodeIDAttr}`}
+                    component={ProblemRanges}
+                  />
+                  <Route
+                    exact
+                    path="/reports/localities"
+                    component={Localities}
+                  />
+                  <Route
+                    exact
+                    path={`/reports/network/:${nodeIDAttr}`}
+                    component={Network}
+                  />
+                  <Route exact path="/reports/network" component={Network} />
+                  <Route exact path="/reports/nodes" component={Nodes} />
+                  <Route
+                    exact
+                    path="/reports/nodes/history"
+                    component={ConnectedDecommissionedNodeHistory}
+                  />
+                  <Route exact path="/reports/settings" component={Settings} />
+                  <Route
+                    exact
+                    path={`/reports/certificates/:${nodeIDAttr}`}
+                    component={Certificates}
+                  />
+                  <Route
+                    exact
+                    path={`/reports/range/:${rangeIDAttr}`}
+                    component={Range}
+                  />
+                  <Route
+                    exact
+                    path={`/reports/stores/:${nodeIDAttr}`}
+                    component={Stores}
+                  />
+                  <Route
+                    exact
+                    path={`/reports/statements/diagnosticshistory`}
+                    component={StatementsDiagnosticsHistoryView}
+                  />
+                  {/* hot ranges */}
+                  <Route exact path={`/hotranges`} component={HotRangesPage} />
+                  {/* old route redirects */}
+                  <Redirect
+                    exact
+                    from="/cluster"
+                    to="/metrics/overview/cluster"
+                  />
+                  <Redirect
+                    from={`/cluster/all/:${dashboardNameAttr}`}
+                    to={`/metrics/:${dashboardNameAttr}/cluster`}
+                  />
+                  <Redirect
+                    from={`/cluster/node/:${nodeIDAttr}/:${dashboardNameAttr}`}
+                    to={`/metrics/:${dashboardNameAttr}/node/:${nodeIDAttr}`}
+                  />
+                  <Redirect exact from="/cluster/nodes" to="/overview/list" />
+                  <Redirect
+                    exact
+                    from={`/cluster/nodes/:${nodeIDAttr}`}
+                    to={`/node/:${nodeIDAttr}`}
+                  />
+                  <Redirect
+                    from={`/cluster/nodes/:${nodeIDAttr}/logs`}
+                    to={`/node/:${nodeIDAttr}/logs`}
+                  />
+                  <Redirect from="/cluster/events" to="/events" />
 
-                <Redirect exact from="/nodes" to="/overview/list" />
+                  <Redirect exact from="/nodes" to="/overview/list" />
 
-                {/* 404 */}
-                <Route path="*" component={NotFound} />
-              </Switch>
-            </Layout>
-          </Route>
-        </Switch>
+                  {/* 404 */}
+                  <Route path="*" component={NotFound} />
+                </Switch>
+              </Layout>
+            </Route>
+          </Switch>
+        </CockroachCloudContext.Provider>
       </ConnectedRouter>
     </Provider>
   );


### PR DESCRIPTION
Backport 1/1 commits from #86264.

/cc @cockroachdb/release

---

Closes #86245

This commit introduces a context `CockroachCloudCountext` that
signifies whether or not the app is within cockroach cloud or
not. This allows us to enable/disable certain features depending
on the platform without plumbing any values. The default context
value is true in order to not set the context explicitly for
cloud components and within the managed-service repo. The
context is provided as false for the db-console app.

This commit also disables the `Time Spent Waiting` column
in active execution tables for CC, since that feature is not yet
available.

Release justification: low risk update to existing
functionality
Release note (ui change): The `time spent waiting` columns for
active execution tables has been  hidden on CC
