### PR TITLE
[DNM] *: check that context.Value works before calling WithValue

### DIFF
--- a/pkg/rpc/stats_handler.go
+++ b/pkg/rpc/stats_handler.go
@@ -146,6 +146,7 @@ func (sh *StatsHandler) HandleRPC(ctx context.Context, rpcStats stats.RPCStats) 
 // ConnTagInfo, and use that to properly update the Stats object
 // belonging to that remote address.
 func (sh *StatsHandler) TagConn(ctx context.Context, cti *stats.ConnTagInfo) context.Context {
+	_ = ctx.Value("non-existent-key")
 	return context.WithValue(ctx, remoteAddrKey{}, cti.RemoteAddr.String())
 }
 

--- a/pkg/server/api_v2_auth.go
+++ b/pkg/server/api_v2_auth.go
@@ -358,6 +358,7 @@ func (a *authenticationV2Mux) ServeHTTP(w http.ResponseWriter, req *http.Request
 		// Valid session found. Set the username in the request context, so
 		// child http.Handlers can access it.
 		ctx := req.Context()
+		_ = ctx.Value("non-existent-key")
 		ctx = context.WithValue(ctx, webSessionUserKey{}, username)
 		ctx = context.WithValue(ctx, webSessionIDKey{}, cookie.ID)
 		req = req.WithContext(ctx)

--- a/pkg/server/authentication.go
+++ b/pkg/server/authentication.go
@@ -565,6 +565,7 @@ func (am *authenticationMux) ServeHTTP(w http.ResponseWriter, req *http.Request)
 	username, cookie, err := am.getSession(w, req)
 	if err == nil {
 		ctx := req.Context()
+		_ = ctx.Value("non-existent-key")
 		ctx = context.WithValue(ctx, webSessionUserKey{}, username)
 		ctx = context.WithValue(ctx, webSessionIDKey{}, cookie.ID)
 		req = req.WithContext(ctx)

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3475,6 +3475,7 @@ type contextStatementKey struct{}
 // withStatement adds a SQL statement to the provided context. The statement
 // will then be included in crash reports which use that context.
 func withStatement(ctx context.Context, stmt tree.Statement) context.Context {
+	_ = ctx.Value("non-existent-key")
 	return context.WithValue(ctx, contextStatementKey{}, stmt)
 }
 

--- a/pkg/util/contextutil/context.go
+++ b/pkg/util/contextutil/context.go
@@ -43,6 +43,7 @@ type CancelWithReasonFunc func(reason error)
 // This function doesn't change the deadline of a context if it already exists.
 func WithCancelReason(ctx context.Context) (context.Context, CancelWithReasonFunc) {
 	val := new(atomic.Value)
+	_ = ctx.Value("non-existent-key")
 	ctx = context.WithValue(ctx, reasonKey{}, val)
 	ctx, cancel := wrap(context.WithCancel(ctx))
 	return ctx, func(reason error) {

--- a/pkg/util/grpcutil/grpc_util.go
+++ b/pkg/util/grpcutil/grpc_util.go
@@ -36,6 +36,7 @@ type localRequestKey struct{}
 
 // NewLocalRequestContext returns a Context that can be used for local (in-process) requests.
 func NewLocalRequestContext(ctx context.Context) context.Context {
+	_ = ctx.Value("non-existent-key")
 	return context.WithValue(ctx, localRequestKey{}, struct{}{})
 }
 

--- a/pkg/util/log/ambient_context.go
+++ b/pkg/util/log/ambient_context.go
@@ -141,6 +141,7 @@ func (ac *AmbientContext) ResetAndAnnotateCtx(ctx context.Context) context.Conte
 			ctx = logtags.WithTags(ctx, ac.tags)
 		}
 		if ac.ServerIDs != nil {
+			_ = ctx.Value("non-existent-key")
 			ctx = context.WithValue(ctx, ServerIdentificationContextKey{}, ac.ServerIDs)
 		}
 		return ctx
@@ -155,6 +156,7 @@ func (ac *AmbientContext) annotateCtxInternal(ctx context.Context) context.Conte
 		ctx = logtags.AddTags(ctx, ac.tags)
 	}
 	if ac.ServerIDs != nil && ctx.Value(ServerIdentificationContextKey{}) == nil {
+		_ = ctx.Value("non-existent-key")
 		ctx = context.WithValue(ctx, ServerIdentificationContextKey{}, ac.ServerIDs)
 	}
 	return ctx
@@ -182,6 +184,7 @@ func (ac *AmbientContext) AnnotateCtxWithSpan(
 			ctx = logtags.AddTags(ctx, ac.tags)
 		}
 		if ac.ServerIDs != nil && ctx.Value(ServerIdentificationContextKey{}) == nil {
+			_ = ctx.Value("non-existent-key")
 			ctx = context.WithValue(ctx, ServerIdentificationContextKey{}, ac.ServerIDs)
 		}
 	}

--- a/pkg/util/log/trace.go
+++ b/pkg/util/log/trace.go
@@ -42,6 +42,7 @@ func (el *ctxEventLog) finish() {
 }
 
 func embedCtxEventLog(ctx context.Context, el *ctxEventLog) context.Context {
+	_ = ctx.Value("non-existent-key")
 	return context.WithValue(ctx, ctxEventLogKey{}, el)
 }
 

--- a/pkg/util/tracing/context.go
+++ b/pkg/util/tracing/context.go
@@ -61,6 +61,7 @@ func maybeWrapCtx(ctx context.Context, sp *Span) (context.Context, *Span) {
 			return ctx, sp
 		}
 	}
+	_ = ctx.Value("non-existent-key")
 	return context.WithValue(ctx, activeSpanKey{}, sp), sp
 }
 


### PR DESCRIPTION
Debugging for https://github.com/cockroachlabs/support/issues/1789

Attempt to force the crash to happen earlier by sprinkling calls to Context.Value in various places. This could be put everywhere we wrap a context (e.g. all WithCancel, WithTimeout, WithDeadline, WithValue) but I've limited it to WithValue for now, since we know that's on the triggering path.

We should still crash with this, just earlier, hopefully closer to the source of the nil Context.

Release note: None