### PR TITLE
clisqlshell: new testing flag `--no-line-editor`

### DIFF
--- a/pkg/cli/clientflags/client_flags.go
+++ b/pkg/cli/clientflags/client_flags.go
@@ -95,6 +95,9 @@ func AddSQLFlags(
 		// then use the value "true".
 		f.Lookup(cliflags.SafeUpdates.Name).NoOptDefVal = "true"
 
+		// --no-line-editor
+		cliflagcfg.BoolFlagDepth(1, f, &sqlCfg.ShellCtx.DisableLineEditor, cliflags.NoLineEditor)
+
 		// --read-only
 		cliflagcfg.BoolFlagDepth(1, f, &sqlCfg.ReadOnly, cliflags.ReadOnly)
 

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -290,6 +290,12 @@ with the specified period. The client will stop watching
 if an execution of the SQL statement(s) fail.`,
 	}
 
+	NoLineEditor = FlagInfo{
+		Name: "no-line-editor",
+		Description: `
+Force disable the interactive line editor. Can help during testing.`,
+	}
+
 	EchoSQL = FlagInfo{
 		Name: "echo-sql",
 		Description: `

--- a/pkg/cli/clisqlshell/BUILD.bazel
+++ b/pkg/cli/clisqlshell/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sql/sqlfsm",
         "//pkg/util/envutil",
         "//pkg/util/syncutil",
+        "//pkg/util/sysutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_knz_go_libedit//:go-libedit",
     ],

--- a/pkg/cli/clisqlshell/context.go
+++ b/pkg/cli/clisqlshell/context.go
@@ -42,6 +42,11 @@ type Context struct {
 	// `demo` command, if that is the command being run.
 	DemoCluster democlusterapi.DemoCluster
 
+	// DisableLineEditor, if set, causes the shell to use a dumb line editor
+	// (disable the interactive one), which simplifies testing by avoiding
+	// escape sequences in the output.
+	DisableLineEditor bool
+
 	// ParseURL is a custom URL parser.
 	//
 	// When left undefined, the code defaults to pgurl.Parse.
@@ -85,6 +90,10 @@ type internalContext struct {
 
 	// current database name, if known. This is maintained on a best-effort basis.
 	dbName string
+
+	// displayPrompt indicates that the prompt should still be displayed,
+	// even when the line editor is disabled.
+	displayPrompt bool
 
 	// hook to run once, then clear, after running the next batch of statements.
 	afterRun func()

--- a/pkg/cli/interactive_tests/test_audit_log.tcl
+++ b/pkg/cli/interactive_tests/test_audit_log.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 set logfile logs/db/logs/cockroach-sql-audit.log
@@ -71,7 +71,7 @@ system "$argv start-single-node --insecure --pid-file=server_pid --background -s
 set logfile logs/db/audit-new/cockroach-sql-audit.log
 
 # Start a client and make a simple audit test.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 send "create database d; create table d.helloworld(x INT);\r"
 eexpect CREATE

--- a/pkg/cli/interactive_tests/test_auto_trace.tcl
+++ b/pkg/cli/interactive_tests/test_auto_trace.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 start_test "Check traces over simple statements"

--- a/pkg/cli/interactive_tests/test_changefeed.tcl
+++ b/pkg/cli/interactive_tests/test_changefeed.tcl
@@ -9,7 +9,7 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that changefeed flushes readable output to the terminal."
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 send "create table target(i int primary key);insert into target values (0);\r"
 eexpect "CREATE"

--- a/pkg/cli/interactive_tests/test_client_side_checking.tcl
+++ b/pkg/cli/interactive_tests/test_client_side_checking.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 start_test "Check that syntax errors are handled client-side when running interactive."
@@ -78,7 +78,7 @@ eexpect "0\r\n:/# "
 end_test
 
 start_test "Check that --debug-sql-cli sets suitable simplified client-side options."
-send "$argv sql --debug-sql-cli\r"
+send "$argv sql --debug-sql-cli --no-line-editor\r"
 eexpect "Welcome"
 
 # Check empty db name for build info query.

--- a/pkg/cli/interactive_tests/test_connect_cmd.tcl
+++ b/pkg/cli/interactive_tests/test_connect_cmd.tcl
@@ -15,7 +15,7 @@ proc start_secure_server {argv certs_dir extra} {
 
 start_secure_server $argv $certs_dir ""
 
-spawn $argv sql --certs-dir=$certs_dir
+spawn $argv sql --certs-dir=$certs_dir --no-line-editor
 eexpect root@
 
 start_test "Test initialization"
@@ -147,7 +147,7 @@ set ::env(HOME) "."
 system "mkdir -p ./.cockroach-certs"
 system "cp $certs_dir/* ./.cockroach-certs/"
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 eexpect "/defaultdb>"
 send "\\c\r"
@@ -163,7 +163,7 @@ eexpect eof
 
 start_test "Check that extra URL params are preserved when changing database"
 
-spawn $argv sql --certs-dir=$certs_dir --url=postgres://root@localhost:26257/defaultdb?options=--search_path%3Dcustom_path&statement_timeout=1234
+spawn $argv sql --no-line-editor --certs-dir=$certs_dir --url=postgres://root@localhost:26257/defaultdb?options=--search_path%3Dcustom_path&statement_timeout=1234
 eexpect root@
 eexpect "/defaultdb>"
 send "SHOW search_path;\r"
@@ -188,7 +188,7 @@ eexpect eof
 
 start_test "Check that the client-side connect cmd prints the current conn details with password redacted"
 
-spawn $argv sql --certs-dir=$certs_dir --url=postgres://foo:abc@localhost:26257/defaultdb
+spawn $argv sql --no-line-editor --certs-dir=$certs_dir --url=postgres://foo:abc@localhost:26257/defaultdb
 eexpect foo@
 send "\\c\r"
 eexpect "Connection string: postgresql://foo:~~~~~~@"
@@ -206,7 +206,7 @@ stop_server $argv
 set ::env(COCKROACH_INSECURE) "true"
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_contextual_help.tcl
+++ b/pkg/cli/interactive_tests/test_contextual_help.tcl
@@ -134,7 +134,7 @@ eexpect eof
 start_test "Check that the hint for a single ? is also printed in non-interactive sessions."
 spawn /bin/bash
 
-send "echo '?' | $argv sql\r"
+send "echo '?' | $argv sql --no-line-editor\r"
 eexpect "Note:"
 eexpect JSON
 eexpect "use '??'"

--- a/pkg/cli/interactive_tests/test_copy.tcl
+++ b/pkg/cli/interactive_tests/test_copy.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 send "DROP TABLE IF EXISTS t;\r"
@@ -91,6 +91,12 @@ eexpect "(6 rows)"
 eexpect root@
 
 end_test
+
+send_eof
+eexpect eof
+
+spawn $argv sql
+eexpect root@
 
 start_test "check CTRL+C during COPY exits the COPY mode as appropriate"
 

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -3,7 +3,7 @@
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check that demo insecure says hello properly"
-spawn $argv demo --insecure=true
+spawn $argv demo --no-line-editor --insecure=true
 # Be polite.
 eexpect "Welcome"
 # Warn the user that they won't get persistence.
@@ -43,7 +43,7 @@ start_test "Check that demo insecure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --no-example-database
+spawn $argv demo --no-line-editor --no-example-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -73,7 +73,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --insecure=true --no-example-database
+spawn $argv demo --no-line-editor --insecure=true --no-example-database
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -98,7 +98,7 @@ start_test "Check that demo secure says hello properly"
 
 # With env var.
 set ::env(COCKROACH_INSECURE) "false"
-spawn $argv demo --no-example-database
+spawn $argv demo --no-line-editor --no-example-database
 eexpect "Welcome"
 eexpect "Username: \"demo\", password"
 eexpect "Directory with certificate files"
@@ -132,7 +132,7 @@ eexpect eof
 
 # With command-line override.
 set ::env(COCKROACH_INSECURE) "true"
-spawn $argv demo --insecure=false --no-example-database
+spawn $argv demo --no-line-editor --insecure=false --no-example-database
 eexpect "Welcome"
 eexpect "Username: \"demo\", password"
 eexpect "defaultdb>"
@@ -156,7 +156,7 @@ end_test
 
 # Test that demo displays connection URLs for nodes in the cluster.
 start_test "Check that node URLs are displayed"
-spawn $argv demo --insecure --no-example-database
+spawn $argv demo --no-line-editor --insecure --no-example-database
 # Check that we see our message.
 eexpect "Connection parameters"
 eexpect "(sql)"
@@ -166,7 +166,7 @@ send_eof
 eexpect eof
 
 # Start the test again with a multi node cluster.
-spawn $argv demo --insecure --nodes 3 --no-example-database
+spawn $argv demo --no-line-editor --insecure --nodes 3 --no-example-database
 
 # Check that we get a message for each node.
 eexpect "Connection parameters"
@@ -189,7 +189,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --insecure=false --no-example-database
+spawn $argv demo --no-line-editor --insecure=false --no-example-database
 # Expect that security related tags are part of the connection URL.
 eexpect "(sql)"
 eexpect "sslmode=require"
@@ -211,7 +211,7 @@ end_test
 
 start_test "Check that the port numbers can be overridden from the command line."
 
-spawn $argv demo --no-example-database --nodes 3 --http-port 8000
+spawn $argv demo --no-line-editor --no-example-database --nodes 3 --http-port 8000
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -228,7 +228,7 @@ eexpect "defaultdb>"
 send_eof
 eexpect eof
 
-spawn $argv demo --no-example-database --nodes 3 --sql-port 23000
+spawn $argv demo --no-line-editor --no-example-database --nodes 3 --sql-port 23000
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -269,7 +269,7 @@ end_test
 
 start_test "Check that demo populates the connection URL in a configured file"
 
-spawn $argv demo --no-example-database --listening-url-file=test.url
+spawn $argv demo --no-line-editor --no-example-database --listening-url-file=test.url
 eexpect "Welcome"
 eexpect "defaultdb>"
 
@@ -280,7 +280,7 @@ send_eof
 eexpect eof
 
 # Ditto, insecure
-spawn $argv demo --no-example-database --listening-url-file=test.url --insecure
+spawn $argv demo --no-line-editor --no-example-database --listening-url-file=test.url --insecure
 eexpect "Welcome"
 eexpect "defaultdb>"
 

--- a/pkg/cli/interactive_tests/test_demo_changefeeds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_changefeeds.tcl
@@ -3,7 +3,7 @@
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Demo core changefeed using format=csv"
-spawn $argv demo --format=csv
+spawn $argv demo --no-line-editor --format=csv
 
 # We should start in a populated database.
 eexpect "movr>"
@@ -24,7 +24,7 @@ eexpect eof
 end_test
 
 start_test "Demo with rangefeeds disabled as they are in real life"
-spawn $argv demo --format=csv --auto-enable-rangefeeds=false
+spawn $argv demo --no-line-editor --format=csv --auto-enable-rangefeeds=false
 
 # We should start in a populated database.
 eexpect "movr>"

--- a/pkg/cli/interactive_tests/test_demo_global.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global.tcl
@@ -9,7 +9,7 @@ start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
 # TODO(ajstorm): Disable multitenancy until #76305 is resolved.
-spawn $argv demo --no-example-database --nodes 9 --global --multitenant=false
+spawn $argv demo --no-line-editor --no-example-database --nodes 9 --global --multitenant=false
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"

--- a/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
+++ b/pkg/cli/interactive_tests/test_demo_global_insecure.tcl
@@ -9,7 +9,7 @@ start_test "Check --global flag runs as expected"
 
 # Start a demo with --global set
 # TODO(ajstorm): Disable multitenancy until #76305 is resolved.
-spawn $argv demo --no-example-database --nodes 9 --global --multitenant=false --insecure
+spawn $argv demo --no-line-editor --no-example-database --nodes 9 --global --multitenant=false --insecure
 
 # Ensure db is defaultdb.
 eexpect "defaultdb>"

--- a/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_memory_warning.tcl
@@ -3,8 +3,11 @@
 source [file join [file dirname $argv0] common.tcl]
 
 start_test "Check demo alerts when there is a memory warning."
-spawn $argv demo --max-sql-memory=10% --nodes=8
+spawn $argv demo --no-line-editor --no-example-database --max-sql-memory=10% --nodes=8
 
 eexpect "WARNING: HIGH MEMORY USAGE"
+
+eexpect "defaultdb>"
+interrupt
 
 end_test

--- a/pkg/cli/interactive_tests/test_demo_multitenant.tcl
+++ b/pkg/cli/interactive_tests/test_demo_multitenant.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 start_test "Check --multitenant flag runs as expected"
 
 # Start a demo with --multitenant set
-spawn $argv demo --empty --nodes 3 --multitenant
+spawn $argv demo --no-line-editor --empty --nodes 3 --multitenant
 
 eexpect "system tenant"
 eexpect "tenant 1"

--- a/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_demo_node_cmds.tcl
@@ -5,7 +5,7 @@ source [file join [file dirname $argv0] common.tcl]
 start_test "Check \\demo commands work as expected"
 # Start a demo with 5 nodes. Set multitenant=false due to unsupported
 # gossip commands below.
-spawn $argv demo movr --nodes=5 --multitenant=false
+spawn $argv demo movr --no-line-editor --nodes=5 --multitenant=false
 
 # Ensure db is movr.
 eexpect "movr>"

--- a/pkg/cli/interactive_tests/test_demo_partitioning.tcl
+++ b/pkg/cli/interactive_tests/test_demo_partitioning.tcl
@@ -16,7 +16,7 @@ eexpect $prompt
 
 start_test "Expect partitioning succeeds"
 # test that partitioning works if a license could be acquired
-send "$argv demo --multitenant=false --geo-partitioned-replicas\r"
+send "$argv demo --no-line-editor --multitenant=false --geo-partitioned-replicas\r"
 
 # wait for the shell to start up
 eexpect "Partitioning the demo database"
@@ -80,7 +80,7 @@ eexpect $prompt
 end_test
 
 start_test "test multi-region setup"
-send "$argv demo movr --geo-partitioned-replicas --multi-region\r"
+send "$argv demo movr --no-line-editor --geo-partitioned-replicas --multi-region\r"
 eexpect "Partitioning the demo database"
 eexpect "movr>"
 
@@ -102,7 +102,7 @@ eexpect "movr>"
 send_eof
 eexpect $prompt
 
-send "$argv demo movr --geo-partitioned-replicas --multi-region --survive=region\r"
+send "$argv demo movr --no-line-editor --geo-partitioned-replicas --multi-region --survive=region\r"
 eexpect "Partitioning the demo database"
 eexpect "movr>"
 
@@ -130,7 +130,7 @@ eexpect $prompt
 end_test
 
 start_test "Expect an error if geo-partitioning is requested with multitenant mode"
-send "$argv demo --geo-partitioned-replicas\r"
+send "$argv demo --no-line-editor --geo-partitioned-replicas\r"
 # expect a failure
 eexpect "operation is unsupported in multi-tenancy mode"
 eexpect $prompt
@@ -138,7 +138,7 @@ end_test
 
 start_test "Expect an error if geo-partitioning is requested and license acquisition is disabled"
 # set the proper environment variable
-send "$argv demo --geo-partitioned-replicas --disable-demo-license\r"
+send "$argv demo --no-line-editor --geo-partitioned-replicas --disable-demo-license\r"
 # expect a failure
 eexpect "enterprise features are needed for this demo"
 eexpect $prompt

--- a/pkg/cli/interactive_tests/test_demo_telemetry.tcl
+++ b/pkg/cli/interactive_tests/test_demo_telemetry.tcl
@@ -6,7 +6,7 @@ start_test "Check cockroach demo telemetry can be disabled"
 
 # set the proper environment variable
 set env(COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING) "true"
-spawn $argv demo
+spawn $argv demo --no-line-editor
 
 # Expect an informational message.
 eexpect "Telemetry disabled by configuration."

--- a/pkg/cli/interactive_tests/test_demo_workload.tcl
+++ b/pkg/cli/interactive_tests/test_demo_workload.tcl
@@ -5,7 +5,7 @@ source [file join [file dirname $argv0] common.tcl]
 start_test "Check cockroach demo --with-load runs the movr workload"
 
 # Start demo with movr and the movr workload.
-spawn $argv demo movr --with-load
+spawn $argv demo movr --with-load  --no-line-editor
 
 eexpect "movr>"
 
@@ -42,7 +42,7 @@ start_test "Check that controlling ranges of the movr dataset works"
 set timeout 30
 # Need to disable multi-tenant mode here, as splitting is not supported.
 # See 54254 for more details.
-spawn $argv demo movr --num-ranges=6 --multitenant=false
+spawn $argv demo movr --num-ranges=6 --multitenant=false  --no-line-editor
 
 eexpect "movr>"
 

--- a/pkg/cli/interactive_tests/test_dump_sig.tcl
+++ b/pkg/cli/interactive_tests/test_dump_sig.tcl
@@ -25,7 +25,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the client also can generate goroutine dumps."
-send "$argv demo --no-example-database\r"
+send "$argv demo --no-line-editor --no-example-database\r"
 eexpect root@
 # Dump goroutines in server.
 system "killall -QUIT `basename \$(realpath $argv)`"

--- a/pkg/cli/interactive_tests/test_error_handling.tcl
+++ b/pkg/cli/interactive_tests/test_error_handling.tcl
@@ -24,7 +24,7 @@ eexpect ":/# "
 send "echo \$?\r"
 eexpect "0\r\n:/# "
 
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect "root@"
 end_test
 

--- a/pkg/cli/interactive_tests/test_exec_log.tcl
+++ b/pkg/cli/interactive_tests/test_exec_log.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 set logfile logs/db/logs/cockroach-sql-exec.log

--- a/pkg/cli/interactive_tests/test_explain_analyze.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze.tcl
@@ -7,7 +7,7 @@ start_server $argv
 start_test "Ensure that EXPLAIN ANALYZE works as expected in the sql shell"
 
 # Spawn a sql shell.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 

--- a/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
+++ b/pkg/cli/interactive_tests/test_explain_analyze_debug.tcl
@@ -14,7 +14,7 @@ start_test "Ensure that EXPLAIN ANALYZE (DEBUG) works as expected in the sql she
 start_server $argv
 
 # Spawn a sql shell.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 
@@ -82,7 +82,7 @@ start_test "Ensure that EXPLAIN ANALYZE (DEBUG) works for a tenant"
 
 start_tenant 5 $argv
 
-spawn $argv sql --port [tenant_port 5]
+spawn $argv sql --no-line-editor --port [tenant_port 5]
 
 set client_spawn_id $spawn_id
 eexpect root@

--- a/pkg/cli/interactive_tests/test_flags.tcl
+++ b/pkg/cli/interactive_tests/test_flags.tcl
@@ -80,7 +80,7 @@ eexpect {Failed running "start"}
 end_test
 
 start_test "Check that demo start-up flags are reported to telemetry"
-send "$argv demo --no-example-database --echo-sql --logtostderr=WARNING\r"
+send "$argv demo --no-line-editor --no-example-database --echo-sql --logtostderr=WARNING\r"
 eexpect "defaultdb>"
 send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.demo.%' ORDER BY 1;\r"
 eexpect feature_name
@@ -103,7 +103,7 @@ end_test
 start_server $argv
 
 start_test "Check that server start-up flags are reported to telemetry"
-send "$argv sql --insecure\r"
+send "$argv sql --insecure --no-line-editor\r"
 eexpect "defaultdb>"
 send "SELECT * FROM crdb_internal.feature_usage WHERE feature_name LIKE 'cli.start-single-node.%' ORDER BY 1;\r"
 eexpect feature_name
@@ -119,7 +119,7 @@ end_test
 start_test "Check that a client can connect using the URL env var"
 send "export COCKROACH_URL=`cat server_url`;\r"
 eexpect ":/# "
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect "defaultdb>"
 send_eof
 eexpect ":/# "
@@ -128,7 +128,7 @@ end_test
 start_test "Check that an invalid URL in the env var produces a reasonable error"
 send "export COCKROACH_URL=invalid_url;\r"
 eexpect ":/# "
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect "ERROR"
 eexpect "setting --url from COCKROACH_URL"
 eexpect "invalid argument"

--- a/pkg/cli/interactive_tests/test_init_command.tcl
+++ b/pkg/cli/interactive_tests/test_init_command.tcl
@@ -19,7 +19,7 @@ set ::env(COCKROACH_CONNECT_TIMEOUT) "1"
 spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect "ERROR: cannot dial server"
 send "exit\r"
 eexpect eof
@@ -34,7 +34,7 @@ start_test "Check that init allows a suspended SQL client to resume"
 # so we don't "expect" anything yet. The point of this test is to
 # verify that the command will succeed after blocking instead of
 # erroring out.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 send "show tables from system.pg_catalog;\r"
 
 # Now initialize the one-node cluster. This will unblock the pending

--- a/pkg/cli/interactive_tests/test_last_statement.tcl
+++ b/pkg/cli/interactive_tests/test_last_statement.tcl
@@ -8,7 +8,7 @@ spawn /bin/bash
 send "PS1=':''/# '\r"
 eexpect ":/# "
 
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 
 start_test "Check that an error in the last statement is propagated to the shell."
@@ -23,7 +23,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that an incomplete last statement in interactive mode is not executed."
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 send "drop database if exists t cascade; create database t; create table t.foo(x int);\r"
 eexpect "CREATE TABLE"
@@ -33,7 +33,7 @@ eexpect " ->"
 send_eof
 eexpect ":/# "
 
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 send "select count(*) from t.foo;\r"
 eexpect "0"

--- a/pkg/cli/interactive_tests/test_local_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_local_cmds.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 start_test "Check that times are displayed by default on interactive terminals."
@@ -30,14 +30,14 @@ end_test
 start_test "Check that \\q terminates the client."
 send "\\q\r"
 eexpect eof
-spawn $argv sql --format=tsv
+spawn $argv sql --no-line-editor --format=tsv
 eexpect root@
 end_test
 
 start_test "Check that quit terminates the client."
 send "quit\r"
 eexpect eof
-spawn $argv sql --format=tsv
+spawn $argv sql --no-line-editor --format=tsv
 eexpect root@
 end_test
 
@@ -50,7 +50,7 @@ end_test
 start_test "Check that exit terminates the client."
 send "exit\r"
 eexpect eof
-spawn $argv sql --format=tsv
+spawn $argv sql --no-line-editor --format=tsv
 eexpect root@
 end_test
 
@@ -320,7 +320,7 @@ stop_server $argv
 start_test "Check that client-side options can be overridden with set"
 
 # First establish a baseline with all the defaults.
-send "$argv demo --no-example-database\r"
+send "$argv demo --no-line-editor --no-example-database\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"
@@ -335,7 +335,7 @@ send_eof
 eexpect ":/# "
 
 # Then verify that the defaults can be overridden.
-send "$argv demo --no-example-database --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
+send "$argv demo --no-line-editor --no-example-database --set=auto_trace=on --set=check_syntax=false --set=echo=true --set=errexit=true --set=prompt1=%n@haa --set=show_times=false\r"
 eexpect root@
 send "\\set display_format csv\r"
 send "\\set\r"

--- a/pkg/cli/interactive_tests/test_log_flags.tcl
+++ b/pkg/cli/interactive_tests/test_log_flags.tcl
@@ -70,7 +70,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that conflicting legacy and new flags are properly rejected for client commands"
-send "$argv sql --insecure --logtostderr=true --log=abc\r"
+send "$argv sql --no-line-editor --insecure --logtostderr=true --log=abc\r"
 eexpect "log is incompatible with legacy discrete logging flag"
 eexpect ":/# "
 end_test

--- a/pkg/cli/interactive_tests/test_notice.tcl
+++ b/pkg/cli/interactive_tests/test_notice.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 # This test ensures notices are being sent as expected.
 
-spawn $argv demo --no-example-database
+spawn $argv demo --no-line-editor --no-example-database
 eexpect root@
 
 start_test "Test that notices always appear at the end after all results."

--- a/pkg/cli/interactive_tests/test_password.tcl
+++ b/pkg/cli/interactive_tests/test_password.tcl
@@ -21,7 +21,7 @@ send "PS1=':''/# '\r"
 set prompt ":/# "
 eexpect $prompt
 
-send "$argv sql --certs-dir=$certs_dir\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir\r"
 eexpect root@
 
 start_test "Test setting password"
@@ -67,7 +67,7 @@ end_test
 
 start_test "Test connect to crdb with password"
 
-send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=myuser\r"
 eexpect "Enter password:"
 send "123\r"
 eexpect myuser@
@@ -87,7 +87,7 @@ send "\\q\r"
 eexpect $prompt
 
 start_test "Test connect to crdb with new own password"
-send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=myuser\r"
 eexpect "Enter password:"
 send "124\r"
 eexpect myuser@
@@ -97,7 +97,7 @@ send "\\q\r"
 eexpect $prompt
 
 start_test "Log in with wrong password"
-send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=myuser\r"
 eexpect "Enter password:"
 send "125\r"
 eexpect "password authentication failed"
@@ -106,7 +106,7 @@ end_test
 
 start_test "Log in using pgpass file"
 system "echo 'localhost:*:*:myuser:124' > $home/.pgpass"
-send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=myuser\r"
 eexpect myuser@
 eexpect "defaultdb>"
 send "\\q\r"
@@ -118,7 +118,7 @@ start_test "Log in using custom pgpass file"
 system "echo 'localhost:*:*:myuser:125' > $home/.pgpass"
 system "echo 'localhost:*:*:myuser:124' > $home/my_pgpass"
 send "export PGPASSFILE=$home/my_pgpass\r"
-send "$argv sql --certs-dir=$certs_dir --user=myuser\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=myuser\r"
 eexpect myuser@
 eexpect "defaultdb>"
 send "\\q\r"
@@ -140,7 +140,7 @@ dbname=defaultdb
 user=myuser
 passfile=$home/my_pgpass
 ' > $home/.pg_service.conf"
-send "$argv sql --url='postgres://myuser@localhost?service=myservice&sslrootcert=$certs_dir/ca.crt'\r"
+send "$argv sql --no-line-editor --url='postgres://myuser@localhost?service=myservice&sslrootcert=$certs_dir/ca.crt'\r"
 eexpect myuser@
 eexpect "defaultdb>"
 send "\\q\r"

--- a/pkg/cli/interactive_tests/test_pretty.tcl
+++ b/pkg/cli/interactive_tests/test_pretty.tcl
@@ -42,7 +42,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that tables are pretty-printed when input and output are a terminal and --format=table is not specified."
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 send "select 1 as WOO;\r"
 eexpect "?-*-\r\n"
@@ -64,7 +64,7 @@ send "\\q\r"
 eexpect ":/# "
 
 start_test "Check that tables are not pretty-printed when output is a terminal and --format=tsv is specified."
-send "$argv sql --format=tsv\r"
+send "$argv sql --no-line-editor --format=tsv\r"
 eexpect root@
 send "select 42 as woo; select 1 as woo;\r"
 eexpect "woo\r\n42\r\n"

--- a/pkg/cli/interactive_tests/test_read_only.tcl
+++ b/pkg/cli/interactive_tests/test_read_only.tcl
@@ -19,7 +19,7 @@ eexpect ":/# "
 end_test
 
 start_test "Check that the read-only flag works interactively"
-send "$argv sql --read-only | cat\r"
+send "$argv sql --no-line-editor --read-only | cat\r"
 # We can't immediately send input, because the shell will eat stdin just before it's ready.
 eexpect "brief introduction"
 sleep 0.4

--- a/pkg/cli/interactive_tests/test_reconnect.tcl
+++ b/pkg/cli/interactive_tests/test_reconnect.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 eexpect root@
 
 start_test "Test initialization"

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -58,7 +58,7 @@ eexpect $prompt
 end_test
 
 start_test "Passwords are not requested when a certificate for the user exists"
-send "$argv sql --user=testuser --certs-dir=$certs_dir\r"
+send "$argv sql --no-line-editor --user=testuser --certs-dir=$certs_dir\r"
 eexpect "testuser@"
 send "\\q\r"
 eexpect $prompt
@@ -66,7 +66,7 @@ end_test
 
 start_test "Check that CREATE USER WITH PASSWORD can be used from transactions."
 # Create a user from a transaction.
-send "$argv sql --certs-dir=$certs_dir\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir\r"
 eexpect "root@"
 send "BEGIN TRANSACTION;\r"
 eexpect "root@"
@@ -77,20 +77,20 @@ eexpect "root@"
 send "\\q\r"
 # Log in with the correct password.
 eexpect $prompt
-send "$argv sql --certs-dir=$certs_dir --user=eisen\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=eisen\r"
 eexpect "Enter password:"
 send "hunter2\r"
 eexpect "eisen@"
 send "\\q\r"
 # Try to log in with an incorrect password.
 eexpect $prompt
-send "$argv sql --certs-dir=$certs_dir --user=eisen\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir --user=eisen\r"
 eexpect "Enter password:"
 send "*****\r"
 eexpect "ERROR: password authentication failed for user eisen"
 eexpect "Failed running \"sql\""
 # Check that history is scrubbed.
-send "$argv sql --certs-dir=$certs_dir\r"
+send "$argv sql --no-line-editor --certs-dir=$certs_dir\r"
 eexpect "root@"
 end_test
 
@@ -108,14 +108,14 @@ set mywd [pwd]
 
 start_test "Check that socket-based login works."
 
-send "$argv sql --url 'postgres://eisen@?host=$mywd&port=26257'\r"
+send "$argv sql --no-line-editor --url 'postgres://eisen@?host=$mywd&port=26257'\r"
 eexpect "Enter password:"
 send "hunter2\r"
 eexpect "eisen@"
 send_eof
 eexpect $prompt
 
-send "$argv sql --url 'postgres://eisen:hunter2@?host=$mywd&port=26257'\r"
+send "$argv sql --no-line-editor --url 'postgres://eisen:hunter2@?host=$mywd&port=26257'\r"
 eexpect "eisen@"
 send_eof
 eexpect $prompt

--- a/pkg/cli/interactive_tests/test_server_sig.tcl
+++ b/pkg/cli/interactive_tests/test_server_sig.tcl
@@ -47,7 +47,7 @@ send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s
 eexpect "restarted"
 
 # Make a client open a connection and keep using it with an open txn.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 send "begin;\r\rselect 1;\r"
@@ -94,7 +94,7 @@ send "$argv start-single-node --insecure --pid-file=server_pid --log-dir=logs -s
 eexpect "restarted"
 
 # Make a client open a connection and keep using it with an open txn.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 send "begin;\r\rselect 1;\r"

--- a/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
+++ b/pkg/cli/interactive_tests/test_sql_demo_node_cmds.tcl
@@ -8,7 +8,7 @@ start_test "Ensure demo commands are not available in the sql shell"
 start_server $argv
 
 # Spawn a sql shell.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 

--- a/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
+++ b/pkg/cli/interactive_tests/test_sql_mem_monitor.tcl
@@ -53,7 +53,7 @@ send "tail -F logs/db/logs/cockroach-stderr.log\r"
 eexpect "stderr capture started"
 
 # Spawn a client.
-spawn $argv sql
+spawn $argv sql --no-line-editor
 set client_spawn_id $spawn_id
 eexpect root@
 

--- a/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
+++ b/pkg/cli/interactive_tests/test_sql_safe_updates.tcl
@@ -9,7 +9,7 @@ send "PS1=':''/# '\r"
 eexpect ":/# "
 
 start_test "Check that dangerous statements are properly rejected when running interactively with terminal output."
-send "$argv sql\r"
+send "$argv sql --no-line-editor\r"
 eexpect root@
 send "create database d;\rcreate table d.t(x int);\r"
 eexpect "CREATE"

--- a/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
+++ b/pkg/cli/interactive_tests/test_sql_version_reporting.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-spawn $argv sql
+spawn $argv sql --no-line-editor
 
 start_test "Check that the client starts with the welcome message."
 eexpect "# Welcome to the CockroachDB SQL shell."
@@ -71,7 +71,7 @@ start_test "Check that the client picks up a new server version, and warns about
 set env(COCKROACH_TESTING_VERSION_TAG) "v0.1.0-fakever"
 start_server $argv
 set env(COCKROACH_TESTING_VERSION_TAG) "v0.2.0-fakever"
-spawn $argv sql
+spawn $argv sql --no-line-editor
 send "select 1;\r"
 eexpect "# Client version: CockroachDB"
 eexpect "# Server version: CockroachDB"

--- a/pkg/cli/interactive_tests/test_style_enabled.tcl
+++ b/pkg/cli/interactive_tests/test_style_enabled.tcl
@@ -6,7 +6,7 @@ start_server $argv
 
 # Try connect and check the session variables match.
 
-spawn $argv sql --url "postgresql://root@localhost:26257?options=-cintervalstyle%3Diso_8601"
+spawn $argv sql --no-line-editor --url "postgresql://root@localhost:26257?options=-cintervalstyle%3Diso_8601"
 eexpect root@
 send "SHOW intervalstyle;\r"
 eexpect "iso_8601"
@@ -14,7 +14,7 @@ eexpect root@
 send_eof
 eexpect eof
 
-spawn $argv sql --url "postgresql://root@localhost:26257?options=-cdatestyle%3Dymd"
+spawn $argv sql --no-line-editor --url "postgresql://root@localhost:26257?options=-cdatestyle%3Dymd"
 eexpect root@
 send "SHOW datestyle;\r"
 eexpect "ISO, YMD"

--- a/pkg/cli/interactive_tests/test_timing.tcl
+++ b/pkg/cli/interactive_tests/test_timing.tcl
@@ -4,7 +4,7 @@ source [file join [file dirname $argv0] common.tcl]
 
 # This test ensures timing displayed in the CLI works as expected.
 
-spawn $argv demo movr
+spawn $argv demo movr --no-line-editor
 eexpect root@
 
 start_test "Test that server execution time and network latency are printed by default."

--- a/pkg/cli/interactive_tests/test_txn_prompt.tcl
+++ b/pkg/cli/interactive_tests/test_txn_prompt.tcl
@@ -8,7 +8,7 @@ spawn /bin/bash
 send "PS1='\\h:''/# '\r"
 eexpect ":/# "
 
-send "$argv sql --host=localhost\r"
+send "$argv sql --no-line-editor --host=localhost\r"
 eexpect root@
 
 ###START tests prompt customization

--- a/pkg/cli/interactive_tests/test_url_login.tcl
+++ b/pkg/cli/interactive_tests/test_url_login.tcl
@@ -8,7 +8,7 @@ start_test "Check that the client can start when no username is specified."
 # This is run as an acceptance test to ensure that the code path
 # that generates the interactive prompt presented to the user is
 # also exercised by the test.
-spawn $argv sql --url "postgresql://localhost:26257?sslmode=disable"
+spawn $argv sql --no-line-editor --url "postgresql://localhost:26257?sslmode=disable"
 eexpect @localhost
 send_eof
 eexpect eof
@@ -25,7 +25,7 @@ set mywd [pwd]
 system "$argv start-single-node --insecure --pid-file=server_pid --socket-dir=. --background -s=path=logs/db >>logs/expect-cmd.log 2>&1;
         $argv sql --insecure -e 'select 1'"
 
-spawn $argv sql --url "postgresql://?host=$mywd&port=26257"
+spawn $argv sql --no-line-editor --url "postgresql://?host=$mywd&port=26257"
 eexpect root@
 send_eof
 eexpect eof

--- a/pkg/util/sysutil/sysutil.go
+++ b/pkg/util/sysutil/sysutil.go
@@ -70,3 +70,13 @@ func IsErrConnectionReset(err error) bool {
 func IsErrConnectionRefused(err error) bool {
 	return errors.Is(err, syscall.ECONNREFUSED)
 }
+
+// InterruptSelf sends SIGHUP to the process itself.
+func InterruptSelf() error {
+	pr, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		// No-op.
+		return nil //nolint:returnerrcheck
+	}
+	return pr.Signal(syscall.SIGHUP)
+}


### PR DESCRIPTION
Needed for #86457.

When running the interactive tests, when a test fails we want to be able to investigate the test logs without noise from the terminal escape codes.

This patch adds a new flag `--no-line-editor` that can be used in these tests.

(It can also arguably be used to demonstrate visually the differences between having a line editor and not having one.)

Release note: None