### PR TITLE
release-22.1: colmem: fix some issues with the memory limiting

### DIFF
--- a/pkg/sql/colexec/external_sort.go
+++ b/pkg/sql/colexec/external_sort.go
@@ -334,10 +334,10 @@ func (s *externalSorter) doneWithCurrentPartition() {
 	}
 }
 
-func (s *externalSorter) resetPartitionsInfoForCurrentPartition() {
-	s.partitionsInfo.tupleCount[s.numPartitions] = 0
-	s.partitionsInfo.totalSize[s.numPartitions] = 0
-	s.partitionsInfo.maxBatchMemSize[s.numPartitions] = 0
+func (s *externalSorter) resetPartitionsInfo(i int) {
+	s.partitionsInfo.tupleCount[i] = 0
+	s.partitionsInfo.totalSize[i] = 0
+	s.partitionsInfo.maxBatchMemSize[i] = 0
 }
 
 func (s *externalSorter) Next() coldata.Batch {
@@ -364,7 +364,7 @@ func (s *externalSorter) Next() coldata.Batch {
 					s.fdState.acquiredFDs = toAcquire
 				}
 			}
-			s.resetPartitionsInfoForCurrentPartition()
+			s.resetPartitionsInfo(s.numPartitions)
 			partitionDone := s.enqueue(b)
 			if partitionDone {
 				s.doneWithCurrentPartition()
@@ -406,7 +406,6 @@ func (s *externalSorter) Next() coldata.Batch {
 			merger := s.createMergerForPartitions(n)
 			merger.Init(s.Ctx)
 			s.numPartitions -= n
-			s.resetPartitionsInfoForCurrentPartition()
 			for b := merger.Next(); ; b = merger.Next() {
 				partitionDone := s.enqueue(b)
 				if b.Length() == 0 || partitionDone {
@@ -500,9 +499,12 @@ func (s *externalSorter) Next() coldata.Batch {
 // merger (which performs the merge of N already sorted partitions while
 // preserving the order of tuples).
 func (s *externalSorter) enqueue(b coldata.Batch) bool {
-	if b.Length() > 0 {
-		batchMemSize := colmem.GetBatchMemSize(b)
-		s.partitionsInfo.tupleCount[s.numPartitions] += uint64(b.Length())
+	if n := b.Length(); n > 0 {
+		// We only need to include the footprint of the tuples that are being
+		// enqueued rather than the total footprint of the batch (which can be
+		// larger if the capacity of the batch is not fully used).
+		batchMemSize := colmem.GetProportionalBatchMemSize(b, int64(n))
+		s.partitionsInfo.tupleCount[s.numPartitions] += uint64(n)
 		s.partitionsInfo.totalSize[s.numPartitions] += batchMemSize
 		if batchMemSize > s.partitionsInfo.maxBatchMemSize[s.numPartitions] {
 			s.partitionsInfo.maxBatchMemSize[s.numPartitions] = batchMemSize
@@ -672,15 +674,16 @@ func (s *externalSorter) createMergerForPartitions(n int) *OrderedSynchronizer {
 
 	// Calculate the limit on the output batch mem size.
 	outputBatchMemSize := s.mergeMemoryLimit
-	for i := 0; i < s.numPartitions; i++ {
+	for i := s.numPartitions - n; i < s.numPartitions; i++ {
 		outputBatchMemSize -= s.partitionsInfo.maxBatchMemSize[i]
+		s.resetPartitionsInfo(i)
 	}
 	// It is possible that the expected usage of the dequeued batches already
 	// exceeds the memory limit (this is likely when the tuples are wide). In
 	// such a scenario we want to produce output batches of relatively large
 	// memory size too, so we give the output batch at least its fair share of
 	// the memory limit.
-	minOutputBatchMemSize := s.mergeMemoryLimit / int64(s.numPartitions+1)
+	minOutputBatchMemSize := s.mergeMemoryLimit / int64(n+1)
 	if outputBatchMemSize < minOutputBatchMemSize {
 		outputBatchMemSize = minOutputBatchMemSize
 	}

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -23,10 +23,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/colmem"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/randgen"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -39,20 +39,33 @@ func init() {
 	randutil.SeedForTests()
 }
 
+const increment = -1
+
+func getAllocator(increment int64) (_ *colmem.Allocator, _ *mon.BoundAccount, cleanup func()) {
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	testMemMonitor := mon.NewMonitor(
+		"test-mem" /* name */, mon.MemoryResource, nil, /* curCount */
+		nil /* maxHist */, increment, math.MaxInt64 /* noteworthy */, st,
+	)
+	testMemMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
+	memAcc := testMemMonitor.MakeBoundAccount()
+	evalCtx := tree.MakeTestingEvalContext(st)
+	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
+	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	cleanup = func() {
+		memAcc.Close(ctx)
+		testMemMonitor.Stop(ctx)
+	}
+	return testAllocator, &memAcc, cleanup
+}
+
 func TestMaybeAppendColumn(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 	t.Run("VectorAlreadyPresent", func(t *testing.T) {
 		b := testAllocator.NewMemBatchWithMaxCapacity([]*types.T{types.Int})
 		b.SetLength(coldata.BatchSize())
@@ -108,16 +121,9 @@ func TestPerformAppend(t *testing.T) {
 	const nullOk = false
 	const resetChance = 0.5
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 
 	batch1 := colexecutils.NewAppendOnlyBufferedBatch(testAllocator, typs, nil /* colsToStore */)
 	batch2 := colexecutils.NewAppendOnlyBufferedBatch(testAllocator, typs, nil /* colsToStore */)
@@ -191,25 +197,9 @@ func TestAccountingHelper(t *testing.T) {
 		require.NoError(t, coldata.SetBatchSizeForTests(oldBatchSize))
 	}()
 
-	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
 	// Use increment of 1 so that no allocations are "reserved".
-	testMemMonitor := mon.NewMonitor(
-		"test-mem",
-		mon.MemoryResource,
-		nil,           /* curCount */
-		nil,           /* maxHist */
-		1,             /* increment */
-		math.MaxInt64, /* noteworthy */
-		st,
-	)
-	testMemMonitor.Start(ctx, nil, mon.MakeStandaloneBudget(math.MaxInt64))
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, _, cleanup := getAllocator(1 /* increment */)
+	defer cleanup()
 
 	// Allocate a scratch bytes value that exceeds the target size in all
 	// scenarios.
@@ -383,17 +373,9 @@ func TestSetAccountingHelper(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
-
+	testAllocator, _, cleanup := getAllocator(increment)
+	defer cleanup()
 	numCols := rng.Intn(10) + 1
 	typs := make([]*types.T, numCols)
 	for i := range typs {
@@ -459,6 +441,78 @@ func TestSetAccountingHelper(t *testing.T) {
 	}
 }
 
+// TestSetAccountingHelperMemoryLimit verifies that colmem.SetAccountingHelper
+// reasonably uses the capacity of already allocated batches.
+func TestSetAccountingHelperMemoryLimit(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	if coldata.BatchSize() < 4 {
+		skip.IgnoreLint(t, "the test assumes coldata.BatchSize() is at least 4")
+	}
+
+	// Use increment of 1 so that no allocations are "reserved".
+	testAllocator, _, cleanup := getAllocator(1 /* increment */)
+	defer cleanup()
+
+	// We need to use at least one type of variable width in order to trigger
+	// more interesting path in AccountForSet.
+	typs := []*types.T{types.Bytes}
+
+	// We will ask the helper for batches of different sizes ("small" doesn't
+	// exceed the memory limit, and "large" exceeds it by too much so it is not
+	// actually allocated according to the ask - instead a "medium" batch is
+	// allocated).
+	largeCap := coldata.BatchSize()
+	smallCap := largeCap / 4
+	mediumCap := smallCap * 2
+	// Use memory limit that is exactly the footprint of the medium batch.
+	memoryLimit := colmem.GetBatchMemSize(testAllocator.NewMemBatchWithFixedCapacity(typs, mediumCap))
+	testAllocator.ReleaseMemory(testAllocator.Used())
+
+	var helper colmem.SetAccountingHelper
+	helper.Init(testAllocator, memoryLimit, typs)
+
+	// Allocate the small batch and ensure that we use all tuples inside of it.
+	b, _ := helper.ResetMaybeReallocate(typs, nil /* oldBatch */, smallCap)
+	var rowIdx int
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, smallCap, rowIdx)
+
+	// Attempt to allocate a batch with too large of a capacity.
+	b, reallocated := helper.ResetMaybeReallocate(typs, b, largeCap)
+	require.True(t, reallocated)
+	// We expect that the ask of largeCap is not satisfied and that the batch
+	// of exactly mediumCap is allocated.
+	require.Equal(t, b.Capacity(), mediumCap)
+	// Ensure that the helper still uses the whole capacity.
+	rowIdx = 0
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, b.Capacity(), rowIdx)
+
+	// Increase the limit by a little so that the previously allocated batch is
+	// below the new limit. This also unsets the memorized max capacity so that
+	// the helper considers allocating a new batch.
+	helper.TestingUpdateMemoryLimit(memoryLimit + 1)
+	// Now try to allocate a batch of medium capacity plus one, but a new batch
+	// won't be allocated because the helper will estimate that it would exceed
+	// the (newly-updated) memory limit.
+	b, reallocated = helper.ResetMaybeReallocate(typs, b, mediumCap+1)
+	require.False(t, reallocated)
+	rowIdx = 0
+	for batchDone := false; !batchDone; {
+		batchDone = helper.AccountForSet(rowIdx)
+		rowIdx++
+	}
+	require.Equal(t, b.Capacity(), rowIdx)
+}
+
 // TestEstimateBatchSizeBytes verifies that EstimateBatchSizeBytes returns such
 // an estimate that it equals the actual footprint of the newly-created batch
 // with no values set.
@@ -466,16 +520,9 @@ func TestEstimateBatchSizeBytes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
-	st := cluster.MakeTestingClusterSettings()
-	testMemMonitor := execinfra.NewTestMemMonitor(ctx, st)
-	defer testMemMonitor.Stop(ctx)
-	memAcc := testMemMonitor.MakeBoundAccount()
-	defer memAcc.Close(ctx)
-	evalCtx := tree.MakeTestingEvalContext(st)
-	testColumnFactory := coldataext.NewExtendedColumnFactory(&evalCtx)
-	testAllocator := colmem.NewAllocator(ctx, &memAcc, testColumnFactory)
+	testAllocator, memAcc, cleanup := getAllocator(increment)
+	defer cleanup()
 
 	numCols := rng.Intn(10) + 1
 	typs := make([]*types.T, numCols)
@@ -484,7 +531,7 @@ func TestEstimateBatchSizeBytes(t *testing.T) {
 	}
 	const numRuns = 10
 	for run := 0; run < numRuns; run++ {
-		memAcc.Clear(ctx)
+		memAcc.Clear(context.Background())
 		numRows := rng.Intn(coldata.BatchSize()) + 1
 		batch := testAllocator.NewMemBatchWithFixedCapacity(typs, numRows)
 		expected := memAcc.Used()


### PR DESCRIPTION
Backport 2/2 commits from #87563.

/cc @cockroachdb/release

---

**colexec: some fixes of the external sort**

This commit fixes some of the relatively benign issues in the external
sort:
- previously we forgot to unset the partition info for all partitions
that are being merged as part of the repeated merging process (we would
only reset the first one because it is overwritten by the newly created
"merged" partition)
- we incorrectly estimated "min output batch size" for the repeated
merging (the calculation was as if all current partitions were being
merged rather than `n`)
- we incorrectly computed the memory size of the enqueued batch. It is
possible that the batch is a "window" or doesn't use the whole capacity,
and previously we were using the total memory footprint.  However, we
need to only include the "proportional" size according to the length of
the batch.

The issues are relatively benign since they would mostly make the verbose
logging incorrect as well as over-estimate the "max batch mem size"
(which would mean that we'd merge the partitions sooner or with
a smaller output batch size).

Release justification: low-risk bug fix.

Release note: None

**colmem: fix some issues with the memory limiting**

This commit fixes a couple of issues with how we do memory-limiting of
batches by the footprint. In particular, the allocator will now estimate
the memory footprint of a batch before allocating a new one and will
clamp the capacity so that the batch stays under the limit. Previously,
we could allocate a batch that would exceed the limit even when all
types are fixed length. This behavior has been present since long time
ago.

Additionally, this commit fixes a recent regression in how
`SetAccountingHelper` uses the capacity of the batch. Previously, if
a new batch is allocated (when variable-width types are present) and
exceeds the memory limit, then the first call to `AccountForSet` would
artificially clamp the used capacity at 1, so the batch might have a lot
of unused capacity. Now the helper will memorize the full capacity right
after the batch is allocated. This regression was introduced in a recent
refactor of the `SetAccountingHelper`. In particular, it could lead to
the external sort (which uses the ordered synchronizer internally which
uses the `SetAccountingHelper`) becoming excruciatingly slow with
"unlucky" low memory limits. The limit would be "unlucky" if it is such
that a batch with capacity `c` doesn't exceed it, but the batch with
capacity `2 * c` would exceed the limit by less than a factor of two. In
such a scenario previously we would allocate the batch of capacity
`2 * c` yet would always use only a single row (because in
`AccountForSet` we would set the max capacity at 1).

Addresses: #87510.

Release justification: bug fix.

Release note: None
