### PR TITLE
norm: do not fold floor division with unit denominator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/float
+++ b/pkg/sql/logictest/testdata/logic_test/float
@@ -174,3 +174,17 @@ query BB
 SELECT 'nan'::decimal IS NAN, 'nan'::decimal IS NOT NAN
 ----
 true  false
+
+statement ok
+CREATE TABLE t87605 (col2 FLOAT8 NULL)
+
+statement ok
+insert into t87605 values (1.234567890123456e+13), (1.234567890123456e+6)
+
+# Regression test for issue #87605.
+# The floor division operator `//` should not be folded away.
+query F
+SELECT ((col2::FLOAT8 // 1.0:::FLOAT8::FLOAT8)::FLOAT8) FROM t87605@[0] ORDER BY 1
+----
+1.234567e+06
+1.2345678901234e+13

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -70,6 +70,12 @@ func (c *CustomFuncs) IsJSON(scalar opt.ScalarExpr) bool {
 	return scalar.DataType().Family() == types.JsonFamily
 }
 
+// IsInt returns true if the given scalar expression is of one of the
+// integer types.
+func (c *CustomFuncs) IsInt(scalar opt.ScalarExpr) bool {
+	return scalar.DataType().Family() == types.IntFamily
+}
+
 // BoolType returns the boolean SQL type.
 func (c *CustomFuncs) BoolType() *types.T {
 	return types.Bool

--- a/pkg/sql/opt/norm/rules/numeric.opt
+++ b/pkg/sql/opt/norm/rules/numeric.opt
@@ -44,7 +44,13 @@
 
 # FoldDivOne folds $left / 1 for numeric types.
 [FoldDivOne, Normalize]
-(Div | FloorDiv $left:* $right:(Const 1))
+(Div $left:* $right:(Const 1))
+=>
+(Cast $left (BinaryType (OpName) $left $right))
+
+# FoldFloorDivOne folds $left // 1 for integer types.
+[FoldFloorDivOne, Normalize]
+(FloorDiv $left:* $right:(Const 1) & (IsInt $left))
 =>
 (Cast $left (BinaryType (OpName) $left $right))
 

--- a/pkg/sql/opt/norm/testdata/rules/fold_constants
+++ b/pkg/sql/opt/norm/testdata/rules/fold_constants
@@ -441,6 +441,27 @@ values
  ├── fd: ()-->(1)
  └── (NULL,)
 
+# Regression test for issue #87605.
+norm expect=FoldBinary
+SELECT 1.333 // 1.0
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (1,)
+
+norm expect=FoldBinary
+SELECT 2::INT // 1.0
+----
+values
+ ├── columns: "?column?":1!null
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── (2,)
+
 # --------------------------------------------------
 # FoldUnary
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/numeric
+++ b/pkg/sql/opt/norm/testdata/rules/numeric
@@ -189,6 +189,30 @@ project
       └── i:2::DECIMAL [as="?column?":8, outer=(2), immutable]
 
 # --------------------------------------------------
+# FoldFloorDivOne
+# --------------------------------------------------
+
+# Regression test for issue #87605.
+# The floor division operator `//` should only be folded when the numerator is
+# an integer.
+norm expect=FoldFloorDivOne
+SELECT
+    a.i // 1 AS r,
+    a.f // 1 AS s,
+    a.d // 1 AS t
+FROM a
+----
+project
+ ├── columns: r:8 s:9 t:10
+ ├── immutable
+ ├── scan a
+ │    └── columns: i:2 f:3 d:4
+ └── projections
+      ├── i:2 [as=r:8, outer=(2)]
+      ├── f:3 // 1.0 [as=s:9, outer=(3), immutable]
+      └── d:4 // 1 [as=t:10, outer=(4), immutable]
+
+# --------------------------------------------------
 # InvertMinus
 # --------------------------------------------------
 norm expect=InvertMinus


### PR DESCRIPTION
Fixes #87605

The floor division operator `//` is like division but drops the
fractional portion of the result. Normalization rule FoldDivOne
rewrites `(column // 1)` as `(column)` which is incorrect if the
data in `column` has fractional digits, as those digits should be
dropped.

The solution is to only fold `(column // 1)` when `column` is one of
the integer types.

Release note (bug fix): This patch fixes incorrect results from
the floor division operator, `//`, when the numerator is non-constant
and the denominator is the constant 1.