### PR TITLE
roachtest: add 4s of sleep after restart when upgrading nodes

### DIFF
--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -433,6 +433,15 @@ func upgradeNodes(
 		settings := install.MakeClusterSettings(install.BinaryOption(binary))
 		settings.Env = append(settings.Env, "COCKROACH_UPGRADE_TO_DEV_VERSION=true")
 		c.Start(ctx, t.L(), startOpts, settings, c.Node(node))
+
+		// We have seen cases where a transient error could occur when this
+		// newly upgraded node serves as a gateway for a distributed query due
+		// to remote nodes not being able to dial back to the gateway for some
+		// reason (investigation of it is tracked in #87634). For now, we're
+		// papering over these flakes by this sleep. For more context, see
+		// #87104.
+		// TODO(yuzefovich): remove this sleep once #87634 is fixed.
+		time.Sleep(4 * time.Second)
 	}
 }
 


### PR DESCRIPTION
We have seen cases where a transient error could occur when a newly-upgraded node serves as a gateway for a distributed query due to remote nodes not being able to dial back to the gateway for some reason (investigation of it is tracked in #87634). For now, we're papering over these flakes by 4 second sleep.

Addresses: #87104.

Release note: None