### PR TITLE
sql: ensure index usage stats reset time is same across nodes

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4656,6 +4656,7 @@ Request object for issuing a index usage stats reset request.
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | node_id | [string](#cockroach.server.serverpb.ResetIndexUsageStatsRequest-string) |  |  | [reserved](#support-status) |
+| cluster_reset_start_time | [google.protobuf.Timestamp](#cockroach.server.serverpb.ResetIndexUsageStatsRequest-google.protobuf.Timestamp) |  | Timestamp for the start time of the latest reset index usage statistics request on the cluster. | [reserved](#support-status) |
 
 
 
@@ -4715,7 +4716,7 @@ Response object returned by TableIndexStatsResponse.
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | statistics | [TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.server.serverpb.TableIndexStatsResponse.ExtendedCollectedIndexUsageStatistics) | repeated |  | [reserved](#support-status) |
-| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableIndexStatsResponse-google.protobuf.Timestamp) |  | Timestamp of the last index usage stats reset. | [reserved](#support-status) |
+| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.TableIndexStatsResponse-google.protobuf.Timestamp) |  | Timestamp of the latest reset index usage statistics request. | [reserved](#support-status) |
 | index_recommendations | [cockroach.sql.IndexRecommendation](#cockroach.server.serverpb.TableIndexStatsResponse-cockroach.sql.IndexRecommendation) | repeated |  | [reserved](#support-status) |
 
 

--- a/pkg/ccl/serverccl/statusccl/tenant_status_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_status_test.go
@@ -494,6 +494,14 @@ WHERE
 			require.NoError(t, err)
 			require.True(t, resp.LastReset.After(timePreReset))
 
+			// IndexUsageStatistics fan-out returns cluster-wide last reset time.
+			// Compare the cluster-wide last reset time from two different node
+			// responses, ensure they are equal.
+			first := testingCluster.TenantStatusSrv(0)
+			firstResp, err := first.IndexUsageStatistics(ctx, &serverpb.IndexUsageStatisticsRequest{})
+			require.NoError(t, err)
+			require.Equal(t, firstResp.LastReset, resp.LastReset)
+
 			// Ensure tenant data isolation.
 			// Check that last reset time was not updated for control cluster.
 			status = controlCluster.TenantStatusSrv(serverccl.RandomServer)

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1787,7 +1787,7 @@ message TableIndexStatsResponse {
   }
 
   repeated ExtendedCollectedIndexUsageStatistics statistics = 1;
-  // Timestamp of the last index usage stats reset.
+  // Timestamp of the latest reset index usage statistics request.
   google.protobuf.Timestamp last_reset = 2 [(gogoproto.stdtime) = true];
   repeated cockroach.sql.IndexRecommendation index_recommendations = 3;
 }
@@ -1795,6 +1795,9 @@ message TableIndexStatsResponse {
 // Request object for issuing a index usage stats reset request.
 message ResetIndexUsageStatsRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
+  // Timestamp for the start time of the latest reset index usage statistics
+  // request on the cluster.
+  google.protobuf.Timestamp cluster_reset_start_time = 3 [(gogoproto.nullable) = false, (gogoproto.stdtime) = true];
 }
 
 // Response object returned by ResetIndexUsageStatsRequest.

--- a/pkg/sql/idxusage/local_index_usage_stats_test.go
+++ b/pkg/sql/idxusage/local_index_usage_stats_test.go
@@ -166,7 +166,7 @@ func TestIndexUsageStatisticsSubsystem(t *testing.T) {
 	t.Run("clear", func(t *testing.T) {
 		actualEntryCount := 0
 		expectedEntryCount := 0
-		localIndexUsage.clear()
+		localIndexUsage.clear(timeutil.Now())
 		err := localIndexUsage.ForEach(IteratorOptions{}, func(_ *roachpb.IndexUsageKey, _ *roachpb.IndexUsageStatistics) error {
 			actualEntryCount++
 			return nil

--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.tsx
@@ -516,7 +516,7 @@ export class DatabaseTablePage extends React.Component<
                     <div className={cx("index-stats__reset-info")}>
                       <Tooltip
                         placement="bottom"
-                        title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
+                        title="Index stats accumulate from the time the index was created or had its stats reset. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
                       >
                         <div
                           className={cx("index-stats__last-reset", "underline")}

--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -232,7 +232,7 @@ export class IndexDetailsPage extends React.Component<
             <div className={cx("reset-info")}>
               <Tooltip
                 placement="bottom"
-                title="Index stats accumulate from the time the index was created or had its stats reset.. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster."
+                title="Index stats accumulate from the time the index was created or had its stats reset.. Clicking ‘Reset all index stats’ will reset index stats for the entire cluster. Last reset is the timestamp at which the last reset started."
               >
                 <div className={cx("last-reset", "underline")}>
                   Last reset:{" "}


### PR DESCRIPTION
Resolves: https://github.com/cockroachdb/cockroach/issues/77451

Previously, the last reset time surfaced by our index usage stats was
node-local. Consequently, the last reset time surfaced to the UI could
change depending on the connected node. This change sets the reset time
across all nodes to the time at which the reset request was received,
ensuring the same reset time across nodes.

Loom video of changes to index usage stats reset tooltips: https://www.loom.com/share/3755a2f658444216b3d60e15c22a9baf

Release note: None