### PR TITLE
release-22.2: catalog: spin off and adopt back-reference validation level

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -278,8 +278,8 @@ func (desc *immutable) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
 	return ids, nil
 }
 
-// ValidateCrossReferences implements the catalog.Descriptor interface.
-func (desc *immutable) ValidateCrossReferences(
+// ValidateForwardReferences implements the catalog.Descriptor interface.
+func (desc *immutable) ValidateForwardReferences(
 	vea catalog.ValidationErrorAccumulator, vdg catalog.ValidationDescGetter,
 ) {
 	// Check multi-region enum type.
@@ -302,13 +302,11 @@ func (desc *immutable) ValidateCrossReferences(
 	}
 }
 
-// ValidateTxnCommit implements the catalog.Descriptor interface.
-func (desc *immutable) ValidateTxnCommit(
+// ValidateBackReferences implements the catalog.Descriptor interface.
+func (desc *immutable) ValidateBackReferences(
 	vea catalog.ValidationErrorAccumulator, vdg catalog.ValidationDescGetter,
 ) {
 	// Check schema references.
-	// This could be done in ValidateCrossReferences but it can be quite expensive
-	// so we do it here instead.
 	for schemaName, schemaInfo := range desc.Schemas {
 		report := func(err error) {
 			vea.Report(errors.Wrapf(err, "schema mapping entry %q (%d)",
@@ -330,6 +328,13 @@ func (desc *immutable) ValidateTxnCommit(
 				schemaDesc.GetName(), schemaDesc.GetID()))
 		}
 	}
+}
+
+// ValidateTxnCommit implements the catalog.Descriptor interface.
+func (desc *immutable) ValidateTxnCommit(
+	vea catalog.ValidationErrorAccumulator, vdg catalog.ValidationDescGetter,
+) {
+	// No-op.
 }
 
 // MaybeIncrementVersion implements the MutableDescriptor interface.

--- a/pkg/sql/catalog/dbdesc/database_test.go
+++ b/pkg/sql/catalog/dbdesc/database_test.go
@@ -279,7 +279,7 @@ func TestValidateCrossDatabaseReferences(t *testing.T) {
 			return nil
 		})
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
+		results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validate.Write, desc)
 		if err := results.CombinedError(); err == nil {
 			if test.err != "" {
 				t.Errorf("%d: expected \"%s\", but found success: %+v", i, expectedErr, test.desc)

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -199,8 +199,11 @@ type Descriptor interface {
 	// ValidateSelf checks the internal consistency of the descriptor.
 	ValidateSelf(vea ValidationErrorAccumulator)
 
-	// ValidateCrossReferences performs cross-reference checks.
-	ValidateCrossReferences(vea ValidationErrorAccumulator, vdg ValidationDescGetter)
+	// ValidateForwardReferences performs forward-reference checks.
+	ValidateForwardReferences(vea ValidationErrorAccumulator, vdg ValidationDescGetter)
+
+	// ValidateBackReferences performs back-reference checks.
+	ValidateBackReferences(vea ValidationErrorAccumulator, vdg ValidationDescGetter)
 
 	// ValidateTxnCommit performs pre-commit checks.
 	ValidateTxnCommit(vea ValidationErrorAccumulator, vdg ValidationDescGetter)

--- a/pkg/sql/catalog/errors.go
+++ b/pkg/sql/catalog/errors.go
@@ -165,7 +165,6 @@ func AsFunctionDescriptor(desc Descriptor) (FunctionDescriptor, error) {
 // WrapDescRefErr wraps an error pertaining to a descriptor id.
 func WrapDescRefErr(id descpb.ID, err error) error {
 	return errors.Wrapf(err, "referenced descriptor ID %d", errors.Safe(id))
-
 }
 
 // WrapDatabaseDescRefErr wraps an error pertaining to a database descriptor id.

--- a/pkg/sql/catalog/funcdesc/BUILD.bazel
+++ b/pkg/sql/catalog/funcdesc/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/dbdesc",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/internal/validate",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/tabledesc",

--- a/pkg/sql/catalog/funcdesc/func_desc_test.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -459,7 +460,7 @@ func TestValidateFuncDesc(t *testing.T) {
 	for i, test := range testData {
 		desc := funcdesc.NewBuilder(&test.desc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		ve := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelCrossReferences, desc)
+		ve := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validate.Write, desc)
 		if err := ve.CombinedError(); err == nil {
 			t.Errorf("#%d expected err: %s, but found nil: %v", i, expectedErr, test.desc)
 		} else if expectedErr != err.Error() {

--- a/pkg/sql/catalog/nstree/catalog.go
+++ b/pkg/sql/catalog/nstree/catalog.go
@@ -199,7 +199,7 @@ func (c Catalog) ValidateWithRecover(
 			ve = append(ve, err)
 		}
 	}()
-	return c.Validate(ctx, version, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, desc)
+	return c.Validate(ctx, version, catalog.NoValidationTelemetry, validate.Write, desc)
 }
 
 // ByteSize returns memory usage of the underlying map in bytes.

--- a/pkg/sql/catalog/schemadesc/schema_desc_test.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc_test.go
@@ -232,7 +232,7 @@ func TestValidateCrossSchemaReferences(t *testing.T) {
 		test.dbDesc.Privileges = privilege
 		cb.UpsertDescriptorEntry(dbdesc.NewBuilder(&test.dbDesc).BuildImmutable())
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
+		const validateCrossReferencesOnly = catalog.ValidationLevelBackReferences &^ catalog.ValidationLevelSelfOnly
 		results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
 		if err := results.CombinedError(); err == nil {
 			if test.err != "" {

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -94,7 +94,11 @@ func (p synthetic) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
 }
 func (p synthetic) ValidateSelf(_ catalog.ValidationErrorAccumulator) {
 }
-func (p synthetic) ValidateCrossReferences(
+func (p synthetic) ValidateForwardReferences(
+	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
+) {
+}
+func (p synthetic) ValidateBackReferences(
 	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
 ) {
 }

--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -139,6 +139,7 @@ func ValidateTTLExpirationColumn(desc catalog.TableDescriptor) error {
 			)
 		}
 	}
+
 	return nil
 }
 

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -2718,7 +2718,7 @@ func TestValidateCrossTableReferences(t *testing.T) {
 			desc := NewBuilder(&test.desc).BuildImmutable()
 			cb.UpsertDescriptorEntry(funcdesc.NewBuilder(&descpb.FunctionDescriptor{ID: 100, Name: "f"}).BuildImmutable())
 			expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-			const validateCrossReferencesOnly = catalog.ValidationLevelCrossReferences &^ (catalog.ValidationLevelCrossReferences >> 1)
+			const validateCrossReferencesOnly = catalog.ValidationLevelBackReferences &^ catalog.ValidationLevelSelfOnly
 			results := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, validateCrossReferencesOnly, desc)
 			if err := results.CombinedError(); err == nil {
 				if test.err != "" {

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -204,8 +204,14 @@ func (v TableImplicitRecordType) GetReferencedDescIDs() (catalog.DescriptorIDSet
 func (v TableImplicitRecordType) ValidateSelf(_ catalog.ValidationErrorAccumulator) {
 }
 
-// ValidateCrossReferences implements the Descriptor interface.
-func (v TableImplicitRecordType) ValidateCrossReferences(
+// ValidateForwardReferences implements the Descriptor interface.
+func (v TableImplicitRecordType) ValidateForwardReferences(
+	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
+) {
+}
+
+// ValidateBackReferences implements the Descriptor interface.
+func (v TableImplicitRecordType) ValidateBackReferences(
 	_ catalog.ValidationErrorAccumulator, _ catalog.ValidationDescGetter,
 ) {
 }

--- a/pkg/sql/catalog/typedesc/type_desc_test.go
+++ b/pkg/sql/catalog/typedesc/type_desc_test.go
@@ -792,7 +792,7 @@ func TestValidateTypeDesc(t *testing.T) {
 	for i, test := range testData {
 		desc := typedesc.NewBuilder(&test.desc).BuildImmutable()
 		expectedErr := fmt.Sprintf("%s %q (%d): %s", desc.DescriptorType(), desc.GetName(), desc.GetID(), test.err)
-		ve := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelCrossReferences, desc)
+		ve := cb.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelBackReferences, desc)
 		if err := ve.CombinedError(); err == nil {
 			t.Errorf("#%d expected err: %s but found nil: %v", i, expectedErr, test.desc)
 		} else if expectedErr != err.Error() {

--- a/pkg/sql/catalog/validate.go
+++ b/pkg/sql/catalog/validate.go
@@ -27,9 +27,12 @@ const (
 	NoValidation ValidationLevel = 0
 	// ValidationLevelSelfOnly means only validate internal descriptor consistency.
 	ValidationLevelSelfOnly ValidationLevel = 1<<(iota+1) - 1
-	// ValidationLevelCrossReferences means do the above and also check
-	// cross-references.
-	ValidationLevelCrossReferences
+	// ValidationLevelForwardReferences means do the above and also check
+	// forward references.
+	ValidationLevelForwardReferences
+	// ValidationLevelBackReferences means do the above and also check
+	// backward references.
+	ValidationLevelBackReferences
 	// ValidationLevelNamespace means do the above and also check namespace
 	// table records.
 	ValidationLevelNamespace
@@ -120,7 +123,7 @@ type ValidationDescGetter interface {
 
 // ValidateOutboundTableRef validates outbound reference to relation descriptor
 // depID from descriptor selfID.
-func ValidateOutboundTableRef(selfID descpb.ID, depID descpb.ID, vdg ValidationDescGetter) error {
+func ValidateOutboundTableRef(depID descpb.ID, vdg ValidationDescGetter) error {
 	referencedTable, err := vdg.GetTableDescriptor(depID)
 	if err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid depends-on relation reference")
@@ -129,21 +132,29 @@ func ValidateOutboundTableRef(selfID descpb.ID, depID descpb.ID, vdg ValidationD
 		return errors.AssertionFailedf("depends-on relation %q (%d) is dropped",
 			referencedTable.GetName(), referencedTable.GetID())
 	}
-	for _, by := range referencedTable.TableDesc().DependedOnBy {
+	return nil
+}
+
+// ValidateOutboundTableRefBackReference validates that the outbound reference
+// to a table descriptor has a matching back-reference.
+func ValidateOutboundTableRefBackReference(selfID descpb.ID, ref TableDescriptor) error {
+	if ref == nil || ref.Dropped() {
+		// Don't follow up on backward references for invalid or irrelevant forward
+		// references.
+		return nil
+	}
+	for _, by := range ref.TableDesc().DependedOnBy {
 		if by.ID == selfID {
 			return nil
 		}
 	}
 	return errors.AssertionFailedf("depends-on relation %q (%d) has no corresponding depended-on-by back reference",
-		referencedTable.GetName(), referencedTable.GetID())
+		ref.GetName(), ref.GetID())
 }
 
-// ValidateOutboundTypeRef validates outbound reference to type descriptor
-// depTypeID from descriptor selfID.
-func ValidateOutboundTypeRef(
-	selfID descpb.ID, depTypeID descpb.ID, vdg ValidationDescGetter,
-) error {
-	typ, err := vdg.GetTypeDescriptor(depTypeID)
+// ValidateOutboundTypeRef validates outbound reference to type descriptor.
+func ValidateOutboundTypeRef(typeID descpb.ID, vdg ValidationDescGetter) error {
+	typ, err := vdg.GetTypeDescriptor(typeID)
 	if err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid depends-on type reference")
 	}
@@ -151,13 +162,23 @@ func ValidateOutboundTypeRef(
 		return errors.AssertionFailedf("depends-on type %q (%d) is dropped",
 			typ.GetName(), typ.GetID())
 	}
+	return nil
+}
+
+// ValidateOutboundTypeRefBackReference validates that the outbound reference
+// to a type descriptor has a matching back-reference.
+func ValidateOutboundTypeRefBackReference(selfID descpb.ID, typ TypeDescriptor) error {
+	if typ == nil || typ.Dropped() {
+		// Don't follow up on backward references for invalid or irrelevant forward
+		// references.
+		return nil
+	}
 
 	for ord := 0; ord < typ.NumReferencingDescriptors(); ord++ {
 		if typ.GetReferencingDescriptorID(ord) == selfID {
 			return nil
 		}
 	}
-
 	return errors.AssertionFailedf("depends-on type %q (%d) has no corresponding referencing-descriptor back references",
 		typ.GetName(), typ.GetID())
 }

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -791,25 +791,25 @@ ALTER TABLE tbl SET (ttl_expire_after = '10 minutes')
 statement ok
 CREATE TABLE ref_table (id INT PRIMARY KEY, ref INT)
 
-statement error foreign keys to/from table with TTL "ttl_table" are not permitted
+statement error foreign keys from table with TTL "ttl_table" are not permitted
 CREATE TABLE ttl_table (id INT PRIMARY KEY, ref INT REFERENCES ref_table(id)) WITH (ttl_expire_after = '10 mins')
 
 statement ok
 CREATE TABLE ttl_table (id INT PRIMARY KEY, ref INT) WITH (ttl_expire_after = '10 mins')
 
-statement error foreign keys to/from table with TTL "ttl_table" are not permitted
+statement error foreign keys to table with TTL "ttl_table" are not permitted
 CREATE TABLE new_ref_table (id INT PRIMARY KEY, ref INT REFERENCES ttl_table(id))
 
-statement error foreign keys to/from table with TTL "ttl_table" are not permitted
+statement error foreign keys to table with TTL "ttl_table" are not permitted
 ALTER TABLE ref_table ADD CONSTRAINT fk FOREIGN KEY (ref) REFERENCES ttl_table (id)
 
-statement error foreign keys to/from table with TTL "ttl_table" are not permitted
+statement error foreign keys from table with TTL "ttl_table" are not permitted
 ALTER TABLE ttl_table ADD CONSTRAINT fk FOREIGN KEY (ref) REFERENCES ttl_table (id)
 
 statement ok
 CREATE TABLE ttl_become_table (id INT PRIMARY KEY, ref INT REFERENCES ref_table (id))
 
-statement error foreign keys to/from table with TTL "ttl_become_table" are not permitted
+statement error foreign keys from table with TTL "ttl_become_table" are not permitted
 ALTER TABLE ttl_become_table SET (ttl_expire_after = '10 minutes')
 
 # Check non-ascending PKs are not permitted.

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,4 +1,4 @@
-subtest lost-table-data
+subtest lost_table_data
 
 statement ok
 CREATE TABLE corruptdesc (v INT8)
@@ -117,7 +117,7 @@ statement ok
 SELECT * FROM corruptdesc;
 
 # Test the crdb_internal.force_delete_table_data function
-subtest force-delete-data
+subtest force_delete_data
 
 statement ok
 CREATE TABLE forcedeletemydata (v int)
@@ -187,3 +187,113 @@ select * from crdb_internal.unsafe_upsert_descriptor($t_id, crdb_internal.json_t
 query I
 SELECT * FROM forcedeletemydata ORDER BY v ASC
 ----
+
+# Test that corrupt back-references should not prevent objects from being queried.
+subtest queryable_despite_corrupt_back_refs
+
+statement ok
+CREATE TABLE corrupt_backref_fk (k INT PRIMARY KEY, v STRING);
+INSERT INTO corrupt_backref_fk (k, v) VALUES (1, 'a');
+CREATE TABLE corrupt_fk (k INT NOT NULL, FOREIGN KEY (k) REFERENCES corrupt_backref_fk (k));
+
+query BB
+SELECT
+	crdb_internal.unsafe_delete_descriptor(id),
+	crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id)
+FROM
+	system.namespace
+WHERE
+	name = 'corrupt_fk'
+----
+true true
+
+query IT
+SELECT * FROM corrupt_backref_fk
+----
+1 a
+
+statement error invalid foreign key backreference
+DROP TABLE corrupt_backref_fk
+
+statement ok
+CREATE TABLE corrupt_backref_view (k INT PRIMARY KEY, v STRING);
+INSERT INTO corrupt_backref_view (k, v) VALUES (1, 'a');
+CREATE VIEW corrupt_view AS SELECT k, v FROM corrupt_backref_view
+
+query BB
+SELECT
+	crdb_internal.unsafe_delete_descriptor(id),
+	crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id)
+FROM
+	system.namespace
+WHERE
+	name = 'corrupt_view'
+----
+true true
+
+query IT
+SELECT * FROM corrupt_backref_view
+----
+1 a
+
+statement error pgcode XX000 invalid depended-on-by relation back reference
+DROP TABLE corrupt_backref_view
+
+statement ok
+CREATE TYPE corrupt_backref_typ AS ENUM ('a', 'b');
+CREATE TABLE corrupt_typ (k INT PRIMARY KEY, v corrupt_backref_typ);
+
+query BB
+SELECT
+	crdb_internal.unsafe_delete_descriptor(id),
+	crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id)
+FROM
+	system.namespace
+WHERE
+	name = 'corrupt_typ'
+----
+true true
+
+query T
+SELECT 'a'::corrupt_backref_typ
+----
+a
+
+statement error pgcode XXUUU referenced descriptor not found
+ALTER TYPE corrupt_backref_typ DROP VALUE 'b'
+
+# This is required to pass the validation tests when the logic test completes.
+subtest cleanup
+
+query TB
+SELECT
+  name,
+	crdb_internal.unsafe_delete_descriptor(id, true)
+FROM
+	system.namespace
+WHERE
+	name LIKE '%corrupt_backref_%'
+ORDER BY
+  name
+----
+_corrupt_backref_typ  true
+corrupt_backref_fk    true
+corrupt_backref_typ   true
+corrupt_backref_view  true
+
+query TBB
+SELECT
+  name,
+	crdb_internal.force_delete_table_data(id),
+	crdb_internal.unsafe_delete_namespace_entry("parentID", "parentSchemaID", name, id)
+FROM
+	system.namespace
+WHERE
+	name LIKE '%corrupt_backref_%'
+ORDER BY
+  name
+----
+_corrupt_backref_typ  true  true
+corrupt_backref_fk    true  true
+corrupt_backref_typ   true  true
+corrupt_backref_view  true  true

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -883,7 +883,7 @@ func validateDescriptor(ctx context.Context, p *planner, descriptor catalog.Desc
 		ctx,
 		p.Txn(),
 		catalog.NoValidationTelemetry,
-		catalog.ValidationLevelCrossReferences,
+		catalog.ValidationLevelBackReferences,
 		descriptor,
 	)
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -370,8 +370,7 @@ func fallBackIfRegionalByRowTable(b BuildCtx, t alterPrimaryKeySpec, tableID cat
 // error if the table is a (row-level-ttl table && (it has a descending
 // key column || it has any inbound/outbound FK constraint)).
 func fallBackIfDescColInRowLevelTTLTables(b BuildCtx, tableID catid.DescID, t alterPrimaryKeySpec) {
-	_, _, rowLevelTTLElem := scpb.FindRowLevelTTL(b.QueryByID(tableID))
-	if rowLevelTTLElem == nil {
+	if _, _, rowLevelTTLElem := scpb.FindRowLevelTTL(b.QueryByID(tableID)); rowLevelTTLElem == nil {
 		return
 	}
 
@@ -384,18 +383,15 @@ func fallBackIfDescColInRowLevelTTLTables(b BuildCtx, tableID catid.DescID, t al
 	}
 
 	_, _, ns := scpb.FindNamespace(b.QueryByID(tableID))
-	hasFKConstraintError := scerrors.NotImplementedErrorf(t.n,
-		`foreign keys to/from table with TTL %q are not permitted`, ns.Name)
 	// Panic if there is any inbound/outbound FK constraints.
-	_, _, inboundFKElem := scpb.FindForeignKeyConstraint(b.BackReferences(tableID))
-	if inboundFKElem != nil {
-		panic(hasFKConstraintError)
+	if _, _, inboundFKElem := scpb.FindForeignKeyConstraint(b.BackReferences(tableID)); inboundFKElem != nil {
+		panic(scerrors.NotImplementedErrorf(t.n,
+			`foreign keys to table with TTL %q are not permitted`, ns.Name))
 	}
-	scpb.ForEachForeignKeyConstraint(b.QueryByID(tableID), func(
-		current scpb.Status, target scpb.TargetStatus, e *scpb.ForeignKeyConstraint,
-	) {
-		panic(hasFKConstraintError)
-	})
+	if _, _, outboundFKElem := scpb.FindForeignKeyConstraint(b.QueryByID(tableID)); outboundFKElem != nil {
+		panic(scerrors.NotImplementedErrorf(t.n,
+			`foreign keys from table with TTL %q are not permitted`, ns.Name))
+	}
 }
 
 func mustRetrievePrimaryIndexElement(b BuildCtx, tableID catid.DescID) (res *scpb.PrimaryIndex) {

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -787,7 +787,13 @@ func (b *testCatalogChangeBatcher) ValidateAndRun(ctx context.Context) error {
 	for _, deletedID := range b.zoneConfigsToDelete.Ordered() {
 		b.s.LogSideEffectf("deleting zone config for #%d", deletedID)
 	}
-	ve := b.s.uncommitted.Validate(ctx, clusterversion.TestingClusterVersion, catalog.NoValidationTelemetry, catalog.ValidationLevelAllPreTxnCommit, b.descs...)
+	ve := b.s.uncommitted.Validate(
+		ctx,
+		clusterversion.TestingClusterVersion,
+		catalog.NoValidationTelemetry,
+		catalog.ValidationLevelAllPreTxnCommit,
+		b.descs...,
+	)
 	return ve.CombinedError()
 }
 

--- a/pkg/sql/testdata/telemetry/error
+++ b/pkg/sql/testdata/telemetry/error
@@ -41,11 +41,11 @@ SELECT crdb_internal.unsafe_upsert_descriptor(id, crdb_internal.json_to_pb('desc
 
 # Table descriptor validation failure on read.
 feature-usage
-SELECT * FROM tbl;
+DROP TABLE tbl CASCADE;
 ----
 error: pq: internal error: relation "tbl" (...): missing fk back reference "tbl_customer_fkey" to "tbl" from "fktbl"
 errorcodes.XX000
-sql.schema.validation_errors.read.cross_references.relation
+sql.schema.validation_errors.read.backward_references.relation
 
 exec
 CREATE TYPE greeting AS ENUM('hello', 'hi');


### PR DESCRIPTION
Previously, forward- and backward-reference-checking was done in one
same validation phase, identified by the
catalog.ValidationLevelCrossReferences constant and a similarly named
method on catalog.Descriptor. This validation phase was exercised both
when reading and when writing descriptors.

The problem with this was that a corrupt back-reference would make
a table unusable until descriptor surgery was performed. While this
might be warranted in the context of schema changes, that's not the case
when it comes to queries, which don't really care about these
back-references. For this reason, we want to bypass back-reference
validation when reading descriptors for the purpose of serving queries.
These reads are characterized by the flag AvoidLeased being unset.

To do this, this commit splits the cross-reference validation level into
two. The back-reference level now exists to check the integrity of
back-references directly, as well as to check that forward references
also have matching back-references in the referenced descriptors.

Fixes #85263.

Release justification: low-risk, high benefit change
Release note: NoneBackport 2/2 commits from #86420.

/cc @cockroachdb/release

---

Previously, forward- and backward-reference-checking was done in one
same validation phase, identified by the
catalog.ValidationLevelCrossReferences constant and a similarly named
method on catalog.Descriptor. This validation phase was exercised both
when reading and when writing descriptors.

The problem with this was that a corrupt back-reference would make
a table unusable until descriptor surgery was performed. While this
might be warranted in the context of schema changes, that's not the case
when it comes to queries, which don't really care about these
back-references. For this reason, we want to bypass back-reference
validation when reading descriptors for the purpose of serving queries.
These reads are characterized by the flag AvoidLeased being unset.

To do this, this commit splits the cross-reference validation level into
two. The back-reference level now exists to check the integrity of
back-references directly, as well as to check that forward references
also have matching back-references in the referenced descriptors.

Fixes #85263.

Release justification: low-risk, high benefit change
Release note: None

---- 

This PR is based on https://github.com/cockroachdb/cockroach/pull/87067 which is the product of what made sense for me to take action on right now regarding https://github.com/cockroachdb/cockroach/pull/86420#issuecomment-1223101292 .


