### PR TITLE
release-22.2: roachtest: make some test failures non release blockers

### DIFF
--- a/pkg/cmd/roachtest/tests/costfuzz.go
+++ b/pkg/cmd/roachtest/tests/costfuzz.go
@@ -26,13 +26,16 @@ import (
 
 func registerCostFuzz(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:            "costfuzz",
-		Owner:           registry.OwnerSQLQueries,
-		Timeout:         time.Hour * 1,
-		RequiresLicense: true,
-		Tags:            nil,
-		Cluster:         r.MakeClusterSpec(1),
-		Run:             runCostFuzz,
+		Name:    "costfuzz",
+		Owner:   registry.OwnerSQLQueries,
+		Timeout: time.Hour * 1,
+		// The tests aren't yet stable, so the issues shouldn't be release
+		// blockers until someone looks at them.
+		NonReleaseBlocker: true,
+		RequiresLicense:   true,
+		Tags:              nil,
+		Cluster:           r.MakeClusterSpec(1),
+		Run:               runCostFuzz,
 	})
 }
 

--- a/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
+++ b/pkg/cmd/roachtest/tests/unoptimized_query_oracle.go
@@ -41,12 +41,15 @@ func registerUnoptimizedQueryOracle(r registry.Registry) {
 	for i := range specs {
 		spec := &specs[i]
 		r.Add(registry.TestSpec{
-			Name:            fmt.Sprintf("unoptimized-query-oracle/disable-rules=%s", spec.disableRules),
-			Owner:           registry.OwnerSQLQueries,
-			Timeout:         time.Hour * 1,
-			RequiresLicense: true,
-			Tags:            nil,
-			Cluster:         r.MakeClusterSpec(1),
+			Name:    fmt.Sprintf("unoptimized-query-oracle/disable-rules=%s", spec.disableRules),
+			Owner:   registry.OwnerSQLQueries,
+			Timeout: time.Hour * 1,
+			// The tests aren't yet stable, so the issues shouldn't be release
+			// blockers until someone looks at them.
+			NonReleaseBlocker: true,
+			RequiresLicense:   true,
+			Tags:              nil,
+			Cluster:           r.MakeClusterSpec(1),
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runQueryComparison(ctx, t, c, &queryComparisonTest{
 					name: "unoptimized-query-oracle",


### PR DESCRIPTION
This commit makes so that we no longer mark issues from the costfuzz nor the unoptimizer query oracle as release blockers on 22.2. These tests are still not fully stable, so we want to reduce the overhead of the triage during the release meeting. However, we do expect to triage it soonish (within a week), so it shouldn't be a problem. Additionally, these tests so far have found only long-standing issues.

Release note: None

Release justification: test-only changes.