### PR TITLE
storage: handle MVCC range keys in all `NewMVCCIterator` callers

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_is_span_empty.go
+++ b/pkg/kv/kvserver/batcheval/cmd_is_span_empty.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/errors"
 )
 
@@ -35,8 +34,6 @@ func IsSpanEmpty(
 	isEmpty, err := storage.MVCCIsSpanEmpty(ctx, reader, storage.MVCCIsSpanEmptyOptions{
 		StartKey: args.Key,
 		EndKey:   args.EndKey,
-		StartTS:  hlc.MinTimestamp, // beginning of time
-		EndTS:    hlc.MaxTimestamp, // end of time
 	})
 	if err != nil {
 		return result.Result{}, errors.Wrap(err, "IsSpanEmpty")

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -92,6 +92,7 @@ func optimizePuts(
 	// don't need to see intents for this purpose since intents also have
 	// provisional values that we will see.
 	iter := reader.NewMVCCIterator(storage.MVCCKeyIterKind, storage.IterOptions{
+		KeyTypes: storage.IterKeyTypePointsAndRanges,
 		// We want to include maxKey in our scan. Since UpperBound is exclusive, we
 		// need to set it to the key after maxKey.
 		UpperBound: maxKey.Next(),

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -265,10 +265,11 @@ type MVCCIterator interface {
 	// ValueProto unmarshals the value the iterator is currently
 	// pointing to using a protobuf decoder.
 	ValueProto(msg protoutil.Message) error
-	// FindSplitKey finds a key from the given span such that the left side of
-	// the split is roughly targetSize bytes. The returned key will never be
-	// chosen from the key ranges listed in keys.NoSplitSpans and will always
-	// sort equal to or after minSplitKey.
+	// FindSplitKey finds a key from the given span such that the left side of the
+	// split is roughly targetSize bytes. It only considers MVCC point keys, not
+	// range keys. The returned key will never be chosen from the key ranges
+	// listed in keys.NoSplitSpans and will always sort equal to or after
+	// minSplitKey.
 	//
 	// DO NOT CALL directly (except in wrapper MVCCIterator implementations). Use the
 	// package-level MVCCFindSplitKey instead. For correct operation, the caller
@@ -1111,11 +1112,13 @@ func GetIntent(reader Reader, key roachpb.Key) (*roachpb.Intent, error) {
 	return &intent, nil
 }
 
-// Scan returns up to max key/value objects starting from start (inclusive)
-// and ending at end (non-inclusive). Specify max=0 for unbounded scans. Since
-// this code may use an intentInterleavingIter, the caller should not attempt
-// a single scan to span local and global keys. See the comment in the
-// declaration of intentInterleavingIter for details.
+// Scan returns up to max point key/value objects from start (inclusive) to end
+// (non-inclusive). Specify max=0 for unbounded scans. Since this code may use
+// an intentInterleavingIter, the caller should not attempt a single scan to
+// span local and global keys. See the comment in the declaration of
+// intentInterleavingIter for details.
+//
+// NB: This function ignores MVCC range keys. It should only be used for tests.
 func Scan(reader Reader, start, end roachpb.Key, max int64) ([]MVCCKeyValue, error) {
 	var kvs []MVCCKeyValue
 	err := reader.MVCCIterate(start, end, MVCCKeyAndIntentsIterKind, IterKeyTypePointsOnly,

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5303,8 +5303,9 @@ func CanGCEntireRange(
 }
 
 // MVCCFindSplitKey finds a key from the given span such that the left side of
-// the split is roughly targetSize bytes. The returned key will never be chosen
-// from the key ranges listed in keys.NoSplitSpans.
+// the split is roughly targetSize bytes. It only considers MVCC point keys, not
+// range keys. The returned key will never be chosen from the key ranges listed
+// in keys.NoSplitSpans.
 func MVCCFindSplitKey(
 	_ context.Context, reader Reader, key, endKey roachpb.RKey, targetSize int64,
 ) (roachpb.Key, error) {

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -5712,19 +5712,31 @@ func computeStatsForIterWithVisitors(
 	return ms, nil
 }
 
-// MVCCIsSpanEmpty returns true if there are no MVCC keys whatsoever in the
-// key span in the requested time interval.
+// MVCCIsSpanEmpty returns true if there are no MVCC keys whatsoever in the key
+// span in the requested time interval. If a time interval is given and any
+// inline values are encountered, an error may be returned.
 func MVCCIsSpanEmpty(
 	ctx context.Context, reader Reader, opts MVCCIsSpanEmptyOptions,
 ) (isEmpty bool, _ error) {
-	iter := NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
-		KeyTypes:     IterKeyTypePointsAndRanges,
-		StartKey:     opts.StartKey,
-		EndKey:       opts.EndKey,
-		StartTime:    opts.StartTS,
-		EndTime:      opts.EndTS,
-		IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
-	})
+	// Only use an MVCCIncrementalIterator if time bounds are given, since it will
+	// error on any inline values, and the caller may want to respect them instead.
+	var iter SimpleMVCCIterator
+	if opts.StartTS.IsEmpty() && opts.EndTS.IsEmpty() {
+		iter = reader.NewMVCCIterator(MVCCKeyAndIntentsIterKind, IterOptions{
+			KeyTypes:   IterKeyTypePointsAndRanges,
+			LowerBound: opts.StartKey,
+			UpperBound: opts.EndKey,
+		})
+	} else {
+		iter = NewMVCCIncrementalIterator(reader, MVCCIncrementalIterOptions{
+			KeyTypes:     IterKeyTypePointsAndRanges,
+			StartKey:     opts.StartKey,
+			EndKey:       opts.EndKey,
+			StartTime:    opts.StartTS,
+			EndTime:      opts.EndTS,
+			IntentPolicy: MVCCIncrementalIterIntentPolicyEmit,
+		})
+	}
 	defer iter.Close()
 	iter.SeekGE(MVCCKey{Key: opts.StartKey})
 	valid, err := iter.Valid()

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1273,7 +1273,7 @@ func cmdIsSpanEmpty(e *evalCtx) error {
 	if err != nil {
 		return err
 	}
-	e.results.buf.Print(isEmpty)
+	e.results.buf.Printf("%t\n", isEmpty)
 	return nil
 }
 

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -1,5 +1,6 @@
 
-# Populate some values
+# Populate some values. The inline value is a special case in
+# that it will cause an error if time bounds are specified.
 
 run ok
 with t=A v=abc resolve
@@ -9,6 +10,7 @@ with t=A v=abc resolve
   put  k=b
   put  k=b/123
   put  k=c
+put k=i v=inline
 ----
 >> at end:
 txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
@@ -17,16 +19,26 @@ data: "a/123"/44.000000000,0 -> /BYTES/abc
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
+# Last test case sees inline value but does not error
+# since no time bound specified.
 run ok
 is_span_empty k=a end=+a
+is_span_empty k=a end=z
+is_span_empty k=a end=+a startTs=45
+is_span_empty k=i end=z
 ----
+false
+false
+true
 false
 
-run ok
-is_span_empty k=a end=z
+# Case in which inline value is encountered under time bounds.
+run error
+is_span_empty k=i startTs=0 ts=1
 ----
-false
+error: (*withstack.withStack:) unexpected inline value found: "i"
 
 run ok
 clear_range k=a end=+a
@@ -36,6 +48,7 @@ data: "a/123"/44.000000000,0 -> /BYTES/abc
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
 is_span_empty k=a end=+a
@@ -54,6 +67,7 @@ clear_range k=a end=-a
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
 is_span_empty k=a end=-a
@@ -67,6 +81,7 @@ clear_range k=a end==b
 data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
 clear_range k=a end=+b
@@ -74,15 +89,33 @@ clear_range k=a end=+b
 >> at end:
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
 clear_range k=a end=-b
 ----
 >> at end:
 data: "c"/44.000000000,0 -> /BYTES/abc
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
 clear_range k=a end=-c
 ----
 >> at end:
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
+
+run ok
+is_span_empty k=a end=z
+----
+false
+
+run ok
+clear_range k=i end=+i
+----
+>> at end:
 <no data>
+
+run ok
+is_span_empty k=a end=z
+----
+true


### PR DESCRIPTION
**storage: handle inline values in `MVCCIsSpanEmpty`**

`MVCCIsSpanEmpty` uses an `MVCCIncrementalIterator` to handle time
bounds. However, this will error if it encounters any inline values.
This patch instead uses a regular MVCC iterator when time bounds are not
given (the typical case), which correctly handles inline values.

Release note: None

**batcheval: use `MVCCIsSpanEmpty` in `EndTxn`**

In addition to code deduplication, this also respects MVCC range
tombstones.

Release note: None
  
**kvserver: respect MVCC range keys in `optimizePuts`**

If many point writes are submitted, `optimizePuts()` looks for virgin
keyspace and switches to blind writes to amortize seek costs. This did
not check for MVCC range keys, which could lead to faulty conflict
checks and stats updates.

Release note: None
  
**storage: note functions that ignore MVCC range keys**

Release note: None

Touches #87366.