### PR TITLE
opt: reduce unnecessary allocations in the optimizer

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -226,7 +226,7 @@ func (b *Builder) Build() (_ exec.Plan, err error) {
 		return nil, err
 	}
 
-	rootRowCount := int64(b.e.(memo.RelExpr).Relational().Stats.RowCountIfAvailable())
+	rootRowCount := int64(b.e.(memo.RelExpr).Relational().Statistics().RowCountIfAvailable())
 	return b.factory.ConstructPlan(plan.root, b.subqueries, b.cascades, b.checks, rootRowCount)
 }
 

--- a/pkg/sql/opt/exec/execbuilder/cascades.go
+++ b/pkg/sql/opt/exec/execbuilder/cascades.go
@@ -241,7 +241,7 @@ func (cb *cascadeBuilder) planCascade(
 			Min: uint32(numBufferedRows),
 			Max: uint32(numBufferedRows),
 		}
-		bindingProps.Stats = props.Statistics{
+		*bindingProps.Statistics() = props.Statistics{
 			Available: true,
 			RowCount:  float64(numBufferedRows),
 		}

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -498,7 +498,7 @@ func (b *Builder) buildArrayFlatten(
 	typ := b.mem.Metadata().ColumnMeta(af.RequestedCol).Type
 	e := b.addSubquery(
 		exec.SubqueryAllRows, typ, root.root, af.OriginalExpr,
-		int64(af.Input.Relational().Stats.RowCountIfAvailable()),
+		int64(af.Input.Relational().Statistics().RowCountIfAvailable()),
 	)
 
 	return tree.NewTypedArrayFlattenExpr(e), nil
@@ -555,7 +555,7 @@ func (b *Builder) buildAny(ctx *buildScalarCtx, scalar opt.ScalarExpr) (tree.Typ
 	typs := types.MakeTuple(contents)
 	subqueryExpr := b.addSubquery(
 		exec.SubqueryAnyRows, typs, plan.root, any.OriginalExpr,
-		int64(any.Input.Relational().Stats.RowCountIfAvailable()),
+		int64(any.Input.Relational().Statistics().RowCountIfAvailable()),
 	)
 
 	// Build the scalar value that is compared against each row.
@@ -591,7 +591,7 @@ func (b *Builder) buildExistsSubquery(
 
 	return b.addSubquery(
 		exec.SubqueryExists, types.Bool, plan.root, exists.OriginalExpr,
-		int64(exists.Input.Relational().Stats.RowCountIfAvailable()),
+		int64(exists.Input.Relational().Statistics().RowCountIfAvailable()),
 	), nil
 }
 
@@ -621,7 +621,7 @@ func (b *Builder) buildSubquery(
 
 	return b.addSubquery(
 		exec.SubqueryOneRow, subquery.Typ, plan.root, subquery.OriginalExpr,
-		int64(input.Relational().Stats.RowCountIfAvailable()),
+		int64(input.Relational().Statistics().RowCountIfAvailable()),
 	), nil
 }
 

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -278,7 +278,8 @@ func makeFilters(
 	}
 
 	// Create a fake Select and input so that normalization rules are run.
-	p := &props.Relational{OutputCols: cols, Cardinality: card, Stats: stats}
+	p := &props.Relational{OutputCols: cols, Cardinality: card}
+	*p.Statistics() = stats
 	fakeRel := f.ConstructFakeRel(&memo.FakeRelPrivate{Props: p})
 	sel := f.ConstructSelect(fakeRel, filters)
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -797,9 +797,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	if !f.HasFlags(ExprFmtHideStats) {
 		if f.HasFlags(ExprFmtHideHistograms) {
-			tp.Childf("stats: %s", relational.Stats.StringWithoutHistograms())
+			tp.Childf("stats: %s", relational.Statistics().StringWithoutHistograms())
 		} else {
-			tp.Childf("stats: %s", &relational.Stats)
+			tp.Childf("stats: %s", relational.Statistics())
 		}
 	}
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -938,7 +938,7 @@ func (b *logicalPropsBuilder) buildWithProps(with *WithExpr, rel *props.Relation
 	// Statistics
 	// ----------
 	// Inherited from the input expression.
-	rel.Stats = inputProps.Stats
+	*rel.Statistics() = *inputProps.Statistics()
 }
 
 func (b *logicalPropsBuilder) buildWithScanProps(withScan *WithScanExpr, rel *props.Relational) {
@@ -2134,7 +2134,7 @@ func ensureLookupJoinInputProps(join *LookupJoinExpr, sb *statisticsBuilder) *pr
 		relational.Cardinality = props.AnyCardinality
 		relational.FuncDeps.CopyFrom(MakeTableFuncDep(md, join.Table))
 		relational.FuncDeps.ProjectCols(relational.OutputCols)
-		relational.Stats = *sb.makeTableStatistics(join.Table)
+		*relational.Statistics() = *sb.makeTableStatistics(join.Table)
 	}
 	return relational
 }
@@ -2156,7 +2156,7 @@ func ensureInvertedJoinInputProps(join *InvertedJoinExpr, sb *statisticsBuilder)
 		relational.FuncDeps.ProjectCols(relational.OutputCols)
 
 		// TODO(rytaft): Change this to use inverted index stats once available.
-		relational.Stats = *sb.makeTableStatistics(join.Table)
+		*relational.Statistics() = *sb.makeTableStatistics(join.Table)
 	}
 	return relational
 }
@@ -2201,7 +2201,7 @@ func ensureInputPropsForIndex(
 		relProps.Cardinality = props.AnyCardinality
 		relProps.FuncDeps.CopyFrom(MakeTableFuncDep(md, tabID))
 		relProps.FuncDeps.ProjectCols(relProps.OutputCols)
-		relProps.Stats = *sb.makeTableStatistics(tabID)
+		*relProps.Statistics() = *sb.makeTableStatistics(tabID)
 	}
 }
 
@@ -2624,7 +2624,7 @@ func (b *logicalPropsBuilder) buildMemoCycleTestRelProps(
 	// failures.
 	rel.OutputCols = inputProps.OutputCols
 	// Make the row count non-zero to avoid assertion failures.
-	rel.Stats.RowCount = 1
+	rel.Statistics().RowCount = 1
 }
 
 // WithUses returns the WithUsesMap for the given expression.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -487,7 +487,7 @@ func (m *Memo) Detach() {
 
 		switch t := parent.(type) {
 		case RelExpr:
-			t.Relational().Stats.ColStats = props.ColStatsMap{}
+			t.Relational().Statistics().ColStats = props.ColStatsMap{}
 		}
 	}
 	clearColStats(m.RootExpr())

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -362,7 +362,7 @@ func TestStatsAvailable(t *testing.T) {
 
 	testNotAvailable := func(expr memo.RelExpr) {
 		traverseExpr(expr, func(e memo.RelExpr) {
-			if e.Relational().Stats.Available {
+			if e.Relational().Statistics().Available {
 				t.Fatal("stats should not be available")
 			}
 		})
@@ -400,7 +400,7 @@ func TestStatsAvailable(t *testing.T) {
 
 	testAvailable := func(expr memo.RelExpr) {
 		traverseExpr(expr, func(e memo.RelExpr) {
-			if !e.Relational().Stats.Available {
+			if !e.Relational().Statistics().Available {
 				t.Fatal("stats should be available")
 			}
 		})

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -269,7 +269,7 @@ func (sb *statisticsBuilder) colStatFromChild(
 // statsFromChild retrieves the main statistics struct from a specific child
 // of the given expression.
 func (sb *statisticsBuilder) statsFromChild(e RelExpr, childIdx int) *props.Statistics {
-	return &e.Child(childIdx).(RelExpr).Relational().Stats
+	return e.Child(childIdx).(RelExpr).Relational().Statistics()
 }
 
 // availabilityFromInput determines the availability of the underlying table
@@ -281,21 +281,21 @@ func (sb *statisticsBuilder) availabilityFromInput(e RelExpr) bool {
 
 	case *LookupJoinExpr:
 		ensureLookupJoinInputProps(t, sb)
-		return t.lookupProps.Stats.Available && t.Input.Relational().Stats.Available
+		return t.lookupProps.Statistics().Available && t.Input.Relational().Statistics().Available
 
 	case *InvertedJoinExpr:
 		ensureInvertedJoinInputProps(t, sb)
-		return t.lookupProps.Stats.Available && t.Input.Relational().Stats.Available
+		return t.lookupProps.Statistics().Available && t.Input.Relational().Statistics().Available
 
 	case *ZigzagJoinExpr:
 		ensureZigzagJoinInputProps(t, sb)
-		return t.leftProps.Stats.Available
+		return t.leftProps.Statistics().Available
 	}
 
 	available := true
 	for i, n := 0, e.ChildCount(); i < n; i++ {
 		if child, ok := e.Child(i).(RelExpr); ok {
-			available = available && child.Relational().Stats.Available
+			available = available && child.Relational().Statistics().Available
 		}
 	}
 	return available
@@ -405,7 +405,7 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	}
 
 	// Check if the requested column statistic is already cached.
-	if stat, ok := e.Relational().Stats.ColStats.Lookup(colSet); ok {
+	if stat, ok := e.Relational().Statistics().ColStats.Lookup(colSet); ok {
 		return stat
 	}
 
@@ -486,7 +486,7 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 
 	case opt.FakeRelOp:
 		rel := e.Relational()
-		return sb.colStatLeaf(colSet, &rel.Stats, &rel.FuncDeps, rel.NotNullCols)
+		return sb.colStatLeaf(colSet, rel.Statistics(), &rel.FuncDeps, rel.NotNullCols)
 	}
 
 	panic(errors.AssertionFailedf("unrecognized relational expression type: %v", redact.Safe(e.Op())))
@@ -779,7 +779,7 @@ func (sb *statisticsBuilder) colAvgSize(tabID opt.TableID, col opt.ColumnID) uin
 // +------+
 
 func (sb *statisticsBuilder) buildScan(scan *ScanExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -974,7 +974,7 @@ func (sb *statisticsBuilder) constrainScan(
 
 func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, scan *ScanExpr) *props.ColumnStatistic {
 	relProps := scan.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	inputColStat := sb.colStatTable(scan.Table, colSet)
 	colStat := sb.copyColStat(colSet, s, inputColStat)
@@ -1001,13 +1001,13 @@ func (sb *statisticsBuilder) colStatScan(colSet opt.ColSet, scan *ScanExpr) *pro
 // +--------+
 
 func (sb *statisticsBuilder) buildSelect(sel *SelectExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(sel)
-	inputStats := &sel.Input.Relational().Stats
+	inputStats := sel.Input.Relational().Statistics()
 	s.RowCount = inputStats.RowCount
 
 	sb.filterRelExpr(sel.Filters, sel, relProps.NotNullCols, relProps, s, &sel.Input.Relational().FuncDeps)
@@ -1019,8 +1019,8 @@ func (sb *statisticsBuilder) colStatSelect(
 	colSet opt.ColSet, sel *SelectExpr,
 ) *props.ColumnStatistic {
 	relProps := sel.Relational()
-	s := &relProps.Stats
-	inputStats := &sel.Input.Relational().Stats
+	s := relProps.Statistics()
+	inputStats := sel.Input.Relational().Statistics()
 	colStat := sb.copyColStatFromChild(colSet, sel, s)
 
 	// It's not safe to use s.Selectivity, because it's possible that some of the
@@ -1041,14 +1041,14 @@ func (sb *statisticsBuilder) colStatSelect(
 // +---------+
 
 func (sb *statisticsBuilder) buildProject(prj *ProjectExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(prj)
 
-	inputStats := &prj.Input.Relational().Stats
+	inputStats := prj.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
 	sb.finalizeFromCardinality(relProps)
@@ -1058,7 +1058,7 @@ func (sb *statisticsBuilder) colStatProject(
 	colSet opt.ColSet, prj *ProjectExpr,
 ) *props.ColumnStatistic {
 	relProps := prj.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	// Columns may be passed through from the input, or they may reference a
 	// higher scope (in the case of a correlated subquery), or they
@@ -1129,7 +1129,7 @@ func (sb *statisticsBuilder) colStatProject(
 func (sb *statisticsBuilder) buildInvertedFilter(
 	invFilter *InvertedFilterExpr, relProps *props.Relational,
 ) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -1148,7 +1148,7 @@ func (sb *statisticsBuilder) buildInvertedFilter(
 
 	// Calculate selectivity and row count
 	// -----------------------------------
-	inputStats := &invFilter.Input.Relational().Stats
+	inputStats := invFilter.Input.Relational().Statistics()
 	s.RowCount = inputStats.RowCount
 	corr := sb.correlationFromMultiColDistinctCounts(constrainedCols, invFilter, s)
 	s.ApplySelectivity(sb.selectivityFromConstrainedCols(constrainedCols, histCols, invFilter, s, corr))
@@ -1161,8 +1161,8 @@ func (sb *statisticsBuilder) colStatInvertedFilter(
 	colSet opt.ColSet, invFilter *InvertedFilterExpr,
 ) *props.ColumnStatistic {
 	relProps := invFilter.Relational()
-	s := &relProps.Stats
-	inputStats := &invFilter.Input.Relational().Stats
+	s := relProps.Statistics()
+	inputStats := invFilter.Input.Relational().Statistics()
 	colStat := sb.copyColStatFromChild(colSet, invFilter, s)
 
 	if s.Selectivity != props.OneSelectivity {
@@ -1189,15 +1189,15 @@ func (sb *statisticsBuilder) buildJoin(
 		return
 	}
 
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(join)
 
-	leftStats := &h.leftProps.Stats
-	rightStats := &h.rightProps.Stats
+	leftStats := h.leftProps.Statistics()
+	rightStats := h.rightProps.Statistics()
 	leftCols := h.leftProps.OutputCols.Copy()
 	rightCols := h.rightProps.OutputCols.Copy()
 	equivReps := h.filtersFD.EquivReps()
@@ -1444,7 +1444,7 @@ func (sb *statisticsBuilder) buildJoin(
 
 func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props.ColumnStatistic {
 	relProps := join.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	var joinType opt.Operator
 	var leftProps, rightProps *props.Relational
@@ -1478,7 +1478,7 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 	case opt.SemiJoinOp, opt.SemiJoinApplyOp, opt.AntiJoinOp, opt.AntiJoinApplyOp:
 		// Column stats come from left side of join.
 		colStat := sb.copyColStat(colSet, s, sb.colStatFromJoinLeft(colSet, join))
-		colStat.ApplySelectivity(s.Selectivity, leftProps.Stats.RowCount)
+		colStat.ApplySelectivity(s.Selectivity, leftProps.Statistics().RowCount)
 		sb.finalizeFromRowCountAndDistinctCounts(colStat, s)
 		return colStat
 
@@ -1501,8 +1501,9 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 		// - For INNER joins, the selectivity impacts the distinct count of all
 		//   columns.
 		var colStat *props.ColumnStatistic
-		inputRowCount := leftProps.Stats.RowCount * rightProps.Stats.RowCount
-		leftNullCount, rightNullCount := leftProps.Stats.RowCount, rightProps.Stats.RowCount
+		inputRowCount := leftProps.Statistics().RowCount * rightProps.Statistics().RowCount
+		leftNullCount := leftProps.Statistics().RowCount
+		rightNullCount := rightProps.Statistics().RowCount
 		if rightCols.Empty() {
 			colStat = sb.copyColStat(colSet, s, sb.colStatFromJoinLeft(colSet, join))
 			leftNullCount = colStat.NullCount
@@ -1544,9 +1545,9 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 		colStat.NullCount = innerJoinNullCount(
 			s.RowCount,
 			leftNullCount,
-			leftProps.Stats.RowCount,
+			leftProps.Statistics().RowCount,
 			rightNullCount,
-			rightProps.Stats.RowCount,
+			rightProps.Statistics().RowCount,
 		)
 
 		switch joinType {
@@ -1557,9 +1558,9 @@ func (sb *statisticsBuilder) colStatJoin(colSet opt.ColSet, join RelExpr) *props
 				leftCols,
 				rightCols,
 				leftNullCount,
-				leftProps.Stats.RowCount,
+				leftProps.Statistics().RowCount,
 				rightNullCount,
-				rightProps.Stats.RowCount,
+				rightProps.Statistics().RowCount,
 				s.RowCount,
 				s.Selectivity.AsFloat()*inputRowCount,
 			)
@@ -1690,14 +1691,14 @@ func (sb *statisticsBuilder) colStatFromJoinRight(
 // +------------+
 
 func (sb *statisticsBuilder) buildIndexJoin(indexJoin *IndexJoinExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(indexJoin)
 
-	inputStats := &indexJoin.Input.Relational().Stats
+	inputStats := indexJoin.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
 	sb.finalizeFromCardinality(relProps)
@@ -1707,7 +1708,7 @@ func (sb *statisticsBuilder) colStatIndexJoin(
 	colSet opt.ColSet, join *IndexJoinExpr,
 ) *props.ColumnStatistic {
 	relProps := join.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	inputProps := join.Input.Relational()
 	inputCols := inputProps.OutputCols
@@ -1732,7 +1733,7 @@ func (sb *statisticsBuilder) colStatIndexJoin(
 
 		// Calculate the distinct count of the lookup columns given the selectivity
 		// of any filters on the input.
-		inputStats := &inputProps.Stats
+		inputStats := inputProps.Statistics()
 		tableStats := sb.makeTableStatistics(join.Table)
 		selectivity := props.MakeSelectivity(inputStats.RowCount / tableStats.RowCount)
 		lookupColStat.ApplySelectivity(selectivity, tableStats.RowCount)
@@ -1769,14 +1770,14 @@ func (sb *statisticsBuilder) colStatIndexJoin(
 func (sb *statisticsBuilder) buildZigzagJoin(
 	zigzag *ZigzagJoinExpr, relProps *props.Relational, h *joinPropsHelper,
 ) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(zigzag)
 
-	leftStats := zigzag.leftProps.Stats
+	leftStats := zigzag.leftProps.Statistics()
 	equivReps := h.filtersFD.EquivReps()
 
 	// We assume that we only plan zigzag joins in cases where the result set
@@ -1850,7 +1851,7 @@ func (sb *statisticsBuilder) buildZigzagJoin(
 // +----------+
 
 func (sb *statisticsBuilder) buildGroupBy(groupNode RelExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -1905,7 +1906,7 @@ func (sb *statisticsBuilder) colStatGroupBy(
 	colSet opt.ColSet, groupNode RelExpr,
 ) *props.ColumnStatistic {
 	relProps := groupNode.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	groupingPrivate := groupNode.Private().(*GroupingPrivate)
 	groupingColSet := groupingPrivate.GroupingCols
@@ -1962,7 +1963,7 @@ func (sb *statisticsBuilder) colStatGroupBy(
 // +--------+
 
 func (sb *statisticsBuilder) buildSetNode(setNode RelExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -2007,7 +2008,7 @@ func (sb *statisticsBuilder) colStatSetNode(
 func (sb *statisticsBuilder) colStatSetNodeImpl(
 	outputCols opt.ColSet, setNode RelExpr, relProps *props.Relational,
 ) *props.ColumnStatistic {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	setPrivate := setNode.Private().(*SetPrivate)
 
 	leftCols := opt.TranslateColSetStrict(outputCols, setPrivate.OutCols, setPrivate.LeftCols)
@@ -2061,7 +2062,7 @@ func (sb *statisticsBuilder) colStatSetNodeImpl(
 
 // buildValues builds the statistics for a VALUES expression.
 func (sb *statisticsBuilder) buildValues(values ValuesContainer, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -2075,7 +2076,7 @@ func (sb *statisticsBuilder) buildValues(values ValuesContainer, relProps *props
 func (sb *statisticsBuilder) colStatValues(
 	colSet opt.ColSet, values *ValuesExpr,
 ) *props.ColumnStatistic {
-	s := &values.Relational().Stats
+	s := values.Relational().Statistics()
 	if len(values.Rows) == 0 {
 		colStat, _ := s.ColStats.Add(colSet)
 		return colStat
@@ -2121,7 +2122,7 @@ func (sb *statisticsBuilder) colStatValues(
 func (sb *statisticsBuilder) colStatLiteralValues(
 	colSet opt.ColSet, values *LiteralValuesExpr,
 ) *props.ColumnStatistic {
-	s := &values.Relational().Stats
+	s := values.Relational().Statistics()
 	if values.Len() == 0 {
 		colStat, _ := s.ColStats.Add(colSet)
 		return colStat
@@ -2166,14 +2167,14 @@ func (sb *statisticsBuilder) colStatLiteralValues(
 // +-------+
 
 func (sb *statisticsBuilder) buildLimit(limit *LimitExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(limit)
 
-	inputStats := &limit.Input.Relational().Stats
+	inputStats := limit.Input.Relational().Statistics()
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
@@ -2191,14 +2192,14 @@ func (sb *statisticsBuilder) buildLimit(limit *LimitExpr, relProps *props.Relati
 }
 
 func (sb *statisticsBuilder) buildTopK(topK *TopKExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(topK)
 
-	inputStats := &topK.Input.Relational().Stats
+	inputStats := topK.Input.Relational().Statistics()
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
@@ -2216,8 +2217,8 @@ func (sb *statisticsBuilder) colStatLimit(
 	colSet opt.ColSet, limit *LimitExpr,
 ) *props.ColumnStatistic {
 	relProps := limit.Relational()
-	s := &relProps.Stats
-	inputStats := &limit.Input.Relational().Stats
+	s := relProps.Statistics()
+	inputStats := limit.Input.Relational().Statistics()
 	colStat := sb.copyColStatFromChild(colSet, limit, s)
 
 	// Scale distinct count based on the selectivity of the limit operation.
@@ -2234,14 +2235,14 @@ func (sb *statisticsBuilder) colStatLimit(
 // +--------+
 
 func (sb *statisticsBuilder) buildOffset(offset *OffsetExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(offset)
 
-	inputStats := &offset.Input.Relational().Stats
+	inputStats := offset.Input.Relational().Statistics()
 
 	// Copy row count from input.
 	s.RowCount = inputStats.RowCount
@@ -2268,8 +2269,8 @@ func (sb *statisticsBuilder) colStatOffset(
 	colSet opt.ColSet, offset *OffsetExpr,
 ) *props.ColumnStatistic {
 	relProps := offset.Relational()
-	s := &relProps.Stats
-	inputStats := &offset.Input.Relational().Stats
+	s := relProps.Statistics()
+	inputStats := offset.Input.Relational().Statistics()
 	colStat := sb.copyColStatFromChild(colSet, offset, s)
 
 	// Scale distinct count based on the selectivity of the offset operation.
@@ -2286,7 +2287,7 @@ func (sb *statisticsBuilder) colStatOffset(
 // +---------+
 
 func (sb *statisticsBuilder) buildMax1Row(max1Row *Max1RowExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -2300,7 +2301,7 @@ func (sb *statisticsBuilder) buildMax1Row(max1Row *Max1RowExpr, relProps *props.
 func (sb *statisticsBuilder) colStatMax1Row(
 	colSet opt.ColSet, max1Row *Max1RowExpr,
 ) *props.ColumnStatistic {
-	s := &max1Row.Relational().Stats
+	s := max1Row.Relational().Statistics()
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = 1
 	colStat.NullCount = s.RowCount * UnknownNullCountRatio
@@ -2316,14 +2317,14 @@ func (sb *statisticsBuilder) colStatMax1Row(
 // +------------+
 
 func (sb *statisticsBuilder) buildOrdinality(ord *OrdinalityExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(ord)
 
-	inputStats := &ord.Input.Relational().Stats
+	inputStats := ord.Input.Relational().Statistics()
 
 	s.RowCount = inputStats.RowCount
 	sb.finalizeFromCardinality(relProps)
@@ -2333,7 +2334,7 @@ func (sb *statisticsBuilder) colStatOrdinality(
 	colSet opt.ColSet, ord *OrdinalityExpr,
 ) *props.ColumnStatistic {
 	relProps := ord.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	colStat, _ := s.ColStats.Add(colSet)
 
@@ -2360,14 +2361,14 @@ func (sb *statisticsBuilder) colStatOrdinality(
 // +------------+
 
 func (sb *statisticsBuilder) buildWindow(window *WindowExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 	s.Available = sb.availabilityFromInput(window)
 
-	inputStats := &window.Input.Relational().Stats
+	inputStats := window.Input.Relational().Statistics()
 
 	// The row count of a window is equal to the row count of its input.
 	s.RowCount = inputStats.RowCount
@@ -2379,7 +2380,7 @@ func (sb *statisticsBuilder) colStatWindow(
 	colSet opt.ColSet, window *WindowExpr,
 ) *props.ColumnStatistic {
 	relProps := window.Relational()
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	colStat, _ := s.ColStats.Add(colSet)
 
@@ -2428,7 +2429,7 @@ func (sb *statisticsBuilder) colStatWindow(
 func (sb *statisticsBuilder) buildProjectSet(
 	projectSet *ProjectSetExpr, relProps *props.Relational,
 ) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -2453,7 +2454,7 @@ func (sb *statisticsBuilder) buildProjectSet(
 	}
 
 	// Multiply by the input row count to get the total.
-	inputStats := &projectSet.Input.Relational().Stats
+	inputStats := projectSet.Input.Relational().Statistics()
 	s.RowCount = zipRowCount * inputStats.RowCount
 
 	sb.finalizeFromCardinality(relProps)
@@ -2462,7 +2463,7 @@ func (sb *statisticsBuilder) buildProjectSet(
 func (sb *statisticsBuilder) colStatProjectSet(
 	colSet opt.ColSet, projectSet *ProjectSetExpr,
 ) *props.ColumnStatistic {
-	s := &projectSet.Relational().Stats
+	s := projectSet.Relational().Statistics()
 	if s.RowCount == 0 {
 		// Short cut if cardinality is 0.
 		colStat, _ := s.ColStats.Add(colSet)
@@ -2470,7 +2471,7 @@ func (sb *statisticsBuilder) colStatProjectSet(
 	}
 
 	inputProps := projectSet.Input.Relational()
-	inputStats := inputProps.Stats
+	inputStats := inputProps.Statistics()
 	inputCols := inputProps.OutputCols
 
 	colStat, _ := s.ColStats.Add(colSet)
@@ -2561,21 +2562,21 @@ func (sb *statisticsBuilder) colStatProjectSet(
 func (sb *statisticsBuilder) buildWithScan(
 	withScan *WithScanExpr, relProps, bindingProps *props.Relational,
 ) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
 	}
 
-	s.Available = bindingProps.Stats.Available
-	s.RowCount = bindingProps.Stats.RowCount
+	s.Available = bindingProps.Statistics().Available
+	s.RowCount = bindingProps.Statistics().RowCount
 	sb.finalizeFromCardinality(relProps)
 }
 
 func (sb *statisticsBuilder) colStatWithScan(
 	colSet opt.ColSet, withScan *WithScanExpr,
 ) *props.ColumnStatistic {
-	s := &withScan.Relational().Stats
+	s := withScan.Relational().Statistics()
 
 	boundExpr := sb.md.WithBinding(withScan.With).(RelExpr)
 
@@ -2596,7 +2597,7 @@ func (sb *statisticsBuilder) colStatWithScan(
 // +--------------------------------+
 
 func (sb *statisticsBuilder) buildMutation(mutation RelExpr, relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps); zeroCardinality {
 		// Short cut if cardinality is 0.
 		return
@@ -2612,7 +2613,7 @@ func (sb *statisticsBuilder) buildMutation(mutation RelExpr, relProps *props.Rel
 func (sb *statisticsBuilder) colStatMutation(
 	colSet opt.ColSet, mutation RelExpr,
 ) *props.ColumnStatistic {
-	s := &mutation.Relational().Stats
+	s := mutation.Relational().Statistics()
 	private := mutation.Private().(*MutationPrivate)
 
 	// Get colstat from child by mapping requested columns to corresponding
@@ -2633,7 +2634,7 @@ func (sb *statisticsBuilder) colStatMutation(
 // +-----------------+
 
 func (sb *statisticsBuilder) buildSequenceSelect(relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	s.Available = true
 	s.RowCount = 1
 	sb.finalizeFromCardinality(relProps)
@@ -2642,7 +2643,7 @@ func (sb *statisticsBuilder) buildSequenceSelect(relProps *props.Relational) {
 func (sb *statisticsBuilder) colStatSequenceSelect(
 	colSet opt.ColSet, seq *SequenceSelectExpr,
 ) *props.ColumnStatistic {
-	s := &seq.Relational().Stats
+	s := seq.Relational().Statistics()
 
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = 1
@@ -2656,7 +2657,7 @@ func (sb *statisticsBuilder) colStatSequenceSelect(
 // +---------+
 
 func (sb *statisticsBuilder) buildUnknown(relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	s.Available = false
 	s.RowCount = unknownGeneratorRowCount
 	sb.finalizeFromCardinality(relProps)
@@ -2665,7 +2666,7 @@ func (sb *statisticsBuilder) buildUnknown(relProps *props.Relational) {
 func (sb *statisticsBuilder) colStatUnknown(
 	colSet opt.ColSet, relProps *props.Relational,
 ) *props.ColumnStatistic {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	colStat, _ := s.ColStats.Add(colSet)
 	colStat.DistinctCount = s.RowCount
@@ -2722,7 +2723,7 @@ func (sb *statisticsBuilder) copyColStat(
 }
 
 func (sb *statisticsBuilder) finalizeFromCardinality(relProps *props.Relational) {
-	s := &relProps.Stats
+	s := relProps.Statistics()
 
 	// We don't ever want row count to be zero unless the cardinality is zero.
 	// This is because the stats may be stale, and we can end up with weird and
@@ -2817,7 +2818,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 	case *IndexJoinExpr:
 		// An index join is like a lookup join with no additional ON filters. The
 		// number of rows processed equals the number of output rows.
-		return e.Relational().Stats.RowCount
+		return e.Relational().Statistics().RowCount
 
 	case *LookupJoinExpr:
 		var lookupJoinPrivate *LookupJoinPrivate
@@ -2833,7 +2834,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 			if t.On.IsTrue() {
 				// If there are no additional ON filters, the number of rows processed
 				// equals the number of output rows.
-				return e.Relational().Stats.RowCount
+				return e.Relational().Statistics().RowCount
 			}
 			lookupJoinPrivate = &t.LookupJoinPrivate
 		}
@@ -2841,7 +2842,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
 		withoutOn := e.Memo().MemoizeLookupJoin(t.Input, nil /* on */, lookupJoinPrivate)
-		return withoutOn.Relational().Stats.RowCount
+		return withoutOn.Relational().Statistics().RowCount
 
 	case *InvertedJoinExpr:
 		var invertedJoinPrivate *InvertedJoinPrivate
@@ -2857,7 +2858,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 			if t.On.IsTrue() {
 				// If there are no additional ON filters, the number of rows processed
 				// equals the number of output rows.
-				return e.Relational().Stats.RowCount
+				return e.Relational().Statistics().RowCount
 			}
 			invertedJoinPrivate = &t.InvertedJoinPrivate
 		}
@@ -2865,7 +2866,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
 		withoutOn := e.Memo().MemoizeInvertedJoin(t.Input, nil /* on */, invertedJoinPrivate)
-		return withoutOn.Relational().Stats.RowCount
+		return withoutOn.Relational().Statistics().RowCount
 
 	case *MergeJoinExpr:
 		var mergeJoinPrivate *MergeJoinPrivate
@@ -2881,7 +2882,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 			if t.On.IsTrue() {
 				// If there are no additional ON filters, the number of rows processed
 				// equals the number of output rows.
-				return e.Relational().Stats.RowCount
+				return e.Relational().Statistics().RowCount
 			}
 			mergeJoinPrivate = &t.MergeJoinPrivate
 		}
@@ -2889,7 +2890,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 		// We need to determine the row count of the join before the
 		// ON conditions are applied.
 		withoutOn := e.Memo().MemoizeMergeJoin(t.Left, t.Right, nil /* on */, mergeJoinPrivate)
-		return withoutOn.Relational().Stats.RowCount
+		return withoutOn.Relational().Statistics().RowCount
 
 	default:
 		if !opt.IsJoinOp(e) {
@@ -2918,7 +2919,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 		default:
 			if len(on) == len(*filters) {
 				// No filters were removed.
-				return e.Relational().Stats.RowCount
+				return e.Relational().Statistics().RowCount
 			}
 
 			switch t := e.(type) {
@@ -2938,7 +2939,7 @@ func (sb *statisticsBuilder) rowsProcessed(e RelExpr) float64 {
 				panic(errors.AssertionFailedf("join type %v not handled", redact.Safe(e.Op())))
 			}
 		}
-		return e.Relational().Stats.RowCount
+		return e.Relational().Statistics().RowCount
 	}
 }
 
@@ -3156,7 +3157,7 @@ func (sb *statisticsBuilder) applyFiltersItem(
 	// want to make sure that we don't include columns that were only present in
 	// equality conjuncts such as var1=var2. The selectivity of these conjuncts
 	// will be accounted for in selectivityFromEquivalencies.
-	s := &relProps.Stats
+	s := relProps.Statistics()
 	scalarProps := filter.ScalarProps()
 	constrainedCols.UnionWith(scalarProps.OuterCols)
 	if scalarProps.Constraints != nil {

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -114,14 +114,14 @@ func TestGetStatsFromConstraint(t *testing.T) {
 
 		relProps := &props.Relational{Cardinality: props.AnyCardinality}
 		relProps.NotNullCols = cs.ExtractNotNullCols(&evalCtx)
-		s := &relProps.Stats
+		s := relProps.Statistics()
 		s.Init(relProps)
 
 		// Calculate distinct counts.
-		sb.applyConstraintSet(cs, true /* tight */, sel, relProps, &relProps.Stats)
+		sb.applyConstraintSet(cs, true /* tight */, sel, relProps, relProps.Statistics())
 
 		// Calculate row count and selectivity.
-		s.RowCount = scan.Relational().Stats.RowCount
+		s.RowCount = scan.Relational().Statistics().RowCount
 		selectivity, _ := sb.selectivityFromMultiColDistinctCounts(cols, sel, s)
 		s.ApplySelectivity(selectivity)
 

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -1306,7 +1306,7 @@ expr colstat=1 colstat=2
     [
       (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
       (Cardinality "-")
-      (Stats `[
+      (stats `[
         {
           "columns": ["a"],
           "distinct_count": 100,

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -137,7 +137,10 @@ func (c *CustomFuncs) canMapJoinOpEquivalenceGroup(
 	found := 0
 	for i := range filters {
 		fd := &filters[i].ScalarProps().FuncDeps
-		filterEqCols := fd.ComputeEquivClosure(fd.EquivReps())
+
+		// Note that EquivReps creates a new ColSet, so it is safe to modify it
+		// in-place with ComputeEquivClosureNoCopy.
+		filterEqCols := fd.ComputeEquivClosureNoCopy(fd.EquivReps())
 		if filterEqCols.Intersects(leftCols) && filterEqCols.Intersects(rightCols) &&
 			filterEqCols.SubsetOf(eqCols) {
 			found++
@@ -206,7 +209,10 @@ func (c *CustomFuncs) mapJoinOpEquivalenceGroup(
 	newFilters := make(memo.FiltersExpr, 0, len(filters))
 	for i := range filters {
 		fd := &filters[i].ScalarProps().FuncDeps
-		filterEqCols := fd.ComputeEquivClosure(fd.EquivReps())
+
+		// Note that EquivReps creates a new ColSet, so it is safe to modify it
+		// in-place with ComputeEquivClosureNoCopy.
+		filterEqCols := fd.ComputeEquivClosureNoCopy(fd.EquivReps())
 		if !filterEqCols.Empty() && filterEqCols.SubsetOf(eqCols) {
 			continue
 		}

--- a/pkg/sql/opt/optbuilder/with.go
+++ b/pkg/sql/opt/optbuilder/with.go
@@ -290,11 +290,11 @@ func (b *Builder) buildCTE(
 	bindingProps.Cardinality = props.AnyCardinality.AtLeast(props.OneCardinality)
 	// We don't really know the input row count, except for the first time we run
 	// the recursive query. We don't have anything better though.
-	bindingProps.Stats.RowCount = initialScope.expr.Relational().Stats.RowCount
+	bindingProps.Statistics().RowCount = initialScope.expr.Relational().Statistics().RowCount
 	// Row count must be greater than 0 or the stats code will throw an error.
 	// Set it to 1 to match the cardinality.
-	if bindingProps.Stats.RowCount < 1 {
-		bindingProps.Stats.RowCount = 1
+	if bindingProps.Statistics().RowCount < 1 {
+		bindingProps.Statistics().RowCount = 1
 	}
 	cteSrc.expr = b.factory.ConstructFakeRel(&memo.FakeRelPrivate{
 		Props: bindingProps,

--- a/pkg/sql/opt/optgen/exprgen/private.go
+++ b/pkg/sql/opt/optgen/exprgen/private.go
@@ -55,6 +55,14 @@ func (eg *exprGen) evalPrivate(privType reflect.Type, expr lang.Expr) interface{
 
 	result := reflect.New(privType)
 
+	getField := func(fn *lang.FuncExpr, fieldName string) (reflect.Value, interface{}) {
+		field := result.Elem().FieldByName(fieldName)
+		if !field.IsValid() {
+			panic(errorf("invalid field %s for %s", fieldName, privType))
+		}
+		return field, eg.convertPrivateFieldValue(privType, fieldName, field.Type(), eg.eval(fn.Args[0]))
+	}
+
 	for _, item := range items {
 		// Each item must be of the form (FieldName Value).
 		fn, ok := item.(*lang.FuncExpr)
@@ -62,14 +70,29 @@ func (eg *exprGen) evalPrivate(privType reflect.Type, expr lang.Expr) interface{
 			panic(errorf("private list must contain items of the form (FieldName Value)"))
 		}
 		fieldName := fn.SingleName()
-		field := result.Elem().FieldByName(fieldName)
-		if !field.IsValid() {
-			panic(errorf("invalid field %s for %s", fieldName, privType))
+		if fieldName == "stats" && privType == reflect.TypeOf(props.Relational{}) {
+			// Special case: the stats field of props.Relational is unexported, so we
+			// have to use the Statistics method. We do this later, so skip for now.
+			continue
 		}
-		val := eg.convertPrivateFieldValue(privType, fieldName, field.Type(), eg.eval(fn.Args[0]))
+		field, val := getField(fn, fieldName)
 		field.Set(reflect.ValueOf(val))
 	}
-	return result.Interface()
+
+	ret := result.Interface()
+
+	// Special case for unexported stats field of props.Relational.
+	if privType == reflect.TypeOf(props.Relational{}) {
+		for _, item := range items {
+			fn, _ := item.(*lang.FuncExpr)
+			if fieldName := fn.SingleName(); fieldName == "stats" {
+				_, val := getField(fn, fieldName)
+				*ret.(*props.Relational).Statistics() = val.(props.Statistics)
+			}
+		}
+	}
+
+	return ret
 }
 
 func (eg *exprGen) convertPrivateFieldValue(

--- a/pkg/sql/opt/optgen/exprgen/testdata/fake
+++ b/pkg/sql/opt/optgen/exprgen/testdata/fake
@@ -25,19 +25,19 @@ expr
   [
     (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
     (Cardinality "5 - 1000")
-    (Stats `[
+    (stats `[
       {
         "columns": ["a"],
         "distinct_count": 100,
-        "null_count": 0, 
-        "row_count": 100, 
+        "null_count": 0,
+        "row_count": 100,
         "created_at": "2018-01-01 1:00:00.00000+00:00"
       },
       {
         "columns": ["b"],
         "distinct_count": 20,
-        "null_count": 5, 
-        "row_count": 100, 
+        "null_count": 5,
+        "row_count": 100,
         "created_at": "2018-01-01 1:00:00.00000+00:00"
       }
     ]`)
@@ -56,33 +56,33 @@ expr
   [
     (OutputCols [ (NewColumn "a" "int") (NewColumn "b" "int") (NewColumn "c" "int")] )
     (Cardinality "-")
-    (Stats `[
+    (stats `[
       {
         "columns": ["a"],
         "distinct_count": 100,
-        "null_count": 0, 
-        "row_count": 100, 
+        "null_count": 0,
+        "row_count": 100,
         "created_at": "2018-01-01 1:00:00.00000+00:00"
       },
       {
         "columns": ["a"],
         "distinct_count": 110,
-        "null_count": 0, 
-        "row_count": 110, 
+        "null_count": 0,
+        "row_count": 110,
         "created_at": "2018-01-02 1:00:00.00000+00:00"
       },
       {
         "columns": ["b"],
         "distinct_count": 20,
-        "null_count": 5, 
-        "row_count": 100, 
+        "null_count": 5,
+        "row_count": 100,
         "created_at": "2018-01-01 1:00:00.00000+00:00"
       },
       {
         "columns": ["b"],
         "distinct_count": 22,
-        "null_count": 5, 
-        "row_count": 120, 
+        "null_count": 5,
+        "row_count": 120,
         "created_at": "2018-01-03 1:00:00.00000+00:00"
       }
     ]`)

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -340,7 +340,7 @@ func remapProvided(provided opt.Ordering, fds *props.FuncDepSet, outCols opt.Col
 				result = append(result, provided[i])
 			}
 		} else {
-			equivCols := fds.ComputeEquivClosure(opt.MakeColSet(col))
+			equivCols := fds.ComputeEquivClosureNoCopy(opt.MakeColSet(col))
 			remappedCol, ok := equivCols.Intersection(outCols).Next(0)
 			if !ok {
 				panic(errors.AssertionFailedf("no output column equivalent to %d", redact.Safe(col)))

--- a/pkg/sql/opt/partialidx/implicator_test.go
+++ b/pkg/sql/opt/partialidx/implicator_test.go
@@ -340,7 +340,8 @@ func makeFilters(
 	}
 
 	// Create a fake Select and input so that normalization rules are run.
-	p := &props.Relational{OutputCols: cols, Cardinality: card, Stats: stats}
+	p := &props.Relational{OutputCols: cols, Cardinality: card}
+	*p.Statistics() = stats
 	fakeRel := f.ConstructFakeRel(&memo.FakeRelPrivate{Props: p})
 	sel := f.ConstructSelect(fakeRel, filters)
 

--- a/pkg/sql/opt/props/logical.go
+++ b/pkg/sql/opt/props/logical.go
@@ -169,9 +169,10 @@ type Relational struct {
 	// For more details, see the header comment for FuncDepSet.
 	FuncDeps FuncDepSet
 
-	// Stats is the set of statistics that apply to this relational expression.
-	// See statistics.go and memo/statistics_builder.go for more details.
-	Stats Statistics
+	// stats is the set of statistics that apply to this relational expression.
+	// See statistics.go and memo/statistics_builder.go for more details. It is
+	// unexported to avoid accidental copying.
+	stats Statistics
 
 	// Rule encapsulates the set of properties that are maintained to assist
 	// with specific sets of transformation rules. They are not intended to be
@@ -338,6 +339,12 @@ type Scalar struct {
 		// been set.
 		HasHoistableSubquery bool
 	}
+}
+
+// Statistics returns the set of statistics that apply to the relational
+// expression.
+func (r *Relational) Statistics() *Statistics {
+	return &r.stats
 }
 
 // IsAvailable returns true if the specified rule property has been populated

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -2015,13 +2015,13 @@ func (ot *OptTester) createTableAs(name tree.TableName, rel memo.RelExpr) (*test
 		// Make sure we have estimated stats for this column.
 		colSet := opt.MakeColSet(col)
 		memo.RequestColStat(&ot.evalCtx, rel, colSet)
-		stat, ok := relProps.Stats.ColStats.Lookup(colSet)
+		stat, ok := relProps.Statistics().ColStats.Lookup(colSet)
 		if !ok {
 			return nil, fmt.Errorf("could not find statistic for column %s", colName)
 		}
 		jsonStats[i] = ot.makeStat(
 			[]string{colName},
-			uint64(int64(math.Round(relProps.Stats.RowCount))),
+			uint64(int64(math.Round(relProps.Statistics().RowCount))),
 			uint64(int64(math.Round(stat.DistinctCount))),
 			uint64(int64(math.Round(stat.NullCount))),
 		)

--- a/pkg/sql/opt/xform/general_funcs.go
+++ b/pkg/sql/opt/xform/general_funcs.go
@@ -500,10 +500,10 @@ func (c *CustomFuncs) splitScanIntoUnionScansOrSelects(
 		// We will construct at most maxScanCount new Scans.
 		scanCount = maxScanCount
 	}
-	rowCount := scan.Relational().Stats.RowCount
+	rowCount := scan.Relational().Statistics().RowCount
 	if limit > 0 {
 		nLogN := rowCount * math.Log2(rowCount)
-		if scan.Relational().Stats.Available &&
+		if scan.Relational().Statistics().Available &&
 			float64(scanCount*randIOCostFactor+limit*seqIOCostFactor) >= nLogN {
 			// Splitting the Scan may not be worth the overhead. Creating a sequence of
 			// Scans and Unions is expensive, so we only want to create the plan if it

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -59,7 +59,7 @@ func (o *Optimizer) TryPlaceholderFastPath() (_ opt.Expr, ok bool, err error) {
 	// performance significantly (see #64214). So we only use the fast path if the
 	// estimated row count is small; typically this will happen when we constrain
 	// columns that form a key and we know there will be at most one row.
-	if rootRelProps.Stats.RowCount > maxRowCountForPlaceholderFastPath {
+	if rootRelProps.Statistics().RowCount > maxRowCountForPlaceholderFastPath {
 		return nil, false, nil
 	}
 

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -666,10 +666,10 @@ func (opc *optPlanningCtx) runExecBuilder(
 		planTop.instrumentation.planGist = gf.PlanGist()
 	}
 	planTop.instrumentation.costEstimate = float64(mem.RootExpr().(memo.RelExpr).Cost())
-	available := mem.RootExpr().(memo.RelExpr).Relational().Stats.Available
+	available := mem.RootExpr().(memo.RelExpr).Relational().Statistics().Available
 	planTop.instrumentation.statsAvailable = available
 	if available {
-		planTop.instrumentation.outputRows = mem.RootExpr().(memo.RelExpr).Relational().Stats.RowCount
+		planTop.instrumentation.outputRows = mem.RootExpr().(memo.RelExpr).Relational().Statistics().RowCount
 	}
 
 	if stmt.ExpectedTypes != nil {


### PR DESCRIPTION
**opt: avoid unnecessary allocations when enforcing ordering**

The optimizer attempts to optimize and cost every expression without
requiring any ordering by adding a `SortExpr` as the expression's parent.
This can be called many times for each expression in the memo group, since
there are often many possible required properties for each group. In
sufficiently complex queries, allocating a `SortExpr` each time can cause
non-neglibile overhead. The expression with ordering enforced by a `SortExpr`
is often not even added to the memo, since this only happens if the result
has a lower cost than the alternative.

This commit adds a scratch `SortExpr` to the optimizer to be used when
optimizing an expression with the ordering enforced. The scratch `SortExpr`
is only reallocated if it gets added to the memo. This removes the
unnecessary allocations.

Release note: None

**opt: unexport relational stats to avoid accidental copies**

Previously, the `props.Statistics` field of `props.Relational` was unexported.
This made it easy to accidentally copy it, which could show up on heap profiles
because `props.Statistics` is a fairly large struct.

This patch unexports `props.Statistics` and exposes a `Relational.Statistics()`
method that returns a pointer to the field. This changes the default behavior
to reference the struct, rather than copying it, in order to prevent accidental
copies in the future (and revert the current ones).

Release note: None

**opt: reduce allocations when building join multiplicity**

This commit adds a `ComputeEquivClosureNoCopy` method to `FuncDepSet`
that performs the function of `ComputeEquivClosure` in-place on the given
`ColSet`. This allows callers to avoid an unnecessary copy if it is ok
to mutate the starting set.

This commit also modifies the multiplicity builder logic to simply build
the equivalence closure in one pass over the filters, rather than first
constructing a `FuncDepSet`. This significantly decreases allocations in
queries with many joins and equality filters.

Release note: None