### PR TITLE
changefeedccl: mark kv senderrors retryable

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/sql",

--- a/pkg/ccl/changefeedccl/changefeedbase/errors.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/errors.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/joberror"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
@@ -108,14 +109,22 @@ func IsRetryableError(err error) bool {
 		return true
 	}
 
+	// During node shutdown it is possible for all outgoing transports used by
+	// the kvfeed to expire, producing a SendError that the node is still able
+	// to propagate to the frontier. This has been known to happen during
+	// cluster upgrades. This scenario should not fail the changefeed.
+	if kvcoord.IsSendError(err) {
+		return true
+	}
+
 	// TODO(knz): this is a bad implementation. Make it go away
 	// by avoiding string comparisons.
 
+	// If a RetryableError occurs on a remote node, DistSQL serializes it such
+	// that we can't recover the structure and we have to rely on this
+	// unfortunate string comparison.
 	errStr := err.Error()
-	if strings.Contains(errStr, retryableErrorString) {
-		// If a RetryableError occurs on a remote node, DistSQL serializes it such
-		// that we can't recover the structure and we have to rely on this
-		// unfortunate string comparison.
+	if strings.Contains(errStr, retryableErrorString) || strings.Contains(errStr, kvcoord.SendErrorString) {
 		return true
 	}
 

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -494,12 +494,6 @@ func (f *kvFeed) runUntilTableEvent(
 		return nil
 	} else if tErr := (*errEndTimeReached)(nil); errors.As(err, &tErr) {
 		return err
-	} else if kvcoord.IsSendError(err) {
-		// During node shutdown it is possible for all outgoing transports used by
-		// the kvfeed to expire, producing a SendError that the node is still able
-		// to propagate to the frontier. This has been known to happen during
-		// cluster upgrades. This scenario should not fail the changefeed.
-		return changefeedbase.MarkRetryableError(err)
 	} else {
 		return err
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2388,8 +2388,12 @@ func TestNewSendError(msg string) error {
 	return newSendError(msg)
 }
 
+// SendErrorString is the prefix for all sendErrors, exported in order to
+// perform cross-node error-checks.
+const SendErrorString = "failed to send RPC"
+
 func (s sendError) Error() string {
-	return "failed to send RPC: " + s.message
+	return SendErrorString + ": " + s.message
 }
 
 // IsSendError returns true if err is a sendError.


### PR DESCRIPTION
Resolves #87300

Changefeeds can encounter senderrors during a normal upgrade procedure and therefore should retry.  This was done in the kvfeed however is apparently not high level enough as a send error was still observed to cause a permanent failure.

This PR moves the senderror checking to the top level IsRetryable check to handle it regardless of its source.

Release justification: low risk important bug fix

Release note (bug fix): Changefeeds will now never permanently error on a "failed to send RPC" error.