### PR TITLE
xform: mark PruneScanCols rule as essential

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -998,6 +998,9 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		// Needed to prevent rule cycles that lead to timeouts and OOMs.
 		int(opt.EliminateProject),
 		int(opt.EliminateSelect),
+		// Needed to make sure that dummy columns are pruned so that the
+		// database name is retrieved correctly.
+		int(opt.PruneScanCols),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
This allows us to not error when retrieving the database name (previously this could fail a logic test or be seen in a demo).

Release note: None