### PR TITLE
release-22.1: sql: change when txn is checked refresh materialized views

### DIFF
--- a/pkg/sql/materialized_view_test.go
+++ b/pkg/sql/materialized_view_test.go
@@ -65,8 +65,17 @@ REFRESH MATERIALIZED VIEW t.v;
 		t.Fatal(err)
 	}
 
+	// Verify that refreshing with a prepared statement works.
+	preparedStmt, err := sqlDB.Prepare(`REFRESH MATERIALIZED VIEW t.v;`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := preparedStmt.Exec(); err != nil {
+		t.Fatal(err)
+	}
+
 	// Add a zone config to delete all table data.
-	_, err := sqltestutils.AddImmediateGCZoneConfig(sqlDB, descBeforeRefresh.GetID())
+	_, err = sqltestutils.AddImmediateGCZoneConfig(sqlDB, descBeforeRefresh.GetID())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Backport 1/1 commits from #87271.

/cc @cockroachdb/release

---


Due to the transaction being checked during planning
and not during execution, refresh materialized views
would fail from the client. Now the transaction is checked
during execution .

Release justification: Bug fix for refresh materialized views

Release note: None
