### PR TITLE
kvserverbase: format CmdIDKey as %x

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/base.go
+++ b/pkg/kv/kvserver/kvserverbase/base.go
@@ -39,7 +39,7 @@ type CmdIDKey string
 
 // SafeFormat implements redact.SafeFormatter.
 func (s CmdIDKey) SafeFormat(sp redact.SafePrinter, verb rune) {
-	sp.Printf("%q", redact.SafeString(s))
+	sp.Printf("%x", redact.SafeString(s))
 }
 
 func (s CmdIDKey) String() string {


### PR DESCRIPTION
This is more legible; these are effectively random bytes.

Extracted from #76126.

Release note: None
