### PR TITLE
sql/schemachanger/*: optimize performance, primarily by adding support for containment

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/explain/drop_database_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/explain/drop_database_multiregion_primary_region
@@ -14,7 +14,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC → TXN_DROPPED Database:{DescID: 104}
  │         │    ├── PUBLIC → TXN_DROPPED Schema:{DescID: 106}
  │         │    ├── PUBLIC → TXN_DROPPED EnumType:{DescID: 105}
- │         │    ├── PUBLIC → TXN_DROPPED AliasType:{DescID: 107}
+ │         │    ├── PUBLIC → TXN_DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
  │         │    ├── PUBLIC → TXN_DROPPED Table:{DescID: 108}
  │         │    ├── PUBLIC → WRITE_ONLY  Column:{DescID: 108, ColumnID: 1}
  │         │    ├── PUBLIC → WRITE_ONLY  Column:{DescID: 108, ColumnID: 4294967295}
@@ -59,7 +59,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
  │         │    ├── PUBLIC      → ABSENT      UserPrivileges:{DescID: 107, Name: admin}
  │         │    ├── PUBLIC      → ABSENT      UserPrivileges:{DescID: 107, Name: public}
  │         │    ├── PUBLIC      → ABSENT      UserPrivileges:{DescID: 107, Name: root}
- │         │    ├── TXN_DROPPED → DROPPED     AliasType:{DescID: 107}
+ │         │    ├── TXN_DROPPED → DROPPED     AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
  │         │    ├── PUBLIC      → ABSENT      ObjectParent:{DescID: 107, ReferencedDescID: 106}
  │         │    ├── PUBLIC      → ABSENT      Namespace:{DescID: 108, Name: table_regional_by_table, ReferencedDescID: 104}
  │         │    ├── PUBLIC      → ABSENT      Owner:{DescID: 108}
@@ -108,7 +108,7 @@ Schema change plan for DROP DATABASE ‹multi_region_test_db› CASCADE;
            │    ├── DROPPED     → ABSENT Database:{DescID: 104}
            │    ├── DROPPED     → ABSENT Schema:{DescID: 106}
            │    ├── DROPPED     → ABSENT EnumType:{DescID: 105}
-           │    ├── DROPPED     → ABSENT AliasType:{DescID: 107}
+           │    ├── DROPPED     → ABSENT AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
            │    ├── DROPPED     → ABSENT Table:{DescID: 108}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108, ColumnID: 1}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108, ColumnID: 4294967295}

--- a/pkg/ccl/schemachangerccl/testdata/explain/drop_table_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/explain/drop_table_multiregion
@@ -35,8 +35,8 @@ Schema change plan for DROP TABLE ‹multi_region_test_db›.‹public›.‹tab
  │         │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}
  │         │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 108, ColumnID: 2}
  │         │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 108, Name: crdb_region, ColumnID: 2}
- │         │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}
- │         │    ├── PUBLIC      → ABSENT      ColumnDefaultExpression:{DescID: 108, ColumnID: 2}
+ │         │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnFamilyID: 0, ColumnID: 2}
+ │         │    ├── PUBLIC      → ABSENT      ColumnDefaultExpression:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnID: 2}
  │         │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 108, ColumnID: 4294967295}
  │         │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 108, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}
  │         │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_database_multiregion_primary_region
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_database_multiregion_primary_region
@@ -24,7 +24,7 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   ├── • EnumType:{DescID: 105}
 │       │   │     PUBLIC → TXN_DROPPED
 │       │   │
-│       │   ├── • AliasType:{DescID: 107}
+│       │   ├── • AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │     PUBLIC → TXN_DROPPED
 │       │   │
 │       │   ├── • Table:{DescID: 108}
@@ -293,13 +293,13 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   │   ├── • SameStagePrecedence dependency from DROPPED Database:{DescID: 104}
 │       │   │   │     rule: "descriptor drop right before removing dependent with attr ref"
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   └── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │         rule: "descriptor drop right before dependent element removal"
 │       │   │
 │       │   ├── • Owner:{DescID: 107}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │   │     rule: "descriptor drop right before dependent element removal"
 │       │   │   │
 │       │   │   └── • skip PUBLIC → ABSENT operations
@@ -308,7 +308,7 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   ├── • UserPrivileges:{DescID: 107, Name: admin}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │   │     rule: "descriptor drop right before dependent element removal"
 │       │   │   │
 │       │   │   └── • skip PUBLIC → ABSENT operations
@@ -317,7 +317,7 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   ├── • UserPrivileges:{DescID: 107, Name: public}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │   │     rule: "descriptor drop right before dependent element removal"
 │       │   │   │
 │       │   │   └── • skip PUBLIC → ABSENT operations
@@ -326,16 +326,16 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   ├── • UserPrivileges:{DescID: 107, Name: root}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
-│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   ├── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │   │     rule: "descriptor drop right before dependent element removal"
 │       │   │   │
 │       │   │   └── • skip PUBLIC → ABSENT operations
 │       │   │         rule: "skip element removal ops on descriptor drop"
 │       │   │
-│       │   ├── • AliasType:{DescID: 107}
+│       │   ├── • AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │   │ TXN_DROPPED → DROPPED
 │       │   │   │
-│       │   │   └── • PreviousStagePrecedence dependency from TXN_DROPPED AliasType:{DescID: 107}
+│       │   │   └── • PreviousStagePrecedence dependency from TXN_DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │         rule: "descriptor TXN_DROPPED before DROPPED"
 │       │   │
 │       │   ├── • ObjectParent:{DescID: 107, ReferencedDescID: 106}
@@ -344,7 +344,7 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
 │       │   │   ├── • SameStagePrecedence dependency from DROPPED Schema:{DescID: 106}
 │       │   │   │     rule: "descriptor drop right before removing dependent with attr ref"
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107}
+│       │   │   └── • SameStagePrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
 │       │   │         rule: "descriptor drop right before dependent element removal"
 │       │   │
 │       │   ├── • Namespace:{DescID: 108, Name: table_regional_by_table, ReferencedDescID: 104}
@@ -661,10 +661,10 @@ EXPLAIN (ddl, verbose) DROP DATABASE multi_region_test_db CASCADE;
         │   │   └── • PreviousTransactionPrecedence dependency from DROPPED EnumType:{DescID: 105}
         │   │         rule: "descriptor DROPPED in transaction before removal"
         │   │
-        │   ├── • AliasType:{DescID: 107}
+        │   ├── • AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
         │   │   │ DROPPED → ABSENT
         │   │   │
-        │   │   └── • PreviousTransactionPrecedence dependency from DROPPED AliasType:{DescID: 107}
+        │   │   └── • PreviousTransactionPrecedence dependency from DROPPED AliasType:{DescID: 107, ReferencedTypeIDs: [105 107]}
         │   │         rule: "descriptor DROPPED in transaction before removal"
         │   │
         │   ├── • Table:{DescID: 108}

--- a/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/explain_verbose/drop_table_multiregion
@@ -164,7 +164,7 @@ EXPLAIN (ddl, verbose) DROP TABLE multi_region_test_db.public.table_regional_by_
 │       │   │   └── • skip PUBLIC → ABSENT operations
 │       │   │         rule: "skip column dependents removal ops on relation drop"
 │       │   │
-│       │   ├── • ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}
+│       │   ├── • ColumnType:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnFamilyID: 0, ColumnID: 2}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
 │       │   │   ├── • SameStagePrecedence dependency from DROPPED Table:{DescID: 108}
@@ -173,10 +173,10 @@ EXPLAIN (ddl, verbose) DROP TABLE multi_region_test_db.public.table_regional_by_
 │       │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 108, ColumnID: 2}
 │       │   │   │     rule: "column no longer public before dependents"
 │       │   │   │
-│       │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 108, ColumnID: 2}
+│       │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnID: 2}
 │       │   │         rule: "column type dependents removed right before column type"
 │       │   │
-│       │   ├── • ColumnDefaultExpression:{DescID: 108, ColumnID: 2}
+│       │   ├── • ColumnDefaultExpression:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnID: 2}
 │       │   │   │ PUBLIC → ABSENT
 │       │   │   │
 │       │   │   ├── • SameStagePrecedence dependency from DROPPED Table:{DescID: 108}
@@ -402,10 +402,10 @@ EXPLAIN (ddl, verbose) DROP TABLE multi_region_test_db.public.table_regional_by_
         │   │   ├── • Precedence dependency from ABSENT ColumnName:{DescID: 108, Name: crdb_region, ColumnID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnType:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnFamilyID: 0, ColumnID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 108, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 108, ReferencedTypeIDs: [105 107], ColumnID: 2}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   └── • Precedence dependency from ABSENT IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 1}

--- a/pkg/sql/schemachanger/rel/database.go
+++ b/pkg/sql/schemachanger/rel/database.go
@@ -72,6 +72,10 @@ type Index struct {
 	// attribute existence from the query itself and to free the query-writer
 	// from needing to define a bogus Var.
 	Exists []Attr
+
+	// Inverted is true if the index is an inverted index over slice membership.
+	// If true, the attributes may only refer to a slice membership type.
+	Inverted bool
 }
 
 // NewDatabase constructs a new Database with the specified indexes.
@@ -82,8 +86,12 @@ func NewDatabase(sc *Schema, indexes ...Index) (*Database, error) {
 			hash:    map[interface{}]int{},
 			strings: map[string]int{},
 		},
-		indexes: make([]index, len(indexes)),
 	}
+	indexes, err := maybeExpandInvertedIndexes(sc, indexes)
+	if err != nil {
+		return nil, err
+	}
+	t.indexes = make([]index, len(indexes))
 	for i, di := range indexes {
 		var set, exists ordinalSet
 		ords := make([]ordinal, len(di.Attrs))
@@ -135,14 +143,82 @@ func NewDatabase(sc *Schema, indexes ...Index) (*Database, error) {
 				)
 			}
 		}
-
-		spec := indexSpec{mask: set, attrs: ords, s: &t.entitySet, exists: exists, where: predicate}
+		spec := indexSpec{
+			mask:       set,
+			attrs:      ords,
+			s:          &t.entitySet,
+			exists:     exists,
+			where:      predicate,
+			isInverted: di.Inverted,
+		}
 		t.indexes[i] = index{
 			indexSpec: spec,
 			tree:      btree.New(32),
 		}
 	}
 	return t, nil
+}
+
+// maybeExpandInvertedIndexes will replace inverted indexes defined by the
+// user with two new indexes corresponding to the inverted attribute in
+// order to enable efficient lookup by either source or value. This is
+// done because generally in rel it is safe to assume that it is efficient
+// to go from an entity to its attribute and that it is also efficient to go
+// from an attribute to the set of entities so long as the attribute is
+// indexed. Because the slice members are not directly a part of the entity
+// in the rel model, we need to index from the entity to the slice member to
+// make that expansion cheap.
+func maybeExpandInvertedIndexes(sc *Schema, indexes []Index) ([]Index, error) {
+	var expanded []Index
+	for _, idx := range indexes {
+		if !idx.Inverted {
+			expanded = append(expanded, idx)
+			continue
+		}
+		if err := validatedInvertedIndexProperties(sc, idx); err != nil {
+			return nil, err
+		}
+		// We validated above that there is just one inverted attribute.
+		attr := idx.Attrs[0]
+		expanded = append(expanded, Index{
+			Attrs:    []Attr{attr, sliceSource, sliceIndex},
+			Exists:   []Attr{attr},
+			Inverted: true,
+		}, Index{
+			Attrs:    []Attr{sliceSource, attr, sliceIndex},
+			Exists:   []Attr{attr},
+			Inverted: true,
+		})
+	}
+	return expanded, nil
+}
+
+// validateInvertedIndexProperties ensures that a user-requested inverted
+// index conforms to the supported properties. Namely, it has one attribute
+// that is a slice attribute and no use of Where or Exists clauses.
+func validatedInvertedIndexProperties(sc *Schema, idx Index) error {
+	if len(idx.Attrs) > 1 {
+		return errors.Errorf("inverted indexes may only reference a single slice attribute, got %v", idx.Attrs)
+	}
+	ord, err := sc.getOrdinal(idx.Attrs[0])
+	switch {
+	case err != nil:
+		return errors.Wrap(err, "invalid index attribute")
+	case !sc.sliceOrdinals.contains(ord):
+		return errors.Errorf(
+			"invalid non-slice index attribute %v for inverted index", idx.Attrs[0],
+		)
+	case len(idx.Where) > 0:
+		return errors.Errorf(
+			"inverted indexes are implicitly partial and cannot be further constrained",
+		)
+	case len(idx.Exists) > 0:
+		return errors.Errorf(
+			"inverted indexes may not have existence constraints",
+		)
+	default:
+		return nil
+	}
 }
 
 // entityStore is an abstraction to permit the relevant recursion of interning
@@ -157,17 +233,29 @@ type entityStore interface {
 
 // insert implements entityStore.
 func (t *Database) insert(v interface{}, es entityStore) (id int, err error) {
+	if existing, ok := t.entitySet.hash[v]; ok {
+		return existing, nil
+	}
 	id, err = t.entitySet.insert(v, es)
 	if err != nil {
 		return 0, err
 	}
 	e := (*values)(&t.entitySet.entities[id])
+	typIdx, ok := e.get(t.schema.typeOrdinal)
+	if !ok {
+		return 0, errors.AssertionFailedf("unknown type for entity %T: %v", v, v)
+	}
+	typ := t.schema.entityTypes[typIdx]
 	for i := range t.indexes {
 		idx := &t.indexes[i]
 		if !idx.matchesPredicate(e) {
 			continue
 		}
 		if idx.exists != 0 && !idx.exists.isContainedIn(e.attrs) {
+			continue
+		}
+		// If this entity is a slice membership entity, it should not go
+		if typ.isSliceMemberType && !idx.isInverted {
 			continue
 		}
 		idx.tree.ReplaceOrInsert(&valuesItem{values: *e, idx: &idx.indexSpec})
@@ -196,11 +284,12 @@ type index struct {
 }
 
 type indexSpec struct {
-	s      *entitySet
-	mask   ordinalSet
-	attrs  []ordinal
-	exists ordinalSet
-	where  values
+	s          *entitySet
+	mask       ordinalSet
+	attrs      []ordinal
+	exists     ordinalSet
+	where      values
+	isInverted bool
 }
 
 // entityIterator is used to iterate Entities.
@@ -266,14 +355,22 @@ func (t *Database) chooseIndex(
 		}
 		// Only allow queries to proceed with no index overlap if this is the
 		// zero-attribute index, which implies the database creator accepts bad
-		// query plans.
-		if overlap == 0 && len(dims[i].attrs) > 0 {
+		// query plans. We'll also permit it in the rare case that this is
+		// an inverted index join and we have some overlap in the attributes.
+		hasSliceAttrs := !hasAttrs.intersection(t.schema.sliceOrdinals).empty()
+		if overlap == 0 && len(dims[i].attrs) > 0 &&
+			(!hasSliceAttrs || dims[i].mask.intersection(hasAttrs).empty()) {
 			continue
 		}
 		if !dims[i].exists.isContainedIn(m.union(hasAttrs)) {
 			continue
 		}
 		if !dims[i].matchesPredicate(&where) {
+			continue
+		}
+		// Only inverted indexes can contain data which references slice ordinals.
+		// If the query is for such an ordinal, it must search an inverted index.
+		if hasSliceAttrs && !dims[i].isInverted {
 			continue
 		}
 		best, bestOverlap = i, overlap

--- a/pkg/sql/schemachanger/rel/doc.go
+++ b/pkg/sql/schemachanger/rel/doc.go
@@ -153,11 +153,16 @@
 // indexes in O(N*log(N)) per statement meaning at worst O(N^2 log(N)) which is
 // acceptable for an N of ~1000 as opposed to O(N^3) which isn't really.
 //
+// # Slices
+//
+// Rel supports inverted indexes over slices. In order to use them, you create
+// an attribute referencing a slice. Internally, rel will create a new
+// element internally for each member. The containment operator can be used
+// to perform an inverted lookup.
+//
 // # Future work
 //
 // Below find a listing of features not yet done.
-//
-//   - Arrays, Maps, Slices.
 //
 //   - It would be nice to have a mechanism to talk about decomposing
 //     data stored in these collections. One approach would be to define

--- a/pkg/sql/schemachanger/rel/entity.go
+++ b/pkg/sql/schemachanger/rel/entity.go
@@ -56,6 +56,9 @@ func (sc *Schema) CompareOn(attrs []Attr, a, b interface{}) (less, eq bool) {
 			if err != nil {
 				panic(err)
 			}
+			if sc.sliceOrdinals.contains(ord) {
+				continue
+			}
 			aav = getAttrValue(at, ord, av)
 			bav = getAttrValue(bt, ord, bv)
 		}

--- a/pkg/sql/schemachanger/rel/internal/entitynodetest/schema.go
+++ b/pkg/sql/schemachanger/rel/internal/entitynodetest/schema.go
@@ -20,9 +20,10 @@ import (
 )
 
 type entity struct {
-	I8  int8
-	PI8 *int8
-	I16 int16
+	I8      int8
+	PI8     *int8
+	I16     int16
+	I16Refs []int16
 }
 
 type node struct {
@@ -67,6 +68,7 @@ const (
 	value
 	left
 	right
+	i16ref
 )
 
 var schema = rel.MustSchema("testschema",
@@ -74,6 +76,7 @@ var schema = rel.MustSchema("testschema",
 		rel.EntityAttr(i8, "I8"),
 		rel.EntityAttr(pi8, "PI8"),
 		rel.EntityAttr(i16, "I16"),
+		rel.EntityAttr(i16ref, "I16Refs"),
 	),
 	rel.EntityMapping(reflect.TypeOf((*node)(nil)),
 		rel.EntityAttr(value, "Value"),

--- a/pkg/sql/schemachanger/rel/internal/entitynodetest/testattr_string.go
+++ b/pkg/sql/schemachanger/rel/internal/entitynodetest/testattr_string.go
@@ -14,11 +14,12 @@ func _() {
 	_ = x[value-3]
 	_ = x[left-4]
 	_ = x[right-5]
+	_ = x[i16ref-6]
 }
 
-const _testAttr_name = "i8pi8i16valueleftright"
+const _testAttr_name = "i8pi8i16valueleftrighti16ref"
 
-var _testAttr_index = [...]uint8{0, 2, 5, 8, 13, 17, 22}
+var _testAttr_index = [...]uint8{0, 2, 5, 8, 13, 17, 22, 28}
 
 func (i testAttr) String() string {
 	if i < 0 || i >= testAttr(len(_testAttr_index)-1) {

--- a/pkg/sql/schemachanger/rel/query_lang.go
+++ b/pkg/sql/schemachanger/rel/query_lang.go
@@ -52,6 +52,18 @@ func (v Var) AttrIn(a Attr, values ...interface{}) Clause {
 	return makeTriple(v, a, (anyExpr)(values))
 }
 
+// AttrContainsVar constrains the entity bound to v to have a slice attribute
+// a which contains an entry bound to the value Var.
+func (v Var) AttrContainsVar(a Attr, value Var) Clause {
+	return makeTriple(v, a, containsExpr{v: value})
+}
+
+// AttrContains constrains the entity bound to v to have a slice attribute
+// a which contains the entry indicated by value.
+func (v Var) AttrContains(a Attr, value interface{}) Clause {
+	return makeTriple(v, a, containsExpr{v: valueExpr{value: value}})
+}
+
 // AttrEqVar constrains the entity bound to v to have a value for
 // the specified attr equal to the variable value.
 func (v Var) AttrEqVar(a Attr, value Var) Clause {

--- a/pkg/sql/schemachanger/rel/query_lang_expr.go
+++ b/pkg/sql/schemachanger/rel/query_lang_expr.go
@@ -53,3 +53,9 @@ func (v notValueExpr) expr() {}
 type anyExpr []interface{}
 
 func (a anyExpr) expr() {}
+
+type containsExpr struct {
+	v expr
+}
+
+func (c containsExpr) expr() {}

--- a/pkg/sql/schemachanger/rel/query_lang_yaml.go
+++ b/pkg/sql/schemachanger/rel/query_lang_yaml.go
@@ -15,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"gopkg.in/yaml.v3"
 )
 
@@ -33,6 +34,10 @@ func (v valueExpr) encoded() interface{} {
 
 func (v notValueExpr) encoded() interface{} {
 	return valueForYAML(v.value)
+}
+
+func (c containsExpr) encoded() interface{} {
+	return c.v.encoded()
 }
 
 func (a anyExpr) encoded() interface{} {
@@ -117,6 +122,10 @@ func clauseStr(lhs string, rhs expr) (string, error) {
 		op = "IN"
 	case notValueExpr:
 		op = "!="
+	case containsExpr:
+		op = "CONTAINS"
+	default:
+		return "", errors.AssertionFailedf("unknown expression type %T", rhs)
 	}
 	return fmt.Sprintf("%s %s %s", lhs, op, rhsStr), nil
 }

--- a/pkg/sql/schemachanger/rel/reltest/registry.go
+++ b/pkg/sql/schemachanger/rel/reltest/registry.go
@@ -11,6 +11,7 @@
 package reltest
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -85,6 +86,17 @@ func (r *Registry) MustGetName(t *testing.T, v interface{}) string {
 
 // GetName is like MustGetName but does not enforce that it exists.
 func (r *Registry) GetName(i interface{}) (string, bool) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		if re, ok := r.(runtime.Error); ok &&
+			strings.Contains(re.Error(), "hash of unhashable type") {
+			return
+		}
+		panic(r)
+	}()
 	got, ok := r.valueToName[i]
 	return got, ok
 }

--- a/pkg/sql/schemachanger/rel/schema.go
+++ b/pkg/sql/schemachanger/rel/schema.go
@@ -21,16 +21,18 @@ import (
 
 // Schema defines a mapping of entities to their attributes and decomposition.
 type Schema struct {
-	name                     string
-	attrs                    []Attr
-	attrTypes                []reflect.Type
-	attrToOrdinal            map[Attr]ordinal
-	entityTypes              []*entityTypeSchema
-	entityTypeSchemas        map[reflect.Type]*entityTypeSchema
-	typeOrdinal, selfOrdinal ordinal
-	stringAttrs              ordinalSet
-	rules                    []*RuleDef
-	rulesByName              map[string]*RuleDef
+	name                                  string
+	attrs                                 []Attr
+	attrTypes                             []reflect.Type
+	sliceOrdinals                         ordinalSet
+	attrToOrdinal                         map[Attr]ordinal
+	entityTypes                           []*entityTypeSchema
+	entityTypeSchemas                     map[reflect.Type]*entityTypeSchema
+	typeOrdinal, selfOrdinal              ordinal
+	sliceIndexOrdinal, sliceSourceOrdinal ordinal
+	stringAttrs                           ordinalSet
+	rules                                 []*RuleDef
+	rulesByName                           map[string]*RuleDef
 }
 
 type entityTypeSchemaSort Schema
@@ -77,6 +79,11 @@ type entityTypeSchema struct {
 
 	// typID is the rank of the type of this entity in the schema.
 	typID uintptr
+
+	// isSliceMemberType is true if this type exists to support containment
+	// operations over a slice type.
+	isSliceMemberType bool
+	sliceAttr         ordinal
 }
 
 type fieldInfo struct {
@@ -87,6 +94,8 @@ type fieldInfo struct {
 	value           func(unsafe.Pointer) interface{}
 	inline          func(unsafe.Pointer) (uintptr, bool)
 	fieldFlags
+
+	sliceMemberType reflect.Type
 }
 
 type fieldFlags int8
@@ -98,6 +107,7 @@ func (f fieldFlags) isInt() bool     { return f&intField != 0 }
 func (f fieldFlags) isUint() bool    { return f&uintField != 0 }
 func (f fieldFlags) isIntLike() bool { return f&(intField|uintField) != 0 }
 func (f fieldFlags) isString() bool  { return f&stringField != 0 }
+func (f fieldFlags) isSlice() bool   { return f&sliceField != 0 }
 
 const (
 	intField fieldFlags = 1 << iota
@@ -105,6 +115,7 @@ const (
 	stringField
 	structField
 	pointerField
+	sliceField
 )
 
 func buildSchema(name string, opts ...SchemaOption) *Schema {
@@ -145,6 +156,14 @@ type schemaBuilder struct {
 	m schemaMappings
 }
 
+func (sb *schemaBuilder) maybeInitializeSliceMemberAttributes() {
+	if sb.sliceIndexOrdinal != 0 {
+		return
+	}
+	sb.sliceIndexOrdinal = sb.maybeAddAttribute(sliceIndex, reflect.TypeOf((*int)(nil)).Elem())
+	sb.sliceSourceOrdinal = sb.maybeAddAttribute(sliceSource, reflect.TypeOf((*interface{})(nil)).Elem())
+}
+
 func (sb *schemaBuilder) maybeAddAttribute(a Attr, typ reflect.Type) ordinal {
 	// TODO(ajwerner): Validate that t is an okay type for an attribute
 	// to be.
@@ -182,7 +201,9 @@ func checkType(typ, exp reflect.Type) error {
 	return nil
 }
 
-func (sb *schemaBuilder) maybeAddTypeMapping(t reflect.Type, attributeMappings []attrMapping) {
+func (sb *schemaBuilder) maybeAddTypeMapping(
+	t reflect.Type, attributeMappings []attrMapping,
+) *entityTypeSchema {
 	isStructPointer := func(tt reflect.Type) bool {
 		return tt.Kind() == reflect.Ptr && tt.Elem().Kind() == reflect.Struct
 	}
@@ -221,6 +242,7 @@ func (sb *schemaBuilder) maybeAddTypeMapping(t reflect.Type, attributeMappings [
 	}
 	sb.entityTypeSchemas[t] = ts
 	sb.entityTypes = append(sb.entityTypes, ts)
+	return ts
 }
 
 func makeFieldFlags(t reflect.Type) (fieldFlags, bool) {
@@ -231,6 +253,8 @@ func makeFieldFlags(t reflect.Type) (fieldFlags, bool) {
 	}
 	kind := t.Kind()
 	switch {
+	case kind == reflect.Slice && !f.isPtr():
+		f |= sliceField
 	case kind == reflect.Struct && f.isPtr():
 		f |= structField
 	case kind == reflect.String:
@@ -259,13 +283,38 @@ func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) 
 	if flags.isPtr() && flags.isScalar() {
 		typ = cur.Elem()
 	}
-	ord := sb.maybeAddAttribute(a, typ)
+	var ord ordinal
+	var sliceMemberType reflect.Type
+	if !flags.isSlice() {
+		ord = sb.maybeAddAttribute(a, typ)
+	} else {
+		// We need to add the slice type and then return, or
+		// perhaps, add some annotation to the type that this
+		// is a slice, and it refers to xyz.
+		sb.maybeInitializeSliceMemberAttributes()
+		// Give the generated struct a field name based on the attribute name.
+		// We could use something generic like "Value" for all value fields of
+		// such structs, but this makes debugging a tad easier because you can
+		// look at the field names of the type in the debugger.
+		fieldName := "F_" + a.String()
+		sliceMemberType = makeSliceMemberType(t, typ, fieldName)
+		st := sb.maybeAddTypeMapping(sliceMemberType, []attrMapping{
+			{a: sliceSource, selectors: []string{"Source"}},
+			{a: sliceIndex, selectors: []string{"Index"}},
+			{a: a, selectors: []string{fieldName}},
+		})
+		st.isSliceMemberType = true
+		ord = sb.attrToOrdinal[a]
+		sb.sliceOrdinals = sb.sliceOrdinals.add(ord)
+		st.sliceAttr = ord
+	}
 
 	f := fieldInfo{
-		fieldFlags: flags,
-		path:       sel,
-		attr:       ord,
-		typ:        typ,
+		fieldFlags:      flags,
+		path:            sel,
+		attr:            ord,
+		typ:             typ,
+		sliceMemberType: sliceMemberType,
 	}
 	makeValueGetter := func(t reflect.Type, offset uintptr) func(u unsafe.Pointer) reflect.Value {
 		return func(u unsafe.Pointer) reflect.Value {
@@ -285,6 +334,15 @@ func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) 
 		vg := makeValueGetter(cur, offset)
 		if f.isPtr() && f.isStruct() {
 			f.value = getPtrValue(vg)
+		} else if f.isSlice() {
+			f.value = func(u unsafe.Pointer) interface{} {
+				got := vg(u)
+				ge := got.Elem()
+				if ge.IsNil() || ge.Len() == 0 {
+					return nil
+				}
+				return ge.Interface()
+			}
 		} else if f.isPtr() && f.isScalar() {
 			f.value = func(u unsafe.Pointer) interface{} {
 				got := vg(u)
@@ -300,6 +358,8 @@ func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) 
 			}
 		}
 		switch {
+		case f.isSlice():
+			// f.inline is not defined
 		case f.isPtr() && f.isInt():
 			f.inline = func(u unsafe.Pointer) (uintptr, bool) {
 				got := vg(u)
@@ -333,7 +393,7 @@ func (sb *schemaBuilder) addTypeAttrMapping(a Attr, t reflect.Type, sel string) 
 	{
 		if f.isStruct() {
 			f.comparableValue = getPtrValue(makeValueGetter(cur, offset))
-		} else {
+		} else if !f.isSlice() {
 			compType := getComparableType(typ)
 			if f.isPtr() && f.isScalar() {
 				compType = reflect.PtrTo(compType)
@@ -401,4 +461,33 @@ func (sc *Schema) getOrdinal(attribute Attr) (ordinal, error) {
 		return 0, errors.Errorf("unknown attribute %s in schema %s", attribute, sc.name)
 	}
 	return ord, nil
+}
+
+// IsSliceAttr returns true if the Attr corresponds to a slice field.
+func (sc *Schema) IsSliceAttr(a Attr) bool {
+	ord, ok := sc.attrToOrdinal[a]
+	return ok && sc.sliceOrdinals.contains(ord)
+}
+
+// Give the struct field indexes constants so that they can be used
+// when setting the fields entity set inserts.
+const (
+	sliceMemberSourceFieldIndex = iota
+	sliceMemberIndexFieldIndex
+	sliceMemberValueFieldIndex
+)
+
+func makeSliceMemberType(srcType, sliceType reflect.Type, valueFieldName string) reflect.Type {
+	fields := [...]reflect.StructField{
+		sliceMemberSourceFieldIndex: {
+			Name: "Source", Type: srcType,
+		},
+		sliceMemberIndexFieldIndex: {
+			Name: "Index", Type: reflect.TypeOf((*int)(nil)).Elem(),
+		},
+		sliceMemberValueFieldIndex: {
+			Name: valueFieldName, Type: sliceType.Elem(),
+		},
+	}
+	return reflect.PtrTo(reflect.StructOf(fields[:]))
 }

--- a/pkg/sql/schemachanger/rel/system_attributes.go
+++ b/pkg/sql/schemachanger/rel/system_attributes.go
@@ -33,6 +33,16 @@ const (
 
 	// Self is an attribute which stores the variable itself.
 	Self
+
+	// sliceSource is the attribute used internally when building
+	// slice member entities to reference the source entity of the slice member.
+	sliceSource
+	// sliceIndex is the attributed used internally when building
+	// slice member entities to reference the index of the slice member in the
+	// slice. It is used to give slice member entities unique identities and to
+	// order slice entries according to their index. At time of writing, there
+	// is no way to access this property in queries.
+	sliceIndex
 )
 
 var _ Attr = systemAttribute(0)

--- a/pkg/sql/schemachanger/rel/systemattribute_string.go
+++ b/pkg/sql/schemachanger/rel/systemattribute_string.go
@@ -10,11 +10,13 @@ func _() {
 	var x [1]struct{}
 	_ = x[Type-1]
 	_ = x[Self-2]
+	_ = x[sliceSource-3]
+	_ = x[sliceIndex-4]
 }
 
-const _systemAttribute_name = "TypeSelf"
+const _systemAttribute_name = "TypeSelfsliceSourcesliceIndex"
 
-var _systemAttribute_index = [...]uint8{0, 4, 8}
+var _systemAttribute_index = [...]uint8{0, 4, 8, 19, 29}
 
 func (i systemAttribute) String() string {
 	i -= 1

--- a/pkg/sql/schemachanger/rel/testdata/entitynode
+++ b/pkg/sql/schemachanger/rel/testdata/entitynode
@@ -1,13 +1,14 @@
 name: entitynode
 data:
-    a: {i8: 1, i16: 1, pi8: 1}
+    a: {i8: 1, i16: 1, i16refs: [1], pi8: 1}
     b: {i8: 2, i16: 2}
     c: {i8: 2, i16: 1}
+    d: {i8: 4, i16: 4, i16refs: [1, 2], pi8: 4}
     na: {value: a}
     nb: {value: b, left: na}
     nc: {value: c, right: nb}
 attributes:
-    a: {i16: 1, i8: 1, pi8: 1}
+    a: {i16: 1, i16ref: [1], i8: 1, pi8: 1}
     b: {i16: 2, i8: 2}
     c: {i16: 1, i8: 2}
     na: {value: a}
@@ -41,7 +42,7 @@ rules:
         - $right[left] = $right-left
         - $right[Type] = '*entitynodetest.node'
         - $right-left[value] = $v
-        - '$v = {i8: 1, pi8: 1, i16: 1}'
+        - '$v = {i8: 1, pi8: 1, i16: 1, i16refs: [1]}'
         - noop(*entitynodetest.node)($na)
     - passThrough($a, $b, $c, $d):
         - rightLeft($a, $b, $c, $d)
@@ -72,7 +73,10 @@ queries:
             - {attrs: [], where: {Type: '*entitynodetest.node'}}
             - {attrs: [left], exists: [left]}
             - {attrs: [right], exists: [right]}
-      data: [a, b, c, na, nb, nc]
+        8:
+            - {attrs: []}
+            - {attrs: [i16ref]}
+      data: [a, b, c, d, na, nb, nc]
       queries:
         a fields:
             query:
@@ -122,7 +126,19 @@ queries:
                 - [a, 1]
                 - [b, 2]
                 - [c, 2]
+                - [d, 4]
             unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
+        list all the entities:
+            query:
+                - $entity[Type] = '*entitynodetest.entity'
+            entities: [$entity]
+            result-vars: [$entity]
+            results:
+                - [a]
+                - [b]
+                - [c]
+                - [d]
+            unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         list all the values with type constraint:
             query:
                 - $value[i8] = $i8
@@ -133,6 +149,7 @@ queries:
                 - [a, 1]
                 - [b, 2]
                 - [c, 2]
+                - [d, 4]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         nodes with elements where i8=2:
             query:
@@ -166,6 +183,7 @@ queries:
                 - [1]
                 - [2]
                 - [2]
+                - [4]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         use a filter:
             query:
@@ -185,6 +203,7 @@ queries:
                 - [a, '*entitynodetest.entity']
                 - [b, '*entitynodetest.entity']
                 - [c, '*entitynodetest.entity']
+                - [d, '*entitynodetest.entity']
                 - [na, '*entitynodetest.node']
                 - [nb, '*entitynodetest.node']
                 - [nc, '*entitynodetest.node']
@@ -227,20 +246,21 @@ queries:
                 - [a]
                 - [b]
                 - [c]
+                - [d]
                 - [na]
                 - [nb]
                 - [nc]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         self eq value:
             query:
-                - '$entity[Self] = {i8: 2, pi8: null, i16: 1}'
+                - '$entity[Self] = {i8: 2, pi8: null, i16: 1, i16refs: []}'
             entities: [$entity]
             result-vars: [$entity]
             results:
                 - [c]
         contradiction due to missing attribute:
             query:
-                - '$entity[Self] = {i8: 2, pi8: null, i16: 1}'
+                - '$entity[Self] = {i8: 2, pi8: null, i16: 1, i16refs: []}'
                 - $entity[pi8] = $pi8
             entities: [$entity]
             result-vars: [$entity, $pi8]
@@ -254,6 +274,7 @@ queries:
                 - [a]
                 - [b]
                 - [c]
+                - [d]
                 - [na]
                 - [nb]
                 - [nc]
@@ -328,7 +349,7 @@ queries:
             error: 'failed to process invalid clause \$e\[i8\] = null: invalid nil \*int8'
         no match in any expr:
             query:
-                - $e[i8] IN [4, 5]
+                - $e[i8] IN [42, 43]
             entities: [$e]
             result-vars: [$e]
             results: []
@@ -336,7 +357,7 @@ queries:
         any clause no match on variable eq:
             query:
                 - $e[i8] = $i8
-                - $i8 IN [3, 4]
+                - $i8 IN [33, 42]
             entities: [$e]
             result-vars: [$e, $i8]
             results: []
@@ -350,6 +371,7 @@ queries:
                 - [a]
                 - [b]
                 - [c]
+                - [d]
             unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         using blank, bind non-nil pointer:
             query:
@@ -358,6 +380,7 @@ queries:
             result-vars: [$e]
             results:
                 - [a]
+                - [d]
             unsatisfiableIndexes: [1, 2, 3, 4, 5, 6, 7]
         e[i8] != 1:
             query:
@@ -368,16 +391,18 @@ queries:
             results:
                 - [b]
                 - [c]
+                - [d]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e != a:
             query:
                 - $e[Type] = '*entitynodetest.entity'
-                - '$e != {i8: 1, pi8: 1, i16: 1}'
+                - '$e != {i8: 1, pi8: 1, i16: 1, i16refs: [1]}'
             entities: [$e]
             result-vars: [$e]
             results:
                 - [b]
                 - [c]
+                - [d]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != 1:
             query:
@@ -389,6 +414,7 @@ queries:
             results:
                 - [b, 2]
                 - [c, 2]
+                - [d, 4]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != 2:
             query:
@@ -399,6 +425,7 @@ queries:
             result-vars: [$e, $v]
             results:
                 - [a, 1]
+                - [d, 4]
             unsatisfiableIndexes: [1, 2, 3, 5, 6, 7]
         e[i8] = v; v != int16(2):
             query:
@@ -449,4 +476,56 @@ queries:
                 - [na, 2]
                 - [nc, 2]
             unsatisfiableIndexes: [1, 2, 3, 5, 6]
+        containment by entity:
+            query:
+                - $n[Type] = '*entitynodetest.node'
+                - $n[value] = $entity
+                - $entity[i16ref] CONTAINS $otheri16
+                - $otherEntity[i16] = $otheri16
+            entities: [$n, $entity, $otherEntity]
+            result-vars: [$n, $entity, $otheri16, $otherEntity]
+            results:
+                - [na, a, 1, c]
+                - [na, a, 1, a]
+            unsatisfiableIndexes: [0, 1, 2, 3, 4, 5, 6, 7]
+        containment by value:
+            query:
+                - $i16 = 1
+                - $entity[i16ref] CONTAINS $i16
+            entities: [$entity]
+            result-vars: [$i16, $entity]
+            results:
+                - [1, a]
+                - [1, d]
+            unsatisfiableIndexes: [0, 1, 2, 3, 4, 5, 6, 7]
+        containment by value with any:
+            query:
+                - $i16 IN [2, 3]
+                - $entity[i16ref] CONTAINS $i16
+            entities: [$entity]
+            result-vars: [$i16, $entity]
+            results:
+                - [2, d]
+            unsatisfiableIndexes: [0, 1, 2, 3, 4, 5, 6, 7]
+        containment by value (fails):
+            query:
+                - $i16 = 3
+                - $entity[i16ref] CONTAINS $i16
+            entities: [$entity]
+            result-vars: [$i16, $entity]
+            results: []
+            unsatisfiableIndexes: [0, 1, 2, 3, 4, 5, 6, 7]
+        join with containment:
+            query:
+                - $inverted_source[i16ref] CONTAINS $i16
+                - $referenced_entity[i16] = $i16
+            entities: [$inverted_source, $referenced_entity]
+            result-vars: [$inverted_source, $i16, $referenced_entity]
+            results:
+                - [a, 1, a]
+                - [a, 1, c]
+                - [d, 1, a]
+                - [d, 1, c]
+                - [d, 2, b]
+            unsatisfiableIndexes: [0, 1, 2, 3, 4, 5, 6, 7]
 comparisons: []

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -67,7 +67,7 @@ func (b *builderState) Ensure(
 	key := screl.ElementString(e)
 	if i, ok := c.elementIndexMap[key]; ok {
 		es := &b.output[i]
-		if !screl.EqualElements(es.element, e) {
+		if !screl.EqualElementKeys(es.element, e) {
 			panic(errors.AssertionFailedf("element key %v does not match element: %s",
 				key, screl.ElementString(es.element)))
 		}

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_drop_column
@@ -132,7 +132,7 @@ ALTER TABLE defaultdb.t DROP COLUMN l
   {columnId: 4, name: l, tableId: 104}
 - [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 4}, ABSENT], PUBLIC]
   {columnId: 4, tableId: 104, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 104, ColumnID: 4}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 104, ColumnID: 4, ReferencedSequenceIDs: [105]}, ABSENT], PUBLIC]
   {columnId: 4, expr: 'nextval(105:::REGCLASS)', tableId: 104, usesSequenceIds: [105]}
 - [[SequenceOwner:{DescID: 104, ColumnID: 4, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {columnId: 4, sequenceId: 105, tableId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_database
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_database
@@ -109,7 +109,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 3, name: val, tableId: 110}
 - [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
   {columnId: 3, isNullable: true, isRelationBeingDropped: true, tableId: 110, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT], PUBLIC]
   {columnId: 3, expr: 'nextval(107:::REGCLASS)', tableId: 110, usesSequenceIds: [107]}
 - [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 110}
@@ -181,7 +181,7 @@ DROP DATABASE db1 CASCADE
   {columnId: 3, name: val, tableId: 109}
 - [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
   {columnId: 3, isNullable: true, isRelationBeingDropped: true, tableId: 109, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT], PUBLIC]
   {columnId: 3, expr: 'nextval(108:::REGCLASS)', tableId: 109, usesSequenceIds: [108]}
 - [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 109}
@@ -371,7 +371,7 @@ DROP DATABASE db1 CASCADE
   {descriptorId: 116, privileges: 512, userName: public}
 - [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 116, privileges: 2, userName: root}
-- [[AliasType:{DescID: 116}, ABSENT], PUBLIC]
+- [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC]
   {closedTypeIds: [115, 116], type: {arrayContents: {family: EnumFamily, oid: 100115, udtMetadata: {arrayTypeOid: 100116}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100116}, typeId: 116}
 - [[ObjectParent:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC]
   {objectId: 116, parentSchemaId: 106}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_owned_by
@@ -78,7 +78,7 @@ DROP OWNED BY r
   {columnId: 3, name: val, tableId: 109}
 - [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
   {columnId: 3, isNullable: true, isRelationBeingDropped: true, tableId: 109, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC]
   {columnId: 3, expr: 'nextval(106:::REGCLASS)', tableId: 109, usesSequenceIds: [106]}
 - [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 109}
@@ -146,7 +146,7 @@ DROP OWNED BY r
   {columnId: 3, name: val, tableId: 108}
 - [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
   {columnId: 3, isNullable: true, isRelationBeingDropped: true, tableId: 108, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 108, ColumnID: 3}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 108, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT], PUBLIC]
   {columnId: 3, expr: 'nextval(107:::REGCLASS)', tableId: 108, usesSequenceIds: [107]}
 - [[Column:{DescID: 108, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 108}
@@ -226,7 +226,7 @@ DROP OWNED BY r
   {descriptorId: 112, privileges: 512, userName: public}
 - [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 112, privileges: 2, userName: root}
-- [[AliasType:{DescID: 112}, ABSENT], PUBLIC]
+- [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC]
   {closedTypeIds: [111, 112], type: {arrayContents: {family: EnumFamily, oid: 100111, udtMetadata: {arrayTypeOid: 100112}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100112}, typeId: 112}
 - [[ObjectParent:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC]
   {objectId: 112, parentSchemaId: 105}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_schema
@@ -81,7 +81,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {columnId: 3, name: val, tableId: 107}
 - [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC]
   {columnId: 3, isNullable: true, isRelationBeingDropped: true, tableId: 107, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC]
   {columnId: 3, expr: 'nextval(106:::REGCLASS)', tableId: 107, usesSequenceIds: [106]}
 - [[Column:{DescID: 107, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 107}
@@ -271,7 +271,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   {descriptorId: 113, privileges: 512, userName: public}
 - [[UserPrivileges:{DescID: 113, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 113, privileges: 2, userName: root}
-- [[AliasType:{DescID: 113}, ABSENT], PUBLIC]
+- [[AliasType:{DescID: 113, ReferencedTypeIDs: [112 113]}, ABSENT], PUBLIC]
   {closedTypeIds: [112, 113], type: {arrayContents: {family: EnumFamily, oid: 100112, udtMetadata: {arrayTypeOid: 100113}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100113}, typeId: 113}
 - [[ObjectParent:{DescID: 113, ReferencedDescID: 104}, ABSENT], PUBLIC]
   {objectId: 113, parentSchemaId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_sequence
@@ -40,11 +40,11 @@ DROP SEQUENCE defaultdb.SQ1 CASCADE
   {sequenceId: 104}
 - [[ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {objectId: 104, parentSchemaId: 101}
-- [[ColumnDefaultExpression:{DescID: 105, ColumnID: 2}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 105, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT], PUBLIC]
   {columnId: 2, expr: 'nextval(104:::REGCLASS)', tableId: 105, usesSequenceIds: [104]}
-- [[ColumnDefaultExpression:{DescID: 106, ColumnID: 2}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT], PUBLIC]
   {columnId: 2, expr: 'nextval(104:::REGCLASS)', tableId: 106, usesSequenceIds: [104]}
-- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 2}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT], PUBLIC]
   {columnId: 2, expr: 'CAST(chr(nextval(104:::REGCLASS)) AS @100107)', tableId: 109, usesSequenceIds: [104], usesTypeIds: [107, 108]}
 
 setup

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_table
@@ -81,13 +81,13 @@ DROP TABLE defaultdb.shipments CASCADE;
   {columnId: 5, name: randcol, tableId: 109}
 - [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 5}, ABSENT], PUBLIC]
   {columnId: 5, isNullable: true, isRelationBeingDropped: true, tableId: 109, type: {family: IntFamily, oid: 20, width: 64}}
-- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT], PUBLIC]
+- [[ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC]
   {columnId: 5, expr: 'nextval(106:::REGCLASS)', tableId: 109, usesSequenceIds: [106]}
 - [[Column:{DescID: 109, ColumnID: 6}, ABSENT], PUBLIC]
   {columnId: 6, pgAttributeNum: 6, tableId: 109}
 - [[ColumnName:{DescID: 109, Name: val, ColumnID: 6}, ABSENT], PUBLIC]
   {columnId: 6, name: val, tableId: 109}
-- [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 6}, ABSENT], PUBLIC]
+- [[ColumnType:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnFamilyID: 0, ColumnID: 6}, ABSENT], PUBLIC]
   {closedTypeIds: [107, 108], columnId: 6, computeExpr: {expr: 'x''80'':::@100107', usesTypeIds: [107, 108]}, isNullable: true, isRelationBeingDropped: true, tableId: 109, type: {family: EnumFamily, oid: 100107, udtMetadata: {arrayTypeOid: 100108}}}
 - [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], PUBLIC]
   {columnId: 4.294967295e+09, isHidden: true, isSystemColumn: true, pgAttributeNum: 4.294967295e+09, tableId: 109}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_type
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_type
@@ -31,7 +31,7 @@ DROP TYPE defaultdb.typ
   {descriptorId: 105, privileges: 512, userName: public}
 - [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC]
   {descriptorId: 105, privileges: 2, userName: root}
-- [[AliasType:{DescID: 105}, ABSENT], PUBLIC]
+- [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], PUBLIC]
   {closedTypeIds: [104, 105], type: {arrayContents: {family: EnumFamily, oid: 100104, udtMetadata: {arrayTypeOid: 100105}}, arrayElemType: EnumFamily, family: ArrayFamily, oid: 100105}, typeId: 105}
 - [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC]
   {objectId: 105, parentSchemaId: 101}

--- a/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules",
     visibility = ["//pkg/sql/schemachanger/scplan:__subpackages__"],
     deps = [
-        "//pkg/sql/catalog/descpb",
         "//pkg/sql/schemachanger/rel",
         "//pkg/sql/schemachanger/scpb",
         "//pkg/sql/schemachanger/scplan/internal/opgen",

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_drop_index.go
@@ -89,8 +89,6 @@ func init() {
 	// set iff the parent relation is dropped. This is a dirty hack, ideally we
 	// should be able to express the _absence_ of a target element as a query
 	// clause.
-	//
-	// TODO(postamar): express this rule in a saner way
 	registerDepRuleForDrop(
 		"partial predicate removed right before secondary index when not dropping relation",
 		scgraph.SameStagePrecedence,
@@ -99,13 +97,9 @@ func init() {
 		func(from, to nodeVars) rel.Clauses {
 			return rel.Clauses{
 				from.Type((*scpb.SecondaryIndexPartial)(nil)),
+				from.descriptorIsNotBeingDropped(),
 				to.Type((*scpb.SecondaryIndex)(nil)),
 				joinOnIndexID(from, to, "table-id", "index-id"),
-				rel.Filter("relationIsNotBeingDropped", from.el)(
-					func(ip *scpb.SecondaryIndexPartial) bool {
-						return !ip.IsRelationBeingDropped
-					},
-				),
 			}
 		},
 	)

--- a/pkg/sql/schemachanger/scplan/internal/rules/dep_two_version.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/dep_two_version.go
@@ -69,7 +69,7 @@ func init() {
 			from.target.AttrEq(screl.TargetStatus, targetStatus.Status()),
 			from.node.AttrEq(screl.CurrentStatus, t.From()),
 			to.node.AttrEq(screl.CurrentStatus, t.To()),
-			descriptorIsNotBeingDropped(from.el),
+			from.descriptorIsNotBeingDropped(),
 		}
 		if len(prePrevStatuses) > 0 {
 			clauses = append(clauses,

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -13,7 +13,6 @@ package rules
 import (
 	"reflect"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
@@ -22,15 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/errors"
 )
-
-func idInIDs(objects []descpb.ID, id descpb.ID) bool {
-	for _, other := range objects {
-		if other == id {
-			return true
-		}
-	}
-	return false
-}
 
 func join(a, b nodeVars, attr rel.Attr, eqVarName rel.Var) rel.Clause {
 	return joinOn(a, attr, b, attr, eqVarName)
@@ -309,14 +299,6 @@ func isWithTypeT(element scpb.Element) bool {
 	return err == nil
 }
 
-func getTypeTOrPanic(element scpb.Element) *scpb.TypeT {
-	ret, err := getTypeT(element)
-	if err != nil {
-		panic(err)
-	}
-	return ret
-}
-
 func getExpression(element scpb.Element) (*scpb.Expression, error) {
 	switch e := element.(type) {
 	case *scpb.ColumnType:
@@ -351,6 +333,15 @@ func getExpression(element scpb.Element) (*scpb.Expression, error) {
 func isWithExpression(element scpb.Element) bool {
 	_, err := getExpression(element)
 	return err == nil
+}
+
+func isTypeDescriptor(element scpb.Element) bool {
+	switch element.(type) {
+	case *scpb.EnumType, *scpb.AliasType:
+		return true
+	default:
+		return false
+	}
 }
 
 func getExpressionOrPanic(element scpb.Element) *scpb.Expression {
@@ -409,7 +400,20 @@ func isConstraintDependent(e scpb.Element) bool {
 	return false
 }
 
-func not(predicate func(e scpb.Element) bool) func(e scpb.Element) bool {
+type elementTypePredicate = func(e scpb.Element) bool
+
+func or(predicates ...elementTypePredicate) elementTypePredicate {
+	return func(e scpb.Element) bool {
+		for _, p := range predicates {
+			if p(e) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func not(predicate elementTypePredicate) elementTypePredicate {
 	return func(e scpb.Element) bool {
 		return !predicate(e)
 	}

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -344,14 +344,6 @@ func isTypeDescriptor(element scpb.Element) bool {
 	}
 }
 
-func getExpressionOrPanic(element scpb.Element) *scpb.Expression {
-	ret, err := getExpression(element)
-	if err != nil {
-		panic(err)
-	}
-	return ret
-}
-
 func isColumnDependent(e scpb.Element) bool {
 	switch e.(type) {
 	case *scpb.ColumnType:

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -230,6 +230,12 @@ func (v nodeVars) referencedSequenceIDsContains(containedIDVar rel.Var) rel.Clau
 	return v.el.AttrContainsVar(screl.ReferencedSequenceIDs, containedIDVar)
 }
 
+// descriptorIsNotBeingDropped is a type-safe shorthand to invoke the
+// rule of the same name on the element.
+func (v nodeVars) descriptorIsNotBeingDropped() rel.Clause {
+	return descriptorIsNotBeingDropped(v.el)
+}
+
 func mkNodeVars(elStr string) nodeVars {
 	el := rel.Var(elStr)
 	return nodeVars{

--- a/pkg/sql/schemachanger/scplan/internal/rules/registry.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/registry.go
@@ -211,6 +211,25 @@ func (v nodeVars) typeFilter(predicatesForTypeOf ...func(element scpb.Element) b
 	return v.Type(valuesForTypeOf...)
 }
 
+// descIDEq defines a clause which will bind idVar to the DescID of the
+// v's element.
+func (v nodeVars) descIDEq(idVar rel.Var) rel.Clause {
+	return v.el.AttrEqVar(screl.DescID, idVar)
+}
+
+// referencedTypeDescIDsContain defines a clause which will bind containedIDVar
+// to a descriptor ID contained in v's element's referenced type IDs.
+func (v nodeVars) referencedTypeDescIDsContain(containedIDVar rel.Var) rel.Clause {
+	return v.el.AttrContainsVar(screl.ReferencedTypeIDs, containedIDVar)
+}
+
+// referencedSequenceIDsContains defines a clause which will bind
+// containedIDVar to a descriptor ID contained in v's element's referenced
+// sequence IDs.
+func (v nodeVars) referencedSequenceIDsContains(containedIDVar rel.Var) rel.Clause {
+	return v.el.AttrContainsVar(screl.ReferencedSequenceIDs, containedIDVar)
+}
+
 func mkNodeVars(elStr string) nodeVars {
 	el := rel.Var(elStr)
 	return nodeVars{

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -1401,12 +1401,12 @@ deprules
   to: column-node
   query:
     - $column-type[Type] = '*scpb.ColumnType'
+    - descriptorIsNotBeingDropped($column-type)
     - $column[Type] = '*scpb.Column'
     - joinOnColumnID($column-type, $column, $table-id, $col-id)
     - toAbsent($column-type-target, $column-target)
     - $column-type-node[CurrentStatus] = ABSENT
     - $column-node[CurrentStatus] = ABSENT
-    - relationIsNotBeingDropped(*scpb.ColumnType)($column-type)
     - joinTargetNode($column-type, $column-type-target, $column-type-node)
     - joinTargetNode($column, $column-target, $column-node)
 - name: constraint dependent absent right before constraint
@@ -1964,9 +1964,9 @@ deprules
   to: index-node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - descriptorIsNotBeingDropped($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
     - transient($partial-predicate-target, $index-target)
     - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
     - $index-node[CurrentStatus] = TRANSIENT_ABSENT
@@ -1978,9 +1978,9 @@ deprules
   to: index-node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - descriptorIsNotBeingDropped($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
     - toAbsent($partial-predicate-target, $index-target)
     - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-node[CurrentStatus] = ABSENT
@@ -1992,9 +1992,9 @@ deprules
   to: index-node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - descriptorIsNotBeingDropped($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
     - $partial-predicate-target[TargetStatus] = TRANSIENT_ABSENT
     - $partial-predicate-node[CurrentStatus] = TRANSIENT_ABSENT
     - $index-target[TargetStatus] = ABSENT
@@ -2007,9 +2007,9 @@ deprules
   to: index-node
   query:
     - $partial-predicate[Type] = '*scpb.SecondaryIndexPartial'
+    - descriptorIsNotBeingDropped($partial-predicate)
     - $index[Type] = '*scpb.SecondaryIndex'
     - joinOnIndexID($partial-predicate, $index, $table-id, $index-id)
-    - relationIsNotBeingDropped(*scpb.SecondaryIndexPartial)($partial-predicate)
     - $partial-predicate-target[TargetStatus] = ABSENT
     - $partial-predicate-node[CurrentStatus] = ABSENT
     - $index-target[TargetStatus] = TRANSIENT_ABSENT

--- a/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/testdata/deprules
@@ -1691,17 +1691,19 @@ deprules
     - $referencing-via-attr-node[CurrentStatus] = ABSENT
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
     - joinTargetNode($referencing-via-attr, $referencing-via-attr-target, $referencing-via-attr-node)
-- name: descriptor drop right before removing dependent with expr ref
+- name: descriptor drop right before removing dependent with expr ref to sequence
   from: referenced-descriptor-node
   kind: SameStagePrecedence
   to: referencing-via-expr-node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
+    - $referenced-descriptor[Type] = '*scpb.Sequence'
+    - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
+    - $referenced-descriptor[DescID] = $seqID
+    - $referencing-via-expr[ReferencedSequenceIDs] CONTAINS $seqID
     - $referencing-via-expr[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-target, $referencing-via-expr-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
     - $referencing-via-expr-node[CurrentStatus] = ABSENT
-    - RefByExpression(scpb.Element, scpb.Element)($referenced-descriptor, $referencing-via-expr)
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
     - joinTargetNode($referencing-via-expr, $referencing-via-expr-target, $referencing-via-expr-node)
 - name: descriptor drop right before removing dependent with type ref
@@ -1709,12 +1711,14 @@ deprules
   kind: SameStagePrecedence
   to: referencing-via-type-node
   query:
-    - $referenced-descriptor[Type] IN ['*scpb.Database', '*scpb.Schema', '*scpb.View', '*scpb.Sequence', '*scpb.Table', '*scpb.EnumType', '*scpb.AliasType']
-    - $referencing-via-type[Type] = '*scpb.ColumnType'
+    - $referenced-descriptor[Type] IN ['*scpb.EnumType', '*scpb.AliasType']
+    - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
+    - $referenced-descriptor[DescID] = $fromDescID
+    - $referencing-via-type[ReferencedTypeIDs] CONTAINS $fromDescID
+    - $referencing-via-type[Type] IN ['*scpb.CheckConstraint', '*scpb.ColumnType', '*scpb.ColumnDefaultExpression', '*scpb.ColumnOnUpdateExpression', '*scpb.SecondaryIndexPartial']
     - toAbsent($referenced-descriptor-target, $referencing-via-type-target)
     - $referenced-descriptor-node[CurrentStatus] = DROPPED
     - $referencing-via-type-node[CurrentStatus] = ABSENT
-    - RefByTypeT(scpb.Element, scpb.Element)($referenced-descriptor, $referencing-via-type)
     - joinTargetNode($referenced-descriptor, $referenced-descriptor-target, $referenced-descriptor-node)
     - joinTargetNode($referencing-via-type, $referencing-via-type-target, $referencing-via-type-node)
 - name: descriptor removal right before dependent element removal

--- a/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
+++ b/pkg/sql/schemachanger/scplan/internal/scgraph/graph.go
@@ -100,6 +100,14 @@ func New(cs scpb.CurrentState) (*Graph, error) {
 				{Attr: rel.Type, Eq: reflect.TypeOf((*screl.Node)(nil))},
 			},
 		},
+		{
+			Attrs:    []rel.Attr{screl.ReferencedTypeIDs},
+			Inverted: true,
+		},
+		{
+			Attrs:    []rel.Attr{screl.ReferencedSequenceIDs},
+			Inverted: true,
+		},
 	}...)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -121,7 +121,7 @@ func TestPlanDataDriven(t *testing.T) {
 // an arbitrary stage in the existing plan: the results should be the same as in
 // the original plan, minus the stages prior to the selected stage.
 // This guarantees the idempotency of the planning scheme, which is a useful
-// property to have. For instance it guarantees that the output of EXPLAIN (DDL)
+// property to have. For instance, it guarantees that the output of EXPLAIN (DDL)
 // represents the plan that actually gets executed in the various execution
 // phases.
 func validatePlan(t *testing.T, plan *scplan.Plan) {

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -10,7 +10,7 @@ StatementPhase stage 1 of 1 with 6 MutationType ops
   transitions:
     [[Column:{DescID: 104, ColumnID: 2}, PUBLIC], ABSENT] -> DELETE_ONLY
     [[ColumnName:{DescID: 104, Name: j, ColumnID: 2}, PUBLIC], ABSENT] -> PUBLIC
-    [[ColumnType:{DescID: 104, ColumnFamilyID: 0, ColumnID: 2}, PUBLIC], ABSENT] -> PUBLIC
+    [[ColumnType:{DescID: 104, ReferencedTypeIDs: [105 106], ColumnFamilyID: 0, ColumnID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 1}, PUBLIC], ABSENT] -> PUBLIC
   ops:
     *scop.MakeAbsentColumnDeleteOnly

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -240,7 +240,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 19 MutationType ops
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 2}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: v1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: v2, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
@@ -463,7 +463,7 @@ PostCommitNonRevertiblePhase stage 2 of 3 with 17 MutationType ops
 PostCommitNonRevertiblePhase stage 3 of 3 with 9 MutationType ops
   transitions:
     [[Column:{DescID: 107, ColumnID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
-    [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
   ops:
     *scop.CreateGCJobForIndex
@@ -534,7 +534,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 2}, WRITE_ONLY]
@@ -558,7 +558,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 3}, WRITE_ONLY]
@@ -609,16 +609,12 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [Column:{DescID: 108, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+- from: [ColumnType:{DescID: 107, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   to:   [Column:{DescID: 107, ColumnID: 2}, ABSENT]
   kind: SameStagePrecedence
   rules: [dependents removed before column; column type removed right before column when not dropping relation]
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   to:   [Column:{DescID: 108, ColumnID: 1}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
@@ -631,6 +627,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   rule: dependents removed before column
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   to:   [Column:{DescID: 108, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT]
@@ -894,10 +894,6 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before dependent element removal
-- from: [View:{DescID: 108}, DROPPED]
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
@@ -907,6 +903,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before dependent element removal
+- from: [View:{DescID: 108}, DROPPED]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
@@ -1179,7 +1179,7 @@ PostCommitNonRevertiblePhase stage 1 of 3 with 20 MutationType ops
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 2}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: v1, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: v2, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
@@ -1407,7 +1407,7 @@ PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops
   transitions:
     [[Column:{DescID: 107, ColumnID: 3}, ABSENT], DELETE_ONLY] -> ABSENT
     [[ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC] -> ABSENT
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
   ops:
     *scop.CreateGCJobForIndex
@@ -1477,7 +1477,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: PreviousTransactionPrecedence
   rule: Column transitions to ABSENT uphold 2-version invariant: WRITE_ONLY->DELETE_ONLY
 - from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 107, ColumnID: 3}, WRITE_ONLY]
@@ -1509,7 +1509,7 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 2}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 108, ColumnID: 3}, WRITE_ONLY]
@@ -1536,11 +1536,11 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT]
   to:   [Column:{DescID: 107, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnDefaultExpression:{DescID: 107, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 107, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT]
   to:   [ColumnType:{DescID: 107, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
@@ -1576,10 +1576,6 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [Column:{DescID: 108, ColumnID: 1}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   to:   [Column:{DescID: 108, ColumnID: 3}, ABSENT]
   kind: Precedence
@@ -1590,6 +1586,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   rule: dependents removed before column
 - from: [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   to:   [Column:{DescID: 108, ColumnID: 4294967295}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
+  to:   [Column:{DescID: 108, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT]
@@ -1857,10 +1857,6 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
-  to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before dependent element removal
-- from: [View:{DescID: 108}, DROPPED]
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
@@ -1870,6 +1866,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]
   to:   [ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before dependent element removal
+- from: [View:{DescID: 108}, DROPPED]
+  to:   [ColumnType:{DescID: 108, ReferencedTypeIDs: [104 105], ColumnFamilyID: 0, ColumnID: 2}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [View:{DescID: 108}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_database
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_database
@@ -60,7 +60,7 @@ StatementPhase stage 1 of 1 with 14 MutationType ops
     [[Column:{DescID: 114, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 114, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[EnumType:{DescID: 115}, ABSENT], PUBLIC] -> TXN_DROPPED
-    [[AliasType:{DescID: 116}, ABSENT], PUBLIC] -> TXN_DROPPED
+    [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[View:{DescID: 117}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[Column:{DescID: 117, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 117, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -142,7 +142,7 @@ PreCommitPhase stage 1 of 1 with 68 MutationType ops
     [[Column:{DescID: 110, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 110, Name: val, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 110, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -177,7 +177,7 @@ PreCommitPhase stage 1 of 1 with 68 MutationType ops
     [[Column:{DescID: 109, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: val, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -271,7 +271,7 @@ PreCommitPhase stage 1 of 1 with 68 MutationType ops
     [[UserPrivileges:{DescID: 116, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 116, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[AliasType:{DescID: 116}, ABSENT], TXN_DROPPED] -> DROPPED
+    [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], TXN_DROPPED] -> DROPPED
     [[ObjectParent:{DescID: 116, ReferencedDescID: 106}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 117, Name: v5, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 117}, ABSENT], PUBLIC] -> ABSENT
@@ -600,7 +600,7 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 74 MutationType ops
     [[Column:{DescID: 114, ColumnID: 4294967295}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 114, ColumnID: 4294967294}, ABSENT], DELETE_ONLY] -> ABSENT
     [[EnumType:{DescID: 115}, ABSENT], DROPPED] -> ABSENT
-    [[AliasType:{DescID: 116}, ABSENT], DROPPED] -> ABSENT
+    [[AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT], DROPPED] -> ABSENT
     [[View:{DescID: 117}, ABSENT], DROPPED] -> ABSENT
     [[Column:{DescID: 117, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 117, ColumnID: 2}, ABSENT], DELETE_ONLY] -> ABSENT
@@ -1263,36 +1263,36 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 74 MutationType ops
 deps
 DROP DATABASE db1 CASCADE
 ----
-- from: [AliasType:{DescID: 116}, DROPPED]
-  to:   [AliasType:{DescID: 116}, ABSENT]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
+  to:   [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, ABSENT]
   kind: PreviousTransactionPrecedence
   rule: descriptor DROPPED in transaction before removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [Namespace:{DescID: 116, Name: _typ, ReferencedDescID: 104}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [ObjectParent:{DescID: 116, ReferencedDescID: 106}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [Owner:{DescID: 116}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [UserPrivileges:{DescID: 116, Name: admin}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [UserPrivileges:{DescID: 116, Name: public}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   to:   [UserPrivileges:{DescID: 116, Name: root}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 116}, TXN_DROPPED]
-  to:   [AliasType:{DescID: 116}, DROPPED]
+- from: [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, TXN_DROPPED]
+  to:   [AliasType:{DescID: 116, ReferencedTypeIDs: [115 116]}, DROPPED]
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [Column:{DescID: 109, ColumnID: 1}, WRITE_ONLY]
@@ -1320,7 +1320,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 3}, WRITE_ONLY]
@@ -1376,7 +1376,7 @@ DROP DATABASE db1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 110, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 110, ColumnID: 3}, WRITE_ONLY]
@@ -1567,19 +1567,19 @@ DROP DATABASE db1 CASCADE
   to:   [ColumnType:{DescID: 117, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT]
   to:   [Column:{DescID: 109, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT]
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
-- from: [ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT]
   to:   [Column:{DescID: 110, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT]
   to:   [ColumnType:{DescID: 110, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
@@ -2152,9 +2152,9 @@ DROP DATABASE db1 CASCADE
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [Sequence:{DescID: 107}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT]
   kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with expr ref
+  rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 107}, DROPPED]
   to:   [Namespace:{DescID: 107, Name: sq1, ReferencedDescID: 104}, ABSENT]
   kind: SameStagePrecedence
@@ -2184,9 +2184,9 @@ DROP DATABASE db1 CASCADE
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [Sequence:{DescID: 108}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT]
   kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with expr ref
+  rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 108}, DROPPED]
   to:   [Namespace:{DescID: 108, Name: sq1, ReferencedDescID: 104}, ABSENT]
   kind: SameStagePrecedence
@@ -2240,7 +2240,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor removal right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [108]}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -2360,7 +2360,7 @@ DROP DATABASE db1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor removal right before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 110, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 110}, DROPPED]

--- a/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_owned_by
@@ -41,7 +41,7 @@ StatementPhase stage 1 of 1 with 9 MutationType ops
     [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> TXN_DROPPED
-    [[AliasType:{DescID: 112}, ABSENT], PUBLIC] -> TXN_DROPPED
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[View:{DescID: 113}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[Column:{DescID: 113, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 113, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -98,7 +98,7 @@ PreCommitPhase stage 1 of 1 with 46 MutationType ops
     [[Column:{DescID: 109, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: val, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 3, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -132,7 +132,7 @@ PreCommitPhase stage 1 of 1 with 46 MutationType ops
     [[Column:{DescID: 108, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: val, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 108, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 108, ColumnID: 3, ReferencedSequenceIDs: [107]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 108, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 108, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -172,7 +172,7 @@ PreCommitPhase stage 1 of 1 with 46 MutationType ops
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[AliasType:{DescID: 112}, ABSENT], TXN_DROPPED] -> DROPPED
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], TXN_DROPPED] -> DROPPED
     [[ObjectParent:{DescID: 112, ReferencedDescID: 105}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 113, Name: v2, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
@@ -395,7 +395,7 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 47 MutationType ops
     [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], DELETE_ONLY] -> ABSENT
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> ABSENT
-    [[AliasType:{DescID: 112}, ABSENT], DROPPED] -> ABSENT
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> ABSENT
     [[View:{DescID: 113}, ABSENT], DROPPED] -> ABSENT
     [[Column:{DescID: 113, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 113, ColumnID: 2}, ABSENT], DELETE_ONLY] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_schema
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_schema
@@ -15,36 +15,36 @@ COMMENT ON TABLE sc1.t1 IS 't1 is good table';
 deps
 DROP SCHEMA defaultdb.SC1 CASCADE
 ----
-- from: [AliasType:{DescID: 112}, DROPPED]
-  to:   [AliasType:{DescID: 112}, ABSENT]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
+  to:   [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT]
   kind: PreviousTransactionPrecedence
   rule: descriptor DROPPED in transaction before removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [Namespace:{DescID: 112, Name: _typ, ReferencedDescID: 100}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [ObjectParent:{DescID: 112, ReferencedDescID: 104}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [Owner:{DescID: 112}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [UserPrivileges:{DescID: 112, Name: admin}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [UserPrivileges:{DescID: 112, Name: public}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   to:   [UserPrivileges:{DescID: 112, Name: root}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 112}, TXN_DROPPED]
-  to:   [AliasType:{DescID: 112}, DROPPED]
+- from: [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, TXN_DROPPED]
+  to:   [AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, DROPPED]
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [Column:{DescID: 106, ColumnID: 1}, WRITE_ONLY]
@@ -72,7 +72,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 106, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 106, ColumnID: 3}, WRITE_ONLY]
@@ -263,11 +263,11 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   to:   [ColumnType:{DescID: 113, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
-- from: [ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT]
   to:   [Column:{DescID: 106, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT]
   to:   [ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
@@ -620,9 +620,9 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [Sequence:{DescID: 105}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT]
   kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with expr ref
+  rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 105}, DROPPED]
   to:   [Namespace:{DescID: 105, Name: sq1, ReferencedDescID: 100}, ABSENT]
   kind: SameStagePrecedence
@@ -676,7 +676,7 @@ DROP SCHEMA defaultdb.SC1 CASCADE
   kind: SameStagePrecedence
   rule: descriptor removal right before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 106}, DROPPED]
@@ -1186,7 +1186,7 @@ StatementPhase stage 1 of 1 with 10 MutationType ops
     [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[EnumType:{DescID: 111}, ABSENT], PUBLIC] -> TXN_DROPPED
-    [[AliasType:{DescID: 112}, ABSENT], PUBLIC] -> TXN_DROPPED
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[View:{DescID: 113}, ABSENT], PUBLIC] -> TXN_DROPPED
     [[Column:{DescID: 113, ColumnID: 1}, ABSENT], PUBLIC] -> WRITE_ONLY
     [[Column:{DescID: 113, ColumnID: 2}, ABSENT], PUBLIC] -> WRITE_ONLY
@@ -1246,7 +1246,7 @@ PreCommitPhase stage 1 of 1 with 49 MutationType ops
     [[Column:{DescID: 106, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 106, Name: val, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 106, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 106, ColumnID: 3, ReferencedSequenceIDs: [105]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 106, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 106, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -1340,7 +1340,7 @@ PreCommitPhase stage 1 of 1 with 49 MutationType ops
     [[UserPrivileges:{DescID: 112, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 112, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[AliasType:{DescID: 112}, ABSENT], TXN_DROPPED] -> DROPPED
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], TXN_DROPPED] -> DROPPED
     [[ObjectParent:{DescID: 112, ReferencedDescID: 104}, ABSENT], PUBLIC] -> ABSENT
     [[Namespace:{DescID: 113, Name: v5, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 113}, ABSENT], PUBLIC] -> ABSENT
@@ -1584,7 +1584,7 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 57 MutationType ops
     [[Column:{DescID: 110, ColumnID: 4294967295}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 110, ColumnID: 4294967294}, ABSENT], DELETE_ONLY] -> ABSENT
     [[EnumType:{DescID: 111}, ABSENT], DROPPED] -> ABSENT
-    [[AliasType:{DescID: 112}, ABSENT], DROPPED] -> ABSENT
+    [[AliasType:{DescID: 112, ReferencedTypeIDs: [111 112]}, ABSENT], DROPPED] -> ABSENT
     [[View:{DescID: 113}, ABSENT], DROPPED] -> ABSENT
     [[Column:{DescID: 113, ColumnID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[Column:{DescID: 113, ColumnID: 2}, ABSENT], DELETE_ONLY] -> ABSENT

--- a/pkg/sql/schemachanger/scplan/testdata/drop_sequence
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_sequence
@@ -95,8 +95,8 @@ PreCommitPhase stage 1 of 1 with 11 MutationType ops
     [[UserPrivileges:{DescID: 104, Name: root}, ABSENT], PUBLIC] -> ABSENT
     [[Sequence:{DescID: 104}, ABSENT], TXN_DROPPED] -> DROPPED
     [[ObjectParent:{DescID: 104, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 105, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 106, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 105, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
       DescriptorID: 104
@@ -186,13 +186,13 @@ deps
 DROP SEQUENCE defaultdb.SQ1 CASCADE
 ----
 - from: [Sequence:{DescID: 104}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 105, ColumnID: 2}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 105, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT]
   kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with expr ref
+  rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 104}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 2}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [104]}, ABSENT]
   kind: SameStagePrecedence
-  rule: descriptor drop right before removing dependent with expr ref
+  rule: descriptor drop right before removing dependent with expr ref to sequence
 - from: [Sequence:{DescID: 104}, DROPPED]
   to:   [Namespace:{DescID: 104, Name: sq1, ReferencedDescID: 100}, ABSENT]
   kind: SameStagePrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -75,14 +75,14 @@ PreCommitPhase stage 1 of 1 with 32 MutationType ops
     [[SequenceOwner:{DescID: 109, ColumnID: 2, ReferencedDescID: 110}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: status, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 4}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: customer_id, ColumnID: 4}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 5}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: randcol, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 4294967295}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 109, Name: crdb_internal_mvcc_timestamp, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967295}, ABSENT], PUBLIC] -> ABSENT
@@ -530,7 +530,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 3}, WRITE_ONLY]
-  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 3}, WRITE_ONLY]
@@ -574,7 +574,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 5}, WRITE_ONLY]
-  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT]
   kind: Precedence
   rule: column no longer public before dependents
 - from: [Column:{DescID: 109, ColumnID: 5}, WRITE_ONLY]
@@ -633,11 +633,11 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
-- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT]
   to:   [Column:{DescID: 109, ColumnID: 5}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT]
+- from: [ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT]
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 5}, ABSENT]
   kind: SameStagePrecedence
   rule: column type dependents removed right before column type
@@ -693,10 +693,6 @@ DROP TABLE defaultdb.shipments CASCADE;
   to:   [Column:{DescID: 109, ColumnID: 2}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
-- from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
-  to:   [Column:{DescID: 109, ColumnID: 3}, ABSENT]
-  kind: Precedence
-  rule: dependents removed before column
 - from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   to:   [Column:{DescID: 109, ColumnID: 4294967294}, ABSENT]
   kind: Precedence
@@ -711,6 +707,10 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: dependents removed before column
 - from: [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 5}, ABSENT]
   to:   [Column:{DescID: 109, ColumnID: 5}, ABSENT]
+  kind: Precedence
+  rule: dependents removed before column
+- from: [ColumnType:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
+  to:   [Column:{DescID: 109, ColumnID: 3}, ABSENT]
   kind: Precedence
   rule: dependents removed before column
 - from: [ColumnType:{DescID: 111, ColumnFamilyID: 0, ColumnID: 1}, ABSENT]
@@ -954,7 +954,7 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 5}, ABSENT]
+  to:   [ColumnDefaultExpression:{DescID: 109, ColumnID: 5, ReferencedSequenceIDs: [106]}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -998,10 +998,6 @@ DROP TABLE defaultdb.shipments CASCADE;
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
-  to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
-  kind: SameStagePrecedence
-  rule: descriptor drop right before dependent element removal
-- from: [Table:{DescID: 109}, DROPPED]
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 4294967294}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
@@ -1015,6 +1011,10 @@ DROP TABLE defaultdb.shipments CASCADE;
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
   to:   [ColumnType:{DescID: 109, ColumnFamilyID: 0, ColumnID: 5}, ABSENT]
+  kind: SameStagePrecedence
+  rule: descriptor drop right before dependent element removal
+- from: [Table:{DescID: 109}, DROPPED]
+  to:   [ColumnType:{DescID: 109, ReferencedTypeIDs: [107 108], ColumnFamilyID: 0, ColumnID: 3}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
 - from: [Table:{DescID: 109}, DROPPED]
@@ -1236,10 +1236,10 @@ PreCommitPhase stage 1 of 1 with 16 MutationType ops
     [[Column:{DescID: 114, ColumnID: 1}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 114, Name: x, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnDefaultExpression:{DescID: 114, ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnDefaultExpression:{DescID: 114, ReferencedTypeIDs: [112 113], ColumnID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 114, ColumnID: 2}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 114, Name: y, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[ColumnType:{DescID: 114, ReferencedTypeIDs: [112 113], ColumnFamilyID: 0, ColumnID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 114, ColumnID: 3}, ABSENT], WRITE_ONLY] -> DELETE_ONLY
     [[ColumnName:{DescID: 114, Name: rowid, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
     [[ColumnType:{DescID: 114, ColumnFamilyID: 0, ColumnID: 3}, ABSENT], PUBLIC] -> ABSENT
@@ -1260,7 +1260,7 @@ PreCommitPhase stage 1 of 1 with 16 MutationType ops
     [[SecondaryIndexPartial:{DescID: 114, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[SecondaryIndex:{DescID: 114, IndexID: 2, ConstraintID: 0}, ABSENT], VALIDATED] -> DELETE_ONLY
     [[IndexName:{DescID: 114, Name: i, IndexID: 2}, ABSENT], PUBLIC] -> ABSENT
-    [[CheckConstraint:{DescID: 114, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
+    [[CheckConstraint:{DescID: 114, ReferencedTypeIDs: [112 113], ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
     [[ConstraintName:{DescID: 114, Name: check, ConstraintID: 2}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped

--- a/pkg/sql/schemachanger/scplan/testdata/drop_type
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_type
@@ -8,7 +8,7 @@ DROP TYPE defaultdb.typ
 StatementPhase stage 1 of 1 with 2 MutationType ops
   transitions:
     [[EnumType:{DescID: 104}, ABSENT], PUBLIC] -> TXN_DROPPED
-    [[AliasType:{DescID: 105}, ABSENT], PUBLIC] -> TXN_DROPPED
+    [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], PUBLIC] -> TXN_DROPPED
   ops:
     *scop.MarkDescriptorAsSyntheticallyDropped
       DescriptorID: 104
@@ -29,7 +29,7 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
     [[UserPrivileges:{DescID: 105, Name: admin}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: public}, ABSENT], PUBLIC] -> ABSENT
     [[UserPrivileges:{DescID: 105, Name: root}, ABSENT], PUBLIC] -> ABSENT
-    [[AliasType:{DescID: 105}, ABSENT], TXN_DROPPED] -> DROPPED
+    [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], TXN_DROPPED] -> DROPPED
     [[ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT], PUBLIC] -> ABSENT
   ops:
     *scop.MarkDescriptorAsDropped
@@ -70,7 +70,7 @@ PreCommitPhase stage 1 of 1 with 7 MutationType ops
 PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
   transitions:
     [[EnumType:{DescID: 104}, ABSENT], DROPPED] -> ABSENT
-    [[AliasType:{DescID: 105}, ABSENT], DROPPED] -> ABSENT
+    [[AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT], DROPPED] -> ABSENT
   ops:
     *scop.LogEvent
       Element:
@@ -128,36 +128,36 @@ PostCommitNonRevertiblePhase stage 1 of 1 with 7 MutationType ops
 deps
 DROP TYPE defaultdb.typ
 ----
-- from: [AliasType:{DescID: 105}, DROPPED]
-  to:   [AliasType:{DescID: 105}, ABSENT]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, ABSENT]
   kind: PreviousTransactionPrecedence
   rule: descriptor DROPPED in transaction before removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [Namespace:{DescID: 105, Name: _typ, ReferencedDescID: 100}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [ObjectParent:{DescID: 105, ReferencedDescID: 101}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [Owner:{DescID: 105}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [UserPrivileges:{DescID: 105, Name: admin}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [UserPrivileges:{DescID: 105, Name: public}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   to:   [UserPrivileges:{DescID: 105, Name: root}, ABSENT]
   kind: SameStagePrecedence
   rule: descriptor drop right before dependent element removal
-- from: [AliasType:{DescID: 105}, TXN_DROPPED]
-  to:   [AliasType:{DescID: 105}, DROPPED]
+- from: [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, TXN_DROPPED]
+  to:   [AliasType:{DescID: 105, ReferencedTypeIDs: [104 105]}, DROPPED]
   kind: PreviousStagePrecedence
   rule: descriptor TXN_DROPPED before DROPPED
 - from: [EnumType:{DescID: 104}, DROPPED]

--- a/pkg/sql/schemachanger/screl/attr.go
+++ b/pkg/sql/schemachanger/screl/attr.go
@@ -77,6 +77,14 @@ const (
 	Element
 	// Target is the reference from a node to a target.
 	Target
+
+	// ReferencedTypeIDs corresponds to a slice of type descriptor IDs referenced
+	// by an element.
+	ReferencedTypeIDs
+	// ReferencedSequenceIDs corresponds to a slice of sequence descriptor IDs
+	// referenced by an element.
+	ReferencedSequenceIDs
+
 	// AttrMax is the largest possible Attr value.
 	// Note: add any new enum values before TargetStatus, leave these at the end.
 	AttrMax = iota - 1
@@ -107,6 +115,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 	),
 	rel.EntityMapping(t((*scpb.AliasType)(nil)),
 		rel.EntityAttr(DescID, "TypeID"),
+		rel.EntityAttr(ReferencedTypeIDs, "ClosedTypeIDs"),
 	),
 	rel.EntityMapping(t((*scpb.EnumType)(nil)),
 		rel.EntityAttr(DescID, "TypeID"),
@@ -161,6 +170,8 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.CheckConstraint)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(ConstraintID, "ConstraintID"),
+		rel.EntityAttr(ReferencedSequenceIDs, "UsesSequenceIDs"),
+		rel.EntityAttr(ReferencedTypeIDs, "UsesTypeIDs"),
 	),
 	rel.EntityMapping(t((*scpb.ForeignKeyConstraint)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
@@ -194,6 +205,7 @@ var elementSchemaOptions = []rel.SchemaOption{
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(ColumnFamilyID, "FamilyID"),
 		rel.EntityAttr(ColumnID, "ColumnID"),
+		rel.EntityAttr(ReferencedTypeIDs, "ClosedTypeIDs"),
 	),
 	rel.EntityMapping(t((*scpb.SequenceOwner)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
@@ -203,10 +215,14 @@ var elementSchemaOptions = []rel.SchemaOption{
 	rel.EntityMapping(t((*scpb.ColumnDefaultExpression)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(ColumnID, "ColumnID"),
+		rel.EntityAttr(ReferencedSequenceIDs, "UsesSequenceIDs"),
+		rel.EntityAttr(ReferencedTypeIDs, "UsesTypeIDs"),
 	),
 	rel.EntityMapping(t((*scpb.ColumnOnUpdateExpression)(nil)),
 		rel.EntityAttr(DescID, "TableID"),
 		rel.EntityAttr(ColumnID, "ColumnID"),
+		rel.EntityAttr(ReferencedSequenceIDs, "UsesSequenceIDs"),
+		rel.EntityAttr(ReferencedTypeIDs, "UsesTypeIDs"),
 	),
 	// Index elements.
 	rel.EntityMapping(t((*scpb.IndexName)(nil)),

--- a/pkg/sql/schemachanger/screl/attr_string.go
+++ b/pkg/sql/schemachanger/screl/attr_string.go
@@ -22,11 +22,13 @@ func _() {
 	_ = x[CurrentStatus-12]
 	_ = x[Element-13]
 	_ = x[Target-14]
+	_ = x[ReferencedTypeIDs-15]
+	_ = x[ReferencedSequenceIDs-16]
 }
 
-const _Attr_name = "DescIDIndexIDColumnFamilyIDColumnIDConstraintIDNameReferencedDescIDCommentTemporaryIndexIDSourceIndexIDTargetStatusCurrentStatusElementTarget"
+const _Attr_name = "DescIDIndexIDColumnFamilyIDColumnIDConstraintIDNameReferencedDescIDCommentTemporaryIndexIDSourceIndexIDTargetStatusCurrentStatusElementTargetReferencedTypeIDsReferencedSequenceIDs"
 
-var _Attr_index = [...]uint8{0, 6, 13, 27, 35, 47, 51, 67, 74, 90, 103, 115, 128, 135, 141}
+var _Attr_index = [...]uint8{0, 6, 13, 27, 35, 47, 51, 67, 74, 90, 103, 115, 128, 135, 141, 158, 179}
 
 func (i Attr) String() string {
 	i -= 1

--- a/pkg/sql/schemachanger/screl/attribute_test.go
+++ b/pkg/sql/schemachanger/screl/attribute_test.go
@@ -33,16 +33,16 @@ func TestGetAttribute(t *testing.T) {
 	// and inequality.
 	expectedStr := `ColumnName:{DescID: 1, Name: foo, ColumnID: 2}`
 	require.Equal(t, expectedStr, ElementString(cn), "Attribute string conversion is broken.")
-	require.True(t, EqualElements(cn, cn))
-	require.False(t, EqualElements(cn, cnDiff))
+	require.True(t, EqualElementKeys(cn, cn))
+	require.False(t, EqualElementKeys(cn, cnDiff))
 
 	// Sanity: Validate type references, then check if type comparisons
 	// work.
 	so := &scpb.SequenceOwner{TableID: 1, ColumnID: 2, SequenceID: 3}
 	expectedStr = `SequenceOwner:{DescID: 1, ColumnID: 2, ReferencedDescID: 3}`
 	require.Equal(t, expectedStr, ElementString(so), "Attribute string conversion is broken.")
-	require.False(t, EqualElements(so, cn))
-	require.False(t, EqualElements(so, cnDiff))
+	require.False(t, EqualElementKeys(so, cn))
+	require.False(t, EqualElementKeys(so, cnDiff))
 }
 
 func BenchmarkCompareElements(b *testing.B) {
@@ -58,7 +58,7 @@ func BenchmarkCompareElements(b *testing.B) {
 	for i := 0; i < int(float64(b.N)/float64(len(elements)*len(elements))); i++ {
 		for _, a := range elements {
 			for _, b := range elements {
-				CompareElements(a, b)
+				Schema.CompareOn(equalityAttrs, a, b)
 			}
 		}
 	}

--- a/pkg/sql/schemachanger/screl/compare.go
+++ b/pkg/sql/schemachanger/screl/compare.go
@@ -20,17 +20,18 @@ var equalityAttrs = func() []rel.Attr {
 	s := make([]rel.Attr, 0, AttrMax)
 	s = append(s, rel.Type)
 	for a := Attr(1); a <= AttrMax; a++ {
-		s = append(s, a)
+		// Do not compare on slice attributes.
+		if !Schema.IsSliceAttr(a) {
+			s = append(s, a)
+		}
 	}
 	return s
 }()
 
-// EqualElements returns true if the two elements are equal.
-func EqualElements(a, b scpb.Element) bool {
+// EqualElementKeys returns true if the two elements are equal over all of
+// their scalar attributes and have the same type. Note that two elements
+// which differ only in the contents of slice attributes will be considered
+// equal by this function.
+func EqualElementKeys(a, b scpb.Element) bool {
 	return Schema.EqualOn(equalityAttrs, a, b)
-}
-
-// CompareElements orders two elements.
-func CompareElements(a, b scpb.Element) (less, eq bool) {
-	return Schema.CompareOn(equalityAttrs, a, b)
 }

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq
@@ -13,7 +13,7 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 106, ColumnID: 2}
  │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 106, Name: l, ColumnID: 2}
  │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
- │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
  │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
  │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_1_of_7
@@ -14,7 +14,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 106, Name: l, ColumnID: 2}
            │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 1, IndexID: 2}
            │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 106, ColumnID: 2, IndexID: 2}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_2_of_7
@@ -32,7 +32,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_3_of_7
@@ -32,7 +32,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_4_of_7
@@ -32,7 +32,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 4 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 8 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_5_of_7
@@ -31,7 +31,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 5 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_6_of_7
@@ -31,7 +31,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 5 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain/add_column_default_seq.rollback_7_of_7
@@ -31,7 +31,7 @@ Schema change plan for rolling back ALTER TABLE ‹db›.public.‹tbl› ADD CO
            ├── 5 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106, ColumnID: 2}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
-           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
            │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}
            └── 10 Mutation operations

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq
@@ -34,7 +34,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │       │   │         rule: "column existence precedes column dependents"
 │       │   │         rule: "column name and type set right after column existence"
 │       │   │
-│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│       │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
 │       │   │   │ ABSENT → PUBLIC
 │       │   │   │
 │       │   │   └── • Precedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
@@ -224,7 +224,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
 │   │   │       ├── • PreviousTransactionPrecedence dependency from DELETE_ONLY Column:{DescID: 106, ColumnID: 2}
 │   │   │       │     rule: "Column transitions to PUBLIC uphold 2-version invariant: DELETE_ONLY->WRITE_ONLY"
 │   │   │       │
-│   │   │       └── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+│   │   │       └── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
 │   │   │             rule: "DEFAULT or ON UPDATE existence precedes writes to column"
 │   │   │
 │   │   ├── • 1 element transitioning toward TRANSIENT_ABSENT
@@ -419,7 +419,7 @@ EXPLAIN (ddl, verbose) ALTER TABLE db.public.tbl ADD COLUMN l INT NOT NULL DEFAU
     │   │   │   ├── • Precedence dependency from PUBLIC ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
-    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+    │   │   │   ├── • Precedence dependency from PUBLIC ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
     │   │   │   │     rule: "column dependents exist before column becomes public"
     │   │   │   │
     │   │   │   ├── • Precedence dependency from PUBLIC PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_1_of_7
@@ -28,7 +28,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -46,10 +46,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 1 of 7;
         │   ├── • ColumnType:{DescID: 106, ColumnFamilyID: 0, ColumnID: 2}
         │   │   │ PUBLIC → ABSENT
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │     PUBLIC → ABSENT
         │   │
         │   ├── • PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_2_of_7
@@ -140,7 +140,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -158,10 +158,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 2 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_3_of_7
@@ -140,7 +140,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -158,10 +158,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 3 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_4_of_7
@@ -140,7 +140,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -158,10 +158,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 4 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_5_of_7
@@ -116,7 +116,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -134,10 +134,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 5 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_6_of_7
@@ -116,7 +116,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -134,10 +134,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 6 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}

--- a/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
+++ b/pkg/sql/schemachanger/testdata/explain_verbose/add_column_default_seq.rollback_7_of_7
@@ -116,7 +116,7 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   │     rule: "dependents removed before column"
         │   │   │     rule: "column type removed right before column when not dropping relation"
         │   │   │
-        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   ├── • Precedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │     rule: "dependents removed before column"
         │   │   │
         │   │   ├── • Precedence dependency from ABSENT PrimaryIndex:{DescID: 106, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}
@@ -134,10 +134,10 @@ EXPLAIN (ddl, verbose) rollback at post-commit stage 7 of 7;
         │   │   ├── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}
         │   │   │     rule: "column no longer public before dependents"
         │   │   │
-        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   │   └── • SameStagePrecedence dependency from ABSENT ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │         rule: "column type dependents removed right before column type"
         │   │
-        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2}
+        │   ├── • ColumnDefaultExpression:{DescID: 106, ColumnID: 2, ReferencedSequenceIDs: [107]}
         │   │   │ PUBLIC → ABSENT
         │   │   │
         │   │   └── • Precedence dependency from WRITE_ONLY Column:{DescID: 106, ColumnID: 2}


### PR DESCRIPTION
#### screl,scplan/rule: adopt containment

#### sql/schemachanger/rel: support inverted indexes and slice containment

This commit introduces some new concepts to rel:
* Slice attributes
* Inverted indexing of slice attributes
* Containment queries over slice attributes

One note is that the only support for containment queries is via an inverted
index. In the future, we could add direct containment evaluation such that if
we have a slice we could go iterate its members.

The basic idea is to introduce a slice membership type for the slice column
and to use the attribute in question to refer to the slice member value.

#### sql/schemachanger/rel: fix embedding support

#### sql/schemachanger/rel: optimize error checking
This change ends up making a huge difference. Otherwise, each subquery
invocation would lead to allocations which showed up in the profiles.

Fixes #86042

Release note: None