### PR TITLE
ui: rename contention to contention time

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -26,7 +26,7 @@ export const insightsColumnLabels = {
   fingerprintID: "Fingerprint ID",
   numRetries: "Retries",
   isFullScan: "Full Scan",
-  contention: "Contention",
+  contention: "Contention Time",
   rowsProcessed: "Rows Processed",
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.tsx
@@ -14,7 +14,7 @@ import "antd/lib/col/style";
 import "antd/lib/row/style";
 import "antd/lib/tabs/style";
 import { cockroach, google } from "@cockroachlabs/crdb-protobuf-client";
-import { Text, InlineAlert } from "@cockroachlabs/ui-components";
+import { InlineAlert, Text } from "@cockroachlabs/ui-components";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { Location } from "history";
 import _, { isNil } from "lodash";
@@ -28,14 +28,14 @@ import { AxisUnits } from "../graphs";
 import { AlignedData, Options } from "uplot";
 
 import {
-  intersperse,
-  unique,
-  queryByName,
   appAttr,
   appNamesAttr,
+  DATE_FORMAT_24_UTC,
+  intersperse,
+  queryByName,
   RenderCount,
   TimestampToMoment,
-  DATE_FORMAT_24_UTC,
+  unique,
 } from "src/util";
 import { getValidErrorsList, Loading } from "src/loading";
 import { Button } from "src/button";
@@ -64,14 +64,15 @@ import {
   ActivateStatementDiagnosticsModal,
 } from "../statementsDiagnostics";
 import {
+  generateContentionTimeseries,
   generateExecCountTimeseries,
   generateExecRetriesTimeseries,
   generateExecuteAndPlanningTimeseries,
   generateRowsProcessedTimeseries,
-  generateContentionTimeseries,
 } from "./timeseriesUtils";
 import { Delayed } from "../delayed";
 import moment from "moment";
+
 type IDuration = google.protobuf.IDuration;
 type StatementDetailsResponse =
   cockroach.server.serverpb.StatementDetailsResponse;
@@ -708,7 +709,7 @@ export class StatementDetails extends React.Component<
           <Row gutter={24}>
             <Col className="gutter-row" span={12}>
               <BarGraphTimeSeries
-                title={`Contention${noSamples}`}
+                title={`Contention Time${noSamples}`}
                 alignedData={contentionTimeseries}
                 uPlotOptions={contentionOps}
                 tooltip={unavailableTooltip}

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -14,14 +14,14 @@ import moment from "moment";
 
 import { Tooltip } from "@cockroachlabs/ui-components";
 import {
+  contentionTime,
+  planningExecutionTime,
+  readFromDisk,
+  readsAndWrites,
   statementDiagnostics,
   statementsRetries,
   statementsSql,
-  readFromDisk,
   writtenToDisk,
-  planningExecutionTime,
-  contentionTime,
-  readsAndWrites,
 } from "src/util";
 
 export type NodeNames = { [nodeId: string]: string };
@@ -45,7 +45,7 @@ export const statisticsColumnLabels = {
   username: "User Name",
   applicationName: "Application Name",
   bytesRead: "Bytes Read",
-  contention: "Contention",
+  contention: "Contention Time",
   database: "Database",
   diagnostics: "Diagnostics",
   executionCount: "Execution Count",


### PR DESCRIPTION
This loom shows the after where everything has been renamed to contention time.
https://www.loom.com/share/7c9beff81980452e9bbaf37c61228f88

closes #87455

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: (ui change): Rename contention to
contention time. This matches other columns like
elapsed time.