### PR TITLE
ui: add copy feature on idx recommendation

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.module.scss
@@ -3,4 +3,15 @@
 .alert-area {
   margin-top: 10px;
   margin-left: -5px;
+
+  .copy-icon {
+    fill: $colors--neutral-0;
+  }
+}
+
+.bottom-corner {
+  align: right;
+  margin-bottom: 0px;
+  float: right;
+  margin-top: -5px;
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -9,6 +9,10 @@
 // licenses/APL.txt.
 
 import React, { useCallback, useState } from "react";
+import copy from "copy-to-clipboard";
+import { message, Icon } from "antd";
+import "antd/lib/message/style";
+import "antd/lib/icon/style";
 import { Modal } from "../modal";
 import { Text, TextTypes } from "../text";
 import { Button } from "../button";
@@ -57,6 +61,7 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
         }
         if (!foundError) {
           setVisible(false);
+          message.success("Recommendation applied");
         }
       },
     );
@@ -68,6 +73,11 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
   };
 
   const onCancelHandler = useCallback(() => setVisible(false), []);
+  const onCopyClick = () => {
+    copy(query);
+    message.success("Copied to clipboard");
+  };
+
   let title = "Update index";
   let btnLAbel = "Update Index";
   let descriptionDocs = <></>;
@@ -153,6 +163,16 @@ const IdxRecAction = (props: idxRecProps): React.ReactElement => {
         </Text>
         <Text textType={TextTypes.Code} className={"code-area"}>
           {query}
+          <br />
+          <Button
+            type={"unstyled-link"}
+            size={"small"}
+            className={cx("bottom-corner")}
+            icon={<Icon type="copy" className={cx("copy-icon")} />}
+            onClick={onCopyClick}
+          >
+            Copy
+          </Button>
         </Text>
         <InlineAlert
           intent="warning"

--- a/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/text/text.module.scss
@@ -47,5 +47,6 @@
   display: block;
   margin-top: 20px;
   margin-left: -5px;
-  padding: 5px;
+  padding: 10px;
+  padding-bottom: 30px;
 }


### PR DESCRIPTION
This commit adds the ability to copy the
index recommendation from the UI, so the user
can run on cli with a user that have the proper
permissions.
This commit also adds a confirmation message
when the recommendation is applied.

Fixes #87743

<img width="591" alt="Screen Shot 2022-09-09 at 8 12 25 PM" src="https://user-images.githubusercontent.com/1017486/189461026-8df064d5-44cf-4c4e-9925-bb99fff3235e.png">

https://www.loom.com/share/f6e70feb2d334b24b78ee8ec8d8a10c3

Release note (ui change): Add ability to copy
the index recommendation to clipboard.