### PR TITLE
dev: ensure libdir is created and populated when running roachprod-stress

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=57
+DEV_VERSION=58
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/roachprod_stress.go
+++ b/pkg/cmd/dev/roachprod_stress.go
@@ -12,6 +12,7 @@ package main
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -87,6 +88,7 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 	// List of targets we need to cross-build.
 	crossTargets := []string{testTarget, stressTarget}
 	// Check whether this target depends on libgeos.
+	dependsOnGeos := false
 	queryArgs := []string{"query", fmt.Sprintf("somepath(%s, //c-deps:libgeos)", testTarget)}
 	queryOutput, err := d.exec.CommandContextSilent(ctx, "bazel", queryArgs...)
 	if err != nil {
@@ -94,6 +96,7 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 	}
 	if strings.TrimSpace(string(queryOutput)) != "" {
 		// If the test depends on geos we additionally want to cross-build it.
+		dependsOnGeos = true
 		crossTargets = append(crossTargets, "//c-deps:libgeos")
 	}
 
@@ -109,24 +112,43 @@ func (d *dev) roachprodStress(cmd *cobra.Command, commandLine []string) error {
 		return err
 	}
 
-	testTargetBasename := strings.Split(targets[0].fullName, ":")[1]
-	// Build roachprod-stress and roachprod.
-	args, buildTargets, err := d.getBasicBuildArgs(ctx, []string{"//pkg/cmd/roachprod-stress"})
+	// Build roachprod-stress.
+	args, roachprodStressTarget, err := d.getBasicBuildArgs(ctx, []string{"//pkg/cmd/roachprod-stress"})
 	if err != nil {
 		return err
 	}
 	if _, err := d.exec.CommandContextSilent(ctx, "bazel", args...); err != nil {
 		return err
 	}
-	if err := d.stageArtifacts(ctx, buildTargets); err != nil {
+	if err := d.stageArtifacts(ctx, roachprodStressTarget); err != nil {
 		return err
 	}
+
 	workspace, err := d.getWorkspace(ctx)
 	if err != nil {
 		return err
 	}
+
+	libdir := path.Join(workspace, "artifacts", "libgeos", "lib")
+	if dependsOnGeos {
+		if err = d.os.MkdirAll(libdir); err != nil {
+			return err
+		}
+		for _, libWithExt := range []string{"libgeos.so", "libgeos_c.so"} {
+			src := filepath.Join(workspace, "artifacts", libWithExt)
+			dst := filepath.Join(libdir, libWithExt)
+			if err := d.os.CopyFile(src, dst); err != nil {
+				return err
+			}
+			if err := d.os.Remove(src); err != nil {
+				return err
+			}
+		}
+	}
+
+	testTargetBasename := strings.Split(targets[0].fullName, ":")[1]
 	// Run roachprod-stress.
-	roachprodStressArgs := []string{cluster, fmt.Sprintf("./%s", pkg), "-testbin", filepath.Join(workspace, "artifacts", testTargetBasename), "-stressbin", filepath.Join(workspace, "artifacts", "stress"), "-libdir", filepath.Join(workspace, "artifacts", "libgeos", "lib")}
+	roachprodStressArgs := []string{cluster, fmt.Sprintf("./%s", pkg), "-testbin", filepath.Join(workspace, "artifacts", testTargetBasename), "-stressbin", filepath.Join(workspace, "artifacts", "stress"), "-libdir", libdir}
 	roachprodStressArgs = append(roachprodStressArgs, strings.Fields(stressCmdArgs)...)
 	roachprodStressArgs = append(roachprodStressArgs, "--")
 	roachprodStressArgs = append(roachprodStressArgs, testArgs...)


### PR DESCRIPTION
Previously, `geos libs` were created under the `artifacts` directory.

This code change copies them into their own directory.
Closes #87643

Release note: None