### PR TITLE
release-22.1: changefeedccl: mark kv senderrors retryable

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
+        "//pkg/kv/kvclient/kvcoord",
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/sql",

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -427,13 +427,6 @@ func (f *kvFeed) runUntilTableEvent(
 		return tErr.Timestamp().Prev(), nil
 	} else if tErr := (*errEndTimeReached)(nil); errors.As(err, &tErr) {
 		return tErr.endTime.Prev(), err
-	} else if kvcoord.IsSendError(err) {
-		// During node shutdown it is possible for all outgoing transports used by
-		// the kvfeed to expire, producing a SendError that the node is still able
-		// to propagate to the frontier. This has been known to happen during
-		// cluster upgrades. This scenario should not fail the changefeed.
-		err = changefeedbase.MarkRetryableError(err)
-		return hlc.Timestamp{}, err
 	} else {
 		return hlc.Timestamp{}, err
 	}

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2351,8 +2351,12 @@ func TestNewSendError(msg string) error {
 	return newSendError(msg)
 }
 
+// SendErrorString is the prefix for all sendErrors, exported in order to
+// perform cross-node error-checks.
+const SendErrorString = "failed to send RPC"
+
 func (s sendError) Error() string {
-	return "failed to send RPC: " + s.message
+	return SendErrorString + ": " + s.message
 }
 
 // IsSendError returns true if err is a sendError.


### PR DESCRIPTION
Backport 1/1 commits from #87763

/cc @cockroachdb/release 

---

Resolves #87300

Changefeeds can encounter senderrors during a normal upgrade procedure and therefore should retry.  This was done in the kvfeed however is apparently not high level enough as a send error was still observed to cause a permanent failure.

This PR moves the senderror checking to the top level IsRetryable check to handle it regardless of its source.

Release justification: low risk important bug fix

Release note (bug fix): Changefeeds will now never permanently error on a "failed to send RPC" error.

---

Release justification: low risk important bug fix