### PR TITLE
ui: update cluster-ui to latest publishd version 22.2.0-prerelease-6

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-5",
+  "version": "22.2.0-prerelease-6",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Update cluster-ui version to match the latest published version.

Release note: None
Release justification: non-production change