### PR TITLE
kvnemesis: reset op.Result

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -119,6 +119,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 			savedTxn = txn
 			for i := range o.Ops {
 				op := &o.Ops[i]
+				op.Result().Reset() // in case we're a retry
 				applyClientOp(ctx, txn, op, true /* inTxn */)
 				// The KV api disallows use of a txn after an operation on it errors.
 				if r := op.Result(); r.Type == ResultType_Error {


### PR DESCRIPTION
We found out (in #87814) after a wild goose chase that op.Result was not
reset, so unless operations were cognizant of this fact and
always fully repopulated the Result field, weird failures
could result from txn retries.

Reset the field.

Release note: None
