### PR TITLE
cdc: add WITH unordered SELECT cdc_set_key

### DIFF
--- a/pkg/ccl/changefeedccl/avro.go
+++ b/pkg/ccl/changefeedccl/avro.go
@@ -826,7 +826,7 @@ func (r *avroDataRecord) nativeFromRow(it cdcevent.Iterator) (interface{}, error
 	if err := it.Datum(func(d tree.Datum, col cdcevent.ResultColumn) (err error) {
 		fieldIdx, ok := r.fieldIdxByName[col.Name]
 		if !ok {
-			return errors.AssertionFailedf("could not find avro field for column %s", col.Name)
+			return errors.AssertionFailedf("could not find avro field for column %s in avro record %+v", col.Name, r)
 		}
 		r.native[col.Name], err = r.Fields[fieldIdx].encodeFn(d)
 		return err

--- a/pkg/ccl/changefeedccl/cdceval/functions.go
+++ b/pkg/ccl/changefeedccl/cdceval/functions.go
@@ -85,6 +85,23 @@ var cdcFunctions = map[string]*tree.ResolvedFunctionDefinition{
 			return rowEvalCtx.updatedRow.SchemaTS
 		},
 	),
+	"cdc_set_key": makeCDCBuiltIn(
+		"cdc_set_key",
+		tree.Overload{
+			Types:      tree.VariadicType{VarType: types.Any},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				var datums []tree.Datum
+				rowEvalContext := rowEvalContextFromEvalContext(evalCtx)
+				for _, arg := range args {
+					datums = append(datums, arg)
+				}
+				rowEvalContext.updatedRow.SetCustomKeyDatums(datums)
+				return tree.DBoolTrue, nil
+			},
+			Info:       "Changes the partition key from the primary key to the input. Always returns true so it can be used in a WHERE clause.",
+			Volatility: volatility.Stable,
+		}),
 	"cdc_prev": makeCDCBuiltIn(
 		"cdc_prev",
 		tree.Overload{

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -426,6 +426,7 @@ func createChangefeedJobRecord(
 		if needDiff {
 			opts.ForceDiff()
 		}
+
 		// TODO: Set the default envelope to row here when using a sink and format
 		// that support it.
 		details.Select = cdceval.AsStringUnredacted(normalized.Clause())
@@ -440,6 +441,17 @@ func createChangefeedJobRecord(
 		if schemachangeOptions.Policy != changefeedbase.OptSchemaChangePolicyStop {
 			return nil, errors.Errorf(`using "AS SELECT" requires option schema_change_policy='stop'`)
 		}
+
+		setsPartitionKey, err := cdceval.CallsFunction(ctx, *p.SemaCtx(), normalized, "cdc_set_key")
+		if err != nil {
+			return nil, err
+		}
+		if setsPartitionKey && !opts.IsSet(changefeedbase.OptUnordered) {
+			return nil, errors.Newf("Use of custom keys means the overall ordering of a row history is no longer guaranteed "+
+				"and therefore requires the WITH %s option.", changefeedbase.OptUnordered,
+			)
+		}
+
 	}
 
 	// TODO(dan): In an attempt to present the most helpful error message to the

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -94,6 +94,7 @@ const (
 	OptWebhookClientTimeout     = `webhook_client_timeout`
 	OptOnError                  = `on_error`
 	OptMetricsScope             = `metrics_label`
+	OptUnordered                = `unordered`
 	OptVirtualColumns           = `virtual_columns`
 
 	OptVirtualColumnsOmitted VirtualColumnVisibility = `omitted`
@@ -312,6 +313,7 @@ var ChangefeedOptionExpectValues = map[string]OptionPermittedValues{
 	OptWebhookClientTimeout:     durationOption,
 	OptOnError:                  enum("pause", "fail"),
 	OptMetricsScope:             stringOption,
+	OptUnordered:                flagOption,
 	OptVirtualColumns:           enum("omitted", "null"),
 }
 
@@ -324,7 +326,7 @@ var CommonOptions = makeStringSet(OptCursor, OptEndTime, OptEnvelope,
 	OptSchemaChangeEvents, OptSchemaChangePolicy,
 	OptProtectDataFromGCOnPause, OptOnError,
 	OptInitialScan, OptNoInitialScan, OptInitialScanOnly,
-	OptMinCheckpointFrequency, OptMetricsScope, OptVirtualColumns, Topics)
+	OptMinCheckpointFrequency, OptMetricsScope, OptUnordered, OptVirtualColumns, Topics)
 
 // SQLValidOptions is options exclusive to SQL sink
 var SQLValidOptions map[string]struct{} = nil


### PR DESCRIPTION
This commit allows a cdc expression to override the default meaning of "key" in changefeed messages.
By default it's the primary key tuple.
If cdc_set_key is invoked, instead the key is a tuple of its arguments. This matters for sinks and encodings where the key is part of the metadata or part of partitioning logic. With most usage,
there can no longer be any end-to-end ordering guarantee, as we're only ordered with respect to the primary key. We therefore require WITH unordered.

Release note (sql change): Changefeed expressions can now set custom partition keys using the following syntax: CREATE CHANGEFEED [INTO ...] WITH unordered[, other options] AS SELECT a,b,c FROM users WHERE cdc_set_key(c,b)

Co-authored-by: Suraj <suraj.rao@cockroachlabs.com>