### PR TITLE
[DNM] xform: sort-avoiding unconstrained non-covering index scan

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -272,7 +272,7 @@ func (cb *cascadeBuilder) planCascade(
 		}
 	}
 
-	o.Memo().SetRoot(relExpr, &physical.Required{})
+	o.Memo().SetRoot(relExpr, physical.MinRequired)
 
 	// 3. Assign placeholders if they exist.
 	if factory.Memo().HasPlaceholders() {

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_indexjoin
@@ -108,17 +108,19 @@ EXPLAIN SELECT * FROM abc WHERE b between 1 AND 3 ORDER BY c, b LIMIT 2;
 distribution: full
 vectorized: true
 ·
-• top-k
-│ order: +c,+b
-│ k: 2
+• limit
+│ count: 2
 │
 └── • filter
     │ filter: (b >= 1) AND (b <= 3)
     │
-    └── • scan
-          missing stats
-          table: abc@abc_pkey
-          spans: FULL SCAN
+    └── • index join
+        │ table: abc@abc_pkey
+        │
+        └── • scan
+              missing stats
+              table: abc@abc_c_b_idx
+              spans: FULL SCAN (SOFT LIMIT)
 
 statement ok
 SET unconstrained_non_covering_index_scan_enabled = true;

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -735,6 +735,48 @@ func TestInternerPhysProps(t *testing.T) {
 	}
 }
 
+func TestInternerOrderingChoice(t *testing.T) {
+	var in interner
+
+	orderingChoice1 := props.ParseOrderingChoice("+(1|2),+3 opt(4,5)")
+	orderingChoice2 := props.ParseOrderingChoice("+(1|2),+3 opt(4,5)")
+	orderingChoice3 := props.ParseOrderingChoice("+(1|2),+3 opt(4,5)")
+	orderingChoice4 := props.ParseOrderingChoice("+(1|2|3),+4 opt(5)")
+	orderingChoice5 := props.ParseOrderingChoice("-(1|2|3),-4 opt(5)")
+	orderingChoice6 := props.ParseOrderingChoice("-(1|2|3),+4 opt(5)")
+	orderingChoice7 := props.ParseOrderingChoice("+(1|2),+3 opt(4,5,6)")
+	orderingChoice8 := props.ParseOrderingChoice("+(1|2),+3 opt(4,5,6)")
+	orderingChoice9 := props.ParseOrderingChoice("-(1|2),-3 opt(4,5,6)")
+
+	testCases := []struct {
+		oc      *props.OrderingChoice
+		inCache bool
+	}{
+		{oc: &orderingChoice1, inCache: false},
+		{oc: &orderingChoice2, inCache: true},
+		{oc: &orderingChoice3, inCache: true},
+		{oc: &orderingChoice4, inCache: false},
+		{oc: &orderingChoice5, inCache: false},
+		{oc: &orderingChoice6, inCache: false},
+		{oc: &orderingChoice7, inCache: false},
+		{oc: &orderingChoice8, inCache: true},
+		{oc: &orderingChoice9, inCache: false},
+		{oc: &orderingChoice9, inCache: true},
+	}
+
+	inCache := make(map[*props.OrderingChoice]bool)
+
+	for _, tc := range testCases {
+		interned := in.InternOrderingChoice(tc.oc)
+		if tc.inCache && !inCache[interned] {
+			t.Errorf("expected ordering choice to already be in cache: %s", tc.oc)
+		} else if !tc.inCache && inCache[interned] {
+			t.Errorf("expected ordering choice to not yet be in cache: %s", tc.oc)
+		}
+		inCache[interned] = true
+	}
+}
+
 func TestInternerCollision(t *testing.T) {
 	var in interner
 

--- a/pkg/sql/opt/optgen/cmd/optgen/explorer_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/explorer_gen.go
@@ -36,6 +36,7 @@ func (g *explorerGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.nestIndent("import (\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/memo\"\n")
+	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/props\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/sem/tree\"\n")
 	g.w.unnest(")\n\n")
 
@@ -51,6 +52,7 @@ func (g *explorerGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 //	  state *exploreState,
 //	  member memo.RelExpr,
 //	  ordinal int,
+//	  orderingHint *props.OrderingChoice,
 //	) (_fullyExplored bool) {
 //	  switch t := member.(type) {
 //	    case *memo.ScanNode:
@@ -67,6 +69,7 @@ func (g *explorerGen) genDispatcher() {
 	g.w.writeIndent("state *exploreState,\n")
 	g.w.writeIndent("member memo.RelExpr,\n")
 	g.w.writeIndent("ordinal int,\n")
+	g.w.writeIndent("orderingHint *props.OrderingChoice,\n")
 	g.w.unnest(") (_fullyExplored bool)")
 	g.w.nest(" {\n")
 	g.w.writeIndent("switch t := member.(type) {\n")
@@ -76,7 +79,7 @@ func (g *explorerGen) genDispatcher() {
 		rules := g.compiled.LookupMatchingRules(string(define.Name)).WithTag("Explore")
 		if len(rules) > 0 {
 			opTyp := g.md.typeOf(define)
-			format := "case *%s: return _e.explore%s(state, t, ordinal)\n"
+			format := "case *%s: return _e.explore%s(state, t, ordinal, orderingHint)\n"
 			g.w.writeIndent(format, opTyp.name, define.Name)
 		}
 	}
@@ -94,6 +97,7 @@ func (g *explorerGen) genDispatcher() {
 //	  _rootState *exploreState,
 //	  _root *memo.ScanNode,
 //	  _rootOrd int,
+//	  _orderingHint *props.OrderingChoice,
 //	) (_fullyExplored bool) {
 //	  _fullyExplored = true
 //
@@ -114,6 +118,7 @@ func (g *explorerGen) genRuleFuncs() {
 		g.w.writeIndent("_rootState *exploreState,\n")
 		g.w.writeIndent("_root *%s,\n", opTyp.name)
 		g.w.writeIndent("_rootOrd int,\n")
+		g.w.writeIndent("_orderingHint *props.OrderingChoice,\n")
 		g.w.unnest(") (_fullyExplored bool)")
 		g.w.nest(" {\n")
 		g.w.writeIndent("_fullyExplored = true\n\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -480,7 +480,7 @@ func (g *newRuleGen) genMatchNameAndChildren(
 			// If the child group is not yet fully explored, then neither is the
 			// root group, since new members in any descendant group make
 			// additional matches possible.
-			g.w.writeIndent("_state := _e.lookupExploreState(%s)\n", context.code)
+			g.w.writeIndent("_state := _e.lookupExploreState(%s, _orderingHint)\n", context.code)
 			g.w.nestIndent("if !_state.fullyExplored {\n")
 			g.w.writeIndent("_fullyExplored = false\n")
 			g.w.unnest("}\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
@@ -77,6 +77,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -84,12 +85,13 @@ func (_e *explorer) exploreGroupMember(
 	state *exploreState,
 	member memo.RelExpr,
 	ordinal int,
+	orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	switch t := member.(type) {
 	case *memo.LimitExpr:
-		return _e.exploreLimit(state, t, ordinal)
+		return _e.exploreLimit(state, t, ordinal, orderingHint)
 	case *memo.InnerJoinExpr:
-		return _e.exploreInnerJoin(state, t, ordinal)
+		return _e.exploreInnerJoin(state, t, ordinal, orderingHint)
 	}
 
 	// No rules for other operator types.
@@ -100,13 +102,14 @@ func (_e *explorer) exploreLimit(
 	_rootState *exploreState,
 	_root *memo.LimitExpr,
 	_rootOrd int,
+	_orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	_fullyExplored = true
 
 	// [PushLimitIntoIndexJoin]
 	{
 		_partlyExplored := _rootOrd < _rootState.start
-		_state := _e.lookupExploreState(_root.Input)
+		_state := _e.lookupExploreState(_root.Input, _orderingHint)
 		if !_state.fullyExplored {
 			_fullyExplored = false
 		}
@@ -120,7 +123,7 @@ func (_e *explorer) exploreLimit(
 			_partlyExplored := _partlyExplored && _ord < _state.start
 			_indexJoin, _ := _member.(*memo.IndexJoinExpr)
 			if _indexJoin != nil {
-				_state := _e.lookupExploreState(_indexJoin.Input)
+				_state := _e.lookupExploreState(_indexJoin.Input, _orderingHint)
 				if !_state.fullyExplored {
 					_fullyExplored = false
 				}
@@ -175,13 +178,14 @@ func (_e *explorer) exploreInnerJoin(
 	_rootState *exploreState,
 	_root *memo.InnerJoinExpr,
 	_rootOrd int,
+	_orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	_fullyExplored = true
 
 	// [TestRootAccess]
 	{
 		_partlyExplored := _rootOrd < _rootState.start
-		_state := _e.lookupExploreState(_root.Left)
+		_state := _e.lookupExploreState(_root.Left, _orderingHint)
 		if !_state.fullyExplored {
 			_fullyExplored = false
 		}
@@ -263,6 +267,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -270,10 +275,11 @@ func (_e *explorer) exploreGroupMember(
 	state *exploreState,
 	member memo.RelExpr,
 	ordinal int,
+	orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	switch t := member.(type) {
 	case *memo.LimitExpr:
-		return _e.exploreLimit(state, t, ordinal)
+		return _e.exploreLimit(state, t, ordinal, orderingHint)
 	}
 
 	// No rules for other operator types.
@@ -284,6 +290,7 @@ func (_e *explorer) exploreLimit(
 	_rootState *exploreState,
 	_root *memo.LimitExpr,
 	_rootOrd int,
+	_orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	_fullyExplored = true
 
@@ -291,7 +298,7 @@ func (_e *explorer) exploreLimit(
 	{
 		_partlyExplored := _rootOrd < _rootState.start
 		scan := _root.Input
-		_state := _e.lookupExploreState(scan)
+		_state := _e.lookupExploreState(scan, _orderingHint)
 		if !_state.fullyExplored {
 			_fullyExplored = false
 		}
@@ -381,6 +388,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -388,10 +396,11 @@ func (_e *explorer) exploreGroupMember(
 	state *exploreState,
 	member memo.RelExpr,
 	ordinal int,
+	orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	switch t := member.(type) {
 	case *memo.LimitExpr:
-		return _e.exploreLimit(state, t, ordinal)
+		return _e.exploreLimit(state, t, ordinal, orderingHint)
 	}
 
 	// No rules for other operator types.
@@ -402,6 +411,7 @@ func (_e *explorer) exploreLimit(
 	_rootState *exploreState,
 	_root *memo.LimitExpr,
 	_rootOrd int,
+	_orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	_fullyExplored = true
 
@@ -409,7 +419,7 @@ func (_e *explorer) exploreLimit(
 	{
 		_partlyExplored := _rootOrd < _rootState.start
 		input := _root.Input
-		_state := _e.lookupExploreState(input)
+		_state := _e.lookupExploreState(input, _orderingHint)
 		if !_state.fullyExplored {
 			_fullyExplored = false
 		}
@@ -533,6 +543,7 @@ package xform
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -540,10 +551,11 @@ func (_e *explorer) exploreGroupMember(
 	state *exploreState,
 	member memo.RelExpr,
 	ordinal int,
+	orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	switch t := member.(type) {
 	case *memo.UnionExpr:
-		return _e.exploreUnion(state, t, ordinal)
+		return _e.exploreUnion(state, t, ordinal, orderingHint)
 	}
 
 	// No rules for other operator types.
@@ -554,6 +566,7 @@ func (_e *explorer) exploreUnion(
 	_rootState *exploreState,
 	_root *memo.UnionExpr,
 	_rootOrd int,
+	_orderingHint *props.OrderingChoice,
 ) (_fullyExplored bool) {
 	_fullyExplored = true
 
@@ -641,7 +654,7 @@ func (_e *explorer) exploreUnion(
 	{
 		_partlyExplored := _rootOrd < _rootState.start
 		left := _root.Left
-		_state := _e.lookupExploreState(left)
+		_state := _e.lookupExploreState(left, _orderingHint)
 		if !_state.fullyExplored {
 			_fullyExplored = false
 		}

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -87,6 +87,10 @@ type OrderingColumnChoice struct {
 	Descending bool
 }
 
+// MinOrderingChoice is a shared empty ordering choice used to facilitate simple
+// pointer-based equality checks of xform.groupStateKey.
+var MinOrderingChoice = &OrderingChoice{}
+
 const (
 	colChoiceRegexStr = `(?:\((\d+(?:\|\d+)*)\))`
 	ordColRegexStr    = `^(?:(?:\+|\-)(?:(\d+)|` + colChoiceRegexStr + `))$`

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/ordering"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/partition"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -63,6 +64,9 @@ func (c *CustomFuncs) GenerateIndexScans(grp memo.RelExpr, scanPrivate *memo.Sca
 			c.e.mem.AddScanToGroup(&scan, grp)
 			return
 		}
+		if scanPrivate.Flags.NoIndexJoin {
+			return
+		}
 
 		// Otherwise, if the index must be forced, then construct an IndexJoin
 		// operator that provides the columns missing from the index. Note that
@@ -72,7 +76,25 @@ func (c *CustomFuncs) GenerateIndexScans(grp memo.RelExpr, scanPrivate *memo.Sca
 		// be explored, even when non-covering and unconstrained, without forcing a
 		// particular index.
 		if !scanPrivate.Flags.ForceIndex && !c.e.mem.AllowUnconstrainedNonCoveringIndexScan() {
-			return
+			orderingHint := c.e.mem.OrderingHint()
+
+			// Allow unconstrained index scans to be explored if an enforcer is being
+			// optimized with an Ordering which the index can provide.
+			if orderingHint != nil && !orderingHint.Any() {
+				savedIndex := scanPrivate.Index
+				scanPrivate.Index = index.Ordinal()
+				ok, _ := ordering.ScanPrivateCanProvide(
+					c.e.mem.Metadata(),
+					scanPrivate,
+					orderingHint,
+				)
+				scanPrivate.Index = savedIndex
+				if !ok {
+					return
+				}
+			} else {
+				return
+			}
 		}
 
 		var sb indexScanBuilder

--- a/pkg/sql/opt/xform/testdata/coster/groupby
+++ b/pkg/sql/opt/xform/testdata/coster/groupby
@@ -157,7 +157,7 @@ limit
  │    │    ├── limit hint: 10.00
  │    │    └── scan c@c_a_idx
  │    │         ├── columns: a:1 rowid:5!null
- │    │         ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │         ├── stats: [rows=1000]
  │    │         ├── cost: 24.42
  │    │         ├── key: (5)
  │    │         ├── fd: (5)-->(1)
@@ -223,7 +223,7 @@ limit
  │    │    ├── limit hint: 10.00
  │    │    └── scan c@c_a_idx
  │    │         ├── columns: a:1 rowid:5!null
- │    │         ├── stats: [rows=1000, distinct(1)=100, null(1)=10]
+ │    │         ├── stats: [rows=1000]
  │    │         ├── cost: 24.42
  │    │         ├── key: (5)
  │    │         ├── fd: (5)-->(1)
@@ -260,7 +260,7 @@ limit
  │    │    ├── limit hint: 10.00
  │    │    └── scan c@c_b_c_d_idx
  │    │         ├── columns: b:2 c:3 rowid:5!null
- │    │         ├── stats: [rows=1000, distinct(2,3)=1000, null(2,3)=0.1]
+ │    │         ├── stats: [rows=1000]
  │    │         ├── cost: 24.72
  │    │         ├── key: (5)
  │    │         ├── fd: (5)-->(2,3)

--- a/pkg/sql/opt/xform/testdata/coster/limit
+++ b/pkg/sql/opt/xform/testdata/coster/limit
@@ -92,7 +92,7 @@ top-k
  ├── ordering: +2,+3
  └── index-join a
       ├── columns: x:1!null y:2 z:3 s:4!null
-      ├── stats: [rows=10000]
+      ├── stats: [rows=10000, distinct(2)=1000, null(2)=0]
       ├── cost: 7744.81875
       ├── key: (1)
       ├── fd: (1)-->(2-4)

--- a/pkg/sql/opt/xform/testdata/coster/topk
+++ b/pkg/sql/opt/xform/testdata/coster/topk
@@ -124,7 +124,7 @@ top-k
  ├── ordering: +3,+2
  └── index-join a
       ├── columns: k:1!null i:2 j:3
-      ├── stats: [rows=10000]
+      ├── stats: [rows=10000, distinct(3)=1000, null(3)=0]
       ├── cost: 7713.72858
       ├── key: (1)
       ├── fd: (1)-->(2,3)

--- a/pkg/sql/opt/xform/testdata/rules/combo
+++ b/pkg/sql/opt/xform/testdata/rules/combo
@@ -160,6 +160,40 @@ New expression 1 of 1:
    └── filters (true)
 
 ================================================================================
+GenerateIndexScans
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1!null b:2!null c:3 x:7!null y:8!null z:9
+   ├── fd: (1)==(7), (7)==(1), (2)==(8), (8)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:7 y:8 z:9
+   └── filters
+        ├── a:1 = x:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+        └── b:2 = y:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+No new expressions.
+
+================================================================================
+GenerateIndexScans
+================================================================================
+Source expression:
+  inner-join (hash)
+   ├── columns: a:1!null b:2!null c:3 x:7!null y:8!null z:9
+   ├── fd: (1)==(7), (7)==(1), (2)==(8), (8)==(2)
+   ├── scan abc
+   │    └── columns: a:1 b:2 c:3
+   ├── scan xyz
+   │    └── columns: x:7 y:8 z:9
+   └── filters
+        ├── a:1 = x:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+        └── b:2 = y:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+
+No new expressions.
+
+================================================================================
 GenerateMergeJoins
 ================================================================================
 Source expression:

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2172,7 +2172,7 @@ memo (optimized, ~5KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~24KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~25KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2202,7 +2202,7 @@ memo (optimized, ~24KB, required=[presentation: w:12] [ordering: +13,+1])
  │    └── []
  │         ├── best: (scan xyz@xy,cols=(1))
  │         └── cost: 1054.32
- ├── G9: (select G16 G17) (scan kuvw@vw,cols=(7-9),constrained)
+ ├── G9: (select G16 G17) (scan kuvw@vw,cols=(7-9),constrained) (scan kuvw@vw,cols=(7-9),constrained)
  │    ├── [ordering: +7 opt(8)]
  │    │    ├── best: (sort G9)
  │    │    └── cost: 25.90
@@ -2295,7 +2295,7 @@ memo (optimized, ~25KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~26KB, required=[])
+memo (optimized, ~27KB, required=[])
  ├── G1: (upsert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 G4 xyz)
@@ -2318,50 +2318,57 @@ memo (optimized, ~26KB, required=[])
  │    └── []
  │         ├── best: (ensure-upsert-distinct-on G13="[ordering: +8 opt(12)]" G14 cols=(8),ordering=+8 opt(12))
  │         └── cost: 1144.67
- ├── G8: (scan xyz,cols=(13-15)) (scan xyz@zyx,cols=(13-15))
+ ├── G8: (scan xyz,cols=(13-15)) (scan xyz@zyx,cols=(13-15)) (index-join G15 xyz,cols=(13-15))
  │    ├── [ordering: +13]
  │    │    ├── best: (scan xyz,cols=(13-15))
  │    │    └── cost: 1084.62
  │    └── []
  │         ├── best: (scan xyz,cols=(13-15))
  │         └── cost: 1084.62
- ├── G9: (filters G15)
+ ├── G9: (filters G16)
  ├── G10: (filters)
  ├── G11: (lookup-join G7 G10 xyz@xy,keyCols=[8],outCols=(8,9,12-14))
  │    └── []
  │         ├── best: (lookup-join G7 G10 xyz@xy,keyCols=[8],outCols=(8,9,12-14))
  │         └── cost: 7194.69
- ├── G12: (case G16 G17 G18)
- ├── G13: (project G19 G20 v w)
+ ├── G12: (case G17 G18 G19)
+ ├── G13: (project G20 G21 v w)
  │    ├── [ordering: +8 opt(12)]
- │    │    ├── best: (project G19="[ordering: +8]" G20 v w)
+ │    │    ├── best: (project G20="[ordering: +8]" G21 v w)
  │    │    └── cost: 1104.64
  │    └── []
- │         ├── best: (project G19 G20 v w)
+ │         ├── best: (project G20 G21 v w)
  │         └── cost: 1104.64
- ├── G14: (aggregations G21 G22)
- ├── G15: (eq G23 G24)
- ├── G16: (true)
- ├── G17: (scalar-list G25)
- ├── G18: (const 2.0)
- ├── G19: (scan kuvw,cols=(8,9)) (scan kuvw@uvw,cols=(8,9)) (scan kuvw@wvu,cols=(8,9)) (scan kuvw@vw,cols=(8,9)) (scan kuvw@w,cols=(8,9))
+ ├── G14: (aggregations G22 G23)
+ ├── G15: (scan xyz@xy,cols=(13,14))
+ │    ├── [ordering: +13]
+ │    │    ├── best: (scan xyz@xy,cols=(13,14))
+ │    │    └── cost: 1064.42
+ │    └── []
+ │         ├── best: (scan xyz@xy,cols=(13,14))
+ │         └── cost: 1064.42
+ ├── G16: (eq G24 G25)
+ ├── G17: (true)
+ ├── G18: (scalar-list G26)
+ ├── G19: (const 2.0)
+ ├── G20: (scan kuvw,cols=(8,9)) (scan kuvw@uvw,cols=(8,9)) (scan kuvw@wvu,cols=(8,9)) (scan kuvw@vw,cols=(8,9)) (scan kuvw@w,cols=(8,9))
  │    ├── [ordering: +8]
  │    │    ├── best: (scan kuvw@vw,cols=(8,9))
  │    │    └── cost: 1084.62
  │    └── []
  │         ├── best: (scan kuvw,cols=(8,9))
  │         └── cost: 1084.62
- ├── G20: (projections G26)
- ├── G21: (first-agg G27)
+ ├── G21: (projections G27)
  ├── G22: (first-agg G28)
- ├── G23: (variable v)
- ├── G24: (variable x)
- ├── G25: (when G29 G28)
- ├── G26: (const 1.0)
- ├── G27: (variable w)
- ├── G28: (variable "?column?")
- ├── G29: (is G24 G30)
- └── G30: (null)
+ ├── G23: (first-agg G29)
+ ├── G24: (variable v)
+ ├── G25: (variable x)
+ ├── G26: (when G30 G29)
+ ├── G27: (const 1.0)
+ ├── G28: (variable w)
+ ├── G29: (variable "?column?")
+ ├── G30: (is G25 G31)
+ └── G31: (null)
 
 # ------------------------------------------------------------------------
 # SplitGroupByScanIntoUnionScans + SplitGroupByFilteredScanIntoUnionScans
@@ -3305,79 +3312,46 @@ INDEX gg (g)
 memo
 SELECT d, e, count(*) FROM defg GROUP BY d, e LIMIT 10
 ----
-memo (optimized, ~19KB, required=[presentation: d:1,e:2,count:8])
- ├── G1: (limit G2 G3) (limit G4 G3) (limit G5 G3) (limit G6 G3)
+memo (optimized, ~10KB, required=[presentation: d:1,e:2,count:8])
+ ├── G1: (limit G2 G3)
  │    └── [presentation: d:1,e:2,count:8]
- │         ├── best: (limit G4="[limit hint: 10.00]" G3)
+ │         ├── best: (limit G2="[limit hint: 10.00]" G3)
  │         └── cost: 641.98
- ├── G2: (group-by G7 G8 cols=(1,2)) (group-by G7 G8 cols=(1,2),ordering=+1)
+ ├── G2: (group-by G4 G5 cols=(1,2)) (group-by G4 G5 cols=(1,2),ordering=+1)
  │    └── [limit hint: 10.00]
- │         ├── best: (group-by G7 G8 cols=(1,2))
- │         └── cost: 1144.90
- ├── G3: (const 10)
- ├── G4: (group-by G9 G8 cols=(1,2)) (group-by G9 G8 cols=(1,2),ordering=+1)
- │    └── [limit hint: 10.00]
- │         ├── best: (group-by G9="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
+ │         ├── best: (group-by G4="[ordering: +1] [limit hint: 10.00]" G5 cols=(1,2),ordering=+1)
  │         └── cost: 641.87
- ├── G5: (group-by G10 G8 cols=(1,2)) (group-by G10 G8 cols=(1,2),ordering=+1)
- │    └── [limit hint: 10.00]
- │         ├── best: (group-by G10="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
- │         └── cost: 642.07
- ├── G6: (group-by G11 G8 cols=(1,2)) (group-by G11 G8 cols=(1,2),ordering=+1)
- │    └── [limit hint: 10.00]
- │         ├── best: (group-by G11="[ordering: +1] [limit hint: 10.00]" G8 cols=(1,2),ordering=+1)
- │         └── cost: 641.97
- ├── G7: (scan defg,cols=(1,2))
+ ├── G3: (const 10)
+ ├── G4: (scan defg,cols=(1,2)) (index-join G6 defg,cols=(1,2)) (index-join G7 defg,cols=(1,2)) (index-join G8 defg,cols=(1,2))
  │    ├── [ordering: +1] [limit hint: 10.00]
- │    │    ├── best: (sort G7)
- │    │    └── cost: 1334.20
+ │    │    ├── best: (index-join G6="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
+ │    │    └── cost: 631.44
  │    └── []
  │         ├── best: (scan defg,cols=(1,2))
  │         └── cost: 1094.72
- ├── G8: (aggregations G12)
- ├── G9: (index-join G13 defg,cols=(1,2))
- │    ├── [ordering: +1] [limit hint: 10.00]
- │    │    ├── best: (index-join G13="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
- │    │    └── cost: 631.44
- │    └── []
- │         ├── best: (index-join G13 defg,cols=(1,2))
- │         └── cost: 7134.44
- ├── G10: (index-join G14 defg,cols=(1,2))
- │    ├── [ordering: +1] [limit hint: 10.00]
- │    │    ├── best: (index-join G14="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
- │    │    └── cost: 631.64
- │    └── []
- │         ├── best: (index-join G14 defg,cols=(1,2))
- │         └── cost: 7154.64
- ├── G11: (index-join G15 defg,cols=(1,2))
- │    ├── [ordering: +1] [limit hint: 10.00]
- │    │    ├── best: (index-join G15="[ordering: +1] [limit hint: 10.00]" defg,cols=(1,2))
- │    │    └── cost: 631.54
- │    └── []
- │         ├── best: (index-join G15 defg,cols=(1,2))
- │         └── cost: 7144.54
- ├── G12: (count-rows)
- ├── G13: (scan defg@dd,cols=(1,5))
+ ├── G5: (aggregations G9)
+ ├── G6: (scan defg@dd,cols=(1,5))
  │    ├── [ordering: +1] [limit hint: 10.00]
  │    │    ├── best: (scan defg@dd,cols=(1,5))
  │    │    └── cost: 24.42
  │    └── []
  │         ├── best: (scan defg@dd,cols=(1,5))
  │         └── cost: 1064.42
- ├── G14: (scan defg@dfg,cols=(1,5))
+ ├── G7: (scan defg@dfg,cols=(1,5))
  │    ├── [ordering: +1] [limit hint: 10.00]
  │    │    ├── best: (scan defg@dfg,cols=(1,5))
  │    │    └── cost: 24.62
  │    └── []
  │         ├── best: (scan defg@dfg,cols=(1,5))
  │         └── cost: 1084.62
- └── G15: (scan defg@df,cols=(1,5))
-      ├── [ordering: +1] [limit hint: 10.00]
-      │    ├── best: (scan defg@df,cols=(1,5))
-      │    └── cost: 24.52
-      └── []
-           ├── best: (scan defg@df,cols=(1,5))
-           └── cost: 1074.52
+ ├── G8: (scan defg@df,cols=(1,5))
+ │    ├── [ordering: +1] [limit hint: 10.00]
+ │    │    ├── best: (scan defg@df,cols=(1,5))
+ │    │    └── cost: 24.52
+ │    └── []
+ │         ├── best: (scan defg@df,cols=(1,5))
+ │         └── cost: 1074.52
+ └── G9: (count-rows)
 
 # Rule will trigger, but because no order is specified and an index matches,
 # this will result in a streaming group by.
@@ -3404,7 +3378,9 @@ limit
  │         └── count-rows [as=count_rows:8]
  └── 10
 
-opt expect=GenerateLimitedGroupByScans
+# GenerateLimitedGroupByScans used to be required to generate this plan,
+# but now GenerateIndexScans can do it.
+opt expect=GenerateIndexScans
 SELECT d, e, count(*) FROM defg GROUP BY d, e ORDER BY d LIMIT 10
 ----
 limit
@@ -3463,7 +3439,7 @@ top-k
 memo
 SELECT d, e, count(*) FROM defg GROUP BY d, e ORDER BY count(*) LIMIT 10
 ----
-memo (optimized, ~6KB, required=[presentation: d:1,e:2,count:8] [ordering: +8])
+memo (optimized, ~10KB, required=[presentation: d:1,e:2,count:8] [ordering: +8])
  ├── G1: (limit G2 G3 ordering=+8) (top-k G2 &{10 +8 })
  │    ├── [presentation: d:1,e:2,count:8] [ordering: +8]
  │    │    ├── best: (top-k G2 &{10 +8 })
@@ -3479,15 +3455,36 @@ memo (optimized, ~6KB, required=[presentation: d:1,e:2,count:8] [ordering: +8])
  │         ├── best: (group-by G4 G5 cols=(1,2))
  │         └── cost: 1144.90
  ├── G3: (const 10)
- ├── G4: (scan defg,cols=(1,2))
+ ├── G4: (scan defg,cols=(1,2)) (index-join G6 defg,cols=(1,2)) (index-join G7 defg,cols=(1,2)) (index-join G8 defg,cols=(1,2))
  │    ├── [ordering: +1]
  │    │    ├── best: (sort G4)
  │    │    └── cost: 1334.20
  │    └── []
  │         ├── best: (scan defg,cols=(1,2))
  │         └── cost: 1094.72
- ├── G5: (aggregations G6)
- └── G6: (count-rows)
+ ├── G5: (aggregations G9)
+ ├── G6: (scan defg@dd,cols=(1,5))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan defg@dd,cols=(1,5))
+ │    │    └── cost: 1064.42
+ │    └── []
+ │         ├── best: (scan defg@dd,cols=(1,5))
+ │         └── cost: 1064.42
+ ├── G7: (scan defg@dfg,cols=(1,5))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan defg@dfg,cols=(1,5))
+ │    │    └── cost: 1084.62
+ │    └── []
+ │         ├── best: (scan defg@dfg,cols=(1,5))
+ │         └── cost: 1084.62
+ ├── G8: (scan defg@df,cols=(1,5))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan defg@df,cols=(1,5))
+ │    │    └── cost: 1074.52
+ │    └── []
+ │         ├── best: (scan defg@df,cols=(1,5))
+ │         └── cost: 1074.52
+ └── G9: (count-rows)
 
 # Rule does not apply because the grouping columns are not the first columns of
 # an index.

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -2507,7 +2507,7 @@ WHERE EXISTS (SELECT 1 FROM dz WHERE z = y)
 AND EXISTS (SELECT 1 FROM bx WHERE x = y)
 AND EXISTS (SELECT 1 FROM abc WHERE a = y)
 ----
-Rules Applied: 134
+Rules Applied: 136
 Groups Added: 73
 
 

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -723,6 +723,9 @@ GenerateConstrainedScans (no changes)
 GenerateZigzagJoins (no changes)
 --------------------------------------------------------------------------------
 --------------------------------------------------------------------------------
+GenerateIndexScans (no changes)
+--------------------------------------------------------------------------------
+--------------------------------------------------------------------------------
 GenerateTopK (higher cost)
 --------------------------------------------------------------------------------
    explain
@@ -1243,36 +1246,36 @@ top-k
  ├── ordering: +6,+7
  └── union-all
       ├── columns: latitude:4!null longitude:5 data1:6!null data2:7!null
-      ├── left columns: latitude:81 longitude:82 data1:83 data2:84
-      ├── right columns: latitude:92 longitude:93 data1:94 data2:95
+      ├── left columns: latitude:103 longitude:104 data1:105 data2:106
+      ├── right columns: latitude:114 longitude:115 data1:116 data2:117
       ├── union-all
-      │    ├── columns: latitude:81!null longitude:82!null data1:83!null data2:84!null
-      │    ├── left columns: latitude:70 longitude:71 data1:72 data2:73
-      │    ├── right columns: latitude:59 longitude:60 data1:61 data2:62
+      │    ├── columns: latitude:103!null longitude:104!null data1:105!null data2:106!null
+      │    ├── left columns: latitude:92 longitude:93 data1:94 data2:95
+      │    ├── right columns: latitude:81 longitude:82 data1:83 data2:84
       │    ├── cardinality: [0 - 30]
       │    ├── union-all
-      │    │    ├── columns: latitude:70!null longitude:71!null data1:72!null data2:73!null
-      │    │    ├── left columns: latitude:37 longitude:38 data1:39 data2:40
-      │    │    ├── right columns: latitude:48 longitude:49 data1:50 data2:51
+      │    │    ├── columns: latitude:92!null longitude:93!null data1:94!null data2:95!null
+      │    │    ├── left columns: latitude:59 longitude:60 data1:61 data2:62
+      │    │    ├── right columns: latitude:70 longitude:71 data1:72 data2:73
       │    │    ├── cardinality: [0 - 20]
       │    │    ├── scan index_tab@d
-      │    │    │    ├── columns: latitude:37!null longitude:38!null data1:39!null data2:40!null
-      │    │    │    ├── constraint: /37/38/39/40/34: [/10/11 - /10/11]
+      │    │    │    ├── columns: latitude:59!null longitude:60!null data1:61!null data2:62!null
+      │    │    │    ├── constraint: /59/60/61/62/56: [/10/11 - /10/11]
       │    │    │    ├── limit: 10
-      │    │    │    └── fd: ()-->(37,38)
+      │    │    │    └── fd: ()-->(59,60)
       │    │    └── scan index_tab@d
-      │    │         ├── columns: latitude:48!null longitude:49!null data1:50!null data2:51!null
-      │    │         ├── constraint: /48/49/50/51/45: [/10/12 - /10/12]
+      │    │         ├── columns: latitude:70!null longitude:71!null data1:72!null data2:73!null
+      │    │         ├── constraint: /70/71/72/73/67: [/10/12 - /10/12]
       │    │         ├── limit: 10
-      │    │         └── fd: ()-->(48,49)
+      │    │         └── fd: ()-->(70,71)
       │    └── scan index_tab@d
-      │         ├── columns: latitude:59!null longitude:60!null data1:61!null data2:62!null
-      │         ├── constraint: /59/60/61/62/56: [/10/13 - /10/13]
+      │         ├── columns: latitude:81!null longitude:82!null data1:83!null data2:84!null
+      │         ├── constraint: /81/82/83/84/78: [/10/13 - /10/13]
       │         ├── limit: 10
-      │         └── fd: ()-->(59,60)
+      │         └── fd: ()-->(81,82)
       └── scan index_tab@d
-           ├── columns: latitude:92!null longitude:93 data1:94!null data2:95!null
-           └── constraint: /92/93/94/95/89
+           ├── columns: latitude:114!null longitude:115 data1:116!null data2:117!null
+           └── constraint: /114/115/116/117/111
                 ├── [/-5 - /-5]
                 └── [/0 - /0]
 
@@ -1837,18 +1840,20 @@ INDEX df (d, f)
 
 # Generates an index scan on dd, dfg, and df and an index join to get all
 # columns, though these are not the best cost plans.
-memo expect=GenerateLimitedTopKScans
+# GenerateLimitedTopKScans is not needed. GenerateIndexScans can generate
+# the best plan
+memo expect=GenerateIndexScans
 SELECT d, e FROM defg ORDER BY d, e LIMIT 10
 ----
-memo (optimized, ~14KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
- ├── G1: (limit G2 G3 ordering=+1,+2) (top-k G2 &{10 +1,+2 }) (top-k G4 &{10 +1,+2 }) (top-k G5 &{10 +1,+2 }) (top-k G6 &{10 +1,+2 }) (top-k G2 &{10 +1,+2 +1}) (top-k G4 &{10 +1,+2 +1}) (top-k G5 &{10 +1,+2 +1}) (top-k G6 &{10 +1,+2 +1})
+memo (optimized, ~9KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
+ ├── G1: (limit G2 G3 ordering=+1,+2) (top-k G2 &{10 +1,+2 }) (top-k G2 &{10 +1,+2 +1})
  │    ├── [presentation: d:1,e:2] [ordering: +1,+2]
  │    │    ├── best: (top-k G2 &{10 +1,+2 })
  │    │    └── cost: 1185.69
  │    └── []
  │         ├── best: (top-k G2 &{10 +1,+2 })
  │         └── cost: 1185.69
- ├── G2: (scan defg,cols=(1,2))
+ ├── G2: (scan defg,cols=(1,2)) (index-join G4 defg,cols=(1,2)) (index-join G5 defg,cols=(1,2)) (index-join G6 defg,cols=(1,2))
  │    ├── [ordering: +1,+2] [limit hint: 10.00]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1345.17
@@ -1862,37 +1867,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
  │         ├── best: (scan defg,cols=(1,2))
  │         └── cost: 1094.72
  ├── G3: (const 10)
- ├── G4: (index-join G7 defg,cols=(1,2))
- │    ├── [ordering: +1]
- │    │    ├── best: (index-join G7="[ordering: +1]" defg,cols=(1,2))
- │    │    └── cost: 7134.44
- │    ├── [ordering: +1] [limit hint: 104.58]
- │    │    ├── best: (index-join G7="[ordering: +1] [limit hint: 104.58]" defg,cols=(1,2))
- │    │    └── cost: 1336.81
- │    └── []
- │         ├── best: (index-join G7 defg,cols=(1,2))
- │         └── cost: 7134.44
- ├── G5: (index-join G8 defg,cols=(1,2))
- │    ├── [ordering: +1]
- │    │    ├── best: (index-join G8="[ordering: +1]" defg,cols=(1,2))
- │    │    └── cost: 7154.64
- │    ├── [ordering: +1] [limit hint: 104.58]
- │    │    ├── best: (index-join G8="[ordering: +1] [limit hint: 104.58]" defg,cols=(1,2))
- │    │    └── cost: 1338.90
- │    └── []
- │         ├── best: (index-join G8 defg,cols=(1,2))
- │         └── cost: 7154.64
- ├── G6: (index-join G9 defg,cols=(1,2))
- │    ├── [ordering: +1]
- │    │    ├── best: (index-join G9="[ordering: +1]" defg,cols=(1,2))
- │    │    └── cost: 7144.54
- │    ├── [ordering: +1] [limit hint: 104.58]
- │    │    ├── best: (index-join G9="[ordering: +1] [limit hint: 104.58]" defg,cols=(1,2))
- │    │    └── cost: 1337.85
- │    └── []
- │         ├── best: (index-join G9 defg,cols=(1,2))
- │         └── cost: 7144.54
- ├── G7: (scan defg@dd,cols=(1,5))
+ ├── G4: (scan defg@dd,cols=(1,5))
  │    ├── [ordering: +1]
  │    │    ├── best: (scan defg@dd,cols=(1,5))
  │    │    └── cost: 1064.42
@@ -1902,7 +1877,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
  │    └── []
  │         ├── best: (scan defg@dd,cols=(1,5))
  │         └── cost: 1064.42
- ├── G8: (scan defg@dfg,cols=(1,5))
+ ├── G5: (scan defg@dfg,cols=(1,5))
  │    ├── [ordering: +1]
  │    │    ├── best: (scan defg@dfg,cols=(1,5))
  │    │    └── cost: 1084.62
@@ -1912,7 +1887,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2] [ordering: +1,+2])
  │    └── []
  │         ├── best: (scan defg@dfg,cols=(1,5))
  │         └── cost: 1084.62
- └── G9: (scan defg@df,cols=(1,5))
+ └── G6: (scan defg@df,cols=(1,5))
       ├── [ordering: +1]
       │    ├── best: (scan defg@df,cols=(1,5))
       │    └── cost: 1074.52
@@ -2002,15 +1977,15 @@ memo (optimized, ~4KB, required=[presentation: d:1,f:3,e:2] [ordering: +1,+3,+2]
 memo expect=GeneratePartialOrderTopK
 SELECT * FROM defg ORDER BY d, f, e LIMIT 10
 ----
-memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2])
- ├── G1: (limit G2 G3 ordering=+1,+3,+2) (top-k G2 &{10 +1,+3,+2 }) (top-k G4 &{10 +1,+3,+2 }) (top-k G5 &{10 +1,+3,+2 }) (top-k G6 &{10 +1,+3,+2 }) (top-k G2 &{10 +1,+3,+2 +1,+3}) (top-k G4 &{10 +1,+3,+2 +1}) (top-k G5 &{10 +1,+3,+2 +1,+3}) (top-k G6 &{10 +1,+3,+2 +1,+3}) (top-k G4 &{10 +1,+3,+2 +1,+3})
+memo (optimized, ~11KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2])
+ ├── G1: (limit G2 G3 ordering=+1,+3,+2) (top-k G2 &{10 +1,+3,+2 }) (top-k G4 &{10 +1,+3,+2 }) (top-k G2 &{10 +1,+3,+2 +1,+3}) (top-k G4 &{10 +1,+3,+2 +1}) (top-k G4 &{10 +1,+3,+2 +1,+3})
  │    ├── [presentation: d:1,e:2,f:3,g:4] [ordering: +1,+3,+2]
- │    │    ├── best: (top-k G6="[ordering: +1,+3] [limit hint: 100.00]" &{10 +1,+3,+2 +1,+3})
+ │    │    ├── best: (top-k G2="[ordering: +1,+3] [limit hint: 100.00]" &{10 +1,+3,+2 +1,+3})
  │    │    └── cost: 737.57
  │    └── []
  │         ├── best: (top-k G2 &{10 +1,+3,+2 })
  │         └── cost: 1206.52
- ├── G2: (scan defg,cols=(1-4))
+ ├── G2: (scan defg,cols=(1-4)) (index-join G5 defg,cols=(1-4)) (index-join G6 defg,cols=(1-4))
  │    ├── [ordering: +1,+3,+2] [limit hint: 10.00]
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1386.46
@@ -2018,8 +1993,8 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+
  │    │    ├── best: (sort G2)
  │    │    └── cost: 1385.37
  │    ├── [ordering: +1,+3] [limit hint: 100.00]
- │    │    ├── best: (sort G2)
- │    │    └── cost: 1385.37
+ │    │    ├── best: (index-join G6="[ordering: +1,+3] [limit hint: 100.00]" defg,cols=(1-4))
+ │    │    └── cost: 728.04
  │    └── []
  │         ├── best: (scan defg,cols=(1-4))
  │         └── cost: 1114.92
@@ -2040,37 +2015,7 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+
  │    └── []
  │         ├── best: (index-join G7 defg,cols=(1-4))
  │         └── cost: 7154.44
- ├── G5: (index-join G8 defg,cols=(1-4))
- │    ├── [ordering: +1,+3]
- │    │    ├── best: (index-join G8="[ordering: +1,+3]" defg,cols=(1-4))
- │    │    └── cost: 7174.84
- │    ├── [ordering: +1,+3] [limit hint: 100.00]
- │    │    ├── best: (index-join G8="[ordering: +1,+3] [limit hint: 100.00]" defg,cols=(1-4))
- │    │    └── cost: 729.04
- │    └── []
- │         ├── best: (index-join G8 defg,cols=(1-4))
- │         └── cost: 7174.84
- ├── G6: (index-join G9 defg,cols=(1-4))
- │    ├── [ordering: +1,+3]
- │    │    ├── best: (index-join G9="[ordering: +1,+3]" defg,cols=(1-4))
- │    │    └── cost: 7164.64
- │    ├── [ordering: +1,+3] [limit hint: 100.00]
- │    │    ├── best: (index-join G9="[ordering: +1,+3] [limit hint: 100.00]" defg,cols=(1-4))
- │    │    └── cost: 728.04
- │    └── []
- │         ├── best: (index-join G9 defg,cols=(1-4))
- │         └── cost: 7164.64
- ├── G7: (scan defg@dd,cols=(1,5))
- │    ├── [ordering: +1]
- │    │    ├── best: (scan defg@dd,cols=(1,5))
- │    │    └── cost: 1064.42
- │    ├── [ordering: +1] [limit hint: 104.58]
- │    │    ├── best: (scan defg@dd,cols=(1,5))
- │    │    └── cost: 122.79
- │    └── []
- │         ├── best: (scan defg@dd,cols=(1,5))
- │         └── cost: 1064.42
- ├── G8: (scan defg@dfg,cols=(1,3-5))
+ ├── G5: (scan defg@dfg,cols=(1,3-5))
  │    ├── [ordering: +1,+3]
  │    │    ├── best: (scan defg@dfg,cols=(1,3-5))
  │    │    └── cost: 1104.82
@@ -2080,22 +2025,32 @@ memo (optimized, ~14KB, required=[presentation: d:1,e:2,f:3,g:4] [ordering: +1,+
  │    └── []
  │         ├── best: (scan defg@dfg,cols=(1,3-5))
  │         └── cost: 1104.82
- └── G9: (scan defg@df,cols=(1,3,5))
-      ├── [ordering: +1,+3]
-      │    ├── best: (scan defg@df,cols=(1,3,5))
-      │    └── cost: 1084.62
-      ├── [ordering: +1,+3] [limit hint: 100.00]
-      │    ├── best: (scan defg@df,cols=(1,3,5))
-      │    └── cost: 120.02
+ ├── G6: (scan defg@df,cols=(1,3,5))
+ │    ├── [ordering: +1,+3]
+ │    │    ├── best: (scan defg@df,cols=(1,3,5))
+ │    │    └── cost: 1084.62
+ │    ├── [ordering: +1,+3] [limit hint: 100.00]
+ │    │    ├── best: (scan defg@df,cols=(1,3,5))
+ │    │    └── cost: 120.02
+ │    └── []
+ │         ├── best: (scan defg@df,cols=(1,3,5))
+ │         └── cost: 1084.62
+ └── G7: (scan defg@dd,cols=(1,5))
+      ├── [ordering: +1]
+      │    ├── best: (scan defg@dd,cols=(1,5))
+      │    └── cost: 1064.42
+      ├── [ordering: +1] [limit hint: 104.58]
+      │    ├── best: (scan defg@dd,cols=(1,5))
+      │    └── cost: 122.79
       └── []
-           ├── best: (scan defg@df,cols=(1,3,5))
-           └── cost: 1084.62
+           ├── best: (scan defg@dd,cols=(1,5))
+           └── cost: 1064.42
 
 # Only index ordering dfg can be used for the topk.
 memo expect=GeneratePartialOrderTopK disable=GenerateLimitedTopKScans
 SELECT d, f, g FROM defg ORDER BY d, g LIMIT 10
 ----
-memo (optimized, ~5KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
+memo (optimized, ~8KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
  ├── G1: (limit G2 G3 ordering=+1,+4) (top-k G2 &{10 +1,+4 }) (top-k G2 &{10 +1,+4 +1})
  │    ├── [presentation: d:1,f:3,g:4] [ordering: +1,+4]
  │    │    ├── best: (top-k G2="[ordering: +1] [limit hint: 104.58]" &{10 +1,+4 +1})
@@ -2103,7 +2058,7 @@ memo (optimized, ~5KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
  │    └── []
  │         ├── best: (top-k G2 &{10 +1,+4 })
  │         └── cost: 1185.79
- ├── G2: (scan defg,cols=(1,3,4)) (scan defg@dfg,cols=(1,3,4))
+ ├── G2: (scan defg,cols=(1,3,4)) (scan defg@dfg,cols=(1,3,4)) (index-join G4 defg,cols=(1,3,4)) (index-join G5 defg,cols=(1,3,4))
  │    ├── [ordering: +1,+4] [limit hint: 10.00]
  │    │    ├── best: (sort G2="[ordering: +1]")
  │    │    └── cost: 1221.18
@@ -2116,7 +2071,27 @@ memo (optimized, ~5KB, required=[presentation: d:1,f:3,g:4] [ordering: +1,+4])
  │    └── []
  │         ├── best: (scan defg@dfg,cols=(1,3,4))
  │         └── cost: 1094.72
- └── G3: (const 10)
+ ├── G3: (const 10)
+ ├── G4: (scan defg@dd,cols=(1,5))
+ │    ├── [ordering: +1]
+ │    │    ├── best: (scan defg@dd,cols=(1,5))
+ │    │    └── cost: 1064.42
+ │    ├── [ordering: +1] [limit hint: 104.58]
+ │    │    ├── best: (scan defg@dd,cols=(1,5))
+ │    │    └── cost: 122.79
+ │    └── []
+ │         ├── best: (scan defg@dd,cols=(1,5))
+ │         └── cost: 1064.42
+ └── G5: (scan defg@df,cols=(1,3,5))
+      ├── [ordering: +1]
+      │    ├── best: (scan defg@df,cols=(1,3,5))
+      │    └── cost: 1084.62
+      ├── [ordering: +1] [limit hint: 104.58]
+      │    ├── best: (scan defg@df,cols=(1,3,5))
+      │    └── cost: 124.88
+      └── []
+           ├── best: (scan defg@df,cols=(1,3,5))
+           └── cost: 1084.62
 
 # Ensure that we don't incorrectly use orderings that don't match the direction.
 memo expect-not=GeneratePartialOrderTopK

--- a/pkg/sql/opt/xform/testdata/rules/scan
+++ b/pkg/sql/opt/xform/testdata/rules/scan
@@ -231,16 +231,26 @@ memo (optimized, ~3KB, required=[presentation: s:4,i:2,f:3] [ordering: +3])
 memo
 SELECT s, i, f FROM a ORDER BY s DESC, i
 ----
-memo (optimized, ~3KB, required=[presentation: s:4,i:2,f:3] [ordering: -4,+2])
- └── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4))
-      ├── [presentation: s:4,i:2,f:3] [ordering: -4,+2]
-      │    ├── best: (sort G1="[ordering: -4]")
-      │    └── cost: 1321.83
+memo (optimized, ~4KB, required=[presentation: s:4,i:2,f:3] [ordering: -4,+2])
+ ├── G1: (scan a,cols=(2-4)) (scan a@s_idx,cols=(2-4)) (index-join G2 a,cols=(2-4))
+ │    ├── [presentation: s:4,i:2,f:3] [ordering: -4,+2]
+ │    │    ├── best: (sort G1="[ordering: -4]")
+ │    │    └── cost: 1321.83
+ │    ├── [ordering: -4]
+ │    │    ├── best: (scan a@s_idx,rev,cols=(2-4))
+ │    │    └── cost: 1195.37
+ │    └── []
+ │         ├── best: (scan a@s_idx,cols=(2-4))
+ │         └── cost: 1094.72
+ └── G2: (scan a@si_idx,cols=(1,2,4))
+      ├── [ordering: -4,+2]
+      │    ├── best: (sort G2="[ordering: -4]")
+      │    └── cost: 1221.18
       ├── [ordering: -4]
-      │    ├── best: (scan a@s_idx,rev,cols=(2-4))
-      │    └── cost: 1195.37
+      │    ├── best: (scan a@si_idx,cols=(1,2,4))
+      │    └── cost: 1094.72
       └── []
-           ├── best: (scan a@s_idx,cols=(2-4))
+           ├── best: (scan a@si_idx,cols=(1,2,4))
            └── cost: 1094.72
 
 # Force an index in order to ensure that an index join is created.
@@ -324,13 +334,20 @@ scan a@si_idx,rev
 memo
 SELECT s, j FROM a ORDER BY s
 ----
-memo (optimized, ~3KB, required=[presentation: s:4,j:5] [ordering: +4])
- └── G1: (scan a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
-      ├── [presentation: s:4,j:5] [ordering: +4]
-      │    ├── best: (scan a@si_idx,rev,cols=(4,5))
-      │    └── cost: 1185.27
+memo (optimized, ~4KB, required=[presentation: s:4,j:5] [ordering: +4])
+ ├── G1: (scan a,cols=(4,5)) (index-join G2 a,cols=(4,5)) (scan a@si_idx,cols=(4,5))
+ │    ├── [presentation: s:4,j:5] [ordering: +4]
+ │    │    ├── best: (scan a@si_idx,rev,cols=(4,5))
+ │    │    └── cost: 1185.27
+ │    └── []
+ │         ├── best: (scan a@si_idx,cols=(4,5))
+ │         └── cost: 1084.62
+ └── G2: (scan a@s_idx,cols=(1,4))
+      ├── [ordering: +4]
+      │    ├── best: (scan a@s_idx,cols=(1,4))
+      │    └── cost: 1084.62
       └── []
-           ├── best: (scan a@si_idx,cols=(4,5))
+           ├── best: (scan a@s_idx,cols=(1,4))
            └── cost: 1084.62
 
 # Consider three different indexes, and pick index with multiple keys.
@@ -423,6 +440,161 @@ insert fk_b
                 │    ├── key: ()
                 │    └── fd: ()-->(7)
                 └── filters (true)
+
+# Regression test for support issue #1453
+exec-ddl
+CREATE TABLE table_a (
+rand_id UUID NOT NULL DEFAULT gen_random_uuid(),
+fk_col INT8 NOT NULL,
+string_col STRING NOT NULL,
+now_col TIMESTAMPTZ NOT NULL DEFAULT now():::TIMESTAMPTZ,
+CONSTRAINT "primary" PRIMARY KEY (rand_id ASC),
+INDEX table_a_fk_col_index (fk_col ASC)
+)
+----
+
+exec-ddl
+CREATE TABLE table_b (
+pk_col INT8 NOT NULL,
+string_col STRING NULL,
+ts_col TIMESTAMPTZ NULL,
+created_at TIMESTAMPTZ NULL,
+CONSTRAINT "primary" PRIMARY KEY (pk_col ASC),
+INDEX table_b_string_col_index (string_col ASC)
+)
+----
+
+# An unconstrained index scan on table_a_fk_col_index should be used because it
+# provides the ordering of the ORDER BY clause.
+opt expect=GenerateIndexScans
+SELECT * FROM table_a a ORDER BY a.fk_col DESC LIMIT 1
+----
+index-join table_a
+ ├── columns: rand_id:1!null fk_col:2!null string_col:3!null now_col:4!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1-4)
+ └── scan table_a@table_a_fk_col_index,rev [as=a]
+      ├── columns: rand_id:1!null fk_col:2!null
+      ├── limit: 1(rev)
+      ├── key: ()
+      └── fd: ()-->(1,2)
+
+# An unconstrained index scan on table_a_fk_col_index should be used because it
+# provides the ordering of the ORDER BY clause.
+opt expect=GenerateIndexScans
+SELECT a.string_col,a.fk_col FROM table_a a
+INNER LOOKUP JOIN table_b b
+ON a.string_col = b.string_col
+ORDER BY a.fk_col DESC
+LIMIT 1
+----
+project
+ ├── columns: string_col:3!null fk_col:2!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2,3)
+ └── limit
+      ├── columns: fk_col:2!null a.string_col:3!null b.string_col:8!null
+      ├── internal-ordering: -2
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(2,3,8), (8)==(3), (3)==(8)
+      ├── inner-join (lookup table_b@table_b_string_col_index [as=b])
+      │    ├── columns: fk_col:2!null a.string_col:3!null b.string_col:8!null
+      │    ├── flags: force lookup join (into right side)
+      │    ├── key columns: [3] = [8]
+      │    ├── fd: (3)==(8), (8)==(3)
+      │    ├── ordering: -2
+      │    ├── limit hint: 1.00
+      │    ├── index-join table_a
+      │    │    ├── columns: fk_col:2!null a.string_col:3!null
+      │    │    ├── ordering: -2
+      │    │    ├── limit hint: 100.00
+      │    │    └── scan table_a@table_a_fk_col_index,rev [as=a]
+      │    │         ├── columns: rand_id:1!null fk_col:2!null
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2)
+      │    │         ├── ordering: -2
+      │    │         └── limit hint: 100.00
+      │    └── filters (true)
+      └── 1
+
+exec-ddl
+ALTER TABLE table_a INJECT STATISTICS '[
+  {
+    "columns": ["fk_col"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "avg_size": 3
+  },
+  {
+    "columns": ["string_col"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "avg_size": 3
+  }
+]'
+----
+
+exec-ddl
+ALTER TABLE table_b INJECT STATISTICS '[
+  {
+    "columns": ["pk_col"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "avg_size": 3
+  },
+  {
+    "columns": ["string_col"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 1000000,
+    "distinct_count": 1000000,
+    "avg_size": 3
+  }
+]'
+----
+
+# With a large number of rows, index join plus nested loop join should be
+# favored over hash join.
+opt expect=GenerateIndexScans
+SELECT a.string_col,a.fk_col FROM table_a a
+INNER JOIN table_b b
+ON a.string_col = b.string_col
+ORDER BY a.fk_col DESC
+LIMIT 2
+----
+project
+ ├── columns: string_col:3!null fk_col:2!null
+ ├── cardinality: [0 - 2]
+ ├── ordering: -2
+ └── limit
+      ├── columns: fk_col:2!null a.string_col:3!null b.string_col:8!null
+      ├── internal-ordering: -2
+      ├── cardinality: [0 - 2]
+      ├── fd: (3)==(8), (8)==(3)
+      ├── ordering: -2
+      ├── inner-join (lookup table_b@table_b_string_col_index [as=b])
+      │    ├── columns: fk_col:2!null a.string_col:3!null b.string_col:8!null
+      │    ├── key columns: [3] = [8]
+      │    ├── fd: (3)==(8), (8)==(3)
+      │    ├── ordering: -2
+      │    ├── limit hint: 2.00
+      │    ├── index-join table_a
+      │    │    ├── columns: fk_col:2!null a.string_col:3!null
+      │    │    ├── ordering: -2
+      │    │    ├── limit hint: 100.00
+      │    │    └── scan table_a@table_a_fk_col_index,rev [as=a]
+      │    │         ├── columns: rand_id:1!null fk_col:2!null
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2)
+      │    │         ├── ordering: -2
+      │    │         └── limit hint: 100.00
+      │    └── filters (true)
+      └── 2
 
 # --------------------------------------------------
 # GenerateLocalityOptimizedScan

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -1259,21 +1259,66 @@ New expression 2 of 2:
              ├── constraint: /-4/-2/1: [/'foo' - /'foo']
              ├── key: (1)
              └── fd: ()-->(4), (1)-->(2)
+
+================================================================================
+GenerateConstrainedScans
+================================================================================
+Source expression:
+  sort
+   ├── columns: s:4!null i:2 f:3  [hidden: k:1!null]
+   ├── key: (1)
+   ├── fd: ()-->(4), (1)-->(2,3)
+   ├── ordering: +1 opt(4) [actual: +1]
+   └── select
+        ├── columns: k:1!null i:2 f:3 s:4!null
+        ├── key: (1)
+        ├── fd: ()-->(4), (1)-->(2,3)
+        ├── scan kifs@s_idx
+        │    ├── columns: k:1!null i:2 f:3 s:4
+        │    ├── key: (1)
+        │    └── fd: (1)-->(2-4)
+        └── filters
+             └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+
+New expression 1 of 2:
+  scan kifs@s_idx
+   ├── columns: s:4!null i:2 f:3  [hidden: k:1!null]
+   ├── constraint: /4/1: [/'foo' - /'foo']
+   ├── key: (1)
+   ├── fd: ()-->(4), (1)-->(2,3)
+   └── ordering: +1 opt(4) [actual: +1]
+
+New expression 2 of 2:
+  index-join kifs
+   ├── columns: s:4!null i:2 f:3  [hidden: k:1!null]
+   ├── key: (1)
+   ├── fd: ()-->(4), (1)-->(2,3)
+   ├── ordering: +1 opt(4) [actual: +1]
+   └── sort
+        ├── columns: k:1!null i:2 s:4!null
+        ├── key: (1)
+        ├── fd: ()-->(4), (1)-->(2)
+        ├── ordering: +1 opt(4) [actual: +1]
+        └── scan kifs@si_idx
+             ├── columns: k:1!null i:2 s:4!null
+             ├── constraint: /-4/-2/1: [/'foo' - /'foo']
+             ├── key: (1)
+             └── fd: ()-->(4), (1)-->(2)
 ----
 ----
 
 memo
 SELECT s, i, f FROM kifs WHERE s='foo' ORDER BY s DESC, i
 ----
-memo (optimized, ~7KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)])
- ├── G1: (select G2 G3) (scan kifs@s_idx,cols=(2-4),constrained) (index-join G4 kifs,cols=(2-4))
+memo (optimized, ~10KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)])
+ ├── G1: (select G2 G3) (scan kifs@s_idx,cols=(2-4),constrained) (index-join G4 kifs,cols=(2-4)) (scan kifs@s_idx,cols=(2-4),constrained) (index-join G5 kifs,cols=(2-4))
  │    ├── [presentation: s:4,i:2,f:3] [ordering: +2 opt(4)]
  │    │    ├── best: (sort G1)
  │    │    └── cost: 25.90
  │    └── []
  │         ├── best: (scan kifs@s_idx,cols=(2-4),constrained)
  │         └── cost: 24.72
- ├── G2: (scan kifs,cols=(2-4)) (scan kifs@s_idx,cols=(2-4))
+ ├── G2: (scan kifs,cols=(2-4)) (scan kifs@s_idx,cols=(2-4)) (index-join G6 kifs,cols=(2-4))
  │    ├── [ordering: +2 opt(4)]
  │    │    ├── best: (sort G2="[ordering: +4]")
  │    │    └── cost: 1177.96
@@ -1283,7 +1328,7 @@ memo (optimized, ~7KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)
  │    └── []
  │         ├── best: (scan kifs@s_idx,cols=(2-4))
  │         └── cost: 1094.72
- ├── G3: (filters G5)
+ ├── G3: (filters G7)
  ├── G4: (scan kifs@si_idx,cols=(1,2,4),constrained)
  │    ├── [ordering: +2 opt(4)]
  │    │    ├── best: (scan kifs@si_idx,rev,cols=(1,2,4),constrained)
@@ -1291,9 +1336,29 @@ memo (optimized, ~7KB, required=[presentation: s:4,i:2,f:3] [ordering: +2 opt(4)
  │    └── []
  │         ├── best: (scan kifs@si_idx,cols=(1,2,4),constrained)
  │         └── cost: 24.72
- ├── G5: (eq G6 G7)
- ├── G6: (variable s)
- └── G7: (const 'foo')
+ ├── G5: (scan kifs@si_idx,cols=(1,2,4),constrained)
+ │    ├── [ordering: +2 opt(4)]
+ │    │    ├── best: (scan kifs@si_idx,rev,cols=(1,2,4),constrained)
+ │    │    └── cost: 25.05
+ │    └── []
+ │         ├── best: (scan kifs@si_idx,cols=(1,2,4),constrained)
+ │         └── cost: 24.72
+ ├── G6: (scan kifs@si_idx,cols=(1,2,4))
+ │    ├── [ordering: +2 opt(4)]
+ │    │    ├── best: (sort G6="[ordering: -4]")
+ │    │    └── cost: 1177.96
+ │    ├── [ordering: +4]
+ │    │    ├── best: (scan kifs@si_idx,rev,cols=(1,2,4))
+ │    │    └── cost: 1195.37
+ │    ├── [ordering: -4]
+ │    │    ├── best: (scan kifs@si_idx,cols=(1,2,4))
+ │    │    └── cost: 1094.72
+ │    └── []
+ │         ├── best: (scan kifs@si_idx,cols=(1,2,4))
+ │         └── cost: 1094.72
+ ├── G7: (eq G8 G9)
+ ├── G8: (variable s)
+ └── G9: (const 'foo')
 
 memo
 SELECT j FROM kifs WHERE s = 'foo'
@@ -8201,7 +8266,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~36KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)
@@ -8217,142 +8282,156 @@ memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
  │         ├── best: (select G4 G5)
  │         └── cost: 1094.66
  ├── G3: (projections)
- ├── G4: (scan t61795 [as=t1],cols=(1-3))
+ ├── G4: (scan t61795 [as=t1],cols=(1-3)) (index-join G10 t61795,cols=(1-3))
  │    ├── [ordering: +2]
  │    │    ├── best: (sort G4)
  │    │    └── cost: 1334.10
  │    └── []
  │         ├── best: (scan t61795 [as=t1],cols=(1-3))
  │         └── cost: 1084.62
- ├── G5: (filters G10 G11)
- ├── G6: (index-join G12 t61795,cols=(1-3))
+ ├── G5: (filters G11 G12)
+ ├── G6: (index-join G13 t61795,cols=(1-3))
  │    ├── [ordering: +2]
- │    │    ├── best: (index-join G12="[ordering: +2]" t61795,cols=(1-3))
+ │    │    ├── best: (index-join G13="[ordering: +2]" t61795,cols=(1-3))
  │    │    └── cost: 3050.07
  │    └── []
- │         ├── best: (index-join G12 t61795,cols=(1-3))
+ │         ├── best: (index-join G13 t61795,cols=(1-3))
  │         └── cost: 3050.07
- ├── G7: (filters G10)
- ├── G8: (union-all G13 G14)
+ ├── G7: (filters G11)
+ ├── G8: (union-all G14 G15)
  │    ├── [ordering: +(2|3)]
- │    │    ├── best: (union-all G13 G14="[ordering: +(17|18)]")
+ │    │    ├── best: (union-all G14 G15="[ordering: +(17|18)]")
  │    │    └── cost: 1099.83
  │    ├── [ordering: +1]
- │    │    ├── best: (union-all G13 G14="[ordering: +16]")
+ │    │    ├── best: (union-all G14 G15="[ordering: +16]")
  │    │    └── cost: 1099.79
  │    └── []
- │         ├── best: (union-all G13 G14)
+ │         ├── best: (union-all G14 G15)
  │         └── cost: 1099.79
- ├── G9: (aggregations G15 G16)
- ├── G10: (eq G17 G18)
- ├── G11: (or G19 G20)
- ├── G12: (select G21 G22)
+ ├── G9: (aggregations G16 G17)
+ ├── G10: (scan t61795@t61795_b_key [as=t1],cols=(1,2))
  │    ├── [ordering: +2]
- │    │    ├── best: (select G21="[ordering: +2]" G22)
+ │    │    ├── best: (scan t61795@t61795_b_key [as=t1],cols=(1,2))
+ │    │    └── cost: 1064.42
+ │    └── []
+ │         ├── best: (scan t61795@t61795_b_key [as=t1],cols=(1,2))
+ │         └── cost: 1064.42
+ ├── G11: (eq G18 G19)
+ ├── G12: (or G20 G21)
+ ├── G13: (select G22 G23)
+ │    ├── [ordering: +2]
+ │    │    ├── best: (select G22="[ordering: +2]" G23)
  │    │    └── cost: 1053.55
  │    └── []
- │         ├── best: (select G21 G22)
+ │         ├── best: (select G22 G23)
  │         └── cost: 1053.55
- ├── G13: (select G23 G24) (select G25 G26) (select G27 G26)
+ ├── G14: (select G24 G25) (select G26 G27) (select G28 G27)
  │    └── []
- │         ├── best: (select G25 G26)
+ │         ├── best: (select G26 G27)
  │         └── cost: 5.10
- ├── G14: (select G28 G29) (select G30 G31)
+ ├── G15: (select G29 G30) (select G31 G32)
  │    ├── [ordering: +(17|18)]
- │    │    ├── best: (sort G14)
+ │    │    ├── best: (sort G15)
  │    │    └── cost: 1094.70
  │    ├── [ordering: +16]
- │    │    ├── best: (select G28="[ordering: +16]" G29)
+ │    │    ├── best: (select G29="[ordering: +16]" G30)
  │    │    └── cost: 1094.66
  │    └── []
- │         ├── best: (select G28 G29)
+ │         ├── best: (select G29 G30)
  │         └── cost: 1094.66
- ├── G15: (const-agg G18)
- ├── G16: (const-agg G17)
- ├── G17: (variable t1.c)
- ├── G18: (variable t1.b)
- ├── G19: (eq G32 G33)
- ├── G20: (ne G18 G34)
- ├── G21: (scan t61795@t61795_b_key [as=t1],cols=(1,2),constrained)
+ ├── G16: (const-agg G19)
+ ├── G17: (const-agg G18)
+ ├── G18: (variable t1.c)
+ ├── G19: (variable t1.b)
+ ├── G20: (eq G33 G34)
+ ├── G21: (ne G19 G35)
+ ├── G22: (scan t61795@t61795_b_key [as=t1],cols=(1,2),constrained)
  │    ├── [ordering: +2]
  │    │    ├── best: (scan t61795@t61795_b_key [as=t1],cols=(1,2),constrained)
  │    │    └── cost: 1043.62
  │    └── []
  │         ├── best: (scan t61795@t61795_b_key [as=t1],cols=(1,2),constrained)
  │         └── cost: 1043.62
- ├── G22: (filters G11)
- ├── G23: (scan t61795 [as=t1],cols=(11-13))
+ ├── G23: (filters G12)
+ ├── G24: (scan t61795 [as=t1],cols=(11-13))
  │    └── []
  │         ├── best: (scan t61795 [as=t1],cols=(11-13))
  │         └── cost: 1084.62
- ├── G24: (filters G35 G36)
- ├── G25: (scan t61795 [as=t1],cols=(11-13),constrained)
+ ├── G25: (filters G36 G37)
+ ├── G26: (scan t61795 [as=t1],cols=(11-13),constrained)
  │    └── []
  │         ├── best: (scan t61795 [as=t1],cols=(11-13),constrained)
  │         └── cost: 5.07
- ├── G26: (filters G35)
- ├── G27: (index-join G37 t61795,cols=(11-13))
+ ├── G27: (filters G36)
+ ├── G28: (index-join G38 t61795,cols=(11-13))
  │    └── []
- │         ├── best: (index-join G37 t61795,cols=(11-13))
+ │         ├── best: (index-join G38 t61795,cols=(11-13))
  │         └── cost: 1059.60
- ├── G28: (scan t61795 [as=t1],cols=(16-18))
+ ├── G29: (scan t61795 [as=t1],cols=(16-18)) (index-join G39 t61795,cols=(16-18))
  │    ├── [ordering: +16]
  │    │    ├── best: (scan t61795 [as=t1],cols=(16-18))
  │    │    └── cost: 1084.62
  │    ├── [ordering: +17]
- │    │    ├── best: (sort G28)
+ │    │    ├── best: (sort G29)
  │    │    └── cost: 1334.10
  │    └── []
  │         ├── best: (scan t61795 [as=t1],cols=(16-18))
  │         └── cost: 1084.62
- ├── G29: (filters G38 G39)
- ├── G30: (index-join G40 t61795,cols=(16-18))
+ ├── G30: (filters G40 G41)
+ ├── G31: (index-join G42 t61795,cols=(16-18))
  │    ├── [ordering: +16]
- │    │    ├── best: (index-join G40="[ordering: +16]" t61795,cols=(16-18))
+ │    │    ├── best: (index-join G42="[ordering: +16]" t61795,cols=(16-18))
  │    │    └── cost: 3118.52
  │    ├── [ordering: +17]
- │    │    ├── best: (index-join G40="[ordering: +17]" t61795,cols=(16-18))
+ │    │    ├── best: (index-join G42="[ordering: +17]" t61795,cols=(16-18))
  │    │    └── cost: 3050.07
  │    └── []
- │         ├── best: (index-join G40 t61795,cols=(16-18))
+ │         ├── best: (index-join G42 t61795,cols=(16-18))
  │         └── cost: 3050.07
- ├── G31: (filters G38)
- ├── G32: (variable t1.a)
- ├── G33: (const 10)
- ├── G34: (function G41 abs)
- ├── G35: (eq G42 G43)
- ├── G36: (eq G44 G33)
- ├── G37: (select G45 G46)
+ ├── G32: (filters G40)
+ ├── G33: (variable t1.a)
+ ├── G34: (const 10)
+ ├── G35: (function G43 abs)
+ ├── G36: (eq G44 G45)
+ ├── G37: (eq G46 G34)
+ ├── G38: (select G47 G48)
  │    └── []
- │         ├── best: (select G45 G46)
+ │         ├── best: (select G47 G48)
  │         └── cost: 1053.54
- ├── G38: (eq G47 G48)
- ├── G39: (ne G48 G49)
- ├── G40: (select G50 G51)
+ ├── G39: (scan t61795@t61795_b_key [as=t1],cols=(16,17))
+ │    ├── [ordering: +17]
+ │    │    ├── best: (scan t61795@t61795_b_key [as=t1],cols=(16,17))
+ │    │    └── cost: 1064.42
+ │    └── []
+ │         ├── best: (scan t61795@t61795_b_key [as=t1],cols=(16,17))
+ │         └── cost: 1064.42
+ ├── G40: (eq G49 G50)
+ ├── G41: (ne G50 G51)
+ ├── G42: (select G52 G53)
  │    ├── [ordering: +16]
- │    │    ├── best: (sort G40)
+ │    │    ├── best: (sort G42)
  │    │    └── cost: 1122.00
  │    ├── [ordering: +17]
- │    │    ├── best: (select G50="[ordering: +17]" G51)
+ │    │    ├── best: (select G52="[ordering: +17]" G53)
  │    │    └── cost: 1053.55
  │    └── []
- │         ├── best: (select G50 G51)
+ │         ├── best: (select G52 G53)
  │         └── cost: 1053.55
- ├── G41: (scalar-list G18)
- ├── G42: (variable t1.c)
- ├── G43: (variable t1.b)
- ├── G44: (variable t1.a)
- ├── G45: (scan t61795@t61795_b_key [as=t1],cols=(11,12),constrained)
+ ├── G43: (scalar-list G19)
+ ├── G44: (variable t1.c)
+ ├── G45: (variable t1.b)
+ ├── G46: (variable t1.a)
+ ├── G47: (scan t61795@t61795_b_key [as=t1],cols=(11,12),constrained)
  │    └── []
  │         ├── best: (scan t61795@t61795_b_key [as=t1],cols=(11,12),constrained)
  │         └── cost: 1043.62
- ├── G46: (filters G36)
- ├── G47: (variable t1.c)
- ├── G48: (variable t1.b)
- ├── G49: (function G52 abs)
- ├── G50: (scan t61795@t61795_b_key [as=t1],cols=(16,17),constrained)
+ ├── G48: (filters G37)
+ ├── G49: (variable t1.c)
+ ├── G50: (variable t1.b)
+ ├── G51: (function G54 abs)
+ ├── G52: (scan t61795@t61795_b_key [as=t1],cols=(16,17),constrained)
  │    ├── [ordering: +16]
- │    │    ├── best: (sort G50)
+ │    │    ├── best: (sort G52)
  │    │    └── cost: 1280.42
  │    ├── [ordering: +17]
  │    │    ├── best: (scan t61795@t61795_b_key [as=t1],cols=(16,17),constrained)
@@ -8360,8 +8439,8 @@ memo (optimized, ~33KB, required=[presentation: a:1] [ordering: +2])
  │    └── []
  │         ├── best: (scan t61795@t61795_b_key [as=t1],cols=(16,17),constrained)
  │         └── cost: 1043.62
- ├── G51: (filters G39)
- └── G52: (scalar-list G48)
+ ├── G53: (filters G41)
+ └── G54: (scalar-list G50)
 
 # --------------------------------------------------
 # SplitDisjunctionAddKey

--- a/pkg/sql/opt/xform/testdata/rules/stats
+++ b/pkg/sql/opt/xform/testdata/rules/stats
@@ -14,9 +14,9 @@ Top normalization rules:
   EliminateProject   applied 1 times.
   PruneJoinLeftCols  applied 1 times.
   PruneJoinRightCols applied 1 times.
-Exploration rules applied 7 times, added 5 expressions.
+Exploration rules applied 9 times, added 5 expressions.
 Top exploration rules:
+  GenerateIndexScans  applied 4 times, added 0 expressions.
   GenerateMergeJoins  applied 2 times, added 2 expressions.
   GenerateLookupJoins applied 2 times, added 2 expressions.
-  GenerateIndexScans  applied 2 times, added 0 expressions.
   ReorderJoins        applied 1 times, added 1 expressions.


### PR DESCRIPTION
Fixes https://github.com/cockroachlabs/support/issues/1453 and #77243

Previously, the optimizer did not explore plans which scan a
non-covering index with no constraints, even if the index can provide
a required ordering. This can prevent an optimal plan from being found
which avoids a sort, or in the case of ORDER BY ... LIMIT, avoids a
full scan.

Now, when optimizing an enforcer of required physical properties, we
save an ordering hint in the memo. When generating index scans for                                
exploration, we no longer skip non-covering unconstrained index scans if 
that index can provide the required ordering.

Release note (performance improvement): This patch adds support for
unconstrained scans of non-covering indexes when the index can be used
to avoid a sort.