### PR TITLE
ui: session details display most recent statement

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionDetails.tsx
@@ -324,7 +324,10 @@ export class SessionDetails extends React.Component<SessionDetailsProps> {
         </>
       );
     }
-    let curStmtInfo = (
+
+    let curStmtInfo = session.last_active_query ? (
+      <SqlBox value={session.last_active_query} size={SqlBoxSize.custom} />
+    ) : (
       <SummaryCard className={cx("details-section")}>
         No Active Statement
       </SummaryCard>


### PR DESCRIPTION
Original that just says: "No Active Statement"
https://www.loom.com/share/0ef3a9abff544684936d2e4f4f7da447

New that shows most recent query.
https://www.loom.com/share/2a8b5139fb80480e85eef7875d5e08db

closes #85252

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: (ui change): On the SQL Activity Session Details page the Most Recent Statement show the last active query instead of No Active Statement.