### PR TITLE
dev: support passing args to bazel when running acceptance tests

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=56
+DEV_VERSION=57
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions


### PR DESCRIPTION
This code change adds a `--verbose` flag when running acceptance tests and supports passing args to bazel.

Closes #86856

Release note: None