### PR TITLE
server: new hybrid listener mode to ease upgrades

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -198,6 +198,10 @@ type Config struct {
 	// clients on a separate address from RPC requests.
 	SplitListenSQL bool
 
+	// KeepHybridSQL indicates whether to keep the hybrid
+	// SQL/RPC listener when SplitListenSQL is true.
+	KeepHybridSQL bool
+
 	// SQLAddr is the configured SQL listen address.
 	// This is used if SplitListenSQL is set to true.
 	SQLAddr string
@@ -269,6 +273,7 @@ func (cfg *Config) InitDefaults() {
 	cfg.DisableTLSForHTTP = false
 	cfg.HTTPAdvertiseAddr = ""
 	cfg.SplitListenSQL = false
+	cfg.KeepHybridSQL = false
 	cfg.SQLAddr = defaultSQLAddr
 	cfg.SQLAdvertiseAddr = cfg.SQLAddr
 	cfg.SocketFile = ""

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -111,6 +111,22 @@ specialized hardware or number of cores (e.g. "gpu", "x16c"). For example:
   --attrs=x16c:gpu</PRE>`,
 	}
 
+	KeepHybridSQL = FlagInfo{
+		Name: "keep-hybrid-sql-port",
+		Description: `
+When specified, the network listener defined with --listen-addr also
+accepts SQL connections, even when --sql-addr is specified.
+<PRE>
+
+</PRE>
+This flag is intended as a transition mode when adding --sql-addr
+to a cluster previously running with a mixed use TCP port.
+After the cluster has been restarted with split ports
+and --keep-hybrid-sql-port, and the SQL client config
+has been updated to use the new SQL port, the cluster can then be restarted
+anew without --keep-hybrid-sql-port.`,
+	}
+
 	Locality = FlagInfo{
 		Name: "locality",
 		Description: `

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -453,6 +453,8 @@ func init() {
 
 		// More server flags.
 
+		cliflagcfg.BoolFlag(f, &serverCfg.KeepHybridSQL, cliflags.KeepHybridSQL)
+
 		cliflagcfg.VarFlag(f, &localityAdvertiseHosts, cliflags.LocalityAdvertiseAddr)
 
 		cliflagcfg.StringFlag(f, &serverCfg.Attrs, cliflags.Attrs)
@@ -904,6 +906,7 @@ func init() {
 		cliflagcfg.VarFlag(f, addr.NewAddrSetter(&serverHTTPAddr, &serverHTTPPort), cliflags.ListenHTTPAddr)
 		cliflagcfg.VarFlag(f, addr.NewAddrSetter(&serverHTTPAdvertiseAddr, &serverHTTPAdvertisePort), cliflags.HTTPAdvertiseAddr)
 		cliflagcfg.VarFlag(f, addr.NewAddrSetter(&serverAdvertiseAddr, &serverAdvertisePort), cliflags.AdvertiseAddr)
+		cliflagcfg.BoolFlag(f, &serverCfg.KeepHybridSQL, cliflags.KeepHybridSQL)
 
 		cliflagcfg.VarFlag(f, &serverCfg.Locality, cliflags.Locality)
 		cliflagcfg.VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -189,7 +189,9 @@ func startTenantInternal(
 			// running in a worker and usually sits on accept(pgL) which unblocks
 			// only when pgL closes. In other words, pgL needs to close when
 			// quiescing starts to allow that worker to shut down.
-			_ = pgL.Close()
+			for _, l := range pgL {
+				_ = l.Close()
+			}
 		}
 		if err := args.stopper.RunAsyncTask(background, "wait-quiesce-pgl", waitQuiesce); err != nil {
 			waitQuiesce(background)


### PR DESCRIPTION
Release note (cli change): For context, in v22.2, we are deprecating starting a server with a mixed RPC/SQL configuration.

However, if a cluster was previously running with a mixed listener, the operator might feel uncomfortable with the transition to split ports:

- if they decide to keep the SQL port as-is and change the RPC port, they need to simultaneously change `--join` and perform a leap of faith and rely on gossip to regain node-node connectivity as the cluster gets restarted.

- if they decide to keep the RPC port as-is and change the SQL port, they need to update their client app / connection pool to use both the old and the new port until all the nodes have been restarted with split ports, potentially causing disruption if the connections to the old port fail with a timeout.

To simplify the transition, CockroachDB now supports a new command-line flag `--keep-hybrid-sql-port`. When specified together with `--sql-addr`, it ensures that SQL connections are still possible on the port specified with `--listen-addr` (i.e. mixed configuration). In effect, it causes two separate SQL listeners to become available.

This makes it possible to orchestrate a transition to split ports as follows:

1. change the CLI flags to `--sql-addr --keep-hybrid-sql-port`. If switching SQL and RPC port numbers, also adjust `--join` as necessary.
2. perform a rolling restart of the cluster.
3. change the client apps to use the new SQL port (if changing the SQL port) or other admin automation to use the new RPC port.
4. ascertain that the configuration is OK.
5. change the CLI flags to remove `--keep-hybrid-sql-port`.
6. perform another rolling restart.