### PR TITLE
roachtest: increase slowness threshold in streamer subtest

### DIFF
--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -591,7 +591,7 @@ func registerTPCHVec(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCHVec(ctx, t, c, newTpchVecPerfTest(
 				"sql.distsql.use_streamer.enabled", /* settingName */
-				1.25,                               /* slownessThreshold */
+				1.5,                                /* slownessThreshold */
 			), baseTestRun)
 		},
 	})


### PR DESCRIPTION
This commit bumps up the slowness threshold for the `streamer` subtest from 1.25 to 1.5 in order to eliminate rare flakes on Q1 (which doesn't use the streamer at all). 1.5 threshold should still be sufficient as a sanity check (that the streamer doesn't become extremely slow).

Fixes: #87791.

Release note: None