### PR TITLE
build: fix Pebble metamorphic race nightly

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_metamorphic_race_impl.sh
@@ -18,7 +18,7 @@ exit_status=0
 # NB: If adjusting the metamorphic test flags below, be sure to also update
 # pkg/cmd/github-post/main.go to ensure the GitHub issue poster includes the
 # correct flags in the reproduction command.
-$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- --config=race --config=ci test \
+$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci -- test --config=race --config=ci \
                                       @com_github_cockroachdb_pebble//internal/metamorphic:metamorphic_test \
                                       --test_timeout=14400 '--test_filter=TestMeta$' \
                                       --define gotags=bazel,invariants \


### PR DESCRIPTION
Fix the Pebble metamorphic nightly with race detector enabled. A change to command-line argument parsing has been preventing it from running.

Release note: None