### PR TITLE
release-22.1: pkg/keys: implement SafeFormatter for roachpb.Key

### DIFF
--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 
@@ -43,6 +44,7 @@ go_test(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -21,11 +21,25 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // PrettyPrintTimeseriesKey is a hook for pretty printing a timeseries key. The
 // timeseries key prefix will already have been stripped off.
 var PrettyPrintTimeseriesKey func(key roachpb.Key) string
+
+// QuoteOpt is a flag option used when pretty-printing keys to indicate whether
+// to quote raw key values.
+type QuoteOpt bool
+
+const (
+	// QuoteRaw is the QuoteOpt used to indicate that we should use quotes when
+	// printing raw keys.
+	QuoteRaw QuoteOpt = true
+	// DontQuoteRaw is the QuoteOpt used to indicate that we shouldn't use quotes
+	// when printing raw keys.
+	DontQuoteRaw QuoteOpt = false
+)
 
 // DictEntry contains info on pretty-printing and pretty-scanning keys in a
 // region of the key space.
@@ -34,6 +48,8 @@ type DictEntry struct {
 	prefix roachpb.Key
 	// print the key's pretty value, key has been removed prefix data
 	ppFunc func(valDirs []encoding.Direction, key roachpb.Key) string
+	// safe format the key's pretty value into a RedactableString
+	sfFunc func(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString
 	// PSFunc parses the relevant prefix of the input into a roachpb.Key,
 	// returning the remainder and the key corresponding to the consumed prefix of
 	// 'input'. Allowed to panic on errors.
@@ -56,9 +72,14 @@ type KeyComprehensionTable []struct {
 	Entries []DictEntry
 }
 
+// KeyDict drives the pretty-printing and pretty-scanning of the key space.
+// This is initialized in init().
+var KeyDict KeyComprehensionTable
+
 var (
-	// ConstKeyDict translates some pretty-printed keys.
-	ConstKeyDict = []struct {
+	// ConstKeyOverrides provides overrides that define how to translate specific
+	// pretty-printed keys.
+	ConstKeyOverrides = []struct {
 		Name  string
 		Value roachpb.Key
 	}{
@@ -66,82 +87,6 @@ var (
 		{"/Min", MinKey},
 		{"/Meta1/Max", Meta1KeyMax},
 		{"/Meta2/Max", Meta2KeyMax},
-	}
-
-	// KeyDict drives the pretty-printing and pretty-scanning of the key space.
-	KeyDict = KeyComprehensionTable{
-		{Name: "/Local", start: LocalPrefix, end: LocalMax, Entries: []DictEntry{
-			{Name: "/Store", prefix: roachpb.Key(LocalStorePrefix),
-				ppFunc: localStoreKeyPrint, PSFunc: localStoreKeyParse},
-			{Name: "/RangeID", prefix: roachpb.Key(LocalRangeIDPrefix),
-				ppFunc: localRangeIDKeyPrint, PSFunc: localRangeIDKeyParse},
-			{Name: "/Range", prefix: LocalRangePrefix, ppFunc: localRangeKeyPrint,
-				PSFunc: parseUnsupported},
-			{Name: "/Lock", prefix: LocalRangeLockTablePrefix, ppFunc: localRangeLockTablePrint,
-				PSFunc: parseUnsupported},
-		}},
-		{Name: "/Meta1", start: Meta1Prefix, end: Meta1KeyMax, Entries: []DictEntry{
-			{Name: "", prefix: Meta1Prefix, ppFunc: print,
-				PSFunc: func(input string) (string, roachpb.Key) {
-					input = mustShiftSlash(input)
-					unq, err := strconv.Unquote(input)
-					if err != nil {
-						panic(err)
-					}
-					if len(unq) == 0 {
-						return "", Meta1Prefix
-					}
-					return "", RangeMetaKey(RangeMetaKey(MustAddr(
-						roachpb.Key(unq)))).AsRawKey()
-				},
-			}},
-		},
-		{Name: "/Meta2", start: Meta2Prefix, end: Meta2KeyMax, Entries: []DictEntry{
-			{Name: "", prefix: Meta2Prefix, ppFunc: print,
-				PSFunc: func(input string) (string, roachpb.Key) {
-					input = mustShiftSlash(input)
-					unq, err := strconv.Unquote(input)
-					if err != nil {
-						panic(&ErrUglifyUnsupported{err})
-					}
-					if len(unq) == 0 {
-						return "", Meta2Prefix
-					}
-					return "", RangeMetaKey(MustAddr(roachpb.Key(unq))).AsRawKey()
-				},
-			}},
-		},
-		{Name: "/System", start: SystemPrefix, end: SystemMax, Entries: []DictEntry{
-			{Name: "/NodeLiveness", prefix: NodeLivenessPrefix,
-				ppFunc: decodeKeyPrint,
-				PSFunc: parseUnsupported,
-			},
-			{Name: "/NodeLivenessMax", prefix: NodeLivenessKeyMax,
-				ppFunc: decodeKeyPrint,
-				PSFunc: parseUnsupported,
-			},
-			{Name: "/StatusNode", prefix: StatusNodePrefix,
-				ppFunc: decodeKeyPrint,
-				PSFunc: parseUnsupported,
-			},
-			{Name: "/tsd", prefix: TimeseriesPrefix,
-				ppFunc: timeseriesKeyPrint,
-				PSFunc: parseUnsupported,
-			},
-			{Name: "/SystemSpanConfigKeys", prefix: SystemSpanConfigPrefix,
-				ppFunc: decodeKeyPrint,
-				PSFunc: parseUnsupported,
-			},
-		}},
-		{Name: "/NamespaceTable", start: NamespaceTableMin, end: NamespaceTableMax, Entries: []DictEntry{
-			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: parseUnsupported},
-		}},
-		{Name: "/Table", start: TableDataMin, end: TableDataMax, Entries: []DictEntry{
-			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: tableKeyParse},
-		}},
-		{Name: "/Tenant", start: TenantTableDataMin, end: TenantTableDataMax, Entries: []DictEntry{
-			{Name: "", prefix: nil, ppFunc: tenantKeyPrint, PSFunc: tenantKeyParse},
-		}},
 	}
 
 	// keyofKeyDict means the key of suffix which is itself a key,
@@ -550,7 +495,9 @@ func localRangeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
 
 // lockTablePrintLockedKey is initialized to prettyPrintInternal in init() to break an
 // initialization loop.
-var lockTablePrintLockedKey func(valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys bool) string
+var lockTablePrintLockedKey func(
+	valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt, skipOverrides bool,
+) string
 
 func localRangeLockTablePrint(valDirs []encoding.Direction, key roachpb.Key) string {
 	var buf bytes.Buffer
@@ -565,7 +512,7 @@ func localRangeLockTablePrint(valDirs []encoding.Direction, key roachpb.Key) str
 		fmt.Fprintf(&buf, "/\"%x\"", key)
 		return buf.String()
 	}
-	buf.WriteString(lockTablePrintLockedKey(valDirs, lockedKey, true))
+	buf.WriteString(lockTablePrintLockedKey(valDirs, lockedKey, QuoteRaw, false /*skipOverrides*/))
 	return buf.String()
 }
 
@@ -630,7 +577,7 @@ func tenantKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
 	if len(key) == 0 {
 		return fmt.Sprintf("/%s", tID)
 	}
-	return fmt.Sprintf("/%s%s", tID, key.StringWithDirs(valDirs, 0))
+	return fmt.Sprintf("/%s%s", tID, key.StringWithDirs(valDirs))
 }
 
 // prettyPrintInternal parse key with prefix in KeyDict.
@@ -640,10 +587,22 @@ func tenantKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
 // type is used (see encoding.go:prettyPrintFirstValue).
 // If the key doesn't match any prefix in KeyDict, return its byte value with
 // quotation and false, or else return its human readable value and true.
-func prettyPrintInternal(valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys bool) string {
-	for _, k := range ConstKeyDict {
-		if key.Equal(k.Value) {
-			return k.Name
+//
+// skipOverrides provides a way to skip the usage of ConstKeyOverrides. This is
+// configurable to enable recursive printing of keys (e.g. from SafeFormat) a way
+// to avoid treating the remainder as a potential match for the overrides in
+// ConstKeyOverrides, which in general, should not apply to the remainder of any key.
+// For example: The key `/Meta1/""` would have `/Meta1` trimmed from the key, and
+// prettyPrintInternal may be called to print the remainder of `""`. This would
+// incorrectly be interpreted as `/Min` if we didn't skip the usage of ConstKeyOverrides.
+func prettyPrintInternal(
+	valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt, skipOverrides bool,
+) string {
+	if !skipOverrides {
+		for _, k := range ConstKeyOverrides {
+			if key.Equal(k.Value) {
+				return k.Name
+			}
 		}
 	}
 
@@ -714,14 +673,210 @@ func prettyPrintInternal(valDirs []encoding.Direction, key roachpb.Key, quoteRaw
 // type is used (see encoding.go:prettyPrintFirstValue).
 //
 // See keysutil.UglyPrint() for an inverse.
+//
+// See SafeFormat for a redaction-safe implementation.
 func PrettyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
-	return prettyPrintInternal(valDirs, key, true /* quoteRawKeys */)
+	return prettyPrintInternal(valDirs, key, QuoteRaw, false /*skipOverrides*/)
+}
+
+// formatTableKey formats the given key in the system tenant table keyspace & redacts any
+// sensitive information from the result. Sensitive information is considered any value other
+// than the table ID or index ID (e.g. any index-key/value-literal).
+//
+// NB: It's the responsibility of the caller to prefix the printed key values with the relevant
+// keyspace identifier (e.g. `/Table`).
+//
+// For example:
+//   - `/42/‹"index key"›`
+//   - `/42/122/‹"index key"›`
+//   - `/42/122/‹"index key"›/‹"some value"›`
+//   - `/42/122/‹"index key"›/‹"some value"›/‹"some other value"›`
+func formatTableKey(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
+	vals, types := encoding.PrettyPrintValuesWithTypes(valDirs, key)
+	prefixLength := 1
+
+	if len(vals) > 0 && types[0] != encoding.Int {
+		buf.Printf("/err:ExpectedTableID-FoundType%v", redact.Safe(types[0]))
+		return buf.RedactableString()
+	}
+
+	// Accommodate cases where the table key contains a primary index field in
+	// the prefix. ex: `/<table id>/<index id>`
+	if len(vals) > 1 && types[1] == encoding.Int {
+		prefixLength++
+	}
+
+	for i := 0; i < prefixLength; i++ {
+		buf.Printf("/%v", redact.Safe(vals[i]))
+	}
+	for _, val := range vals[prefixLength:] {
+		buf.Printf("/%s", val)
+	}
+	return buf.RedactableString()
+}
+
+// formatTenantKey formats the given key for a tenant table & redacts any sensitive information
+// from the result. Sensitive information is considered any value other than the TenantID,
+// table ID, or index ID (e.g. any index-key/value-literal).
+//
+// NB: It's the responsibility of the caller to prefix the printed key values with the relevant
+// keyspace identifier (e.g. `/Tenant`).
+//
+// For example:
+//   - `/5/Table/42/‹"index key"›`
+//   - `/5/Table/42/122/‹"index key"›`
+func formatTenantKey(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
+	key, tID, err := DecodeTenantPrefix(key)
+	if err != nil {
+		buf.Printf("/err:%v", err)
+		return buf.RedactableString()
+	}
+
+	buf.Printf("/%s", tID)
+	if len(key) != 0 {
+		buf.Print(safeFormatInternal(valDirs, key))
+	}
+	return buf.RedactableString()
+}
+
+// SafeFormat is the generalized redaction function used to redact pretty-printed keys.
+func SafeFormat(w redact.SafeWriter, valDirs []encoding.Direction, key roachpb.Key) {
+	w.Print(safeFormatInternal(valDirs, key))
+}
+
+func safeFormatInternal(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	for _, k := range ConstKeyOverrides {
+		if key.Equal(k.Value) {
+			return redact.Sprint(redact.Safe(k.Name))
+		}
+	}
+
+	helper := func(key roachpb.Key, isRemainder bool) redact.RedactableString {
+		var b redact.StringBuilder
+		for _, k := range KeyDict {
+			if key.Compare(k.start) >= 0 && (k.end == nil || key.Compare(k.end) <= 0) {
+				if k.end != nil && k.end.Compare(key) == 0 {
+					b.Print(redact.Safe(k.Name))
+					b.Print(redact.Safe("/Max"))
+					return b.RedactableString()
+				}
+
+				for _, e := range k.Entries {
+					if bytes.HasPrefix(key, e.prefix) && e.sfFunc != nil {
+						b.Print(redact.Safe(k.Name))
+						key = key[len(e.prefix):]
+						b.Print(redact.Safe(e.Name))
+						b.Print(e.sfFunc(valDirs, key))
+						return b.RedactableString()
+					}
+				}
+			}
+		}
+		// If we reach this point, the key is not recognized based on KeyDict, or no `sfFunc`
+		// is defined for the keyspace. Therefore, we fall back to the standard pretty print
+		// functionality and avoid marking safe from a redaction perspective.
+		// NB: This will lead to the entirety of the pretty-printed key to be redactable, e.g:
+		//		Unredacted: `‹/SomeKeyspace/42›`
+		//		Redacted:   `‹x›`
+		return redact.Sprint(prettyPrintInternal(valDirs, key, QuoteRaw, isRemainder /*skipOverrides*/))
+	}
+
+	for _, k := range keyOfKeyDict {
+		if bytes.HasPrefix(key, k.prefix) {
+			key = key[len(k.prefix):]
+			str := helper(key, true /* isRemainder */)
+			if len(str) > 0 && strings.Index(str.StripMarkers(), "/") != 0 {
+				return redact.Sprintf("%v/%v", redact.Sprint(k.name), str)
+			}
+			return redact.Sprintf("%v%v", redact.Sprint(k.name), str)
+		}
+	}
+	return helper(key, false /* isRemainder */)
 }
 
 func init() {
 	roachpb.PrettyPrintKey = PrettyPrint
+	roachpb.SafeFormatKey = SafeFormat
 	roachpb.PrettyPrintRange = PrettyPrintRange
 	lockTablePrintLockedKey = prettyPrintInternal
+
+	// KeyDict drives the pretty-printing and pretty-scanning of the key space.
+	KeyDict = KeyComprehensionTable{
+		{Name: "/Local", start: LocalPrefix, end: LocalMax, Entries: []DictEntry{
+			{Name: "/Store", prefix: roachpb.Key(LocalStorePrefix),
+				ppFunc: localStoreKeyPrint, PSFunc: localStoreKeyParse},
+			{Name: "/RangeID", prefix: roachpb.Key(LocalRangeIDPrefix),
+				ppFunc: localRangeIDKeyPrint, PSFunc: localRangeIDKeyParse},
+			{Name: "/Range", prefix: LocalRangePrefix, ppFunc: localRangeKeyPrint,
+				PSFunc: parseUnsupported},
+			{Name: "/Lock", prefix: LocalRangeLockTablePrefix, ppFunc: localRangeLockTablePrint,
+				PSFunc: parseUnsupported},
+		}},
+		{Name: "/Meta1", start: Meta1Prefix, end: Meta1KeyMax, Entries: []DictEntry{
+			{Name: "", prefix: Meta1Prefix, ppFunc: print,
+				PSFunc: func(input string) (string, roachpb.Key) {
+					input = mustShiftSlash(input)
+					unq, err := strconv.Unquote(input)
+					if err != nil {
+						panic(err)
+					}
+					if len(unq) == 0 {
+						return "", Meta1Prefix
+					}
+					return "", RangeMetaKey(RangeMetaKey(MustAddr(
+						roachpb.Key(unq)))).AsRawKey()
+				},
+			}},
+		},
+		{Name: "/Meta2", start: Meta2Prefix, end: Meta2KeyMax, Entries: []DictEntry{
+			{Name: "", prefix: Meta2Prefix, ppFunc: print,
+				PSFunc: func(input string) (string, roachpb.Key) {
+					input = mustShiftSlash(input)
+					unq, err := strconv.Unquote(input)
+					if err != nil {
+						panic(&ErrUglifyUnsupported{err})
+					}
+					if len(unq) == 0 {
+						return "", Meta2Prefix
+					}
+					return "", RangeMetaKey(MustAddr(roachpb.Key(unq))).AsRawKey()
+				},
+			}},
+		},
+		{Name: "/System", start: SystemPrefix, end: SystemMax, Entries: []DictEntry{
+			{Name: "/NodeLiveness", prefix: NodeLivenessPrefix,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
+			{Name: "/NodeLivenessMax", prefix: NodeLivenessKeyMax,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
+			{Name: "/StatusNode", prefix: StatusNodePrefix,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
+			{Name: "/tsd", prefix: TimeseriesPrefix,
+				ppFunc: timeseriesKeyPrint,
+				PSFunc: parseUnsupported,
+			},
+			{Name: "/SystemSpanConfigKeys", prefix: SystemSpanConfigPrefix,
+				ppFunc: decodeKeyPrint,
+				PSFunc: parseUnsupported,
+			},
+		}},
+		{Name: "/NamespaceTable", start: NamespaceTableMin, end: NamespaceTableMax, Entries: []DictEntry{
+			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: parseUnsupported},
+		}},
+		{Name: "/Table", start: TableDataMin, end: TableDataMax, Entries: []DictEntry{
+			{Name: "", prefix: nil, ppFunc: decodeKeyPrint, PSFunc: tableKeyParse, sfFunc: formatTableKey},
+		}},
+		{Name: "/Tenant", start: TenantTableDataMin, end: TenantTableDataMax, Entries: []DictEntry{
+			{Name: "", prefix: nil, ppFunc: tenantKeyPrint, PSFunc: tenantKeyParse, sfFunc: formatTenantKey},
+		}},
+	}
 }
 
 // PrettyPrintRange pretty prints a compact representation of a key range. The
@@ -736,7 +891,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 	if maxChars < 8 {
 		maxChars = 8
 	}
-	prettyStart := prettyPrintInternal(nil /* valDirs */, start, false /* quoteRawKeys */)
+	prettyStart := prettyPrintInternal(nil /* valDirs */, start, DontQuoteRaw, false /*skipOverrides*/)
 	if len(end) == 0 {
 		if len(prettyStart) <= maxChars {
 			return prettyStart
@@ -745,7 +900,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 		b.WriteRune('…')
 		return b.String()
 	}
-	prettyEnd := prettyPrintInternal(nil /* valDirs */, end, false /* quoteRawKeys */)
+	prettyEnd := prettyPrintInternal(nil /* valDirs */, end, DontQuoteRaw, false /*skipOverrides*/)
 	i := 0
 	// Find the common prefix.
 	for ; i < len(prettyStart) && i < len(prettyEnd) && prettyStart[i] == prettyEnd[i]; i++ {

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4401,7 +4401,7 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	br.Error = roachpb.NewError(errors.New("boom"))
 	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
 	{
-		exp := `have been waiting 8.16s (120 attempts) for RPC Get [‹"a"›,‹/Min›) to` +
+		exp := `have been waiting 8.16s (120 attempts) for RPC Get [‹"a"›,/Min) to` +
 			` r9:‹{x-z}› [<no replicas>, next=0, gen=0]; resp: ‹(err: boom)›`
 		var s redact.StringBuilder
 		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -417,8 +417,8 @@ func (r *Replica) adminSplitWithDescriptor(
 	}
 	extra += splitSnapshotWarningStr(r.RangeID, r.RaftStatus())
 
-	log.Infof(ctx, "initiating a split of this range at key %s [r%d] (%s)%s",
-		splitKey.StringWithDirs(nil /* valDirs */, 50 /* maxLen */), rightRangeID, reason, extra)
+	log.Infof(ctx, "initiating a split of this range at key %v [r%d] (%s)%s",
+		splitKey, rightRangeID, reason, extra)
 
 	if err := r.store.DB().Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		return splitTxnAttempt(ctx, r.store, txn, rightRangeID, splitKey, args.ExpirationTime, desc)

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -69,12 +69,23 @@ var (
 
 	// PrettyPrintKey prints a key in human readable format. It's
 	// implemented in package git.com/cockroachdb/cockroach/keys to avoid
-	// package circle import.
+	// circular package import dependencies (see keys.PrettyPrint for
+	// implementation).
 	// valDirs correspond to the encoding direction of each encoded value
 	// in the key (if known). If left unspecified, the default encoding
 	// direction for each value type is used (see
 	// encoding.go:prettyPrintFirstValue).
+	// See SafeFormatKey for a redaction-safe implementation.
 	PrettyPrintKey func(valDirs []encoding.Direction, key Key) string
+
+	// SafeFormatKey is the generalized redaction function used to redact pretty
+	// printed keys. It's implemented in git.com/cockroachdb/cockroach/keys to
+	// avoid circular package import dependencies (see keys.SafeFormat for
+	// implementation).
+	// valDirs correspond to the encoding direction of each encoded value
+	// in the key (if known). If left unspecified, the default encoding
+	// direction for each value type is used (see encoding.go:prettyPrintFirstValue).
+	SafeFormatKey func(w redact.SafeWriter, valDirs []encoding.Direction, key Key)
 
 	// PrettyPrintRange prints a key range in human readable format. It's
 	// implemented in package git.com/cockroachdb/cockroach/keys to avoid
@@ -127,13 +138,18 @@ func (rk RKey) PrefixEnd() RKey {
 	return RKey(keysbase.PrefixEnd(rk))
 }
 
+// SafeFormat - see Key.SafeFormat.
+func (rk RKey) SafeFormat(w redact.SafePrinter, r rune) {
+	rk.AsRawKey().SafeFormat(w, r)
+}
+
 func (rk RKey) String() string {
 	return Key(rk).String()
 }
 
-// StringWithDirs - see Key.String.WithDirs.
-func (rk RKey) StringWithDirs(valDirs []encoding.Direction, maxLen int) string {
-	return Key(rk).StringWithDirs(valDirs, maxLen)
+// StringWithDirs - see Key.StringWithDirs.
+func (rk RKey) StringWithDirs(valDirs []encoding.Direction) string {
+	return Key(rk).StringWithDirs(valDirs)
 }
 
 // Key is a custom type for a byte string in proto
@@ -198,28 +214,29 @@ func (k Key) Compare(b Key) int {
 	return bytes.Compare(k, b)
 }
 
+// SafeFormat implements the redact.SafeFormatter interface.
+func (k Key) SafeFormat(w redact.SafePrinter, _ rune) {
+	SafeFormatKey(w, nil /* valDirs */, k)
+}
+
 // String returns a string-formatted version of the key.
 func (k Key) String() string {
-	return k.StringWithDirs(nil /* valDirs */, 0 /* maxLen */)
+	return redact.StringWithoutMarkers(k)
 }
 
 // StringWithDirs is the value encoding direction-aware version of String.
 //
 // Args:
-// valDirs: The direction for the key's components, generally needed for correct
-// 	decoding. If nil, the values are pretty-printed with default encoding
-// 	direction.
-// maxLen: If not 0, only the first maxLen chars from the decoded key are
-//   returned, plus a "..." suffix.
-func (k Key) StringWithDirs(valDirs []encoding.Direction, maxLen int) string {
+//
+//	valDirs: The direction for the key's components, generally needed for
+//	correct decoding. If nil, the values are pretty-printed with default
+//	encoding direction.
+func (k Key) StringWithDirs(valDirs []encoding.Direction) string {
 	var s string
 	if PrettyPrintKey != nil {
 		s = PrettyPrintKey(valDirs, k)
 	} else {
 		s = fmt.Sprintf("%q", []byte(k))
-	}
-	if maxLen != 0 && len(s) > maxLen {
-		return s[0:maxLen] + "..."
 	}
 	return s
 }

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -94,12 +94,6 @@ func TestBatchRequestString(t *testing.T) {
 		act := ba.String()
 		require.Equal(t, exp, act)
 	}
-
-	{
-		exp := `Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›),... 76 skipped ..., Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), Get [‹/Min›,‹/Min›), EndTxn(abort) [‹/Min›], [txn: 6ba7b810], [wait-policy: Error], [can-forward-ts], [bounded-staleness, min_ts_bound: 0.000000001,0, min_ts_bound_strict, max_ts_bound: 0.000000002,0]`
-		act := redact.Sprint(ba)
-		require.EqualValues(t, exp, act)
-	}
 }
 
 func TestKeyString(t *testing.T) {

--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -70,7 +70,7 @@ func IndexKeyValDirs(index catalog.Index) []encoding.Direction {
 // currently true for the fields we care about stripping (the table and index
 // ID).
 func PrettyKey(valDirs []encoding.Direction, key roachpb.Key, skip int) string {
-	p := key.StringWithDirs(valDirs, 0 /* maxLen */)
+	p := key.StringWithDirs(valDirs)
 	for i := 0; i <= skip; i++ {
 		n := strings.IndexByte(p[1:], '/')
 		if n == -1 {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1852,6 +1852,9 @@ func PrettyPrintValue(valDirs []Direction, b []byte, sep string) string {
 	if allDecoded {
 		return s1
 	}
+	// If we failed to decoded everything above, assume the key was the result of a
+	// `PrefixEnd()`. Attempt to undo PrefixEnd & retry the process, otherwise return
+	// what we were able to decode.
 	if undoPrefixEnd, ok := UndoPrefixEnd(b); ok {
 		// When we UndoPrefixEnd, we may have lost a tail of 0xFFs. Try to add
 		// enough of them to get something decoded. This is best-effort, we have to stop
@@ -1870,6 +1873,66 @@ func PrettyPrintValue(valDirs []Direction, b []byte, sep string) string {
 	return s1
 }
 
+// PrettyPrintValuesWithTypes returns a slice containing each contiguous decodable value
+// in the provided byte slice along with a slice containing the type of each value.
+// The directions each value is encoded may be provided. If valDirs is nil,
+// all values are decoded and printed with the default direction (ascending).
+func PrettyPrintValuesWithTypes(valDirs []Direction, b []byte) (vals []string, types []Type) {
+	vals1, types1, allDecoded := prettyPrintValuesWithTypesImpl(valDirs, b)
+	if allDecoded {
+		return vals1, types1
+	}
+	// If we failed to decoded everything above, assume the key was the result of a
+	// `PrefixEnd()`. Attempt to undo PrefixEnd & retry the process, otherwise return
+	// what we were able to decode.
+	if undoPrefixEnd, ok := UndoPrefixEnd(b); ok {
+		// When we UndoPrefixEnd, we may have lost a tail of 0xFFs. Try to add
+		// enough of them to get something decoded. This is best-effort, we have to stop
+		// somewhere.
+		cap := 20
+		if len(valDirs) > len(b) {
+			cap = len(valDirs) - len(b)
+		}
+		for i := 0; i < cap; i++ {
+			if vals2, types2, allDecoded := prettyPrintValuesWithTypesImpl(valDirs, undoPrefixEnd); allDecoded {
+				vals2 = append(vals2, "PrefixEnd")
+				types2 = append(types2, Bytes)
+				return vals2, types2
+			}
+			undoPrefixEnd = append(undoPrefixEnd, 0xFF)
+		}
+	}
+	return vals1, types1
+}
+
+func prettyPrintValuesWithTypesImpl(
+	valDirs []Direction, b []byte,
+) (vals []string, types []Type, allDecoded bool) {
+	allDecoded = true
+	for len(b) > 0 {
+		var valDir Direction
+		if len(valDirs) > 0 {
+			valDir = valDirs[0]
+			valDirs = valDirs[1:]
+		}
+
+		bb, s, err := prettyPrintFirstValue(valDir, b)
+		if err != nil {
+			// If we fail to decode, mark as unknown and attempt
+			// to continue - it's possible we can still decode the
+			// remainder of the key bytes.
+			allDecoded = false
+			vals = append(vals, "???")
+			types = append(types, Unknown)
+		} else {
+			vals = append(vals, s)
+			types = append(types, PeekType(b))
+		}
+		b = bb
+	}
+	return vals, types, allDecoded
+}
+
 func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bool) {
 	allDecoded := true
 	var buf strings.Builder
@@ -1886,6 +1949,9 @@ func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bo
 
 		bb, s, err := prettyPrintFirstValue(valDir, b)
 		if err != nil {
+			// If we fail to decode, mark as unknown and attempt
+			// to continue - it's possible we can still decode the
+			// remainder of the key bytes.
 			allDecoded = false
 			buf.WriteString(sep)
 			buf.WriteByte('?')

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -133,7 +133,7 @@ outer:
 				Wrapped: errors.New("known key, but unsupported subtype"),
 			}
 		}
-		for _, v := range keys.ConstKeyDict {
+		for _, v := range keys.ConstKeyOverrides {
 			if strings.HasPrefix(input, v.Name) {
 				output = append(output, v.Value...)
 				input = input[len(v.Name):]


### PR DESCRIPTION
Backport 1/1 commits from #86813.

/cc @cockroachdb/release

---

Currently, when a key is logged, the entirety of the pretty-printed
key is redacted, hindering observability when parsing through redacted
logs (something that will become more common with upcoming compliance
requirements).

For example, prior to this patch, a pretty-printed key would appear
in the following way for the unredacted/redacted cases, respectively:

	- unredacted: ‹/Table/42/1222/"index key"›
	- redacted:   ‹x›

This patch addresses this by implementing the SafeFormatter interface
for `roachpb.Key` and `roachpb.RKey`, yielding the following result
when looking at the same example above:

	- unredacted: /Table/42/1222/‹"index key"›
	- redacted:   /Table/42/1222/‹x›

While the index key itself remains redacted, the ability to see the
specific table, index, and in the case of tenant tables, the tenant
itself, provides much better observability into which table & index
a log line is referring to than before.

Note that this implementation is only partial. It currently only
supports keys that fall in the `/Table` keyspace for application
tenants and system tenants. Keyspaces such as Meta1, Meta2, Local,
etc. are not yet supported, but can be added with much more ease
in the future now that the example has been set.

Finally, we remove the `maxLen` and related truncation logic from
`StringWithDirs`, as this is no longer used. Furthermore, the
truncation was invalid as it could have truncated a utf-8
sequence in the wrong place, making the result invalid utf-8.

This PR is a continuation of the work originally done by @kzh in
https://github.com/cockroachdb/cockroach/pull/67065. See the original PR for some initial discussions. 

Release note (security update): redacted logs will now reveal
pretty-printed keys, except for the index key values themselves.
For example `/Table/42/1222/‹x›` will be shown instead of `‹x›`
(which was shown previously). This improved redaction is available
for the `/Table` keyspace for both system and application tenants.
Other keyspaces such as `/Meta1`, `/Meta2`, `/Local`, etc. are not
yet supported.

Release justification: low risk, high benefit observability changes

Addresses https://github.com/cockroachdb/cockroach/issues/86316
