### PR TITLE
backupccl: prevent restore schema_only from inserting stats

### DIFF
--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -177,12 +176,6 @@ func (d *datadrivenTestState) addServer(t *testing.T, cfg serverCfg) error {
 	}
 	if cfg.testingKnobCfg != "" {
 		switch cfg.testingKnobCfg {
-		case "RecoverFromIterPanic":
-			params.ServerArgs.Knobs.DistSQL = &execinfra.TestingKnobs{
-				BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
-					RecoverFromIterPanic: true,
-				},
-			}
 		default:
 			t.Fatalf("TestingKnobCfg %s not found", cfg.testingKnobCfg)
 		}

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1857,6 +1857,11 @@ func insertStats(
 	latestStats []*stats.TableStatisticProto,
 ) error {
 	details := job.Details().(jobspb.RestoreDetails)
+
+	if details.SchemaOnly {
+		// Only insert table stats from the backup manifest if actual data was restored.
+		return nil
+	}
 	if details.StatsInserted {
 		return nil
 	}

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only
@@ -122,6 +122,13 @@ exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 
+
+## ensure no table statistics are inserted on behalf of all previous schema_only restores
+query-sql
+SELECT * FROM system.table_statistics;
+----
+
+
 # There should be no data in the user tables.
 query-sql
 SELECT * FROM d2.t1;

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-validation-only
@@ -126,6 +126,13 @@ exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d2';
 ----
 
+
+## ensure no table statistics are inserted on behalf of all previous schema_only restores
+query-sql
+SELECT * FROM system.table_statistics;
+----
+
+
 # There should be no data in the user tables.
 query-sql
 SELECT * FROM d2.t1;
@@ -154,12 +161,6 @@ INSERT INTO d2.t2 VALUES ('hi');
 # Part 2: test this checks corrupt data
 ########
 
-# A new cluster that recovers from checksum error.
-# A pebble bug causes the readAsOfIterator.Close() to panic. This should not occur.
-# TODO(msbutler): refactor test once this is addressed.
-new-server name=s3 share-io-dir=s1 allow-implicit-access testingKnobCfg=RecoverFromIterPanic
-----
-
 corrupt-backup uri='nodelocal://0/full_database_backup/'
 ----
 
@@ -168,8 +169,7 @@ exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, new_db_name='d3';
 ----
 
-# But verify-backup-table-data catches it
-# TODO(msbutler): refactor the test once this is addressed
+# But verify_backup_table_data catches the corrupt backup file
 exec-sql expect-error-regex=(pebble/table: invalid table 000000)
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/full_database_backup/' with schema_only, verify_backup_table_data, new_db_name='d4';
 ----

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1598,9 +1598,6 @@ type BackupRestoreTestingKnobs struct {
 	// testing. This is typically the bulk mem monitor if not
 	// specified here.
 	BackupMemMonitor *mon.BytesMonitor
-
-	// RecoverFromIterClosePanic prevents the node from panicing during ReadAsOfIterator.Close
-	RecoverFromIterPanic bool
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
This small patch prevents restore with schema_only from writing the backup stats from the backup manifest, leading to temporary misleading estimated row counts on restored tables.

This patch also cleans up some testing infrastucture on the restore verify-table-data tests that was necessary to prevent spurious panics before https://github.com/cockroachdb/pebble/pull/1921 landed.

Fixes #87221