### PR TITLE
descs: fix txn commit waiting on wrong lease version

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -366,6 +366,16 @@ func (tc *Collection) finalizeDescriptors(
 			"len(validationLevels) = %d should be equal to len(descs) = %d",
 			len(validationLevels), len(descs))
 	}
+	// Add the descriptors to the uncommitted layer if we want them to be mutable.
+	if flags.RequireMutable {
+		for i, desc := range descs {
+			mut, err := tc.uncommitted.ensureMutable(ctx, desc)
+			if err != nil {
+				return err
+			}
+			descs[i] = mut
+		}
+	}
 	// Ensure that all descriptors are sufficiently validated.
 	requiredLevel := validate.MutableRead
 	if !flags.RequireMutable && !flags.AvoidLeased {
@@ -384,17 +394,6 @@ func (tc *Collection) finalizeDescriptors(
 		for _, desc := range toValidate {
 			tc.stored.UpdateValidationLevel(desc, requiredLevel)
 		}
-	}
-	// Add the descriptors to the uncommitted layer if we want them to be mutable.
-	if !flags.RequireMutable {
-		return nil
-	}
-	for i, desc := range descs {
-		mut, err := tc.uncommitted.ensureMutable(ctx, desc)
-		if err != nil {
-			return err
-		}
-		descs[i] = mut
 	}
 	return nil
 }

--- a/pkg/sql/catalog/descs/table.go
+++ b/pkg/sql/catalog/descs/table.go
@@ -83,7 +83,8 @@ func (tc *Collection) GetLeasedImmutableTableByID(
 func (tc *Collection) GetUncommittedMutableTableByID(
 	id descpb.ID,
 ) (catalog.TableDescriptor, *tabledesc.Mutable, error) {
-	original, mut := tc.uncommitted.getUncommittedMutableByID(id)
+	original := tc.uncommitted.getOriginalByID(id)
+	mut := tc.uncommitted.getUncommittedMutableByID(id)
 	if mut == nil {
 		return nil, nil, nil
 	}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -979,9 +979,11 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) error 
 	// Now that we've committed, if we modified any descriptor we need to make sure
 	// to release the leases for them so that the schema change can proceed and
 	// we don't block the client.
-	if descs := ex.extraTxnState.descCollection.GetDescriptorsWithNewVersion(); descs != nil {
-		ex.extraTxnState.descCollection.ReleaseLeases(ctx)
+	withNewVersion, err := ex.extraTxnState.descCollection.GetOriginalPreviousIDVersionsForUncommitted()
+	if err != nil || withNewVersion == nil {
+		return err
 	}
+	ex.extraTxnState.descCollection.ReleaseLeases(ctx)
 	return nil
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1921,3 +1921,32 @@ DROP INDEX t1_57592@idx;
 
 statement error pgcode XXA00 there is no unique constraint matching given keys for referenced table t1_57592
 COMMIT
+
+# Regression test for issue #87672 in which the lease manager would wait on
+# the wrong version to be released.
+subtest regression_87672
+
+statement ok
+CREATE DATABASE db_87672;
+
+statement ok
+USE db_87672;
+
+statement ok
+CREATE SCHEMA sc;
+
+statement ok
+BEGIN;
+
+statement ok
+CREATE SCHEMA sc2;
+
+statement ok
+SELECT * FROM crdb_internal.tables;
+
+statement ok
+DROP SCHEMA sc;
+
+# Prior to fixing this bug, this commit would hang indefinitely.
+statement ok
+COMMIT;

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -1520,20 +1520,16 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v INT);
 					Required: true, AvoidLeased: true,
 				},
 			}
-			tbl, err := col.GetImmutableTableByID(ctx, txn, tableDesc.GetID(), flags)
+			tbl, err := col.GetMutableTableByID(ctx, txn, tableDesc.GetID(), flags)
 			if err != nil {
 				return err
 			}
-			table := tabledesc.NewBuilder(tbl.TableDesc()).BuildExistingMutableTable()
-			if err != nil {
-				return err
-			}
-			table.MaybeIncrementVersion()
+			tbl.Version++
 			ba := txn.NewBatch()
-			if err := col.WriteDescToBatch(ctx, false /* kvTrace */, table, ba); err != nil {
+			if err := col.WriteDescToBatch(ctx, false /* kvTrace */, tbl, ba); err != nil {
 				return err
 			}
-			version = table.GetVersion()
+			version = tbl.GetVersion()
 
 			// Here we don't want to actually wait for the backfill to drop its lease.
 			// To avoid that, we hack the machinery which tries oh so hard to make it


### PR DESCRIPTION
Recent work on the descs.Collection (PR #87067) introduced a regression
in which it would return bad lease.IDVersion versions for the uncommitted
descriptors.

Fixes #87672.

Release justification: important bug fix
Release note: None