### PR TITLE
diagrams: Fixed replace text for alter_table_set_storage_param

### DIFF
--- a/docs/generated/sql/bnf/alter_table_set_storage_param.bnf
+++ b/docs/generated/sql/bnf/alter_table_set_storage_param.bnf
@@ -1,3 +1,3 @@
 alter_onetable_stmt ::=
-	'ALTER' 'TABLE' table_name 'SET' '(' storage_parameter_key '=' var_value ) ) )* ')'
-	| 'ALTER' 'TABLE' 'IF' 'EXISTS' table_name 'SET' '(' storage_parameter_key '=' var_value ) ) )* ')'
+	'ALTER' 'TABLE' table_name 'SET' '(' storage_parameter_key '=' var_value ')'
+	| 'ALTER' 'TABLE' 'IF' 'EXISTS' table_name 'SET' '(' storage_parameter_key '=' var_value ')'

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -423,7 +423,7 @@ var specs = []stmtSpec{
 		stmt:   "alter_onetable_stmt",
 		inline: []string{"alter_table_cmds", "alter_table_cmd", "storage_parameter_list", "storage_parameter"},
 		regreplace: map[string]string{
-			`var_value.*`: `var_value ) ) )* ')'`,
+			`var_value.*`: `var_value ')'`,
 		},
 		match: []*regexp.Regexp{regexp.MustCompile("relation_expr 'SET")},
 		replace: map[string]string{


### PR DESCRIPTION
The diagram was causing the Publish SQL Grammar Diagrams to fail for release-22.1. This change should fix that.

Fixes DOC-5649

Release note: None

Release justification: SQL grammar diagram update