### PR TITLE
sql: Fix notice fail cause by URL

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3413,7 +3413,16 @@ func (t *logicTest) finishExecQuery(query logicQuery, rows *gosql.Rows, err erro
 		}
 		for i := range query.expectedResults {
 			expected, actual := query.expectedResults[i], actualResults[i]
-			resultMatches := expected == actual
+			var resultMatches bool
+			if query.noticetrace {
+				resultMatches, err = regexp.MatchString(expected, actual)
+				if err != nil {
+					return errors.CombineErrors(makeError(), err)
+				}
+			} else {
+				resultMatches = expected == actual
+			}
+
 			// Results are flattened into columns for each row.
 			// To find the coltype for the given result, mod the result number
 			// by the number of coltypes.

--- a/pkg/sql/logictest/testdata/logic_test/notice
+++ b/pkg/sql/logictest/testdata/logic_test/notice
@@ -57,4 +57,4 @@ UNLISTEN temp
 ----
 NOTICE: unimplemented: CRDB does not support LISTEN, making UNLISTEN a no-op
 HINT: You have attempted to use a feature that is not yet implemented.
-See: https://go.crdb.dev/issue-v/41522/v22.2
+See: https://go.crdb.dev/issue-v/41522/*


### PR DESCRIPTION
Fixes #87367
This commit added regex matching so changing versions dont cause notice test to fail.

Release justification: Bug fix
Release note: None