### PR TITLE
kvserver: rm obsolete version checks in consistency checker

### DIFF
--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -66,9 +66,11 @@ const replicaChecksumGCInterval = time.Hour
 //   - ContainsEstimates==false, i.e. the stats claimed they were correct.
 //
 // Before issuing the fatal error, the cluster bootstrap version is verified.
-// We know that old versions of CockroachDB sometimes violated this invariant,
-// but we want to exclude these violations, focusing only on cases in which we
-// know old CRDB versions (<19.1 at time of writing) were not involved.
+// Note that on clusters that originally got bootstrapped on older releases
+// (definitely 19.1, and likely also more recent ones) we know of the existence
+// of stats bugs, so it has to be expected to see the assertion fire there.
+//
+// This env var is intended solely for use in Cockroach Labs testing.
 var fatalOnStatsMismatch = envutil.EnvOrDefaultBool("COCKROACH_ENFORCE_CONSISTENT_STATS", false)
 
 // replicaChecksum contains progress on a replica checksum computation.

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -246,13 +246,10 @@ func (r *Replica) checkConsistencyImpl(
 		// essentially paced by the consistency checker so we won't call this too often.
 		log.Infof(ctx, "triggering stats recomputation to resolve delta of %+v", results[0].Response.Delta)
 
-		req := roachpb.RecomputeStatsRequest{
-			RequestHeader: roachpb.RequestHeader{Key: args.Key},
-		}
-
 		var b kv.Batch
-		b.AddRawRequest(&req)
-
+		b.AddRawRequest(&roachpb.RecomputeStatsRequest{
+			RequestHeader: roachpb.RequestHeader{Key: args.Key},
+		})
 		err := r.store.db.Run(ctx, &b)
 		return resp, roachpb.NewError(err)
 	}


### PR DESCRIPTION
Code paths affected by these checks are triggered for clusters bootstrapped more than 3 releases behind, and when the `fatalOnStatsMismatch` switch is on. This does not happen.

Release note: None