### PR TITLE
opt: reduce allocations in extracting join conditions

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1179,7 +1179,7 @@ func (b *Builder) buildHashJoin(join memo.RelExpr) (execPlan, error) {
 		}
 	}
 
-	leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
+	leftEq, rightEq := memo.ExtractJoinEqualityColumns(
 		leftExpr.Relational().OutputCols,
 		rightExpr.Relational().OutputCols,
 		*filters,

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -149,13 +149,12 @@ func (b *ConstraintBuilder) Build(
 	// eqFilterOrds calculated during Init would no longer be valid because the
 	// ordinals of the filters will have changed.
 	leftEq, rightEq, eqFilterOrds :=
-		memo.ExtractJoinEqualityColumns(b.leftCols, b.rightCols, onFilters)
+		memo.ExtractJoinEqualityColumnsWithFilterOrds(b.leftCols, b.rightCols, onFilters)
 	rightEqSet := rightEq.ToSet()
 
 	// Retrieve the inequality columns from onFilters.
-	_, rightCmp, inequalityFilterOrds := memo.ExtractJoinConditionColumns(
-		b.leftCols, b.rightCols, onFilters, true, /* inequality */
-	)
+	rightCmp, inequalityFilterOrds :=
+		memo.ExtractJoinInequalityRightColumnsWithFilterOrds(b.leftCols, b.rightCols, onFilters)
 
 	allFilters := append(onFilters, optionalFilters...)
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -299,7 +299,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		fmt.Fprintf(f.Buffer, "%v", e.Op())
 		if opt.IsJoinNonApplyOp(t) {
 			// All join ops that weren't handled above execute as a hash join.
-			if leftEqCols, _, _ := ExtractJoinEqualityColumns(
+			if leftEqCols := ExtractJoinEqualityLeftColumns(
 				e.Child(0).(RelExpr).Relational().OutputCols,
 				e.Child(1).(RelExpr).Relational().OutputCols,
 				*e.Child(2).(*FiltersExpr),

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -850,11 +850,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	on := join.Child(2).(*memo.FiltersExpr)
 	leftCols := join.Child(0).(memo.RelExpr).Relational().OutputCols
 	rightCols := join.Child(1).(memo.RelExpr).Relational().OutputCols
-	var filtersToSkip util.FastIntSet
-	_, _, toSkip := memo.ExtractJoinEqualityColumns(leftCols, rightCols, *on)
-	for _, idx := range toSkip {
-		filtersToSkip.Add(idx)
-	}
+	filtersToSkip := memo.ExtractJoinConditionFilterOrds(leftCols, rightCols, *on, false /* inequality */)
 	filterSetup, filterPerRow := c.computeFiltersCost(*on, filtersToSkip)
 	cost += filterSetup
 

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1131,7 +1131,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 
 			// If there are any equalities across the columns of the two indexes,
 			// push them into the zigzag join spec.
-			leftEq, rightEq, _ := memo.ExtractJoinEqualityColumns(
+			leftEq, rightEq := memo.ExtractJoinEqualityColumns(
 				leftCols, rightCols, innerFilters,
 			)
 			leftEqCols, rightEqCols := eqColsForZigzag(


### PR DESCRIPTION
This commit reduces allocations in join condition extract functions by only allocating slices when necessary.

```
name                         old time/op    new time/op    delta
SlowQueries/slow-query-1-24    36.6ms ± 0%    35.6ms ± 0%   -2.79%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-24     516ms ± 1%     506ms ± 0%   -1.87%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-24    99.5ms ± 1%    98.8ms ± 2%     ~     (p=0.310 n=5+5)

name                         old alloc/op   new alloc/op   delta
SlowQueries/slow-query-1-24    12.1MB ± 0%    11.9MB ± 0%   -2.22%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-24     156MB ± 0%     154MB ± 0%   -1.12%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-24    47.5MB ± 0%    47.5MB ± 0%   -0.01%  (p=0.008 n=5+5)

name                         old allocs/op  new allocs/op  delta
SlowQueries/slow-query-1-24      129k ± 0%      110k ± 0%  -14.70%  (p=0.008 n=5+5)
SlowQueries/slow-query-2-24     1.24M ± 0%     1.14M ± 0%   -8.50%  (p=0.008 n=5+5)
SlowQueries/slow-query-3-24      359k ± 0%      359k ± 0%   -0.12%  (p=0.008 n=5+5)
```

Release note: None