### PR TITLE
changefeedccl: parallelize event consumption 

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -10,6 +10,8 @@ bulkio.backup.file_size	byte size	128 MiB	target size for individual data files 
 bulkio.backup.read_timeout	duration	5m0s	amount of time after which a read attempt is considered timed out, which causes the backup to fail
 bulkio.backup.read_with_priority_after	duration	1m0s	amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads
 bulkio.stream_ingestion.minimum_flush_interval	duration	5s	the minimum timestamp between flushes; flushes may still occur if internal buffers fill up
+changefeed.event_consumer_worker_queue_size	integer	16	if changefeed.event_consumer_workers is enabled, this setting sets the maxmimum number of eventswhich a worker can buffer
+changefeed.event_consumer_workers	integer	8	the number of workers to use when processing events; 0 or 1 disables
 changefeed.node_throttle_config	string		specifies node level throttling configuration for all changefeeeds
 changefeed.schema_feed.read_with_priority_after	duration	1m0s	retry with high priority if we were not able to read descriptors for too long; 0 disables
 cloudstorage.http.custom_ca	string		custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -16,6 +16,8 @@
 <tr><td><code>bulkio.backup.read_timeout</code></td><td>duration</td><td><code>5m0s</code></td><td>amount of time after which a read attempt is considered timed out, which causes the backup to fail</td></tr>
 <tr><td><code>bulkio.backup.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads</td></tr>
 <tr><td><code>bulkio.stream_ingestion.minimum_flush_interval</code></td><td>duration</td><td><code>5s</code></td><td>the minimum timestamp between flushes; flushes may still occur if internal buffers fill up</td></tr>
+<tr><td><code>changefeed.event_consumer_worker_queue_size</code></td><td>integer</td><td><code>16</code></td><td>if changefeed.event_consumer_workers is enabled, this setting sets the maxmimum number of eventswhich a worker can buffer</td></tr>
+<tr><td><code>changefeed.event_consumer_workers</code></td><td>integer</td><td><code>8</code></td><td>the number of workers to use when processing events; 0 or 1 disables</td></tr>
 <tr><td><code>changefeed.node_throttle_config</code></td><td>string</td><td><code></code></td><td>specifies node level throttling configuration for all changefeeeds</td></tr>
 <tr><td><code>changefeed.schema_feed.read_with_priority_after</code></td><td>duration</td><td><code>1m0s</code></td><td>retry with high priority if we were not able to read descriptors for too long; 0 disables</td></tr>
 <tr><td><code>cloudstorage.http.custom_ca</code></td><td>string</td><td><code></code></td><td>custom root CA (appended to system's default CAs) for verifying certificates when interacting with HTTPS storage</td></tr>

--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -225,6 +225,7 @@ go_test(
         "//pkg/sql/parser",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
+        "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/flowinfra",
+        "//pkg/util",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/errors"
 )
 
@@ -231,3 +232,23 @@ var UseMuxRangeFeed = settings.RegisterBoolSetting(
 	"if true, changefeed uses multiplexing rangefeed RPC",
 	false,
 )
+
+// EventConsumerWorkers specifies the maximum number of workers to use when
+// processing  events.
+var EventConsumerWorkers = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"changefeed.event_consumer_workers",
+	"the number of workers to use when processing events; 0 or 1 disables",
+	int64(util.ConstantWithMetamorphicTestRange("changefeed.consumer_max_workers", 8, 0, 32)),
+	settings.NonNegativeInt,
+).WithPublic()
+
+// EventConsumerWorkerQueueSize specifies the maximum number of events a worker buffer.
+var EventConsumerWorkerQueueSize = settings.RegisterIntSetting(
+	settings.TenantWritable,
+	"changefeed.event_consumer_worker_queue_size",
+	"if changefeed.event_consumer_workers is enabled, this setting sets the maxmimum number of events"+
+		"which a worker can buffer",
+	int64(util.ConstantWithMetamorphicTestRange("changefeed.event_consumer_worker_queue_size", 16, 0, 16)),
+	settings.NonNegativeInt,
+).WithPublic()

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -10,18 +10,24 @@ package changefeedccl
 
 import (
 	"context"
+	"hash"
+	"hash/crc32"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -32,8 +38,16 @@ type eventContext struct {
 	topic string
 }
 
+type eventConsumer interface {
+	ConsumeEvent(ctx context.Context, ev kvevent.Event) error
+	Close() error
+	Flush(ctx context.Context) error
+}
+
+type frontier interface{ Frontier() hlc.Timestamp }
+
 type kvEventToRowConsumer struct {
-	frontier  *span.Frontier
+	frontier
 	encoder   Encoder
 	scratch   bufalloc.ByteAllocator
 	sink      EventSink
@@ -48,11 +62,87 @@ type kvEventToRowConsumer struct {
 	topicNamer           *TopicNamer
 }
 
+func newEventConsumer(
+	ctx context.Context,
+	flowCtx *execinfra.FlowCtx,
+	feed ChangefeedConfig,
+	spanFrontier *span.Frontier,
+	cursor hlc.Timestamp,
+	sink EventSink,
+	details ChangefeedConfig,
+	expr execinfrapb.Expression,
+	knobs TestingKnobs,
+	metrics *Metrics,
+	isSinkless bool,
+) (eventConsumer, EventSink, error) {
+	cfg := flowCtx.Cfg
+	evalCtx := flowCtx.EvalCtx
+
+	makeConsumer := func(s EventSink, frontier frontier) (eventConsumer, error) {
+		var err error
+		encodingOpts, err := feed.Opts.GetEncodingOptions()
+		if err != nil {
+			return nil, err
+		}
+		encoder, err := getEncoder(encodingOpts, feed.Targets)
+		if err != nil {
+			return nil, err
+		}
+
+		var topicNamer *TopicNamer
+		if encodingOpts.TopicInValue {
+			topicNamer, err = MakeTopicNamer(feed.Targets)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return newKVEventToRowConsumer(ctx, cfg, evalCtx, frontier, cursor, s,
+			encoder, details, expr, knobs, topicNamer)
+	}
+
+	// TODO (jayshrivastava) enable parallel consumers for sinkless changefeeds
+	numWorkers := changefeedbase.EventConsumerWorkers.Get(&cfg.Settings.SV)
+	if numWorkers <= 1 || isSinkless {
+		c, err := makeConsumer(sink, spanFrontier)
+		if err != nil {
+			return nil, nil, err
+		}
+		return c, sink, err
+	}
+
+	c := &parallelEventConsumer{
+		g:            ctxgroup.WithContext(ctx),
+		hasher:       makeHasher(),
+		metrics:      metrics,
+		termCh:       make(chan struct{}),
+		flushCh:      make(chan struct{}, 1),
+		doneCh:       make(chan struct{}),
+		numWorkers:   numWorkers,
+		workerCh:     make([]chan kvevent.Event, numWorkers),
+		workerChSize: changefeedbase.EventConsumerWorkerQueueSize.Get(&cfg.Settings.SV),
+		spanFrontier: spanFrontier,
+	}
+	ss := &safeSink{wrapped: sink, beforeFlush: c.Flush}
+	c.makeConsumer = func() (eventConsumer, error) {
+		return makeConsumer(ss, c)
+	}
+
+	if err := c.startWorkers(); err != nil {
+		return nil, nil, err
+	}
+	return c, ss, nil
+}
+
+func makeHasher() hash.Hash32 {
+	return crc32.New(crc32.MakeTable(crc32.IEEE))
+}
+
 func newKVEventToRowConsumer(
 	ctx context.Context,
 	cfg *execinfra.ServerConfig,
 	evalCtx *eval.Context,
-	frontier *span.Frontier,
+	frontier frontier,
 	cursor hlc.Timestamp,
 	sink EventSink,
 	encoder Encoder,
@@ -239,4 +329,235 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 		log.Infof(ctx, `r %s: %s -> %s`, updatedRow.TableName, keyCopy, valueCopy)
 	}
 	return nil
+}
+
+// Close is a noop for the kvEventToRowConsumer because it
+// has no goroutines in flight.
+func (c *kvEventToRowConsumer) Close() error {
+	return nil
+}
+
+// Flush is a noop for the kvEventToRowConsumer because it does not buffer any events.
+func (c *kvEventToRowConsumer) Flush(ctx context.Context) error {
+	return nil
+}
+
+type parallelEventConsumer struct {
+	// g is a group used to manage worker goroutines.
+	g ctxgroup.Group
+
+	// hasher is used to shard keys into worker queues.
+	hasher hash.Hash32
+
+	metrics *Metrics
+
+	// doneCh is used to shut down all workers when
+	// parallelEventConsumer.Close() is called.
+	doneCh chan struct{}
+
+	// makeConsumer creates a single-threaded consumer
+	// which encodes and emits events.
+	makeConsumer func() (eventConsumer, error)
+
+	// numWorkers is the number of worker threads.
+	numWorkers int64
+	// workerCh stores the event buffer for each worker.
+	// It is a fixed size array with length numWorkers.
+	workerCh []chan kvevent.Event
+	// workerChSize is the maximum number of events a worker can buffer.
+	workerChSize int64
+
+	// spanFrontier stores the frontier for the aggregator
+	// that spawned this event consumer.
+	spanFrontier *span.Frontier
+
+	// termErr and termCh are used to save the first error that occurs
+	// in any worker and signal all workers to stop.
+	//
+	// inFlight, waiting, and flushCh are used to flush the sink.
+	//
+	// flushFrontier tracks the local frontier. It is set to the
+	// spanFrontier upon flushing. This guarantees that workers are
+	// not buffering events which have timestamps lower than the frontier.
+	mu struct {
+		syncutil.Mutex
+		termErr error
+
+		inFlight      int
+		waiting       bool
+		flushFrontier hlc.Timestamp
+	}
+	termCh  chan struct{}
+	flushCh chan struct{}
+}
+
+var _ eventConsumer = (*parallelEventConsumer)(nil)
+
+func (c *parallelEventConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Event) error {
+	startTime := timeutil.Now().UnixNano()
+	defer func() {
+		time := timeutil.Now().UnixNano()
+		c.metrics.ParallelConsumerConsumeNanos.Inc(time - startTime)
+	}()
+
+	bucket := c.getBucketForEvent(ev)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.termCh:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.mu.termErr
+	case c.workerCh[bucket] <- ev:
+		c.incInFlight()
+		return nil
+	}
+}
+
+// getBucketForEvent returns a deterministic value  between [0,
+// parallelEventConsumer.numWorkers).
+//
+// This is used to ensure events of the same key get sent to the same worker.
+// Events of the same key are sent to the same worker so per-key ordering is
+// maintained.
+func (c *parallelEventConsumer) getBucketForEvent(ev kvevent.Event) int64 {
+	c.hasher.Reset()
+	c.hasher.Write(ev.KV().Key)
+	return int64(c.hasher.Sum32()) % c.numWorkers
+}
+
+func (c *parallelEventConsumer) startWorkers() error {
+	// Create the consumers in a separate loop so that returning
+	// in case of an error is simple and does not require
+	// shutting down goroutines.
+	consumers := make([]eventConsumer, c.numWorkers)
+	for i := int64(0); i < c.numWorkers; i++ {
+		consumer, err := c.makeConsumer()
+		if err != nil {
+			return err
+		}
+		consumers[i] = consumer
+	}
+
+	for i := int64(0); i < c.numWorkers; i++ {
+		c.workerCh[i] = make(chan kvevent.Event, c.workerChSize)
+
+		// c.g.GoCtx requires a func(context.Context), so
+		// a closure is used to pass the consumer and id to
+		// the worker.
+		id := i
+		consumer := consumers[i]
+		workerClosure := func(ctx2 context.Context) error {
+			return c.workerLoop(ctx2, consumer, id)
+		}
+		c.g.GoCtx(workerClosure)
+	}
+	return nil
+}
+
+func (c *parallelEventConsumer) workerLoop(
+	ctx context.Context, consumer eventConsumer, id int64,
+) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-c.doneCh:
+			return nil
+		case <-c.termCh:
+			c.mu.Lock()
+			defer c.mu.Unlock()
+			return c.mu.termErr
+		case e := <-c.workerCh[id]:
+			if err := consumer.ConsumeEvent(ctx, e); err != nil {
+				return c.setWorkerError(err)
+			}
+			c.decInFlight()
+		}
+	}
+}
+
+func (c *parallelEventConsumer) incInFlight() {
+	c.mu.Lock()
+	c.mu.inFlight++
+	c.mu.Unlock()
+	c.metrics.ParallelConsumerInFlightEvents.Inc(1)
+}
+
+func (c *parallelEventConsumer) decInFlight() {
+	c.mu.Lock()
+	c.mu.inFlight--
+	c.metrics.ParallelConsumerInFlightEvents.Dec(1)
+	notifyFlush := c.mu.waiting && c.mu.inFlight == 0
+	c.mu.Unlock()
+
+	// If someone is waiting on a flush, signal to them
+	// that there are no more events.
+	if notifyFlush {
+		c.flushCh <- struct{}{}
+	}
+}
+
+func (c *parallelEventConsumer) setWorkerError(err error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.mu.termErr == nil {
+		c.mu.termErr = err
+		close(c.termCh)
+	}
+
+	return err
+}
+
+// Flush flushes the consumer by blocking until all events are consumed,
+// or until there is an error.
+func (c *parallelEventConsumer) Flush(ctx context.Context) error {
+	startTime := timeutil.Now().UnixNano()
+	defer func() {
+		time := timeutil.Now().UnixNano()
+		c.metrics.ParallelConsumerFlushNanos.Inc(time - startTime)
+	}()
+
+	needFlush := func() bool {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if c.mu.inFlight > 0 {
+			c.mu.waiting = true
+		}
+		return c.mu.waiting
+	}
+
+	if !needFlush() {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.termCh:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		return c.mu.termErr
+	case <-c.flushCh:
+		c.mu.Lock()
+		c.mu.waiting = false
+		c.mu.flushFrontier = c.spanFrontier.Frontier()
+		c.mu.Unlock()
+		return nil
+	}
+}
+
+func (c *parallelEventConsumer) Frontier() hlc.Timestamp {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.mu.flushFrontier
+}
+
+func (c *parallelEventConsumer) Close() error {
+	// Signal the done channel and wait for all workers to finish.
+	// If an error occurred, at least one worker will return an error, so
+	// it will be returned by c.g.Wait().
+	close(c.doneCh)
+	return c.g.Wait()
 }

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1436,6 +1436,24 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Nprocs Consume Event Nanos",
+				Metrics: []string{
+					"changefeed.nprocs_consume_event_nanos",
+				},
+			},
+			{
+				Title: "Nprocs Flush Nanos",
+				Metrics: []string{
+					"changefeed.nprocs_flush_nanos",
+				},
+			},
+			{
+				Title: "Nprocs In Flight Count",
+				Metrics: []string{
+					"changefeed.nprocs_in_flight_count",
+				},
+			},
+			{
 				Title: "Flushed Bytes",
 				Metrics: []string{
 					"changefeed.flushed_bytes",

--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/util/hlc",
         "//pkg/util/interval",
+        "//pkg/util/syncutil",
     ],
 )
 

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // frontierEntry represents a timestamped span. It is used as the nodes in both
@@ -91,6 +92,7 @@ func (h *frontierHeap) Pop() interface{} {
 
 // Frontier tracks the minimum timestamp of a set of spans.
 type Frontier struct {
+	syncutil.Mutex
 	// tree contains `*frontierEntry` items for the entire current tracked
 	// span set. Any tracked spans that have never been `Forward`ed will have a
 	// zero timestamp. If any entries needed to be split along a tracking
@@ -153,6 +155,12 @@ func (f *Frontier) AddSpansAt(startAt hlc.Timestamp, spans ...roachpb.Span) erro
 
 // Frontier returns the minimum timestamp being tracked.
 func (f *Frontier) Frontier() hlc.Timestamp {
+	f.Lock()
+	defer f.Unlock()
+	return f.frontierLocked()
+}
+
+func (f *Frontier) frontierLocked() hlc.Timestamp {
 	if f.minHeap.Len() == 0 {
 		return hlc.Timestamp{}
 	}
@@ -161,6 +169,8 @@ func (f *Frontier) Frontier() hlc.Timestamp {
 
 // PeekFrontierSpan returns one of the spans at the Frontier.
 func (f *Frontier) PeekFrontierSpan() roachpb.Span {
+	f.Lock()
+	defer f.Unlock()
 	if f.minHeap.Len() == 0 {
 		return roachpb.Span{}
 	}
@@ -176,11 +186,13 @@ func (f *Frontier) PeekFrontierSpan() roachpb.Span {
 // set boundary). Similarly, an entry created by a previous Forward may be
 // partially overlapped and have to be split into two entries.
 func (f *Frontier) Forward(span roachpb.Span, ts hlc.Timestamp) (bool, error) {
-	prevFrontier := f.Frontier()
+	f.Lock()
+	defer f.Unlock()
+	prevFrontier := f.frontierLocked()
 	if err := f.insert(span, ts); err != nil {
 		return false, err
 	}
-	return prevFrontier.Less(f.Frontier()), nil
+	return prevFrontier.Less(f.frontierLocked()), nil
 }
 
 // extendRangeToTheLeft extends the range to the left of the range, provided those
@@ -390,6 +402,8 @@ type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 // Entries invokes the given callback with the current timestamp for each
 // component span in the tracked span set.
 func (f *Frontier) Entries(fn Operation) {
+	f.Lock()
+	defer f.Unlock()
 	f.tree.Do(func(i interval.Interface) bool {
 		spe := i.(*frontierEntry)
 		return fn(spe.span, spe.ts).asBool()
@@ -415,6 +429,8 @@ func (f *Frontier) Entries(fn Operation) {
 // Note: neither [a-b) nor [m, q) will be emitted since they fall outside the spans
 // tracked by this frontier.
 func (f *Frontier) SpanEntries(span roachpb.Span, op Operation) {
+	f.Lock()
+	defer f.Unlock()
 	todoRange := span.AsRange()
 
 	f.tree.DoMatching(func(i interval.Interface) bool {
@@ -440,6 +456,8 @@ func (f *Frontier) SpanEntries(span roachpb.Span, op Operation) {
 
 // String implements Stringer.
 func (f *Frontier) String() string {
+	f.Lock()
+	defer f.Unlock()
 	var buf strings.Builder
 	f.tree.Do(func(i interval.Interface) bool {
 		if buf.Len() != 0 {


### PR DESCRIPTION
Fixes: https://github.com/cockroachdb/cockroach/issues/86902

### span: make span.Frontier thread safe
Make `span.Frontier` thread safe by default.

Release note: None

### changefeedccl: parallelize event consumption
Previously, KV events were consumed and processed by changefeed
aggregator using a single, synchronous Go routine. This PR makes
it possible to run up to `changefeed.event_consumer_workers`
consumers to consume events concurrently. The cluster setting
`changefeed.event_consumer_worker_queue_size` is added to help
control the number of concurrent events we can have in flight.

Specifying `changefeed.event_consumer_workers=0` keeps existing
single threaded implementation.

Release note (enterprise change): This change adds the cluster setting
`changefeed.event_consumer_workers` which allows changefeeds to
process events concurrently.
