### PR TITLE
ui: add transaction exec id to blocking stmts table

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/execContentionTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/execContentionTable.tsx
@@ -25,7 +25,7 @@ const getID = (item: ContendedExecution, execType: ExecutionType) =>
 export function makeContentionColumns(
   execType: ExecutionType,
 ): ColumnDescriptor<ContendedExecution>[] {
-  return [
+  const columns: ColumnDescriptor<ContendedExecution | null>[] = [
     {
       name: "executionID",
       title: executionsTableTitles.executionID(execType),
@@ -51,6 +51,19 @@ export function makeContentionColumns(
       ),
       sort: item => item.query,
     },
+    execType === "statement"
+      ? {
+          name: "transactionID",
+          title: executionsTableTitles.executionID("transaction"),
+          cell: item => (
+            <Link to={`/execution/transaction/${item.transactionExecutionID}`}>
+              {item.transactionExecutionID}
+            </Link>
+          ),
+          sort: item => item.transactionExecutionID,
+          alwaysShow: true,
+        }
+      : null,
     {
       name: "status",
       title: executionsTableTitles.status(execType),
@@ -75,6 +88,7 @@ export function makeContentionColumns(
       sort: item => item.contentionTime.asSeconds(),
     },
   ];
+  return columns.filter(col => col);
 }
 
 interface ContentionTableProps {


### PR DESCRIPTION
Follow up to #87793

Previously, if an active statement was blocked, we would show the statement it was blocked by in a table in the form of the statement execution id and sql query. Since it is possible for the txn a stmt is blocked by to not be currently executing a query, these columns could be blank and it was not possible to figure out which txn was blocking the stmt. This commit adds the Transaction Execution ID column for the blocked statements table in the active statement details view so that we can link to the blocking txn even when there is no stmt being executed by the blocking txn..

Release note (ui change): transaction execution id column now exists in the blocked statements table in the active stmt details page


<img width="972" alt="image" src="https://user-images.githubusercontent.com/20136951/189532799-a92752a1-dc50-4906-af21-c1010b2ff09f.png">
