### PR TITLE
ui: add insights link and fix no insights message

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/emptySchemaInsightsTablePlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/emptySchemaInsightsTablePlaceholder.tsx
@@ -12,9 +12,17 @@ import React from "react";
 import { EmptyTable, EmptyTableProps } from "src/empty";
 import magnifyingGlassImg from "src/assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "src/assets/emptyState/empty-table-results.svg";
+import { Anchor } from "../../anchor";
+import { insights } from "../../util";
+
+const footer = (
+  <Anchor href={insights} target="_blank">
+    Learn more about insights.
+  </Anchor>
+);
 
 const emptySearchResults = {
-  title: "No schema insight match your search.",
+  title: "No schema insights match your search.",
   icon: magnifyingGlassImg,
 };
 
@@ -24,8 +32,9 @@ export const EmptySchemaInsightsTablePlaceholder: React.FC<{
   const emptyPlaceholderProps: EmptyTableProps = props.isEmptySearchResults
     ? emptySearchResults
     : {
-        title: "No schema insight since this page was last refreshed.",
+        title: "No insight events since this page was last refreshed.",
         icon: emptyTableResultsImg,
+        footer,
       };
 
   return <EmptyTable {...emptyPlaceholderProps} />;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/emptyInsightsTablePlaceholder.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/emptyInsightsTablePlaceholder.tsx
@@ -11,13 +11,13 @@
 import React from "react";
 import { EmptyTable, EmptyTableProps } from "src/empty";
 import { Anchor } from "src/anchor";
-import { transactionContention } from "src/util";
+import { insights } from "src/util";
 import magnifyingGlassImg from "src/assets/emptyState/magnifying-glass.svg";
 import emptyTableResultsImg from "src/assets/emptyState/empty-table-results.svg";
 
 const footer = (
-  <Anchor href={transactionContention} target="_blank">
-    Learn more about transaction contention.
+  <Anchor href={insights} target="_blank">
+    Learn more about insights.
   </Anchor>
 );
 

--- a/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/docs.ts
@@ -134,3 +134,4 @@ export const performanceTuningRecipes = docsURLNoVersion(
 export const transactionContention = docsURL(
   "transactions.html#transaction-contention",
 );
+export const insights = docsURL("ui-insights-page.html");


### PR DESCRIPTION
- Change transaction contention link to insights link on workload insights pages.
<img width="1271" alt="Screen Shot 2022-09-12 at 11 43 25 AM" src="https://user-images.githubusercontent.com/54999459/189710256-08c01bc4-f49f-4652-b0ae-71fcbcfb4fba.png">

- Add insights link to schema insights page.
- Change no insights message on schema insights page to match message on workload insights page.
<img width="634" alt="Screen Shot 2022-09-12 at 11 43 01 AM" src="https://user-images.githubusercontent.com/54999459/189710316-5c33625e-ea60-40ee-acd2-68a8c866a72a.png">

Fixes #87198

Note:
- Insights page (https://www.cockroachlabs.com/docs/dev/ui-insights-page.html) does not currently exist, but will be added later in another pr (https://github.com/cockroachdb/docs/pull/15074)

Release note (ui change): Add insights link to all insights pages, and change schema insights message to match message on workload insights page.