### PR TITLE
kvnemesis: support non-transactional DeleteRange

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -295,11 +295,14 @@ func applyBatchOp(
 		}
 	}
 	runErr := runFn(ctx, b)
-	if runErr == nil && !inTxn {
-		o.Txn = syntheticTxnAtTime(b.RawResponse().Timestamp)
-	}
 
 	o.Result = resultError(ctx, runErr)
+	if runErr == nil && !inTxn {
+		o.SynTxn = syntheticTxnAtTime(b.RawResponse().Timestamp)
+	} else {
+		_ = runErr
+	}
+
 	for i := range o.Ops {
 		switch subO := o.Ops[i].GetValue().(type) {
 		case *GetOperation:

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -232,7 +232,7 @@ func applyClientOp(ctx context.Context, db clientI, op *Operation, inTxn bool) {
 				// to be have like a transactional one that used the 1PC optimization.
 				// Use the timestamp at which the command wrote (and read) to set up
 				// a transaction and which will be used to verify the history.
-				o.Txn = syntheticTxnAtTime(b.RawResponse().Timestamp)
+				o.SynTxn = syntheticTxnAtTime(b.RawResponse().Timestamp)
 			}
 			o.Result.Type = ResultType_Keys
 			for _, deletedKey := range b.RawResponse().Responses[0].GetDeleteRange().Keys {

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -13,7 +13,6 @@ package kvnemesis
 import (
 	"context"
 	gosql "database/sql"
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -64,12 +63,6 @@ func TestApplier(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
 	}
 
-	checkPanics := func(t *testing.T, s Step, expectedPanic string) {
-		t.Helper()
-		_ /* trace */, err := a.Apply(ctx, &s)
-		require.EqualError(t, err, fmt.Sprintf("panic applying step %s: %v", s, expectedPanic))
-	}
-
 	// Basic operations
 	check(t, step(get(`a`)), `db0.Get(ctx, "a") // (nil, nil)`)
 	check(t, step(scan(`a`, `c`)), `db1.Scan(ctx, "a", "c", 0) // ([], nil)`)
@@ -118,8 +111,15 @@ db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 }) // context canceled
 		`)
 
-	checkPanics(t, step(delRange(`b`, `d`)), `non-transactional DelRange operations currently unsupported`)
-	checkPanics(t, step(batch(delRange(`b`, `d`))), `non-transactional batch DelRange operations currently unsupported`)
+	check(t, step(delRange(`b`, `d`)), `
+db1.DelRange(ctx, "b", "d", true) // ([], nil)`)
+	check(t, step(batch(delRange(`b`, `d`))), `
+{
+  b := &Batch{}
+  b.DelRange(ctx, "b", "d", true) // ([], nil)
+  db0.Run(ctx, b) // nil
+}
+`)
 
 	// Batch
 	check(t, step(batch(put(`b`, `2`), get(`a`), del(`b`), del(`c`), scan(`a`, `c`), reverseScanForUpdate(`a`, `e`))), `

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -227,8 +227,7 @@ func newAllOperationsConfig() GeneratorConfig {
 // operations/make some operations more likely.
 func NewDefaultConfig() GeneratorConfig {
 	config := newAllOperationsConfig()
-	// TODO(sarkesian): Enable non-transactional DelRange once #69642 is fixed.
-	config.Ops.DB.DeleteRange = 0
+	config.Ops.DB.DeleteRange = 1
 	config.Ops.Batch.Ops.DeleteRange = 0
 	// TODO(sarkesian): Enable DeleteRange in comingled batches once #71236 is fixed.
 	config.Ops.ClosureTxn.CommitBatchOps.DeleteRange = 0

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -67,6 +67,7 @@ message DeleteRangeOperation {
   bytes key = 1;
   bytes end_key = 2;
   Result result = 3 [(gogoproto.nullable) = false];
+  roachpb.Transaction txn = 4;
 }
 
 message SplitOperation {

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -21,7 +21,7 @@ import "util/hlc/timestamp.proto";
 message BatchOperation {
   repeated Operation ops = 1 [(gogoproto.nullable) = false];
   Result result = 2 [(gogoproto.nullable) = false];
-  roachpb.Transaction txn = 3;
+  roachpb.Transaction syn_txn = 3;
 }
 
 enum ClosureTxnType {

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -21,6 +21,7 @@ import "util/hlc/timestamp.proto";
 message BatchOperation {
   repeated Operation ops = 1 [(gogoproto.nullable) = false];
   Result result = 2 [(gogoproto.nullable) = false];
+  roachpb.Transaction txn = 3;
 }
 
 enum ClosureTxnType {

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -68,7 +68,7 @@ message DeleteRangeOperation {
   bytes key = 1;
   bytes end_key = 2;
   Result result = 3 [(gogoproto.nullable) = false];
-  roachpb.Transaction txn = 4;
+  roachpb.Transaction syn_txn = 4;
 }
 
 message SplitOperation {

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -553,11 +553,8 @@ func (v *validator) processOp(txnID *string, op Operation) {
 					break
 				}
 				maybeSynTxn = t.SynTxn
-				s := t.SynTxn.String()
+				s := t.SynTxn.ID.String()
 				txnID = &s
-			}
-			for _, op := range t.Ops {
-				v.processOp(txnID, op)
 			}
 			if maybeSynTxn != nil {
 				v.checkAtomic(`batch`, t.Result, maybeSynTxn, t.Ops...)

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -388,9 +388,9 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		// the *non-transactional* case.
 		//
 		// [^1]: see applyClientOp.
-		var optTxn *roachpb.Transaction
+		var maybeSynTxn *roachpb.Transaction
 		if txnID == nil {
-			optTxn = t.Txn
+			maybeSynTxn = t.Txn
 			s := t.Txn.ID.String()
 			txnID = &s
 		}
@@ -422,11 +422,11 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		}
 		v.observedOpsByTxn[*txnID] = append(v.observedOpsByTxn[*txnID], scan)
 		v.observedOpsByTxn[*txnID] = append(v.observedOpsByTxn[*txnID], deleteOps...)
-		if optTxn != nil {
-			// If this is a non-txn'al DeleteRange, in which case optTxn is a
+		if maybeSynTxn != nil {
+			// If this is a non-txn'al DeleteRange, in which case maybeSynTxn is a
 			// *synthetic txn*, verify that txn now. (Otherwise, verification happens
 			// for the surrounding ClosureTxnOperation).
-			v.checkAtomic(`deleterange`, t.Result, optTxn, op)
+			v.checkAtomic(`deleterange`, t.Result, maybeSynTxn, op)
 		}
 	case *ScanOperation:
 		v.failIfError(op, t.Result)

--- a/pkg/kv/kvnemesis/validator.go
+++ b/pkg/kv/kvnemesis/validator.go
@@ -541,11 +541,14 @@ func (v *validator) processOp(txnID *string, op Operation) {
 		if !resultIsRetryable(t.Result) {
 			v.failIfError(op, t.Result)
 			if txnID == nil {
-				v.checkAtomic(`batch`, t.Result, nil, t.Ops...)
-			} else {
-				for _, op := range t.Ops {
-					v.processOp(txnID, op)
-				}
+				s := t.Txn.String()
+				txnID = &s
+			}
+			for _, op := range t.Ops {
+				v.processOp(txnID, op)
+			}
+			if t.Txn != nil {
+				v.checkAtomic(`batch`, t.Result, t.Txn, t.Ops...)
 			}
 		}
 	case *ClosureTxnOperation:


### PR DESCRIPTION
Deletions are tricky for `kvnemesis`. Broadly speaking, kvnemesis relies
on a rangefeed emitting the mutations of the KV layer in timestamp
order, and, by using unique values, can identify each emitted update
with the transaction that wrote it and thus its timestamp. It then uses
this property to ensure that for each operation there exists at least
one timestamp at which all of its reads and writes were valid.

Unfortunately by their very nature, deletions do not write a value; a
tombstone describes the `nil` value. `kvnemesis` thus resorts to the
other piece of information: the timestamp at which the key was deleted.
Assuming it knows at which timestamp each delete operation executed, it
can match up tombstones by key and timestamp.

Unfortunately, at present, the timestamp of a non-transactional Delete
operation is not known to `kvnemesis`, and so the verification is
weakened to check only the cardinality of tombstones seen for the
affected key[^1].

DeleteRange adds one layer of complexity: the need to discover the
keys that are being deleted. The ReturnKeys option makes this possible,
however it returns only the keys, not the, at the time, topmost value.
During validation, DeleteRange is modeled as a specialized scan
(observing only values with a non-nil topmost version) followed
by point deletions on the keys thus detected.

TODO: need to verbalize why exactly it wasn't possible to do with
DeleteRange what was hitherto done with Delete.

... and thus DeleteRange was only supported inside of a transaction.

This commit experiments with an improvement to how `DeleteRange` is
handled that allows it to be used outside of a transaction. The
approach is simple: tell kvnemesis at which timestamp the DeleteRange
executed; this can be read off the `BatchResponse` header. From that
point on, a synthetic transaction proto can be instantiated at that
write timestamp and the validation of the DeleteRange continues as
though it had been in a proper transaction.

A similar approach is possible for `Delete` and `BatchOperation`.

It also stands to reason that we should fundamentally rethink how
kvnemesis works. It is reasonable to use the execution timestamp
for all operations including read-only transactions. Operations can
thus be sorted; operations at the same timestamp must be non-overlapping
(and can be asserted as such)[^2], and we don't have to construct valid
read intervals any more. Instead, we just have to verify that the
observations of and updates at each timestamp are congruent with the
history observed via the rangefeed.

[^1]: and the author doesn't understand exactly what this ends up still
verifying and how exactly it works.
[^2]: can a read-only transaction end up chosing the same timestamp and
see the results of a read-write txn? Or does the uncertainty interval
reliably prevent this?

----

Unfortunately this fails within a minute under [^1] and I still have to
dig into that. Most often with something like:

```
        scan result not ordered correctly: [w]/Table/100/"80a792bb":missing->v-13 [s]/Table/100/"{21e3c66c"-78adf507"}:{0:[1662984388.287933000,0, <max>), gap:[<min>, 1662984388.132968000,0),[1662984388.135950000,0, 1662984388.159811000,0),[1662984388.290777000,0, 1662984388.298606000,2),[1662984388.298606000,2, <max>),[1662984388.159811000,0, 1662984388.287933000,0),[1662984388.287933000,0, 1662984388.290777000,0)}->[/Table/100/"2c19295b":v-12] [dr.s]/Table/100/"{6a68d8b6"-cc4ffffa"}:{0:[1662984388.725803000,0, <max>),[1662984388.174947000,0, 1662984388.179752000,0), 1:[1662984388.134425000,0, <max>), 2:[1662984388.179752000,0, <max>), 3:[1662984388.725803000,0, <max>),[1662984388.174947000,0, 1662984388.179752000,0), 4:[1662984388.298606000,2, <max>), 5:[1662984388.134425000,0, <max>), 6:[1662984388.179752000,0, <max>), gap:[<min>, 1662984388.286995000,0),[1662984388.286995000,0, <max>)}->[/Table/100/"80a792bb", /Table/100/"c03b580c", /Table/100/"c8ea142a", /Table/100/"80a792bb", /Table/100/"92e040d4", /Table/100/"c03b580c", /Table/100/"c8ea142a"] [dr.d]/Table/100/"80a792bb":missing-><nil> [dr.d]/Table/100/"c03b580c":missing-><nil> [dr.d]/Table/100/"c8ea142a":missing-><nil> [dr.d]/Table/100/"80a792bb":1662984388.725803000,0-><nil> [dr.d]/Table/100/"92e040d4":1662984388.725803000,0-><nil> [dr.d]/Table/100/"c03b580c":1662984388.725803000,0-><nil> [dr.d]/Table/100/"c8ea142a":1662984388.725803000,0-><nil>
```

and occasionally (can provoke it by disabling the previous check):

```
    kvnemesis_test.go:68: failure:
        committed txn missing write: [dr.s]/Table/100/"{31253ae2"-a9a5cb30"}:{0:[1662984535.430129000,1, 1662984535.440445000,1), 1:[1662984535.430129000,1, 1662984535.440445000,1),[1662984535.295556000,0, 1662984535.300234000,0), gap:[<min>, 1662984535.291653000,0),[1662984535.294438000,0, 1662984535.298365000,0),[1662984535.298365000,0, 1662984535.440445000,1),[1662984535.440445000,1, <max>)}->[/Table/100/"6b13ee3d", /Table/100/"9452a455"] [dr.d]/Table/100/"6b13ee3d":missing-><nil> [dr.d]/Table/100/"9452a455":missing-><nil> [rs]/Table/100/"{131e3dd2"-2446f663"}:{0:[1662984535.302494000,0, <max>), gap:[<min>, <max>)}->[/Table/100/"14836c8e":v-6] [rs]/Table/100/"{463547d0"-dc31edd0"}:{gap:[<min>, 1662984535.291653000,0),[<min>, 1662984535.291653000,0),[1662984535.294438000,0, 1662984535.295556000,0),[1662984535.294438000,0, 1662984535.298365000,0),[<min>, 1662984535.291653000,0),[<min>, 1662984535.291653000,0),[1662984535.294438000,0, 1662984535.295556000,0),[1662984535.294438000,0, 1662984535.298365000,0),[1662984535.298365000,0, 1662984535.299767000,0),[1662984535.298365000,0, 1662984535.440445000,1),[1662984535.440445000,1, <max>),[1662984535.300234000,0, 1662984535.430129000,1),[1662984535.299767000,0, 1662984535.430129000,1),[1662984535.300234000,0, 1662984535.430129000,1)}->[] [w]/Table/100/"8acf86b1":1662984535.544835000,0->v-3
```

[^1] `./dev test --stress --filter TestKVNemesisSingleNode ./pkg/kv/kvnemesis/`

Fixes https://github.com/cockroachdb/cockroach/issues/69642.

Release note: None