### PR TITLE
roachtest: do not generate division ops in costfuzz and unoptimized tests

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -182,6 +182,7 @@ func runOneRoundQueryComparison(
 		// TODO(mgartner): Re-enable aggregate functions when we can guarantee
 		// they are deterministic.
 		sqlsmith.DisableAggregateFuncs(),
+		sqlsmith.DisableDivision(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),
 	)

--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -335,6 +335,10 @@ func makeBinOp(s *Smither, typ *types.T, refs colRefs) (tree.TypedExpr, bool) {
 			op.RightType = transform.rightType
 		}
 	}
+	if s.disableDivision &&
+		(op.Operator.Symbol == treebin.Div || op.Operator.Symbol == treebin.FloorDiv) {
+		return nil, false
+	}
 	left := makeScalar(s, op.LeftType, refs)
 	right := makeScalar(s, op.RightType, refs)
 	return castType(

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -97,6 +97,7 @@ type Smither struct {
 	disableIndexHints          bool
 	lowProbWhereWithJoinTables bool
 	disableInsertSelect        bool
+	disableDivision            bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -434,6 +435,13 @@ var LowProbabilityWhereClauseWithJoinTables = simpleOption("low probability wher
 // source expression is nullable and the target column is not.
 var DisableInsertSelect = simpleOption("disable insert select", func(s *Smither) {
 	s.disableInsertSelect = true
+})
+
+// DisableDivision disables generation of the division operator (/) and the
+// floor division operator (//).
+// TODO(mgartner): Remove this once #86790 is addressed.
+var DisableDivision = simpleOption("disable division", func(s *Smither) {
+	s.disableDivision = true
 })
 
 // CompareMode causes the Smither to generate statements that have


### PR DESCRIPTION
The division (`/`) and floor division (`//`) operators were making costfuzz and unoptimized-query-oracle tests flaky. This commit disables generation of these operators as a temporary mitigation for these flakes.

Informs #86790

Release note: None