### PR TITLE
scheduledlogging: various fixes to index stat collection

### DIFF
--- a/pkg/sql/scheduledlogging/BUILD.bazel
+++ b/pkg/sql/scheduledlogging/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -180,25 +180,24 @@ func captureIndexUsageStats(
 			continue
 		}
 		stmt := fmt.Sprintf(`
-		SELECT
-		 ti.descriptor_name as table_name,
-		 ti.descriptor_id as table_id,
-		 ti.index_name,
-		 ti.index_id,
-		 ti.index_type,
-		 ti.is_unique,
-		 ti.is_inverted,
-		 total_reads,
-		 last_read,
-		 ti.created_at,
-     t.schema_name
-	  FROM %[1]s.crdb_internal.index_usage_statistics AS us
+  SELECT ti.descriptor_name as table_name,
+         ti.descriptor_id as table_id,
+         ti.index_name,
+         ti.index_id,
+         ti.index_type,
+         ti.is_unique,
+         ti.is_inverted,
+         total_reads,
+         last_read,
+         ti.created_at,
+         t.schema_name
+    FROM %[1]s.crdb_internal.index_usage_statistics us
     JOIN %[1]s.crdb_internal.table_indexes ti
-		ON us.index_id = ti.index_id
-		 AND us.table_id = ti.descriptor_id
-    JOIN %[1]s.crdb_internal.tables t 
-    ON ti.descriptor_id = t.table_id
-		ORDER BY total_reads ASC;`,
+      ON us.index_id = ti.index_id
+     AND us.table_id = ti.descriptor_id
+    JOIN %[1]s.crdb_internal.tables t
+      ON ti.descriptor_id = t.table_id
+ORDER BY total_reads ASC;`,
 			databaseName.String())
 
 		it, err := ie.QueryIteratorEx(

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -138,13 +138,23 @@ func Start(
 func (s *CaptureIndexUsageStatsLoggingScheduler) start(ctx context.Context, stopper *stop.Stopper) {
 	_ = stopper.RunAsyncTask(ctx, "capture-index-usage-stats", func(ctx context.Context) {
 		// Start the scheduler immediately.
-		for timer := time.NewTimer(0 * time.Second); ; timer.Reset(s.durationUntilNextInterval()) {
+		timer := time.NewTimer(0 * time.Second)
+		defer timer.Stop()
+
+		for {
 			select {
 			case <-stopper.ShouldQuiesce():
-				timer.Stop()
 				return
 			case <-timer.C:
 				s.currentCaptureStartTime = timeutil.Now()
+				dur := s.durationUntilNextInterval()
+				if dur < time.Second {
+					// Avoid intervals that are too short, to prevent a hot
+					// spot on this task.
+					dur = time.Second
+				}
+				timer.Reset(dur)
+
 				if !telemetryCaptureIndexUsageStatsEnabled.Get(&s.st.SV) {
 					continue
 				}
@@ -275,13 +285,12 @@ ORDER BY total_reads ASC;`,
 func logIndexUsageStatsWithDelay(
 	ctx context.Context, events []logpb.EventPayload, stopper *stop.Stopper, delay time.Duration,
 ) {
-
 	// Log the first event immediately.
 	timer := time.NewTimer(0 * time.Second)
+	defer timer.Stop()
 	for len(events) > 0 {
 		select {
 		case <-stopper.ShouldQuiesce():
-			timer.Stop()
 			return
 		case <-timer.C:
 			event := events[0]
@@ -291,7 +300,6 @@ func logIndexUsageStatsWithDelay(
 			timer.Reset(delay)
 		}
 	}
-	timer.Stop()
 }
 
 func getAllDatabaseNames(ctx context.Context, ie sqlutil.InternalExecutor) (tree.NameList, error) {

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -39,7 +39,7 @@ var telemetryCaptureIndexUsageStatsEnabled = settings.RegisterBoolSetting(
 )
 
 var telemetryCaptureIndexUsageStatsInterval = settings.RegisterDurationSetting(
-	settings.SystemOnly,
+	settings.TenantReadOnly,
 	"sql.telemetry.capture_index_usage_stats.interval",
 	"the scheduled interval time between capturing index usage statistics when capturing index usage statistics is enabled",
 	8*time.Hour,
@@ -47,7 +47,7 @@ var telemetryCaptureIndexUsageStatsInterval = settings.RegisterDurationSetting(
 )
 
 var telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval = settings.RegisterDurationSetting(
-	settings.SystemOnly,
+	settings.TenantReadOnly,
 	"sql.telemetry.capture_index_usage_stats.check_enabled_interval",
 	"the scheduled interval time between checks to see if index usage statistics has been enabled",
 	10*time.Minute,
@@ -55,7 +55,7 @@ var telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval = settings.Registe
 )
 
 var telemetryCaptureIndexUsageStatsLoggingDelay = settings.RegisterDurationSetting(
-	settings.SystemOnly,
+	settings.TenantReadOnly,
 	"sql.telemetry.capture_index_usage_stats.logging_delay",
 	"the time delay between emitting individual index usage stats logs, this is done to "+
 		"mitigate the log-line limit of 10 logs per second on the telemetry pipeline",

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -252,12 +252,10 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 			previousTimestamp = currentTimestamp
 		}
 
-		nanoSecondDiff := currentTimestamp - previousTimestamp
-		// We allow for integer division to remove any miscellaneous nanosecond
-		// delay from the logging.
-		secondDiff := nanoSecondDiff / 1e9
-		actualDuration := time.Duration(secondDiff) * time.Second
-		require.Equal(t, expectedDuration, actualDuration)
+		actualDuration := time.Duration(currentTimestamp-previousTimestamp) * time.Nanosecond
+		// Use a time window to afford some non-determinisim in the test.
+		require.Greater(t, expectedDuration, actualDuration-time.Second)
+		require.Greater(t, actualDuration+time.Second, expectedDuration)
 		previousTimestamp = currentTimestamp
 	}
 }

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -12,6 +12,7 @@ package scheduledlogging
 
 import (
 	"context"
+	"encoding/json"
 	"math"
 	"regexp"
 	"sort"
@@ -117,23 +118,39 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	db.Exec(t, "CREATE DATABASE test2")
 
 	// Test fix for #85577.
-	db.Exec(t, `CREATE DATABASE "test-hyphen"`)
+	db.Exec(t, `CREATE DATABASE "mIxEd-CaSe""woo☃"`)
+	db.Exec(t, `CREATE DATABASE "index"`)
 
 	// Create a table for each database.
 	db.Exec(t, "CREATE TABLE test.test_table (num INT PRIMARY KEY, letter char)")
 	db.Exec(t, "CREATE TABLE test2.test2_table (num INT PRIMARY KEY, letter char)")
+	db.Exec(t, `CREATE TABLE "mIxEd-CaSe""woo☃"."sPe-CiAl✔" (num INT PRIMARY KEY, "HeLlO☀" char)`)
+	db.Exec(t, `CREATE TABLE "index"."index" (num INT PRIMARY KEY, "index" char)`)
 
 	// Create an index on each created table (each table now has two indices:
 	// primary and this one)
-	db.Exec(t, "CREATE INDEX ON test.test_table (letter)")
-	db.Exec(t, "CREATE INDEX ON test2.test2_table (letter)")
+	db.Exec(t, `CREATE INDEX ON test.test_table (letter)`)
+	db.Exec(t, `CREATE INDEX ON test2.test2_table (letter)`)
+	db.Exec(t, `CREATE INDEX "IdX✏" ON "mIxEd-CaSe""woo☃"."sPe-CiAl✔" ("HeLlO☀")`)
+	db.Exec(t, `CREATE INDEX "index" ON "index"."index" ("index")`)
+
+	expectedIndexNames := []string{
+		"test2_table_letter_idx",
+		"test2_table_pkey",
+		"test_table_letter_idx",
+		"test_table_pkey",
+		"sPe-CiAl✔_pkey",
+		"IdX✏",
+		"index",
+		"index_pkey",
+	}
 
 	// Check that telemetry log file contains all the entries we're expecting, at the scheduled intervals.
 
 	// Enable capture of index usage stats.
 	telemetryCaptureIndexUsageStatsEnabled.Override(context.Background(), &s.ClusterSettings().SV, true)
 
-	expectedTotalNumEntriesInSingleInterval := 4
+	expectedTotalNumEntriesInSingleInterval := 8
 	expectedNumberOfIndividualIndexEntriesInSingleInterval := 1
 
 	// Expect index usage statistics logs once the schedule disabled interval has passed.
@@ -141,6 +158,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
 		return checkNumTotalEntriesAndNumIndexEntries(t,
+			expectedIndexNames,
 			expectedTotalNumEntriesInSingleInterval,
 			expectedNumberOfIndividualIndexEntriesInSingleInterval,
 		)
@@ -163,6 +181,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
 		return checkNumTotalEntriesAndNumIndexEntries(t,
+			expectedIndexNames,
 			expectedTotalNumEntriesAfterTwoIntervals,
 			expectedNumberOfIndividualIndexEntriesAfterTwoIntervals,
 		)
@@ -180,6 +199,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
 		return checkNumTotalEntriesAndNumIndexEntries(t,
+			expectedIndexNames,
 			expectedTotalNumEntriesAfterThreeIntervals,
 			expectedNumberOfIndividualIndexEntriesAfterThreeIntervals,
 		)
@@ -247,7 +267,10 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 // log entries for each index. Also checks that each log entry contains a node_id
 // field, used to filter node-duplicate logs downstream.
 func checkNumTotalEntriesAndNumIndexEntries(
-	t *testing.T, expectedTotalEntries int, expectedIndividualIndexEntries int,
+	t *testing.T,
+	expectedIndexNames []string,
+	expectedTotalEntries int,
+	expectedIndividualIndexEntries int,
 ) error {
 	// Fetch log entries.
 	entries, err := log.FetchEntriesFromFiles(
@@ -257,7 +280,6 @@ func checkNumTotalEntriesAndNumIndexEntries(
 		regexp.MustCompile(`"EventType":"captured_index_usage_stats"`),
 		log.WithMarkedSensitiveData,
 	)
-
 	if err != nil {
 		return err
 	}
@@ -267,46 +289,43 @@ func checkNumTotalEntriesAndNumIndexEntries(
 		return errors.Newf("expected %d total entries, got %d", expectedTotalEntries, len(entries))
 	}
 
-	var (
-		numEntriesForTestTablePrimaryKeyIndex  int
-		numEntriesForTestTableLetterIndex      int
-		numEntriesForTest2TablePrimaryKeyIndex int
-		numEntriesForTest2TableLetterIndex     int
-	)
+	countByIndex := make(map[string]int)
 
 	for _, e := range entries {
 		t.Logf("checking entry: %v", e)
-		if strings.Contains(e.Message, `"IndexName":"test_table_pkey"`) {
-			numEntriesForTestTablePrimaryKeyIndex++
-		}
-		if strings.Contains(e.Message, `"IndexName":"test_table_letter_idx"`) {
-			numEntriesForTestTableLetterIndex++
-		}
-		if strings.Contains(e.Message, `"IndexName":"test2_table_pkey"`) {
-			numEntriesForTest2TablePrimaryKeyIndex++
-		}
-		if strings.Contains(e.Message, `"IndexName":"test2_table_letter_idx"`) {
-			numEntriesForTest2TableLetterIndex++
-		}
 		// Check that the entry has a tag for a node ID of 1.
 		if !strings.Contains(e.Tags, `n1`) {
-			return errors.Newf("expected the entry's tags to include n1, but include got %s", e.Tags)
+			t.Fatalf("expected the entry's tags to include n1, but include got %s", e.Tags)
+		}
+
+		var s struct {
+			IndexName string `json:"IndexName"`
+		}
+		err := json.Unmarshal([]byte(e.Message), &s)
+		if err != nil {
+			t.Fatal(err)
+		}
+		countByIndex[s.IndexName] = countByIndex[s.IndexName] + 1
+	}
+
+	t.Logf("found index counts: %+v", countByIndex)
+
+	if expected, actual := expectedTotalEntries/expectedIndividualIndexEntries, len(countByIndex); actual != expected {
+		return errors.Newf("expected %d indexes, got %d", expected, actual)
+	}
+
+	for idxName, c := range countByIndex {
+		if c != expectedIndividualIndexEntries {
+			return errors.Newf("for index %s: expected entry count %d, got %d",
+				idxName, expectedIndividualIndexEntries, c)
 		}
 	}
 
-	// Assert that we have the correct number index usage statistic entries for
-	// each index we created across the tables in each database.
-	if expectedIndividualIndexEntries != numEntriesForTestTablePrimaryKeyIndex {
-		return errors.Newf("expected %d test_table primary key index entries, got %d", expectedIndividualIndexEntries, numEntriesForTestTablePrimaryKeyIndex)
+	for _, idxName := range expectedIndexNames {
+		if _, ok := countByIndex[idxName]; !ok {
+			return errors.Newf("no entry found for index %s", idxName)
+		}
 	}
-	if expectedIndividualIndexEntries != numEntriesForTestTableLetterIndex {
-		return errors.Newf("expected %d test_table letter index entries, got %d", expectedIndividualIndexEntries, numEntriesForTestTableLetterIndex)
-	}
-	if expectedIndividualIndexEntries != numEntriesForTest2TablePrimaryKeyIndex {
-		return errors.Newf("expected %d test2_table primary key index entries, got %d", expectedIndividualIndexEntries, numEntriesForTest2TablePrimaryKeyIndex)
-	}
-	if expectedIndividualIndexEntries != numEntriesForTest2TableLetterIndex {
-		return errors.Newf("expected %d test2_table letter index entries, got %d", expectedIndividualIndexEntries, numEntriesForTest2TableLetterIndex)
-	}
+
 	return nil
 }

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -65,6 +66,9 @@ func (s *stubDurations) getOverlapDuration() time.Duration {
 
 func TestCaptureIndexUsageStats(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+
+	skip.UnderShort(t, "#87772")
+
 	sc := log.ScopeWithoutShowLogs(t)
 	defer sc.Close(t)
 

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -140,7 +140,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// Assert that we have the expected number of total logs and expected number
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
-		return checkNumTotalEntriesAndNumIndexEntries(
+		return checkNumTotalEntriesAndNumIndexEntries(t,
 			expectedTotalNumEntriesInSingleInterval,
 			expectedNumberOfIndividualIndexEntriesInSingleInterval,
 		)
@@ -162,7 +162,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// Assert that we have the expected number of total logs and expected number
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
-		return checkNumTotalEntriesAndNumIndexEntries(
+		return checkNumTotalEntriesAndNumIndexEntries(t,
 			expectedTotalNumEntriesAfterTwoIntervals,
 			expectedNumberOfIndividualIndexEntriesAfterTwoIntervals,
 		)
@@ -179,7 +179,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	// Assert that we have the expected number of total logs and expected number
 	// of logs for each index.
 	testutils.SucceedsWithin(t, func() error {
-		return checkNumTotalEntriesAndNumIndexEntries(
+		return checkNumTotalEntriesAndNumIndexEntries(t,
 			expectedTotalNumEntriesAfterThreeIntervals,
 			expectedNumberOfIndividualIndexEntriesAfterThreeIntervals,
 		)
@@ -247,7 +247,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 // log entries for each index. Also checks that each log entry contains a node_id
 // field, used to filter node-duplicate logs downstream.
 func checkNumTotalEntriesAndNumIndexEntries(
-	expectedTotalEntries int, expectedIndividualIndexEntries int,
+	t *testing.T, expectedTotalEntries int, expectedIndividualIndexEntries int,
 ) error {
 	// Fetch log entries.
 	entries, err := log.FetchEntriesFromFiles(
@@ -275,6 +275,7 @@ func checkNumTotalEntriesAndNumIndexEntries(
 	)
 
 	for _, e := range entries {
+		t.Logf("checking entry: %v", e)
 		if strings.Contains(e.Message, `"IndexName":"test_table_pkey"`) {
 			numEntriesForTestTablePrimaryKeyIndex++
 		}


### PR DESCRIPTION
As I was reviewing #87525, I noticed that the actual test cases were missing.
Then, as I tried to fix that, I discovered a couple of other shortcomings. This PR fixes them.

Fixes #87771.
Informs #87772.

