### PR TITLE
changefeedccl: Make kvevent.Event memory efficient

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -354,7 +354,7 @@ func TestChangefeedSendError(t *testing.T) {
 
 		// Allow triggering a single sendError
 		sendErrorCh := make(chan error, 1)
-		knobs.FeedKnobs.OnRangeFeedValue = func(_ roachpb.KeyValue) error {
+		knobs.FeedKnobs.OnRangeFeedValue = func() error {
 			select {
 			case err := <-sendErrorCh:
 				return err

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -146,8 +145,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		if !c.details.Opts.GetFilters().WithDiff {
 			return cdcevent.Row{}, nil
 		}
-		prevKV := roachpb.KeyValue{Key: ev.KV().Key, Value: ev.PrevValue()}
-		return c.decoder.DecodeKV(ctx, prevKV, prevSchemaTimestamp)
+		return c.decoder.DecodeKV(ctx, ev.PrevKeyValue(), prevSchemaTimestamp)
 	}()
 	if err != nil {
 		// Column families are stored contiguously, so we'll get

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -130,7 +130,7 @@ func (b *blockingBuffer) pop() (e Event, ok bool, err error) {
 		// If the batching event consumer does not have periodic flush configured,
 		// we may never be able to make forward progress.
 		// So, we issue the flush request to the consumer to ensure that we release some memory.
-		e = Event{flush: true}
+		e = Event{et: TypeFlush}
 		ok = true
 	}
 
@@ -203,7 +203,7 @@ func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
 	}
 
 	// Acquire the quota first.
-	alloc := int64(changefeedbase.EventMemoryMultiplier.Get(b.sv) * float64(e.approxSize))
+	alloc := int64(changefeedbase.EventMemoryMultiplier.Get(b.sv) * float64(e.ApproximateSize()))
 	if l := changefeedbase.PerChangefeedMemLimit.Get(b.sv); alloc > l {
 		return errors.Newf("event size %d exceeds per changefeed limit %d", alloc, l)
 	}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -234,7 +234,7 @@ var errChangefeedCompleted = errors.New("changefeed completed")
 func (f *kvFeed) run(ctx context.Context) (err error) {
 	emitResolved := func(ts hlc.Timestamp, boundary jobspb.ResolvedSpan_BoundaryType) error {
 		for _, sp := range f.spans {
-			if err := f.writer.Add(ctx, kvevent.MakeResolvedEvent(sp, ts, boundary)); err != nil {
+			if err := f.writer.Add(ctx, kvevent.NewBackfillResolvedEvent(sp, ts, boundary)); err != nil {
 				return err
 			}
 		}

--- a/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvfeed/testing_knobs.go
@@ -19,7 +19,7 @@ type TestingKnobs struct {
 	// BeforeScanRequest is a callback invoked before issuing Scan request.
 	BeforeScanRequest func(b *kv.Batch) error
 	// OnRangeFeedValue invoked when rangefeed receives a value.
-	OnRangeFeedValue func(kv roachpb.KeyValue) error
+	OnRangeFeedValue func() error
 	// ShouldSkipCheckpoint invoked when rangefed receives a checkpoint.
 	// Returns true if checkpoint should be skipped.
 	ShouldSkipCheckpoint func(*roachpb.RangeFeedCheckpoint) bool


### PR DESCRIPTION
Fixes #84709

`kvevent.Event` structure is very inefficient in its use of pointers.  The number of pointers in the structure makes go GC processes more expensive, resulting in loss of performance in the cluster.

This is particularly clear during the initial scan, when changefeeds rapidly allocate large number of events, which are then (rapidly) releases -- putting pressure on the go runtime GC.

This PR replaces the use of multiple pointers with a single `*roachpb.RangeFeedEvent`.  The direct use of `*roachpb.RangeFeedEvent` is beneficial since this is the (already allocated) event we receive from rangefeed RPC once changefeed completes the initial scan.

Release justification: significant reduction of the changefeed impact on the foreground SQL latency.

Release note (enterprise change): Changefeeds are more efficient during initial scan and backfill.  The impact on runtime GC signficantly reduced, resulting in significant reduction of the changefeed impact on the foreground SQL latency.