### PR TITLE
backupccl: tenants should be restored in their correct state

### DIFF
--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -1,0 +1,60 @@
+new-server name=s1
+----
+
+# Create a few tenants.
+exec-sql
+SELECT crdb_internal.create_tenant(5);
+----
+
+exec-sql
+SELECT crdb_internal.create_tenant(6);
+----
+
+# Drop one of them.
+exec-sql
+SELECT crdb_internal.destroy_tenant(5);
+----
+
+query-sql
+SELECT id,active,crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true) FROM system.tenants;
+----
+5 false {"id": "5", "state": "DROP"}
+6 true {"id": "6", "state": "ACTIVE"}
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster'
+----
+
+exec-sql expect-error-regex=(tenant 5 is not active)
+BACKUP TENANT 5 INTO 'nodelocal://1/tenant5'
+----
+regex matches error
+
+exec-sql
+BACKUP TENANT 6 INTO 'nodelocal://1/tenant6'
+----
+
+new-server name=s2 share-io-dir=s1
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://1/cluster'
+----
+
+# A dropped tenant should be restored as an inactive tenant.
+query-sql
+SELECT id,active,crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true) FROM system.tenants;
+----
+5 false {"id": "5", "state": "DROP"}
+6 true {"id": "6", "state": "ACTIVE"}
+
+exec-sql
+RESTORE TENANT 6 FROM LATEST IN 'nodelocal://1/tenant6' WITH tenant = '7';
+----
+
+query-sql
+SELECT id,active,crdb_internal.pb_to_json('cockroach.sql.sqlbase.TenantInfo', info, true) FROM system.tenants;
+----
+5 false {"id": "5", "state": "DROP"}
+6 true {"id": "6", "state": "ACTIVE"}
+7 true {"id": "7", "state": "ACTIVE"}


### PR DESCRIPTION
Previously, all backed up tenants were unconditionally moved through an `ADD` and then `ACTIVE` state during a cluster/tenant restore. This behaviour appears incorrect. If the tenant was backed up in and adding or dropped state then it should be restored in the same state as well.

This change only moves `ACTIVE` backed up tenants through an `ADD` and then `ACTIVE` state thereby fixing this bug.

Fixes: #87915

Release note (bug fix): Cluster and tenant restores of dropped or adding tenants would incorrectly activate those tenants during restore.