### PR TITLE
storage: use new Pebble SST iterators everywhere

### DIFF
--- a/docs/tech-notes/mvcc-range-tombstones.md
+++ b/docs/tech-notes/mvcc-range-tombstones.md
@@ -538,13 +538,12 @@ methods as the main Pebble engine, notably `PutMVCCRangeKey()`. Refer to the
 
 However, the old `SSTIterator` does not support range keys, as it is built on a
 more primitive SST iterator infrastructure that e.g. does not support combined
-point/range key iteration. `NewPebbleSSTIterator()` can be used instead to
-construct a new `MVCCIterator` for SSTs using the same `pebbleIterator`
-implementation that is used for Pebble itself, supporting the same options and
-functionality, including MVCC range keys. Notably, this also supports iteration
-across several multiplexed SSTs, replacing the current `multiIterator` with a
-much more capable implementation that will be particularly useful for backup
-restoration.
+point/range key iteration. `NewSSTIterator()` can be used instead to construct a
+new `MVCCIterator` for SSTs using the same `pebbleIterator` implementation that
+is used for Pebble itself, supporting the same options and functionality,
+including MVCC range keys. Notably, this also supports iteration across several
+multiplexed SSTs, replacing the current `multiIterator` with a much more capable
+implementation that will be particularly useful for backup restoration.
 
 ### Exports
 
@@ -569,7 +568,7 @@ example, if there is a range tombstone `[b-d)@5`, and iteration stops between
 contain `[b-c\0)@5` and the next SST will contain `[c-d)@5`. This ensures that
 the range tombstones in each SST cover `c`, but the range tombstones in the
 SSTs overlap at `[c-c\0)@5`. This will not present a problem with multiplexed
-iteration using `NewPebbleSSTIterator()`, nor with `AddSSTable`.
+iteration using `NewSSTIterator()`, nor with `AddSSTable`.
 
 ### `AddSSTable` Ingestion
 

--- a/pkg/ccl/backupccl/file_sst_sink.go
+++ b/pkg/ccl/backupccl/file_sst_sink.go
@@ -318,7 +318,7 @@ func (s *fileSSTSink) copyPointKeys(dataSST []byte) error {
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	}
-	iter, err := storage.NewPebbleMemSSTIterator(dataSST, false, iterOpts)
+	iter, err := storage.NewMemSSTIterator(dataSST, false, iterOpts)
 	if err != nil {
 		return err
 	}
@@ -351,7 +351,7 @@ func (s *fileSSTSink) copyRangeKeys(dataSST []byte) error {
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,
 	}
-	iter, err := storage.NewPebbleMemSSTIterator(dataSST, false, iterOpts)
+	iter, err := storage.NewMemSSTIterator(dataSST, false, iterOpts)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/backupccl/restore_data_processor_test.go
+++ b/pkg/ccl/backupccl/restore_data_processor_test.go
@@ -72,7 +72,7 @@ func slurpSSTablesLatestKey(
 			LowerBound: keys.LocalMax,
 			UpperBound: keys.MaxKey,
 		}
-		sst, err := storage.NewPebbleSSTIterator([][]sstable.ReadableFile{{file}}, iterOpts, false /* forwardOnly */)
+		sst, err := storage.NewSSTIterator([][]sstable.ReadableFile{{file}}, iterOpts, false /* forwardOnly */)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2087,7 +2087,7 @@ func fetchDescVersionModificationTime(
 		t.Fatal(pErr.GoError())
 	}
 	for _, file := range res.(*roachpb.ExportResponse).Files {
-		it, err := storage.NewPebbleMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+		it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypePointsAndRanges,
 			LowerBound: keys.MinKey,
 			UpperBound: keys.MaxKey,

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2087,7 +2087,11 @@ func fetchDescVersionModificationTime(
 		t.Fatal(pErr.GoError())
 	}
 	for _, file := range res.(*roachpb.ExportResponse).Files {
-		it, err := storage.NewMemSSTIterator(file.SST, false /* verify */)
+		it, err := storage.NewPebbleMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			LowerBound: keys.MinKey,
+			UpperBound: keys.MaxKey,
+		})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -2099,6 +2103,9 @@ func fetchDescVersionModificationTime(
 				continue
 			}
 			k := it.UnsafeKey()
+			if _, hasRange := it.HasPointAndRange(); hasRange {
+				t.Fatalf("unexpected MVCC range key at %s", k)
+			}
 			remaining, _, _, err := s.Codec.DecodeIndexPrefix(k.Key)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -665,7 +665,12 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	found := errors.New(``)
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := storage.NewMemSSTIterator(file.SST, false /* verify */)
+			it, err := storage.NewPebbleMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+				// NB: We assume there will be no MVCC range tombstones here.
+				KeyTypes:   storage.IterKeyTypePointsOnly,
+				LowerBound: keys.MinKey,
+				UpperBound: keys.MaxKey,
+			})
 			if err != nil {
 				return err
 			}

--- a/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
+++ b/pkg/ccl/changefeedccl/schemafeed/schema_feed.go
@@ -665,7 +665,7 @@ func (tf *schemaFeed) fetchDescriptorVersions(
 	found := errors.New(``)
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := storage.NewPebbleMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
+			it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, storage.IterOptions{
 				// NB: We assume there will be no MVCC range tombstones here.
 				KeyTypes:   storage.IterKeyTypePointsOnly,
 				LowerBound: keys.MinKey,

--- a/pkg/ccl/storageccl/external_sst_reader.go
+++ b/pkg/ccl/storageccl/external_sst_reader.go
@@ -97,7 +97,7 @@ func newMemPebbleSSTReader(
 		}
 		inMemorySSTs = append(inMemorySSTs, content)
 	}
-	return storage.NewPebbleMultiMemSSTIterator(inMemorySSTs, false, iterOps)
+	return storage.NewMultiMemSSTIterator(inMemorySSTs, false, iterOps)
 }
 
 // ExternalSSTReader returns a PebbleSSTIterator for the SSTs in external storage,
@@ -117,7 +117,7 @@ func ExternalSSTReader(
 ) (storage.SimpleMVCCIterator, error) {
 	// TODO(jackson): Change the interface to accept a two-dimensional
 	// [][]StoreFiles slice, and propagate that structure to
-	// NewPebbleSSTIterator.
+	// NewSSTIterator.
 
 	if !remoteSSTs.Get(&storeFiles[0].Store.Settings().SV) {
 		return newMemPebbleSSTReader(ctx, storeFiles, encryption, iterOpts)
@@ -168,7 +168,7 @@ func ExternalSSTReader(
 	// NB: It's okay to pass forwardOnly=true, because this function returns a
 	// SimpleMVCCIterator which does not provide an interface for reverse
 	// iteration.
-	return storage.NewPebbleSSTIterator(readerLevels, iterOpts, true /* forwardOnly */)
+	return storage.NewSSTIterator(readerLevels, iterOpts, true /* forwardOnly */)
 }
 
 type sstReader struct {

--- a/pkg/ccl/streamingccl/utils.go
+++ b/pkg/ccl/streamingccl/utils.go
@@ -43,7 +43,7 @@ func ScanSST(
 
 	// We iterate points and ranges separately on the SST for clarity
 	// and simplicity.
-	pointIter, err := storage.NewPebbleMemSSTIterator(sst.Data, true,
+	pointIter, err := storage.NewMemSSTIterator(sst.Data, true,
 		storage.IterOptions{
 			KeyTypes: storage.IterKeyTypePointsOnly,
 			// Only care about upper bound as we are iterating forward.
@@ -68,7 +68,7 @@ func ScanSST(
 		}
 	}
 
-	rangeIter, err := storage.NewPebbleMemSSTIterator(sst.Data, true,
+	rangeIter, err := storage.NewMemSSTIterator(sst.Data, true,
 		storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypeRangesOnly,
 			UpperBound: scanWithin.EndKey,

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -658,7 +658,7 @@ func (b *SSTBatcher) addSSTable(
 		LowerBound: start,
 		UpperBound: end,
 	}
-	iter, err := storage.NewPebbleMemSSTIterator(sstBytes, true, iterOpts)
+	iter, err := storage.NewMemSSTIterator(sstBytes, true, iterOpts)
 	if err != nil {
 		return err
 	}
@@ -785,7 +785,7 @@ func (b *SSTBatcher) addSSTable(
 					}
 
 					// Needs a new iterator with new bounds.
-					statsIter, err := storage.NewPebbleMemSSTIterator(sstBytes, true, storage.IterOptions{
+					statsIter, err := storage.NewMemSSTIterator(sstBytes, true, storage.IterOptions{
 						KeyTypes:   storage.IterKeyTypePointsOnly,
 						LowerBound: right.start,
 						UpperBound: right.end,

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -77,7 +77,7 @@ func TestDuplicateHandling(t *testing.T) {
 				LowerBound: keys.LocalMax,
 				UpperBound: keys.MaxKey,
 			}
-			it, err := storage.NewPebbleMemSSTIterator(file.SST, false /* verify */, iterOpts)
+			it, err := storage.NewMemSSTIterator(file.SST, false /* verify */, iterOpts)
 			require.NoError(t, err)
 			defer it.Close()
 			for it.SeekGE(storage.NilKey); ; it.Next() {

--- a/pkg/kv/kvclient/revision_reader.go
+++ b/pkg/kv/kvclient/revision_reader.go
@@ -53,7 +53,7 @@ func GetAllRevisions(
 			LowerBound: file.Span.Key,
 			UpperBound: file.Span.EndKey,
 		}
-		iter, err := storage.NewPebbleMemSSTIterator(file.SST, true, iterOpts)
+		iter, err := storage.NewMemSSTIterator(file.SST, true, iterOpts)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -240,7 +240,7 @@ func EvalAddSSTable(
 	// Verify that the keys in the sstable are within the range specified by the
 	// request header, and if the request did not include pre-computed stats,
 	// compute the expected MVCC stats delta of ingesting the SST.
-	sstIter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+	sstIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
@@ -395,7 +395,7 @@ func EvalAddSSTable(
 		log.VEventf(ctx, 2, "ingesting SST (%d keys/%d bytes) via regular write batch", stats.KeyCount, len(sst))
 
 		// Ingest point keys.
-		pointIter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		pointIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypePointsOnly,
 			UpperBound: keys.MaxKey,
 		})
@@ -429,7 +429,7 @@ func EvalAddSSTable(
 		}
 
 		// Ingest range keys.
-		rangeIter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		rangeIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypeRangesOnly,
 			UpperBound: keys.MaxKey,
 		})
@@ -494,7 +494,7 @@ func EvalAddSSTable(
 func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.MVCCStats) error {
 
 	// Check SST point keys.
-	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+	iter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsOnly,
 		UpperBound: keys.MaxKey,
 	})
@@ -529,7 +529,7 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 	}
 
 	// Check SST range keys.
-	iter, err = storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+	iter, err = storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypeRangesOnly,
 		UpperBound: keys.MaxKey,
 	})
@@ -575,7 +575,7 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 	// same timestamp as the given statistics, since they may contain
 	// timing-dependent values (typically MVCC garbage, i.e. multiple versions).
 	if stats != nil {
-		iter, err = storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		iter, err = storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypePointsAndRanges,
 			LowerBound: keys.MinKey,
 			UpperBound: keys.MaxKey,

--- a/pkg/kv/kvserver/batcheval/cmd_export_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_export_test.go
@@ -82,7 +82,7 @@ func TestExportCmd(t *testing.T) {
 				LowerBound: keys.LocalMax,
 				UpperBound: keys.MaxKey,
 			}
-			sst, err := storage.NewPebbleMemSSTIterator(file.SST, true, iterOpts)
+			sst, err := storage.NewMemSSTIterator(file.SST, true, iterOpts)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}
@@ -510,7 +510,7 @@ func loadSST(t *testing.T, data []byte, start, end roachpb.Key) []storage.MVCCKe
 		LowerBound: start,
 		UpperBound: end,
 	}
-	sst, err := storage.NewPebbleMemSSTIterator(data, true, iterOpts)
+	sst, err := storage.NewMemSSTIterator(data, true, iterOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -225,14 +225,14 @@ func TestReplicaRangefeed(t *testing.T) {
 			require.Equal(t, expEvents, events)
 
 			for _, sst := range ssts {
-				expIter, err := storage.NewPebbleMemSSTIterator(sst.expect, false, storage.IterOptions{
+				expIter, err := storage.NewMemSSTIterator(sst.expect, false, storage.IterOptions{
 					LowerBound: keys.MinKey,
 					UpperBound: keys.MaxKey,
 				})
 				require.NoError(t, err)
 				defer expIter.Close()
 
-				sstIter, err := storage.NewPebbleMemSSTIterator(sst.actual, false, storage.IterOptions{
+				sstIter, err := storage.NewMemSSTIterator(sst.actual, false, storage.IterOptions{
 					LowerBound: keys.MinKey,
 					UpperBound: keys.MaxKey,
 				})

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -225,11 +225,17 @@ func TestReplicaRangefeed(t *testing.T) {
 			require.Equal(t, expEvents, events)
 
 			for _, sst := range ssts {
-				expIter, err := storage.NewMemSSTIterator(sst.expect, false)
+				expIter, err := storage.NewPebbleMemSSTIterator(sst.expect, false, storage.IterOptions{
+					LowerBound: keys.MinKey,
+					UpperBound: keys.MaxKey,
+				})
 				require.NoError(t, err)
 				defer expIter.Close()
 
-				sstIter, err := storage.NewMemSSTIterator(sst.actual, false)
+				sstIter, err := storage.NewPebbleMemSSTIterator(sst.actual, false, storage.IterOptions{
+					LowerBound: keys.MinKey,
+					UpperBound: keys.MaxKey,
+				})
 				require.NoError(t, err)
 				defer sstIter.Close()
 

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -1512,8 +1512,8 @@ message ExportRequest {
 	// which covers the point key at c, but resuming from c@2 will contain the
 	// MVCC range tombstone [c-f)@5 which overlaps with the MVCC range tombstone
 	// in the previous response in the interval [c-c\0)@5. This overlap will not
-	// cause problems with multiplexed iteration using NewPebbleSSTIterator(),
-	// nor when ingesting the SSTs via `AddSSTable`.
+	// cause problems with multiplexed iteration using NewSSTIterator(), nor when
+	// ingesting the SSTs via `AddSSTable`.
   bool split_mid_key = 13;
 
   // Return the exported SST data in the response.

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -276,7 +276,13 @@ func getDescriptorsFromStoreForInterval(
 	subsequentModificationTime := upperBound
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := kvstorage.NewMemSSTIterator(file.SST, false /* verify */)
+			it, err := kvstorage.NewPebbleMemSSTIterator(file.SST, false, /* verify */
+				kvstorage.IterOptions{
+					// NB: We assume there will be no MVCC range tombstones here.
+					KeyTypes:   kvstorage.IterKeyTypePointsOnly,
+					LowerBound: keys.MinKey,
+					UpperBound: keys.MaxKey,
+				})
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -276,7 +276,7 @@ func getDescriptorsFromStoreForInterval(
 	subsequentModificationTime := upperBound
 	for _, file := range res.(*roachpb.ExportResponse).Files {
 		if err := func() error {
-			it, err := kvstorage.NewPebbleMemSSTIterator(file.SST, false, /* verify */
+			it, err := kvstorage.NewMemSSTIterator(file.SST, false, /* verify */
 				kvstorage.IterOptions{
 					// NB: We assume there will be no MVCC range tombstones here.
 					KeyTypes:   kvstorage.IterKeyTypePointsOnly,

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -1793,7 +1793,7 @@ func runMVCCExportToSST(b *testing.B, opts mvccExportToSSTOpts) {
 	}
 
 	// Run sanity checks on last produced SST.
-	it, err := NewPebbleMemSSTIterator(
+	it, err := NewMemSSTIterator(
 		buf.Bytes(), true /* verify */, IterOptions{
 			LowerBound: keys.LocalMax,
 			UpperBound: roachpb.KeyMax,
@@ -1913,11 +1913,11 @@ func runSSTIterator(b *testing.B, variant string, numKeys int, verify bool) {
 	switch variant {
 	case "legacy":
 		makeSSTIterator = func(data []byte, verify bool) (SimpleMVCCIterator, error) {
-			return NewMemSSTIterator(data, verify)
+			return NewLegacyMemSSTIterator(data, verify)
 		}
 	case "pebble":
 		makeSSTIterator = func(data []byte, verify bool) (SimpleMVCCIterator, error) {
-			return NewPebbleMemSSTIterator(data, verify, IterOptions{
+			return NewMemSSTIterator(data, verify, IterOptions{
 				KeyTypes:   IterKeyTypePointsAndRanges,
 				LowerBound: keys.MinKey,
 				UpperBound: keys.MaxKey,

--- a/pkg/storage/multi_iterator.go
+++ b/pkg/storage/multi_iterator.go
@@ -47,6 +47,9 @@ var _ SimpleMVCCIterator = &multiIterator{}
 // If two iterators have an entry with exactly the same key and timestamp, the
 // one with a higher index in this constructor arg is preferred. The other is
 // skipped.
+//
+// Deprecated, use NewSSTIterator() instead. See:
+// https://github.com/cockroachdb/cockroach/issues/87943
 func MakeMultiIterator(iters []SimpleMVCCIterator) SimpleMVCCIterator {
 	return &multiIterator{
 		iters:                        iters,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -6131,8 +6131,8 @@ type MVCCExportOptions struct {
 	// which covers the point key at c, but resuming from c@2 will contain the
 	// MVCC range tombstone [c-f)@5 which overlaps with the MVCC range tombstone
 	// in the previous response in the interval [c-c\0)@5. This overlap will not
-	// cause problems with multiplexed iteration using NewPebbleSSTIterator(),
-	// nor when ingesting the SSTs via `AddSSTable`.
+	// cause problems with multiplexed iteration using NewSSTIterator(), nor when
+	// ingesting the SSTs via `AddSSTable`.
 	StopMidKey bool
 	// ResourceLimiter limits how long iterator could run until it exhausts allocated
 	// resources. Export queries limiter in its iteration loop to break out once

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1300,7 +1300,7 @@ func cmdExport(e *evalCtx) error {
 	}
 	e.results.buf.Printf("\n")
 
-	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
+	iter, err := NewMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
 		UpperBound: keys.MaxKey,
 	})
@@ -1724,7 +1724,7 @@ func cmdSSTIterNew(e *evalCtx) error {
 	for i, sst := range e.ssts {
 		ssts[len(ssts)-i-1] = sst
 	}
-	iter, err := NewPebbleMultiMemSSTIterator(ssts, sstIterVerify, IterOptions{
+	iter, err := NewMultiMemSSTIterator(ssts, sstIterVerify, IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
 		UpperBound: keys.MaxKey,
 	})

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -241,7 +241,7 @@ func assertExportedKVs(
 		require.Nil(t, expected)
 		return
 	}
-	sst, err := NewPebbleMemSSTIterator(data, false, IterOptions{
+	sst, err := NewMemSSTIterator(data, false, IterOptions{
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
 	})

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -241,7 +241,10 @@ func assertExportedKVs(
 		require.Nil(t, expected)
 		return
 	}
-	sst, err := NewMemSSTIterator(data, false)
+	sst, err := NewPebbleMemSSTIterator(data, false, IterOptions{
+		LowerBound: keys.MinKey,
+		UpperBound: keys.MaxKey,
+	})
 	require.NoError(t, err)
 	defer sst.Close()
 

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -6323,7 +6323,7 @@ func exportAllData(t *testing.T, engine Engine, limits queryLimits) []MVCCKey {
 
 func sstToKeys(t *testing.T, data []byte) []MVCCKey {
 	var results []MVCCKey
-	it, err := NewPebbleMemSSTIterator(data, false, IterOptions{
+	it, err := NewMemSSTIterator(data, false, IterOptions{
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
 	})

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -6323,7 +6323,10 @@ func exportAllData(t *testing.T, engine Engine, limits queryLimits) []MVCCKey {
 
 func sstToKeys(t *testing.T, data []byte) []MVCCKey {
 	var results []MVCCKey
-	it, err := NewMemSSTIterator(data, false)
+	it, err := NewPebbleMemSSTIterator(data, false, IterOptions{
+		LowerBound: keys.MinKey,
+		UpperBound: keys.MaxKey,
+	})
 	require.NoError(t, err, "Failed to read exported data")
 	defer it.Close()
 	for it.SeekGE(MVCCKey{Key: []byte{}}); ; {

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -118,7 +118,7 @@ func TestPebbleIterator_ExternalCorruption(t *testing.T) {
 	b := f.Bytes()
 	b[rng.Intn(len(b))]++
 
-	it, err := NewPebbleSSTIterator([][]sstable.ReadableFile{{vfs.NewMemFile(b)}},
+	it, err := NewSSTIterator([][]sstable.ReadableFile{{vfs.NewMemFile(b)}},
 		IterOptions{UpperBound: roachpb.KeyMax}, false)
 
 	// We may error early, while opening the iterator.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -75,7 +75,7 @@ func CheckSSTConflicts(
 	//
 	// TODO(bilal): Expose reader.Properties.NumRangeKeys() here, so we don't
 	// need to read the SST to figure out if it has range keys.
-	rkIter, err := NewPebbleMemSSTIterator(sst, false /* verify */, IterOptions{
+	rkIter, err := NewMemSSTIterator(sst, false /* verify */, IterOptions{
 		KeyTypes:   IterKeyTypeRangesOnly,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
@@ -138,7 +138,7 @@ func CheckSSTConflicts(
 	})
 	defer extIter.Close()
 
-	sstIter, err := NewPebbleMemSSTIterator(sst, false, IterOptions{
+	sstIter, err := NewMemSSTIterator(sst, false, IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
 		UpperBound: end.Key,
 	})
@@ -929,7 +929,7 @@ func UpdateSSTTimestamps(
 	defer writer.Close()
 
 	// Rewrite point keys.
-	iter, err := NewPebbleMemSSTIterator(sst, false /* verify */, IterOptions{
+	iter, err := NewMemSSTIterator(sst, false /* verify */, IterOptions{
 		KeyTypes:   IterKeyTypePointsOnly,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,
@@ -957,7 +957,7 @@ func UpdateSSTTimestamps(
 	}
 
 	// Rewrite range keys.
-	iter, err = NewPebbleMemSSTIterator(sst, false /* verify */, IterOptions{
+	iter, err = NewMemSSTIterator(sst, false /* verify */, IterOptions{
 		KeyTypes:   IterKeyTypeRangesOnly,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,

--- a/pkg/storage/sst_iterator_test.go
+++ b/pkg/storage/sst_iterator_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func runTestSSTIterator(t *testing.T, iter SimpleMVCCIterator, allKVs []MVCCKeyValue) {
+func runTestLegacySSTIterator(t *testing.T, iter SimpleMVCCIterator, allKVs []MVCCKeyValue) {
 	// Drop the first kv so we can test Seek.
 	expected := allKVs[1:]
 
@@ -74,7 +74,7 @@ func runTestSSTIterator(t *testing.T, iter SimpleMVCCIterator, allKVs []MVCCKeyV
 	}
 }
 
-func TestSSTIterator(t *testing.T) {
+func TestLegacySSTIterator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -121,23 +121,23 @@ func TestSSTIterator(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		iter, err := NewSSTIterator(file)
+		iter, err := NewLegacySSTIterator(file)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 		defer iter.Close()
-		runTestSSTIterator(t, iter, allKVs)
+		runTestLegacySSTIterator(t, iter, allKVs)
 	})
 	t.Run("Mem", func(t *testing.T) {
-		iter, err := NewMemSSTIterator(sstFile.Data(), false)
+		iter, err := NewLegacyMemSSTIterator(sstFile.Data(), false)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
 		defer iter.Close()
-		runTestSSTIterator(t, iter, allKVs)
+		runTestLegacySSTIterator(t, iter, allKVs)
 	})
 	t.Run("AsOf", func(t *testing.T) {
-		iter, err := NewMemSSTIterator(sstFile.Data(), false)
+		iter, err := NewLegacyMemSSTIterator(sstFile.Data(), false)
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -155,7 +155,7 @@ func TestSSTIterator(t *testing.T) {
 				asOfKVs = append(asOfKVs, kv)
 			}
 			asOfIter := NewReadAsOfIterator(iter, asOf)
-			runTestSSTIterator(t, asOfIter, asOfKVs)
+			runTestLegacySSTIterator(t, asOfIter, asOfKVs)
 		}
 	})
 }

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -175,7 +175,7 @@ func TestSSTWriterRangeKeys(t *testing.T) {
 
 	require.NoError(t, sst.Finish())
 
-	iter, err := NewPebbleMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
+	iter, err := NewMemSSTIterator(sstFile.Bytes(), false /* verify */, IterOptions{
 		KeyTypes:   IterKeyTypePointsAndRanges,
 		UpperBound: keys.MaxKey,
 	})

--- a/pkg/testutils/storageutils/scan.go
+++ b/pkg/testutils/storageutils/scan.go
@@ -107,7 +107,7 @@ func ScanRange(t *testing.T, r storage.Reader, desc roachpb.RangeDescriptor) KVs
 func ScanSST(t *testing.T, sst []byte) KVs {
 	t.Helper()
 
-	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+	iter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,

--- a/pkg/testutils/storageutils/stats.go
+++ b/pkg/testutils/storageutils/stats.go
@@ -33,7 +33,7 @@ func EngineStats(t *testing.T, engine storage.Reader, nowNanos int64) *enginepb.
 func SSTStats(t *testing.T, sst []byte, nowNanos int64) *enginepb.MVCCStats {
 	t.Helper()
 
-	iter, err := storage.NewPebbleMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+	iter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 		KeyTypes:   storage.IterKeyTypePointsAndRanges,
 		LowerBound: keys.MinKey,
 		UpperBound: keys.MaxKey,


### PR DESCRIPTION
**storage: use new Pebble SST iterators everywhere**

This patch replaces all uses of the old SST iterators with the new,
Pebble-based ones.

Touches #87366.

Release note: None
  
**storage: rename SST iterators**

This patch renames the SST iterators. There are no functional changes.

* `NewSSTIterator` → `NewLegacySSTIterator`
* `NewMemSSTIterator` → `NewLegacyMemSSTIterator`
* `sstIterator` → `legacySSTIterator`
* `NewPebbleSSTIterator` → `NewSSTIterator`
* `NewPebbleMemSSTIterator` → `NewMemSSTIterator`
* `NewPebbleMultiMemSSTIterator` → `NewMultiMemSSTIterator`

The legacy SST iterator is kept around for benchmark comparisons, and in
case we discover problems with the new SST iterators.

Release note: None