### PR TITLE
pkg/keys: mark reserved key prefixes as safe when safeformatting

### DIFF
--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -105,6 +105,14 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 			makeKey(tenSysCodec.TablePrefix(42), []byte{0x12, 'a', 0x00, 0x03}),
 			`/Table/42/‹???›`,
 		},
+		{
+			"marks safe reserved key prefix",
+			makeKey(keys.Meta1Prefix,
+				tenSysCodec.TablePrefix(42),
+				encoding.EncodeStringAscending(nil, "California"),
+				encoding.EncodeStringAscending(nil, "Los Angeles")),
+			`/Meta1/Table/42/‹"California"›/‹"Los Angeles"›`,
+		},
 	}
 
 	for _, test := range testCases {

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -117,7 +117,7 @@ outer:
 	for len(input) > 0 {
 		if entries != nil {
 			for _, v := range entries {
-				if strings.HasPrefix(input, v.Name) {
+				if strings.HasPrefix(input, string(v.Name)) {
 					input = input[len(v.Name):]
 					if v.PSFunc == nil {
 						return mkErr(nil)
@@ -134,14 +134,14 @@ outer:
 			}
 		}
 		for _, v := range keys.ConstKeyOverrides {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				output = append(output, v.Value...)
 				input = input[len(v.Name):]
 				continue outer
 			}
 		}
 		for _, v := range s.keyComprehension {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				// No appending to output yet, the dictionary will take care of
 				// it.
 				input = input[len(v.Name):]


### PR DESCRIPTION
Recently, work was done to reduce the redaction of pretty-printed keys when interpolated into log messages. It was identified that some key prefixes were not being marked safe during the safe formatting (mainly - `/Meta1` and `/Meta2`).

This patch provides a small update to fix this, properly marking these key prefixes as safe.

Release note (security update): redacted logs will now reveal the `/Meta1` and `/Meta2` key prefixes when pretty-printing keys. Index key values themselves will remain unredacted.