### PR TITLE
ci: fix validation for mixed version schema change corpus

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_corpus_nightly_impl.sh
@@ -143,7 +143,7 @@ done
 
 # Any generated corpus should be validated on the current version first, which
 # indicates we can replay it on the same version.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test --config=ci \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
     //pkg/sql/schemachanger/corpus:corpus_test \
     --test_arg=--declarative-corpus=$ARTIFACTS_DIR/corpus-mixed \
     --test_filter='^TestValidateCorpuses$' \


### PR DESCRIPTION
Informs: #86381

Previously, the command for validating the mixed
version corpus was invalid. This patch fixes the validation 
command to address this, so the mixed version corpus is 
automatically uploaded.

Release note: None