### PR TITLE
ci: fix invocation of `bazci` in `publish-sql-grammar-diagrams`

### DIFF
--- a/build/teamcity/cockroach/publish-sql-grammar-diagrams-impl.sh
+++ b/build/teamcity/cockroach/publish-sql-grammar-diagrams-impl.sh
@@ -3,5 +3,5 @@
 set -xeuo pipefail
 
 bazel build //pkg/cmd/bazci --config=ci
-$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci --config ci \
-				   build //docs/generated/sql/bnf //docs/generated/sql/bnf:svg
+$(bazel info bazel-bin --config=ci)/pkg/cmd/bazci/bazci_/bazci -- build --config ci \
+				   //docs/generated/sql/bnf //docs/generated/sql/bnf:svg


### PR DESCRIPTION
Release note: None