### PR TITLE
kvevent: Fix bookkeeping related to out of quota handling

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -52,6 +52,8 @@ go_test(
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
+        "//pkg/util",
+        "//pkg/util/contextutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer.go
@@ -79,32 +79,34 @@ func newMemBuffer(
 		metrics:  metrics,
 		sv:       sv,
 	}
+	b.mu.queue = &bufferEventChunkQueue{}
+
+	// Quota pool notifies out of quota events through notifyOutOfQuota
+	quota := &memQuota{acc: acc, notifyOutOfQuota: b.notifyOutOfQuota}
 
 	opts := []quotapool.Option{
 		quotapool.OnSlowAcquisition(slowAcquisitionThreshold, logSlowAcquisition(slowAcquisitionThreshold)),
+		// OnWaitStart invoked once by quota pool when request cannot acquire quota.
 		quotapool.OnWaitStart(func(ctx context.Context, poolName string, r quotapool.Request) {
 			if onWaitStart != nil {
 				onWaitStart(ctx, poolName, r)
 			}
-			b.mu.Lock()
-			b.mu.numBlocked++
-			b.mu.Unlock()
+			b.producerBlocked()
 		}),
+		// Similarly, this function is invoked by quota pool once, when the quota
+		// have been obtained *after* OnWaitStart
 		quotapool.OnWaitFinish(
 			func(ctx context.Context, poolName string, r quotapool.Request, start time.Time) {
 				metrics.BufferPushbackNanos.Inc(timeutil.Since(start).Nanoseconds())
-				b.mu.Lock()
-				b.mu.numBlocked--
-				b.mu.Unlock()
+				b.quotaAcquiredAfterWait()
 			},
 		),
 	}
-	quota := &memQuota{acc: acc, notifyOutOfQuota: b.notifyOutOfQuota}
+
 	b.qp = allocPool{
 		AbstractPool: quotapool.New("changefeed", quota, opts...),
 		metrics:      metrics,
 	}
-	b.mu.queue = &bufferEventChunkQueue{}
 
 	return b
 }
@@ -119,8 +121,7 @@ func (b *blockingBuffer) pop() (e Event, ok bool, err error) {
 	}
 
 	e, ok = b.mu.queue.dequeue()
-
-	if !ok && b.mu.numBlocked > 0 && b.mu.canFlush {
+	if !ok && b.mu.canFlush {
 		// Here, we know that we are blocked, waiting for memory; yet we have nothing queued up
 		// (and thus, no resources that could be released by draining the queue).
 		// This means that all the previously added entries have been read by the consumer,
@@ -151,10 +152,38 @@ func (b *blockingBuffer) notifyOutOfQuota(canFlush bool) {
 	b.mu.canFlush = canFlush
 	b.mu.Unlock()
 
-	select {
-	case b.signalCh <- struct{}{}:
-	default:
+	if canFlush {
+		select {
+		case b.signalCh <- struct{}{}:
+		default:
+		}
 	}
+}
+
+// producerBlocked in invoked by quota pool to notify blocking buffer
+// that producer is blocked.
+func (b *blockingBuffer) producerBlocked() {
+	b.mu.Lock()
+	b.mu.numBlocked++
+	b.mu.Unlock()
+}
+
+// quotaAcquiredAfterWait is invoked by quota pool to notify blocking buffer
+// that quota has been acquired after being blocked.
+// NB: always called after producerBlocked
+func (b *blockingBuffer) quotaAcquiredAfterWait() {
+	b.mu.Lock()
+	if b.mu.numBlocked > 0 {
+		b.mu.numBlocked--
+	} else {
+		logcrash.ReportOrPanic(context.Background(), b.sv,
+			"quotaAcquiredAfterWait called with 0 blocked consumers")
+	}
+	if b.mu.numBlocked == 0 {
+		// Clear out canFlush since we know that producers no longer blocked.
+		b.mu.canFlush = false
+	}
+	b.mu.Unlock()
 }
 
 // Get implements kvevent.Reader interface.
@@ -200,8 +229,10 @@ func (b *blockingBuffer) enqueue(ctx context.Context, e Event) (err error) {
 
 // Add implements Writer interface.
 func (b *blockingBuffer) Add(ctx context.Context, e Event) error {
-	if e.alloc.ap != nil {
-		// Use allocation associated with the event itself.
+	// Immediately enqueue event if it already has allocation,
+	// or if it's a Flush request -- which has no allocations.
+	// Such events happen when we switch from backfill to rangefeed mode.
+	if e.alloc.ap != nil || e.et == TypeFlush {
 		return b.enqueue(ctx, e)
 	}
 
@@ -354,7 +385,6 @@ func (r *memRequest) Acquire(
 		canFlush := quota.allocated == 0 || quota.canAllocateBelow > 0
 		quota.notifyOutOfQuota(canFlush)
 	}
-
 	return fulfilled, tryAgainAfter
 }
 

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -115,6 +115,9 @@ func (e *Event) Type() Type {
 
 // ApproximateSize returns events approximate size in bytes.
 func (e *Event) ApproximateSize() int {
+	if e.et == TypeFlush {
+		return 0
+	}
 	return e.ev.Size() + int(unsafe.Sizeof(Event{}))
 }
 


### PR DESCRIPTION
Fix a bug in blocking buffer bookkeeping which could cause an out of quota event to not be delivered when there is a single consumer.

Fixes #87828

Release note: None
Release justification: bug fix