### PR TITLE
build: fix Pebble nightly metamoprhic test

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_impl.sh
@@ -18,7 +18,7 @@ exit_status=0
 # NB: If adjusting the metamorphic test flags below, be sure to also update
 # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
 # correct flags in the reproduction command.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=ci test \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_timeout=25200 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \


### PR DESCRIPTION
The Pebble nightly metamorphic tests have been failing, presumably due to stricter parsing of command-line parameters in bazci.

Release note: None