### PR TITLE
storepool: ignore drain state during replica placement

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -2382,7 +2382,7 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 		{leaseholder: 4, existing: nil, expected: false},
 		{leaseholder: 3, existing: replicas(1), expected: true},
 		{leaseholder: 3, existing: replicas(1, 2), expected: true},
-		{leaseholder: 3, existing: replicas(2), expected: false},
+		{leaseholder: 3, existing: replicas(2), expected: true},
 		{leaseholder: 3, existing: replicas(3), expected: false},
 		{leaseholder: 3, existing: replicas(4), expected: false},
 		{leaseholder: 4, existing: replicas(1), expected: true},
@@ -2403,7 +2403,7 @@ func TestAllocatorShouldTransferLease(t *testing.T) {
 				nil, /* replicaStats */
 			)
 			if c.expected != result {
-				t.Fatalf("expected %v, but found %v", c.expected, result)
+				t.Errorf("expected %v, but found %v", c.expected, result)
 			}
 		})
 	}
@@ -2435,8 +2435,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(stores, t)
 
-	// UNAVAILABLE is the node liveness status used for a node that's draining.
-	nl.SetNodeStatus(1, livenesspb.NodeLivenessStatus_UNAVAILABLE)
+	nl.SetNodeStatus(1, livenesspb.NodeLivenessStatus_DRAINING)
 
 	testCases := []struct {
 		leaseholder roachpb.StoreID
@@ -2449,7 +2448,7 @@ func TestAllocatorShouldTransferLeaseDraining(t *testing.T) {
 		{leaseholder: 4, existing: nil, expected: false},
 		{leaseholder: 2, existing: replicas(1), expected: false},
 		{leaseholder: 3, existing: replicas(1), expected: false},
-		{leaseholder: 3, existing: replicas(1, 2), expected: false},
+		{leaseholder: 3, existing: replicas(1, 2), expected: true},
 		{leaseholder: 3, existing: replicas(1, 2, 4), expected: false},
 		{leaseholder: 4, existing: replicas(1), expected: false},
 		{leaseholder: 4, existing: replicas(1, 2), expected: true},
@@ -2753,8 +2752,8 @@ func TestAllocatorLeasePreferencesMultipleStoresPerLocality(t *testing.T) {
 		// When `excludeLeaseRepl` = false, we'd expect either store 2 or 3
 		// to be produced by `TransferLeaseTarget` (since both of them have
 		// less-than-mean leases). In this case, the rng should produce 3.
-		{1, replicas(1, 2, 3), preferEast, 0, 3},
-		{3, replicas(1, 3, 5), preferEast, 0, 1},
+		{1, replicas(1, 2, 3), preferEast, 0, 2},
+		{3, replicas(1, 3, 5), preferEast, 1, 1},
 		{5, replicas(1, 4, 5), preferEast, 1, 1},
 		{5, replicas(3, 4, 5), preferEast, 3, 3},
 		{1, replicas(1, 5, 6), preferEast, 0, 5},

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -2516,29 +2516,6 @@ func TestRangeInfoAfterSplit(t *testing.T) {
 	}
 }
 
-// TestDrainRangeRejection verifies that an attempt to transfer a range to a
-// draining store fails.
-func TestDrainRangeRejection(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-	tc := testcluster.StartTestCluster(t, 2, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-	})
-	defer tc.Stopper().Stop(ctx)
-
-	key := tc.ScratchRange(t)
-	repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(key))
-
-	drainingIdx := 1
-	tc.GetFirstStoreFromServer(t, 1).SetDraining(true, nil /* reporter */, false /* verbose */)
-	chgs := roachpb.MakeReplicationChanges(roachpb.ADD_VOTER, tc.Target(drainingIdx))
-	if _, err := repl.ChangeReplicas(context.Background(), repl.Desc(), kvserverpb.SnapshotRequest_REBALANCE, kvserverpb.ReasonRangeUnderReplicated, "", chgs); !testutils.IsError(err, "store is draining") {
-		t.Fatalf("unexpected error: %+v", err)
-	}
-}
-
 func TestChangeReplicasGeneration(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -877,8 +877,8 @@ func TestNodeLivenessConcurrentIncrementEpochs(t *testing.T) {
 }
 
 // TestNodeLivenessSetDraining verifies that when draining, a node's liveness
-// record is updated and the node will not be present in the store list of other
-// nodes once they are aware of its draining state.
+// record is updated but the node continues to be present in the store list of
+// other nodes once they are aware of its draining state.
 func TestNodeLivenessSetDraining(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -943,7 +943,7 @@ func TestNodeLivenessSetDraining(t *testing.T) {
 
 	// Draining node disappears from store lists.
 	{
-		const expectedLive = 2
+		const expectedLive = 3
 		// Executed in a retry loop to wait until the new liveness record has
 		// been gossiped to the rest of the cluster.
 		testutils.SucceedsSoon(t, func() error {
@@ -958,9 +958,9 @@ func TestNodeLivenessSetDraining(t *testing.T) {
 						curNodeID,
 					)
 				}
-				if nodeIDAppearsInStoreList(drainingNodeID, sl) {
+				if !nodeIDAppearsInStoreList(drainingNodeID, sl) {
 					return errors.Errorf(
-						"expected node %d not to appear in node %d's store list",
+						"expected node %d to appear in node %d's store list",
 						drainingNodeID,
 						curNodeID,
 					)

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -644,8 +644,8 @@ func drain(ctx context.Context, t *testing.T, client serverpb.AdminClient, drain
 	require.NoError(t, err)
 }
 
-// TestSnapshotsToDrainingNodes tests that rebalancing snapshots to draining
-// receivers are rejected, but Raft snapshots aren't.
+// TestSnapshotsToDrainingNodes tests that both rebalancing and raft snapshots
+// to draining receivers are accepted.
 func TestSnapshotsToDrainingNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -669,7 +669,7 @@ func TestSnapshotsToDrainingNodes(t *testing.T) {
 		// Now, we try to add a replica to it, we expect that to fail.
 		scratchKey := tc.ScratchRange(t)
 		_, err = tc.AddVoters(scratchKey, makeReplicationTargets(drainingNodeID)...)
-		require.Regexp(t, "store is draining", err)
+		require.NoError(t, err)
 	})
 
 	t.Run("raft snapshots", func(t *testing.T) {


### PR DESCRIPTION
See release note below. By making this change, we open the doors to more uses (internally within the DB, and by operators externally) of the drain state. By focusing its effect "purely" on range leases, we can operationalize the following scheme for ex.:

- When new nodes are being added, add them in the drained state. This would prevent range leases from being moved to it, though still allowing it to get fully caught up.
- Once caught up, unset the drain state to allow the node to serve leaseholder traffic.

We've observed elsewhere that nodes being added to a busy cluster can be disruptive to foreground traffic, partly because of leases being too-quickly moved onto the new nodes. These new nodes typically exhibit high disk bandwidth and CPU use while being caught up, with effects on tail latencies for requests served on those nodes. It's useful in such cases to prevent leases from being moved onto new nodes, though still allowing it to house new replicas. This can be done manually by operators, or perhaps automatically by the database (see #87847). To this end, we repurpose the primitive provided by `drain` instead of introducing something else entirely. It's no longer the case that draining a node must follow a node shut down (though it can -- we expect that mode of use to continue and be typical). The fact that we now permit new replicas being placed on draining nodes brings with it questions around failure tolerance targets — since draining nodes are more likely than not to be shut down soon and we're possibly upreplicating to a place where we're likely to soon lose the new replica. This is true, but we also observe that currently the node being drained does not actively shed its replicas, so when shut down, it does in fact reduce failure tolerance for replicas already on that node. With this change we're just no longer special casing replicas added while the node is being drained (typically a few minutes before shut down).

Release note (general change): Previously nodes that were marked as draining (through `cockroach node drain`) were considered as invalid targets for replica placement. This prevented new replicas from being added to the node though it did not cause the node to actively shed its replicas. This is in contrast to drain's effect on range leases, where a node drain does in fact cause a node to actively shed its leases and block incoming ones. After this change a draining node is permitted to acquire new replicas. In fact, draining no longer has an effect on replica placement whatsoever -- it only affects leases. Decommissioning is the parallel to draining that applies to replicas, wherein a node marked as decomissioning actively sheds its replicas in addition to preventing new ones from being placed onto it. If operators were using this command to actively prevent replicas from being placed on a node, consider using `cockroach node decommission` instead, or declaring a zone config with a negative constraint in the `lease_preferences` field by excluding the node(s) in question. Our shut down docs[1] will need to be updated.
[1]: https://www.cockroachlabs.com/docs/v22.1/node-shutdown#node-shutdown-sequence

Touches #87858 (stale issue).