### PR TITLE
scgraph: make searching dep edges more efficient

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/scgraph/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/BUILD.bazel
@@ -5,6 +5,7 @@ load("//build:STRINGER.bzl", "stringer")
 go_library(
     name = "scgraph",
     srcs = [
+        "dep_edge_alloc.go",
         "dep_edge_tree.go",
         "edge.go",
         "graph.go",

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/dep_edge_alloc.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/dep_edge_alloc.go
@@ -1,0 +1,69 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package scgraph
+
+// depEdgeAlloc is used to amortize allocation of DepEdge objects.
+type depEdgeAlloc struct {
+	// a is the currently unfilled slice of DepEdges. Calls to new will extend
+	// this slice until it reaches its capacity. When the capacity is reached,
+	// a new slice will be allocated. In this way, we amortize the cost of
+	// allocating new objects, and we avoid ever copying the allocated objects.
+	a []DepEdge
+}
+
+// minCap and maxCap are used to control the dynamic allocation size for
+// blocks of allocations.
+const minCap, maxCap = 1 << 6 /* 64 */, 1 << 14 /* 16384 */
+
+// new constructs a new DepEdge.
+func (a *depEdgeAlloc) new(de DepEdge) *DepEdge {
+	if a.a == nil {
+		a.a = make([]DepEdge, 0, minCap)
+	} else if len(a.a) == cap(a.a) {
+		newCap := 2 * cap(a.a)
+		if newCap > maxCap {
+			newCap = maxCap
+		}
+		a.a = make([]DepEdge, 0, newCap)
+	}
+	idx := len(a.a)
+	a.a = append(a.a, de)
+	return &a.a[idx]
+}
+
+// depEdgeTreeEntryAlloc is used to amortize allocation of depEdgeTreeEntry
+// values.
+type depEdgeTreeEntryAlloc struct {
+	// a is the currently unfilled slice of depEdgeTreeEntry objects. Calls to
+	// new will extend this slice until it reaches its capacity. When the
+	// capacity is reached, a new slice will be allocated. In this way, we
+	// amortize the cost of allocating new objects, and we avoid ever copying
+	// the allocated objects.
+	a []depEdgeTreeEntry
+}
+
+// new constructs a new depEdgeTreeEntry.
+func (a *depEdgeTreeEntryAlloc) new(k edgeKey, order edgeTreeOrder, de *DepEdge) *depEdgeTreeEntry {
+	if a.a == nil {
+		a.a = make([]depEdgeTreeEntry, 0, minCap)
+	} else if len(a.a) == cap(a.a) {
+		newCap := 2 * cap(a.a)
+		if newCap > maxCap {
+			newCap = maxCap
+		}
+		a.a = make([]depEdgeTreeEntry, 0, newCap)
+	}
+	idx := len(a.a)
+	a.a = append(a.a, depEdgeTreeEntry{
+		edgeKey: k, order: order, kind: edge, edge: de,
+	})
+	return &a.a[idx]
+}

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/dep_edge_tree.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/dep_edge_tree.go
@@ -11,100 +11,250 @@
 package scgraph
 
 import (
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
+	"github.com/cockroachdb/errors"
 	"github.com/google/btree"
 )
-
-type depEdgeTree struct {
-	t     *btree.BTree
-	order edgeTreeOrder
-	cmp   nodeCmpFn
-}
-
-type nodeCmpFn func(a, b *screl.Node) (less, eq bool)
-
-func newDepEdgeTree(order edgeTreeOrder, cmp nodeCmpFn) *depEdgeTree {
-	const degree = 8 // arbitrary
-	return &depEdgeTree{
-		t:     btree.New(degree),
-		order: order,
-		cmp:   cmp,
-	}
-}
 
 // edgeTreeOrder order in which the edge tree is sorted,
 // either based on from/to node indexes.
 type edgeTreeOrder bool
-
-func (o edgeTreeOrder) first(e Edge) *screl.Node {
-	if o == fromTo {
-		return e.From()
-	}
-	return e.To()
-}
-
-func (o edgeTreeOrder) second(e Edge) *screl.Node {
-	if o == toFrom {
-		return e.From()
-	}
-	return e.To()
-}
 
 const (
 	fromTo edgeTreeOrder = true
 	toFrom edgeTreeOrder = false
 )
 
-// edgeTreeEntry BTree items for tracking edges
-// in an ordered manner.
-type edgeTreeEntry struct {
-	t    *depEdgeTree
-	edge *DepEdge
+// getTargetIdxFunc is used to get the location of the node in the graph.
+type getTargetIdxFunc = func(n *screl.Node) targetIdx
+
+// depEdges is a data structure to store the set of depEdges. It offers
+// in-order traversal of edges from or to any node in the graph.
+type depEdges struct {
+	fromTo *btree.BTree
+	toFrom *btree.BTree
+
+	getTargetIdx getTargetIdxFunc
+	edgeAlloc    depEdgeAlloc
+	entryAlloc   depEdgeTreeEntryAlloc
 }
 
-func (et *depEdgeTree) insert(e *DepEdge) {
-	et.t.ReplaceOrInsert(&edgeTreeEntry{
-		t:    et,
-		edge: e,
+// makeDepEdges constructs the depEdge structure.
+func makeDepEdges(getTargetIdx getTargetIdxFunc) depEdges {
+	const degree = 32 // arbitrary
+	return depEdges{
+		fromTo:       btree.New(degree),
+		toFrom:       btree.New(degree),
+		getTargetIdx: getTargetIdx,
+	}
+}
+
+// insertOrUpdate will insert a new dep edge if no such edge exists between
+// from and to. Otherwise, it will update the edge accordingly. An error
+// may be returned if the kind is incompatible with the existing kind for
+// the edge. For example, one cannot have a rule which indicates
+// PreviousStagePrecedence and also SameStagePrecedence; that would be
+// impossible to fulfill. Precedence is compatible with other kind of
+// edge, but other kinds of edges are not compatible with each other.
+func (et *depEdges) insertOrUpdate(rule Rule, kind DepEdgeKind, from, to *screl.Node) error {
+	k := makeEdgeKey(et.getTargetIdx, from, to)
+	if got, ok := et.get(k); ok {
+		return updateExistingDepEdge(rule, kind, got)
+	}
+	de := et.edgeAlloc.new(DepEdge{
+		kind:  kind,
+		from:  from,
+		to:    to,
+		rules: []Rule{rule},
 	})
+	et.fromTo.ReplaceOrInsert(et.entryAlloc.new(k, fromTo, de))
+	et.toFrom.ReplaceOrInsert(et.entryAlloc.new(k, toFrom, de))
+	return nil
 }
 
-func (et *depEdgeTree) get(e *DepEdge) *DepEdge {
-	got, ok := et.t.Get(&edgeTreeEntry{
-		t:    et,
-		edge: e,
-	}).(*edgeTreeEntry)
-	if !ok {
-		return nil
-	}
-	return got.edge
-}
-
-func (et *depEdgeTree) iterateSourceNode(n *screl.Node, it DepEdgeIterator) (err error) {
-	e := &edgeTreeEntry{t: et, edge: &DepEdge{}}
-	if et.order == fromTo {
-		e.edge.from = n
-	} else {
-		e.edge.to = n
-	}
-	et.t.AscendGreaterOrEqual(e, func(i btree.Item) (wantMore bool) {
-		e := i.(*edgeTreeEntry)
-		if et.order.first(e.edge) != n {
-			return false
+// updateExistingDepEdge is called from insertOrUpdate when there already
+// exists an edge in the graph between the two nodes. The logic asserts that
+// the rule kinds are compatible, and adds the rule to the list of rules that
+// this edge represents.
+//
+// TODO(ajwerner): PreviousTransactionPrecedence could be seen as compatible
+// with PreviousStagePrecedence.
+func updateExistingDepEdge(rule Rule, kind DepEdgeKind, got *DepEdge) error {
+	if got.kind != kind && kind != Precedence {
+		if got.kind != Precedence {
+			return errors.AssertionFailedf(
+				"inconsistent dep edge kinds: %s rule %q conflicts with %s",
+				rule.Kind, rule.Name, got,
+			)
 		}
-		err = it(e.edge)
+		got.kind = kind
+	}
+	got.rules = append(got.rules, rule)
+	return nil
+}
+
+// iterateFromNode iterates the set of edges from the passed node.
+func (et *depEdges) iterateFromNode(n *screl.Node, it DepEdgeIterator) (err error) {
+	return iterateDepEdges(
+		fromTo, et.fromTo, et.getTargetIdx(n), n.CurrentStatus, it,
+	)
+}
+
+// iterateFromNode iterates the set of edges to the passed node.
+func (et *depEdges) iterateToNode(n *screl.Node, it DepEdgeIterator) (err error) {
+	return iterateDepEdges(
+		toFrom, et.toFrom, et.getTargetIdx(n), n.CurrentStatus, it,
+	)
+}
+
+// iterateDepEdges iterates the dependency edges in the tree t in the requested
+// order such that all edges visit match the requested target and status for
+// the "first" entry in that order. If the order is fromTo, all edges from the
+// (target, status) node will be visited, and if the order is toFrom, then all
+// edges to that (target, status) node will be visited.
+func iterateDepEdges(
+	order edgeTreeOrder, t *btree.BTree, target targetIdx, status scpb.Status, it DepEdgeIterator,
+) (err error) {
+	var idx int
+	if order == toFrom {
+		idx = 1
+	}
+	var qk edgeKey
+	qk.targets[idx] = target
+	qk.statuses[idx] = uint8(status)
+	k1, k2 := getDepEdgeTreeEntry(), getDepEdgeTreeEntry()
+	defer putDepEdgeTreeEntry(k1)
+	defer putDepEdgeTreeEntry(k2)
+	*k1 = depEdgeTreeEntry{edgeKey: qk, order: order, kind: queryStart}
+	*k2 = depEdgeTreeEntry{edgeKey: qk, order: order, kind: queryEnd}
+	t.AscendRange(k1, k2, func(i btree.Item) (wantMore bool) {
+		err = it(i.(*depEdgeTreeEntry).edge)
 		return err == nil
 	})
 	return iterutil.Map(err)
 }
 
-// Less implements btree.Item.
-func (e *edgeTreeEntry) Less(otherItem btree.Item) bool {
-	o := otherItem.(*edgeTreeEntry)
-	if less, eq := e.t.cmp(e.t.order.first(e.edge), e.t.order.first(o.edge)); !eq {
-		return less
+// iterates iterates all edges.
+func (et *depEdges) iterate(it DepEdgeIterator) (err error) {
+	et.fromTo.Ascend(func(i btree.Item) bool {
+		err = it(i.(*depEdgeTreeEntry).edge)
+		return err == nil
+	})
+	return iterutil.Map(err)
+}
+
+// get looks up a dep edge with an edgeKey.
+func (et *depEdges) get(k edgeKey) (*DepEdge, bool) {
+	qk := getDepEdgeTreeEntry()
+	defer putDepEdgeTreeEntry(qk)
+	*qk = depEdgeTreeEntry{edgeKey: k, order: fromTo}
+	if got := et.fromTo.Get(qk); got != nil {
+		return got.(*depEdgeTreeEntry).edge, true
 	}
-	less, _ := e.t.cmp(e.t.order.second(e.edge), e.t.order.second(o.edge))
+	return nil, false
+}
+
+// edgeKeyOrdinal corresponds to the ordinal in the arrays of edgeKey.
+type edgeKeyOrdinal uint8
+
+const (
+	// fromOrdinal is used for the array entries corresponding to the from node.
+	fromOrdinal edgeKeyOrdinal = 0
+	// toOrdinal is used for the array entries corresponding to the to node.
+	toOrdinal edgeKeyOrdinal = 1
+
+	numEdgeKeyOrdinals int = 2
+)
+
+// edgeKey stores two node identities in a packed structure which uses
+// only two words. It also places the statuses at the end so that when
+// embedded in depEdgeTreeEntry, only 4 words in total are used.
+type edgeKey struct {
+	targets  [numEdgeKeyOrdinals]targetIdx
+	statuses [numEdgeKeyOrdinals]uint8
+}
+
+// makeEdgeKey constructs an edgeKey for two nodes.
+func makeEdgeKey(getTargetIdx getTargetIdxFunc, from, to *screl.Node) edgeKey {
+	return edgeKey{
+		targets: [numEdgeKeyOrdinals]targetIdx{
+			fromOrdinal: getTargetIdx(from),
+			toOrdinal:   getTargetIdx(to)},
+		statuses: [numEdgeKeyOrdinals]uint8{
+			fromOrdinal: uint8(from.CurrentStatus),
+			toOrdinal:   uint8(to.CurrentStatus),
+		},
+	}
+}
+
+// depEdgeTreeEntryKind is an entry in one of the two depEdges trees.
+// The order indicates the tree this entry is a member of, and how to
+// perform comparisons with other entries. The kind field is used to
+// determine how to order the entry in the case of queries. The edge
+// points to the value of the corresponding edge.
+type depEdgeTreeEntry struct {
+	edgeKey
+	order edgeTreeOrder
+	kind  depEdgeTreeEntryKind
+	edge  *DepEdge
+}
+
+// depEdgeTreeEntryKind indicates whether the entry corresponds to an edge,
+// a key start value or a query end value.
+type depEdgeTreeEntryKind uint8
+
+const (
+	edge depEdgeTreeEntryKind = iota
+	queryStart
+	queryEnd
+)
+
+func (ek *depEdgeTreeEntry) Less(other btree.Item) bool {
+	o := other.(*depEdgeTreeEntry)
+	less, eq := cmpEdgeTreeEntry(ek, o, true /* first */)
+	if eq {
+		less, _ = cmpEdgeTreeEntry(ek, o, false /* first */)
+	}
 	return less
+}
+
+func cmpEdgeTreeEntry(a, b *depEdgeTreeEntry, first bool) (less, eq bool) {
+	var ord edgeKeyOrdinal
+	if a.order == fromTo && first || a.order == toFrom && !first {
+		ord = fromOrdinal
+	} else {
+		ord = toOrdinal
+	}
+	if ta, tb := a.targets[ord], b.targets[ord]; ta != tb {
+		return ta < tb, false
+	}
+	if sa, sb := a.statuses[ord], b.statuses[ord]; sa != sb {
+		return sa < sb, false
+	}
+	if a.kind != b.kind {
+		return a.kind == queryStart || b.kind == queryEnd, false
+	}
+	return false, true
+}
+
+// depEdgeTreeEntryPool pools depEdgeTreeEntry objects. This turns out to be
+// important because these objects are used when querying the depEdges, which
+// happens many times.
+var depEdgeTreeEntryPool = sync.Pool{
+	New: func() interface{} {
+		return &depEdgeTreeEntry{}
+	},
+}
+
+func getDepEdgeTreeEntry() (a *depEdgeTreeEntry) {
+	return depEdgeTreeEntryPool.Get().(*depEdgeTreeEntry)
+}
+
+func putDepEdgeTreeEntry(a *depEdgeTreeEntry) {
+	*a = depEdgeTreeEntry{}
+	depEdgeTreeEntryPool.Put(a)
 }

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -36,16 +36,17 @@ type Graph struct {
 	targetNodes []map[scpb.Status]*screl.Node
 
 	// Maps a target to its index in targetNodes.
-	targetIdxMap map[*scpb.Target]int
+	targetIdxMap map[*scpb.Target]targetIdx
+
+	// depEdges stores the DepEdges to facilitate efficient lookups.
+	depEdges depEdges
+
+	// opEdges stores all OpEdges in the order they were added.
+	opEdges []*OpEdge
 
 	// opEdgesFrom maps a Node to an opEdge that proceeds
 	// from it. A Node may have at most one opEdge from it.
 	opEdgesFrom map[*screl.Node]*OpEdge
-
-	// depEdgesFrom and depEdgesTo map a Node from and to its dependencies.
-	// A Node dependency is another target node which cannot be reached before
-	// reaching this node.
-	depEdgesFrom, depEdgesTo *depEdgeTree
 
 	// opToOpEdge maps from an operation back to the
 	// opEdge that generated it as an index.
@@ -55,10 +56,11 @@ type Graph struct {
 	// any operations.
 	noOpOpEdges map[*OpEdge]map[RuleName]struct{}
 
-	edges []Edge
-
 	entities *rel.Database
 }
+
+// targetIdx is the index in the targets slice where a given target resides.
+type targetIdx uint32
 
 // RuleName is the name of a rule. It exists as a type to avoid redaction and
 // clarify the meaning of the string.
@@ -103,21 +105,22 @@ func New(cs scpb.CurrentState) (*Graph, error) {
 		return nil, err
 	}
 	g := Graph{
-		targetIdxMap: map[*scpb.Target]int{},
+		targetIdxMap: map[*scpb.Target]targetIdx{},
 		opEdgesFrom:  map[*screl.Node]*OpEdge{},
 		noOpOpEdges:  map[*OpEdge]map[RuleName]struct{}{},
 		opToOpEdge:   map[scop.Op]*OpEdge{},
 		entities:     db,
 	}
-	g.depEdgesFrom = newDepEdgeTree(fromTo, g.compareNodes)
-	g.depEdgesTo = newDepEdgeTree(toFrom, g.compareNodes)
+	g.depEdges = makeDepEdges(func(n *screl.Node) targetIdx {
+		return g.targetIdxMap[n.Target]
+	})
 	for i, status := range cs.Current {
 		t := &cs.Targets[i]
 		if existing, ok := g.targetIdxMap[t]; ok {
 			return nil, errors.Errorf("invalid initial state contains duplicate target: %v and %v", *t, cs.Targets[existing])
 		}
 		idx := len(g.targets)
-		g.targetIdxMap[t] = idx
+		g.targetIdxMap[t] = targetIdx(idx)
 		g.targets = append(g.targets, t)
 		n := &screl.Node{Target: t, CurrentStatus: status}
 		g.targetNodes = append(g.targetNodes, map[scpb.Status]*screl.Node{status: n})
@@ -137,10 +140,9 @@ func (g *Graph) ShallowClone() *Graph {
 		targetNodes:  g.targetNodes,
 		targetIdxMap: g.targetIdxMap,
 		opEdgesFrom:  g.opEdgesFrom,
-		depEdgesFrom: g.depEdgesFrom,
-		depEdgesTo:   g.depEdgesTo,
+		depEdges:     g.depEdges,
+		opEdges:      g.opEdges,
 		opToOpEdge:   g.opToOpEdge,
-		edges:        g.edges,
 		entities:     g.entities,
 		noOpOpEdges:  make(map[*OpEdge]map[RuleName]struct{}),
 	}
@@ -219,7 +221,7 @@ func (g *Graph) AddOpEdges(
 		return errors.Errorf("duplicate outbound op edge %v and %v",
 			oe, existing)
 	}
-	g.edges = append(g.edges, oe)
+	g.opEdges = append(g.opEdges, oe)
 	typ := scop.MutationType
 	for i, op := range ops {
 		if i == 0 {
@@ -253,30 +255,17 @@ func (g *Graph) AddDepEdge(
 	toTarget *scpb.Target,
 	toStatus scpb.Status,
 ) (err error) {
-	de := &DepEdge{kind: kind}
 	rule := Rule{Name: ruleName, Kind: kind}
-	if de.from, err = g.getOrCreateNode(fromTarget, fromStatus); err != nil {
+	from, err := g.getOrCreateNode(fromTarget, fromStatus)
+	if err != nil {
 		return err
 	}
-	if de.to, err = g.getOrCreateNode(toTarget, toStatus); err != nil {
+	to, err := g.getOrCreateNode(toTarget, toStatus)
+	if err != nil {
 		return err
 	}
-	if got := g.depEdgesFrom.get(de); got != nil {
-		if got.kind != kind && kind != Precedence {
-			if got.kind != Precedence {
-				return errors.AssertionFailedf("inconsistent dep edge kinds: %s rule %q conflicts with %s",
-					rule.Kind, rule.Name, got)
-			}
-			got.kind = kind
-		}
-		got.rules = append(got.rules, rule)
-		return
-	}
-	de.rules = []Rule{rule}
-	g.edges = append(g.edges, de)
-	g.depEdgesFrom.insert(de)
-	g.depEdgesTo.insert(de)
-	return nil
+	return g.depEdges.insertOrUpdate(rule, kind, from, to)
+
 }
 
 // MarkAsNoOp marks an edge as no-op, so that no operations are emitted from
@@ -384,21 +373,4 @@ func cycleErrorDetail(target *screl.Node, edge Edge, pred map[*screl.Node]Edge) 
 	sb.WriteString(screl.NodeString(target))
 	sb.WriteRune('\n')
 	return sb.String()
-}
-
-// compareNodes compares two nodes in a graph. A nil nodes is the minimum value.
-func (g *Graph) compareNodes(a, b *screl.Node) (less, eq bool) {
-	switch {
-	case a == b:
-		return false, true
-	case a == nil:
-		return true, false
-	case b == nil:
-		return false, false
-	case a.Target == b.Target:
-		return a.CurrentStatus < b.CurrentStatus, a.CurrentStatus == b.CurrentStatus
-	default:
-		aIdx, bIdx := g.targetIdxMap[a.Target], g.targetIdxMap[b.Target]
-		return aIdx < bIdx, aIdx == bIdx
-	}
 }

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/iteration.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/iteration.go
@@ -40,12 +40,14 @@ type EdgeIterator func(e Edge) error
 
 // ForEachEdge iterates the edges in the graph.
 func (g *Graph) ForEachEdge(it EdgeIterator) error {
-	for _, e := range g.edges {
+	for _, e := range g.opEdges {
 		if err := it(e); err != nil {
 			return iterutil.Map(err)
 		}
 	}
-	return nil
+	return g.depEdges.iterate(func(de *DepEdge) error {
+		return it(de)
+	})
 }
 
 // DepEdgeIterator is used to iterate dep edges. Return iterutil.StopIteration
@@ -55,11 +57,11 @@ type DepEdgeIterator func(de *DepEdge) error
 // ForEachDepEdgeFrom iterates the dep edges in the graph with the selected
 // source.
 func (g *Graph) ForEachDepEdgeFrom(n *screl.Node, it DepEdgeIterator) (err error) {
-	return g.depEdgesFrom.iterateSourceNode(n, it)
+	return g.depEdges.iterateFromNode(n, it)
 }
 
 // ForEachDepEdgeTo iterates the dep edges in the graph with the selected
 // destination.
 func (g *Graph) ForEachDepEdgeTo(n *screl.Node, it DepEdgeIterator) (err error) {
-	return g.depEdgesTo.iterateSourceNode(n, it)
+	return g.depEdges.iterateToNode(n, it)
 }


### PR DESCRIPTION
This change optimizes the indexing and searching of dependency edges. It does a few things:

1) It uses a more efficient lookup structure for comparing entries in the dep
   edge tree. We can now compare two entries directly without any indirections.
2) It amortizes allocations of dep edges and their corresponding tree entries.
3) It pools the keys used to query the entries in the trees.

The last optimization is probably the most important. On the whole, this commit leads to a 30% improvement in the runtime of dropping the django test database when compared to https://github.com/cockroachdb/cockroach/pull/87820.

Relates to #86042.

Release justification: Important performance improvement.