### PR TITLE
backupccl: avoid RESTORE failure in face of transaction restart

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1559,6 +1559,10 @@ type BackupRestoreTestingKnobs struct {
 	// span has been exported.
 	RunAfterExportingSpanEntry func(ctx context.Context, response *roachpb.ExportResponse)
 
+	// RunAfterMovingSystemTables runs after we process any conflicting system
+	// tables during a cluster RESTORE.
+	RunAfterMovingSystemTables func(ctx context.Context, txn *kv.Txn, db *kv.DB)
+
 	// BackupMonitor is used to overwrite the monitor used by backup during
 	// testing. This is typically the bulk mem monitor if not
 	// specified here.


### PR DESCRIPTION
Previously, if the transaction running cluster restore planning hit a restart, the restore would fail with:

    failed to move conflicting system table: copy-to-temp-table:
    relation "system.crdb_internal_copy_tenant_settings" does not
    exist

In 22.1, the internal executor does not correctly manage descriptor collections. As a result, uncommitted objects are only visible to subsequent operations because of a fallback that exists in the descriptor lease code. Namely, when a name isn't found, it is looked up from KV.

https://github.com/cockroachdb/cockroach/blob/04a8d58408be7bad414ffa1a6804367e3ac87709/pkg/sql/catalog/descs/descriptor.go#L334

However, the KV lookup code also maintains a cache for system tables, under the assumption that they do not change.

https://github.com/cockroachdb/cockroach/blob/04a8d58408be7bad414ffa1a6804367e3ac87709/pkg/sql/catalog/descs/kv_descriptors.go#L35-L37

https://github.com/cockroachdb/cockroach/blob/04a8d58408be7bad414ffa1a6804367e3ac87709/pkg/sql/catalog/descs/kv_descriptors.go#L143-L159

Thus, when first run, the ID for crdb_internal_copy_tenant_settings is cached.

When the planning transaction restarts, we look for conflicts again. Now, while our previous attempt to move the table was successful, we likely still find a conflict.  We find a conflict because the `DROP TABLE` DDL statement did not remove the descriptor. Rather, it put it in a drop state. The code that finds all system table descriptors does not filter dropped tables and thus we still find a conflict. (Also note that in 22.1 the internal executor does not correctly create the schema change job for the DROP TABLE statement, so it is unlikely that the descriptor was ever going to fully removed).

When we attempt to process this conflict again, we create a new crdb_internal_copy_tenant_settings table. This works because we create this table directly through KV and do not depend on name to ID resolution.

Now, when we go to run the INSERT statement, we lookup the table by name. That lookup will fail to find the name in the descriptor collection's leased data, but it _will_ find it in the cache maintained by the KV lookup code. The ID it finds is the ID for what is now the tenant_settings table. The name resolution code notices this name mismatch, filters this result, and produces the above error.

https://github.com/cockroachdb/cockroach/blob/04a8d58408be7bad414ffa1a6804367e3ac87709/pkg/sql/catalog/descs/kv_descriptors.go#L208-L217

This PR makes a small change that seems to improve our chances of succeeding.

First, we move the drop of the old system table to use direct KV interactions. This "fixes" the issue because on retry we no longer find a conflict as the old system table's descriptor is completely removed rather than sitting in a dropped state.

I've also changed the INSERT to not use names at all to avoid that particular code from generating cache entries, but a cache entry is still created in the RENAME code.

One may ask whether it is a problem that there might be a cached entry in the KV lookup code for the system table's name pointing at the old ID. I believe there likely is. I defer to schema about what to do about this. While most lookups I observed hit the lease data, anything using LookupSystemTableID will likely go through the cached KV data. However, right now it appears the only thing using that function is the tenant settings watcher, which was likely started before the table is moved, so it already is following the wrong span.

Release note (bug fix): Fixes a bug that would result in a failed cluster restore.

Release justification: Critical bug fix.