### PR TITLE
ui: change the unkown insight to the proper slow execution

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -108,7 +108,7 @@ const highContentionInsight = (
   let threshold = latencyThreshold + "ms";
   if (!latencyThreshold) {
     threshold =
-      "the value of the sql.insights.latency_threshold cluster setting";
+      "the value of the 'sql.insights.latency_threshold' cluster setting";
   }
   const description = `This ${execType} has been waiting on other ${execType}s to execute for longer than ${threshold}.`;
   return {
@@ -120,8 +120,16 @@ const highContentionInsight = (
   };
 };
 
-const slowExecutionInsight = (execType: InsightExecEnum): Insight => {
-  const description = `Unable to identify a specific cause for this ${execType}.`;
+const slowExecutionInsight = (
+  execType: InsightExecEnum,
+  latencyThreshold: number,
+): Insight => {
+  let threshold = latencyThreshold + "ms";
+  if (!latencyThreshold) {
+    threshold =
+      "the value of the 'sql.insights.latency_threshold' cluster setting";
+  }
+  const description = `This ${execType} took longer than ${threshold} to execute.`;
   return {
     name: InsightNameEnum.slowExecution,
     label: "Slow Execution",
@@ -160,8 +168,7 @@ const suboptimalPlanInsight = (execType: InsightExecEnum): Insight => {
 
 const highRetryCountInsight = (execType: InsightExecEnum): Insight => {
   const description =
-    `This ${execType} was slow because of being retried multiple times, again due ` +
-    `to contention. The "high" threshold may be configured by the ` +
+    `This ${execType} has being retried more times than the value of the ` +
     `'sql.insights.high_retry_count.threshold' cluster setting.`;
   return {
     name: InsightNameEnum.highRetryCount,
@@ -204,7 +211,7 @@ export const getInsightFromProblem = (
     case InsightNameEnum.highRetryCount:
       return highRetryCountInsight(execOption);
     default:
-      return slowExecutionInsight(execOption);
+      return slowExecutionInsight(execOption, latencyThreshold);
   }
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -234,7 +234,7 @@ export function insightType(type: InsightType): string {
     case "FailedExecution":
       return "Failed Execution";
     default:
-      return "Insight";
+      return "Slow Execution";
   }
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetails.tsx
@@ -123,6 +123,10 @@ export class StatementInsightDetails extends React.Component<StatementInsightDet
           default:
             rec = {
               type: "Unknown",
+              details: {
+                duration: insightDetails.elapsedTimeMillis,
+                description: insight.description,
+              },
             };
             break;
         }

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.module.scss
@@ -18,6 +18,9 @@
   .table-link {
     color: $colors--link
   }
+  a {
+    color: $colors--link
+  }
 }
 
 .margin-bottom {

--- a/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insightsTable/insightsTable.tsx
@@ -15,7 +15,12 @@ import classNames from "classnames/bind";
 import styles from "./insightsTable.module.scss";
 import { StatementLink } from "../statementsTable";
 import IdxRecAction from "../insights/indexActionBtn";
-import { Duration, statementsRetries } from "../util";
+import {
+  clusterSettings,
+  Duration,
+  performanceBestPractices,
+  statementsRetries,
+} from "../util";
 import { Anchor } from "../anchor";
 import { Link } from "react-router-dom";
 import { performanceTuningRecipes } from "../util";
@@ -71,6 +76,15 @@ function typeCell(value: string): React.ReactElement {
 function descriptionCell(
   insightRec: InsightRecommendation,
 ): React.ReactElement {
+  const clusterSettingsLink = (
+    <>
+      {"This threshold can be configured in "}
+      <Anchor href={clusterSettings} target="_blank">
+        cluster settings
+      </Anchor>
+      {"."}
+    </>
+  );
   switch (insightRec.type) {
     case "CreateIndex":
     case "ReplaceIndex":
@@ -129,7 +143,7 @@ function descriptionCell(
           </div>
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Description: </span>{" "}
-            {insightRec.details.description}
+            {insightRec.details.description} {clusterSettingsLink}
           </div>
         </>
       );
@@ -142,7 +156,7 @@ function descriptionCell(
           </div>
           <div className={cx("description-item")}>
             <span className={cx("label-bold")}>Description: </span>{" "}
-            {insightRec.details.description}
+            {insightRec.details.description} {clusterSettingsLink}
             {" Learn more about "}
             <Anchor href={statementsRetries} target="_blank">
               retries
@@ -186,7 +200,19 @@ function descriptionCell(
       return (
         <>
           <div className={cx("description-item")}>
-            Unable to identify specific reasons why this execution was slow.
+            <span className={cx("label-bold")}>Elapsed Time: </span>
+            {Duration(insightRec.details.duration * 1e6)}
+          </div>
+          <div className={cx("description-item")}>
+            <span className={cx("label-bold")}>Description: </span>{" "}
+            {insightRec.details.description} {clusterSettingsLink}
+          </div>
+          <div className={cx("description-item")}>
+            {"Learn about "}
+            <Anchor href={performanceBestPractices} target="_blank">
+              SQL performance best practices
+            </Anchor>
+            {" to optimize slow queries."}
           </div>
         </>
       );

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -82,12 +82,16 @@ export const nodeLivenessIssues = docsURL(
 export const howItWork = docsURL("cockroach-quit.html#how-it-works");
 export const clusterStore = docsURL("cockroach-start.html#store");
 export const clusterGlossary = docsURL("architecture/overview.html#glossary");
+export const clusterSettings = docsURL("cluster-settings");
 export const reviewOfCockroachTerminology = docsURL(
   "ui-replication-dashboard.html#review-of-cockroachdb-terminology",
 );
 export const sessionsTable = docsURL("ui-sessions-page.html");
 export const tableStatsClusterSetting = docsURL(
   "cost-based-optimizer.html#control-automatic-statistics",
+);
+export const performanceBestPractices = docsURL(
+  "performance-best-practices-overview",
 );
 // Note that these explicitly don't use the current version, since we want to
 // link to the most up-to-date documentation available.


### PR DESCRIPTION
Previously, when we didn't have a reason to why the statement was slow, we were showing a message about unable to identify the problem.
Since we do know it was slow, this commit changes it to the proper message about the statement being slow. This commit also adds a link to cluster settings
documentation to all insights that are dependent on a cluster setting.
The value for the cluster setting is being added
in another issue: #86760

Fixes #87740

Before
<img width="648" alt="Screen Shot 2022-09-09 at 7 16 59 PM" src="https://user-images.githubusercontent.com/1017486/189457730-1fa05dbb-a928-4dad-beec-b15cb5a0a381.png">


After
<img width="1301" alt="Screen Shot 2022-09-11 at 8 58 24 AM" src="https://user-images.githubusercontent.com/1017486/189529424-e4e49093-81ed-4ba2-9616-56a24dc7150e.png">

Release note (ui change): Improve message when there is no insight problem detected. Now we show the statement was slow and how long it took.