### PR TITLE
kvserver: detect MVCC range keys during engine init

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -466,9 +466,8 @@ func TestInitializeEngineErrors(t *testing.T) {
 	stopper.AddCloser(eng)
 
 	// Bootstrap should fail if engine has no cluster version yet.
-	if err := InitEngine(ctx, eng, testIdent); !testutils.IsError(err, `no cluster version`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	err := InitEngine(ctx, eng, testIdent)
+	require.ErrorContains(t, err, "no cluster version")
 
 	require.NoError(t, WriteClusterVersion(ctx, eng, clusterversion.TestingClusterVersion))
 
@@ -480,14 +479,22 @@ func TestInitializeEngineErrors(t *testing.T) {
 	store := NewStore(ctx, cfg, eng, &roachpb.NodeDescriptor{NodeID: 1})
 
 	// Can't init as haven't bootstrapped.
-	if err := store.Start(ctx, stopper); !errors.HasType(err, (*NotBootstrappedError)(nil)) {
-		t.Errorf("unexpected error initializing un-bootstrapped store: %+v", err)
-	}
+	err = store.Start(ctx, stopper)
+	require.ErrorIs(t, err, &NotBootstrappedError{})
 
 	// Bootstrap should fail on non-empty engine.
-	if err := InitEngine(ctx, eng, testIdent); !testutils.IsError(err, `cannot be bootstrapped`) {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	err = InitEngine(ctx, eng, testIdent)
+	require.ErrorContains(t, err, "cannot be bootstrapped")
+
+	// Bootstrap should fail on MVCC range key in engine.
+	require.NoError(t, eng.PutMVCCRangeKey(storage.MVCCRangeKey{
+		StartKey:  roachpb.Key("a"),
+		EndKey:    roachpb.Key("b"),
+		Timestamp: hlc.MinTimestamp,
+	}, storage.MVCCValue{}))
+
+	err = InitEngine(ctx, eng, testIdent)
+	require.ErrorContains(t, err, "found mvcc range key")
 }
 
 // create a Replica and add it to the store. Note that replicas

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -560,6 +560,7 @@ func assertEnginesEmpty(engines []storage.Engine) error {
 	for _, engine := range engines {
 		err := func() error {
 			iter := engine.NewEngineIterator(storage.IterOptions{
+				KeyTypes:   storage.IterKeyTypePointsAndRanges,
 				UpperBound: roachpb.KeyMax,
 			})
 			defer iter.Close()
@@ -570,11 +571,12 @@ func assertEnginesEmpty(engines []storage.Engine) error {
 				if err != nil {
 					return err
 				}
+				hasPoint, hasRange := iter.HasPointAndRange()
 
 				// The store cluster version key is written multiple times,
 				// including before bootstrapping or joining a cluster.
 				// Skip it if it exists.
-				if storeClusterVersionKey.Equal(k.Key) {
+				if hasPoint && !hasRange && storeClusterVersionKey.Equal(k.Key) {
 					continue
 				}
 				return errors.New("engine is not empty")


### PR DESCRIPTION
This patch detects and errors on existing MVCC range keys during engine initialization, similarly to point keys.

Touches #87366.

Release note: None