### PR TITLE
storage: remove `Reader.MVCCGet` and `MVCCGetProto`

### DIFF
--- a/pkg/ccl/storageccl/engineccl/BUILD.bazel
+++ b/pkg/ccl/storageccl/engineccl/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/storage",
         "//pkg/storage/enginepb",
         "//pkg/testutils",
+        "//pkg/testutils/storageutils",
         "//pkg/util/encoding",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",

--- a/pkg/kv/kvserver/batch_spanset_test.go
+++ b/pkg/kv/kvserver/batch_spanset_test.go
@@ -11,7 +11,6 @@
 package kvserver
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"testing"
@@ -21,10 +20,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSpanSetBatchBoundaries(t *testing.T) {
@@ -113,23 +114,12 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 	})
 
 	t.Run("reads inside range", func(t *testing.T) {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if value, err := batch.MVCCGet(insideKey); err != nil {
-			t.Errorf("failed to read inside the range: %+v", err)
-		} else if !bytes.Equal(value, []byte("value")) {
-			t.Errorf("failed to read previously written value, got %q", value)
-		}
-		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
-		if _, _, _, err := batch.MVCCGetProto(insideKey, nil); err != nil {
-			t.Errorf("MVCCGetProto: unexpected error %v", err)
-		}
-		if err := batch.MVCCIterate(
+		require.Equal(t, []byte("value"), storageutils.MVCCGetRaw(t, batch, insideKey))
+		require.NoError(t, batch.MVCCIterate(
 			insideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
 			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
 				return nil
-			}); err != nil {
-			t.Errorf("MVCCIterate: unexpected error %v", err)
-		}
+			}))
 	})
 
 	// Reads outside the range fail.
@@ -138,13 +128,8 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 	}
 
 	t.Run("reads before range", func(t *testing.T) {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.MVCCGet(outsideKey); !isReadSpanErr(err) {
-			t.Errorf("Get: unexpected error %v", err)
-		}
-		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
-		if _, _, _, err := batch.MVCCGetProto(outsideKey, nil); !isReadSpanErr(err) {
-			t.Errorf("MVCCGetProto: unexpected error %v", err)
+		if _, err := storageutils.MVCCGetRawWithError(t, batch, outsideKey); !isReadSpanErr(err) {
+			t.Errorf("MVCCGet: unexpected error %v", err)
 		}
 		if err := batch.MVCCIterate(
 			outsideKey.Key, insideKey2.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
@@ -156,13 +141,8 @@ func TestSpanSetBatchBoundaries(t *testing.T) {
 	})
 
 	t.Run("reads after range", func(t *testing.T) {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.MVCCGet(outsideKey3); !isReadSpanErr(err) {
-			t.Errorf("Get: unexpected error %v", err)
-		}
-		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
-		if _, _, _, err := batch.MVCCGetProto(outsideKey3, nil); !isReadSpanErr(err) {
-			t.Errorf("MVCCGetProto: unexpected error %v", err)
+		if _, err := storageutils.MVCCGetRawWithError(t, batch, outsideKey3); !isReadSpanErr(err) {
+			t.Errorf("MVCCGet: unexpected error %v", err)
 		}
 		if err := batch.MVCCIterate(
 			insideKey2.Key, outsideKey4.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
@@ -342,12 +322,7 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 
 	// Reads.
 	for _, batch := range []storage.Batch{batchBefore, batchDuring} {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if res, err := batch.MVCCGet(rkey); err != nil {
-			t.Errorf("failed to read inside the range: %+v", err)
-		} else if !bytes.Equal(res, value) {
-			t.Errorf("failed to read previously written value, got %q", res)
-		}
+		require.Equal(t, value, storageutils.MVCCGetRaw(t, batch, rkey))
 	}
 
 	isReadSpanErr := func(err error) bool {
@@ -355,15 +330,10 @@ func TestSpanSetBatchTimestamps(t *testing.T) {
 	}
 
 	for _, batch := range []storage.Batch{batchAfter, batchNonMVCC} {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if _, err := batch.MVCCGet(rkey); !isReadSpanErr(err) {
+		if _, err := storageutils.MVCCGetRawWithError(t, batch, rkey); !isReadSpanErr(err) {
 			t.Errorf("Get: unexpected error %v", err)
 		}
 
-		//lint:ignore SA1019 historical usage of deprecated batch.MVCCGetProto is OK
-		if _, _, _, err := batch.MVCCGetProto(rkey, nil); !isReadSpanErr(err) {
-			t.Errorf("MVCCGetProto: unexpected error %v", err)
-		}
 		if err := batch.MVCCIterate(
 			rkey.Key, rkey.Key, storage.MVCCKeyAndIntentsIterKind, storage.IterKeyTypePointsOnly,
 			func(v storage.MVCCKeyValue, _ storage.MVCCRangeKeyStack) error {
@@ -556,12 +526,7 @@ func TestSpanSetNonMVCCBatch(t *testing.T) {
 
 	// Reads.
 	for _, batch := range []storage.Batch{batchNonMVCC, batchMVCC} {
-		//lint:ignore SA1019 historical usage of deprecated batch.Get is OK
-		if res, err := batch.MVCCGet(rkey); err != nil {
-			t.Errorf("read disallowed through non-MVCC latch: %+v", err)
-		} else if !bytes.Equal(res, value) {
-			t.Errorf("failed to read previously written value, got %q", res)
-		}
+		require.Equal(t, value, storageutils.MVCCGetRaw(t, batch, rkey))
 	}
 }
 

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -424,36 +424,6 @@ func (s spanSetReader) Closed() bool {
 	return s.r.Closed()
 }
 
-func (s spanSetReader) MVCCGet(key storage.MVCCKey) ([]byte, error) {
-	if s.spansOnly {
-		if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := s.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: key.Key}, s.ts); err != nil {
-			return nil, err
-		}
-	}
-	//lint:ignore SA1019 implementing deprecated interface function (Get) is OK
-	return s.r.MVCCGet(key)
-}
-
-func (s spanSetReader) MVCCGetProto(
-	key storage.MVCCKey, msg protoutil.Message,
-) (bool, int64, int64, error) {
-	if s.spansOnly {
-		if err := s.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
-			return false, 0, 0, err
-		}
-	} else {
-		if err := s.spans.CheckAllowedAt(SpanReadOnly, roachpb.Span{Key: key.Key}, s.ts); err != nil {
-			return false, 0, 0, err
-		}
-	}
-	//lint:ignore SA1019 implementing deprecated interface function (MVCCGetProto) is OK
-	return s.r.MVCCGetProto(key, msg)
-}
-
 func (s spanSetReader) MVCCIterate(
 	start, end roachpb.Key,
 	iterKind storage.MVCCIterKind,

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -523,19 +523,6 @@ type Reader interface {
 	// that they are not using a closed engine. Intended for use within package
 	// engine; exported to enable wrappers to exist in other packages.
 	Closed() bool
-	// MVCCGet returns the value for the given key, nil otherwise. Semantically, it
-	// behaves as if an iterator with MVCCKeyAndIntentsIterKind was used.
-	//
-	// Deprecated: use storage.MVCCGet instead.
-	MVCCGet(key MVCCKey) ([]byte, error)
-	// MVCCGetProto fetches the value at the specified key and unmarshals it
-	// using a protobuf decoder. Returns true on success or false if the
-	// key was not found. On success, returns the length in bytes of the
-	// key and the value. Semantically, it behaves as if an iterator with
-	// MVCCKeyAndIntentsIterKind was used.
-	//
-	// Deprecated: use MVCCIterator.ValueProto instead.
-	MVCCGetProto(key MVCCKey, msg protoutil.Message) (ok bool, keyBytes, valBytes int64, err error)
 	// MVCCIterate scans from the start key to the end key (exclusive), invoking
 	// the function f on each key value pair. The inputs are copies, and safe to
 	// retain beyond the function call. It supports interleaved iteration over

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -35,7 +35,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1078,43 +1077,6 @@ func (p *Pebble) Closed() bool {
 	return p.closed
 }
 
-// MVCCGet implements the Engine interface.
-func (p *Pebble) MVCCGet(key MVCCKey) ([]byte, error) {
-	return mvccGetHelper(key, p)
-}
-
-func mvccGetHelper(key MVCCKey, reader wrappableReader) ([]byte, error) {
-	if len(key.Key) == 0 {
-		return nil, emptyKeyError()
-	}
-	r := wrapReader(reader)
-	// Doing defer r.Free() does not inline.
-	v, err := r.MVCCGet(key)
-	r.Free()
-	return v, err
-}
-
-func (p *Pebble) rawMVCCGet(key []byte) ([]byte, error) {
-	ret, closer, err := p.db.Get(key)
-	if closer != nil {
-		retCopy := make([]byte, len(ret))
-		copy(retCopy, ret)
-		ret = retCopy
-		closer.Close()
-	}
-	if errors.Is(err, pebble.ErrNotFound) || len(ret) == 0 {
-		return nil, nil
-	}
-	return ret, err
-}
-
-// MVCCGetProto implements the Engine interface.
-func (p *Pebble) MVCCGetProto(
-	key MVCCKey, msg protoutil.Message,
-) (ok bool, keyBytes, valBytes int64, err error) {
-	return pebbleGetProto(p, key, msg)
-}
-
 // MVCCIterate implements the Engine interface.
 func (p *Pebble) MVCCIterate(
 	start, end roachpb.Key,
@@ -1988,42 +1950,6 @@ func (p *pebbleReadOnly) Closed() bool {
 	return p.closed
 }
 
-func (p *pebbleReadOnly) MVCCGet(key MVCCKey) ([]byte, error) {
-	return mvccGetHelper(key, p)
-}
-
-func (p *pebbleReadOnly) rawMVCCGet(key []byte) ([]byte, error) {
-	if p.closed {
-		panic("using a closed pebbleReadOnly")
-	}
-	// Cannot delegate to p.parent.rawMVCCGet since we need to use p.durability.
-	onlyReadGuaranteedDurable := false
-	if p.durability == GuaranteedDurability {
-		onlyReadGuaranteedDurable = true
-	}
-	options := pebble.IterOptions{
-		LowerBound:                key,
-		UpperBound:                encoding.BytesNext(key),
-		OnlyReadGuaranteedDurable: onlyReadGuaranteedDurable,
-	}
-	iter := p.parent.db.NewIter(&options)
-	defer func() {
-		// Already handled error.
-		_ = iter.Close()
-	}()
-	valid := iter.SeekGE(key)
-	if !valid {
-		return nil, iter.Error()
-	}
-	return iter.Value(), nil
-}
-
-func (p *pebbleReadOnly) MVCCGetProto(
-	key MVCCKey, msg protoutil.Message,
-) (ok bool, keyBytes, valBytes int64, err error) {
-	return pebbleGetProto(p, key, msg)
-}
-
 func (p *pebbleReadOnly) MVCCIterate(
 	start, end roachpb.Key,
 	iterKind MVCCIterKind,
@@ -2263,39 +2189,6 @@ func (p *pebbleSnapshot) Closed() bool {
 	return p.closed
 }
 
-// Get implements the Reader interface.
-func (p *pebbleSnapshot) MVCCGet(key MVCCKey) ([]byte, error) {
-	if len(key.Key) == 0 {
-		return nil, emptyKeyError()
-	}
-	r := wrapReader(p)
-	// Doing defer r.Free() does not inline.
-	v, err := r.MVCCGet(key)
-	r.Free()
-	return v, err
-}
-
-func (p *pebbleSnapshot) rawMVCCGet(key []byte) ([]byte, error) {
-	ret, closer, err := p.snapshot.Get(key)
-	if closer != nil {
-		retCopy := make([]byte, len(ret))
-		copy(retCopy, ret)
-		ret = retCopy
-		closer.Close()
-	}
-	if errors.Is(err, pebble.ErrNotFound) || len(ret) == 0 {
-		return nil, nil
-	}
-	return ret, err
-}
-
-// MVCCGetProto implements the Reader interface.
-func (p *pebbleSnapshot) MVCCGetProto(
-	key MVCCKey, msg protoutil.Message,
-) (ok bool, keyBytes, valBytes int64, err error) {
-	return pebbleGetProto(p, key, msg)
-}
-
 // MVCCIterate implements the Reader interface.
 func (p *pebbleSnapshot) MVCCIterate(
 	start, end roachpb.Key,
@@ -2347,25 +2240,6 @@ func (p *pebbleSnapshot) SupportsRangeKeys() bool {
 func (p *pebbleSnapshot) PinEngineStateForIterators() error {
 	// Snapshot already pins state, so nothing to do.
 	return nil
-}
-
-// pebbleGetProto uses Reader.MVCCGet, so it not as efficient as a function
-// that can unmarshal without copying bytes. But we don't care about
-// efficiency, since this is used to implement Reader.MVCCGetProto, which is
-// deprecated and only used in tests.
-func pebbleGetProto(
-	reader Reader, key MVCCKey, msg protoutil.Message,
-) (ok bool, keyBytes, valBytes int64, err error) {
-	val, err := reader.MVCCGet(key)
-	if err != nil || val == nil {
-		return false, 0, 0, err
-	}
-	keyBytes = int64(key.Len())
-	valBytes = int64(len(val))
-	if msg != nil {
-		err = protoutil.Unmarshal(val, msg)
-	}
-	return true, keyBytes, valBytes, err
 }
 
 // ExceedMaxSizeError is the error returned when an export request

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1065,8 +1065,7 @@ func TestPebbleFlushCallbackAndDurabilityRequirement(t *testing.T) {
 	require.NoError(t, roGuaranteedPinned.PinEngineStateForIterators())
 	// Returns the value found or nil.
 	checkGetAndIter := func(reader Reader) []byte {
-		v, err := reader.MVCCGet(k)
-		require.NoError(t, err)
+		v := mvccGetRaw(t, reader, k)
 		iter := reader.NewMVCCIterator(MVCCKeyIterKind, IterOptions{UpperBound: k.Key.Next()})
 		defer iter.Close()
 		iter.SeekGE(k)

--- a/pkg/testutils/storageutils/BUILD.bazel
+++ b/pkg/testutils/storageutils/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "kv.go",
         "mocking.go",
+        "mvcc.go",
         "scan.go",
         "sst.go",
         "stats.go",

--- a/pkg/testutils/storageutils/mvcc.go
+++ b/pkg/testutils/storageutils/mvcc.go
@@ -1,0 +1,37 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package storageutils
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// MVCCGetRaw fetches a raw MVCC value, for use in tests.
+func MVCCGetRaw(t *testing.T, r storage.Reader, key storage.MVCCKey) []byte {
+	value, err := MVCCGetRawWithError(t, r, key)
+	require.NoError(t, err)
+	return value
+}
+
+// MVCCGetRawWithError is like MVCCGetRaw, but returns an error rather than
+// failing the test.
+func MVCCGetRawWithError(t *testing.T, r storage.Reader, key storage.MVCCKey) ([]byte, error) {
+	iter := r.NewMVCCIterator(storage.MVCCKeyAndIntentsIterKind, storage.IterOptions{Prefix: true})
+	defer iter.Close()
+	iter.SeekGE(key)
+	if ok, err := iter.Valid(); err != nil || !ok {
+		return nil, err
+	}
+	return iter.Value(), nil
+}


### PR DESCRIPTION
These methods were deprecated and only used in tests. They did not support MVCC range keys either, so this patch removes them rather than adding range key support. Corresponding test helpers have been added.

`TestBatchConcurrency` is removed, because the use of consistent batch iterators for reads have a fixed engine view and thus no longer exhibit the behavior that the test asserts.

Touches #87366.
Resolves #87953.

Release note: None