### PR TITLE
ui: fix crash when there is no text

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/util/format.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/format.ts
@@ -212,7 +212,7 @@ export function Count(count: number): string {
 
 // limitText returns a shortened form of text that surpasses a given limit
 export const limitText = (text: string, limit: number): string => {
-  return text.length > limit ? text.slice(0, limit - 3).concat("...") : text;
+  return text?.length > limit ? text.slice(0, limit - 3).concat("...") : text;
 };
 
 // limitStringArray returns a shortened form of text that surpasses a given limit


### PR DESCRIPTION
Previously, when there was no text, the function
to limit the size of text would crash.
This commits adds a check to see if the text exists before trying to truncate it.

Partially addresses #87757

Release note (bug fix): ui no longer crashes when there is no text being passed to the limit text function.