### PR TITLE
backupccl: remap IDs without conflicts

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -184,8 +184,8 @@ CREATE TABLE data2.foo (a int);
 
 	doneRestore := make(chan struct{})
 	go func() {
+		defer close(doneRestore)
 		sqlDBRestore.Exec(t, `RESTORE FROM $1`, localFoo)
-		close(doneRestore)
 	}()
 
 	// Check that zones are restored during pre-restore.


### PR DESCRIPTION
Previously when remapping IDs in system tables during restore, we would set the old ID ot the new ID however this could fail if there was an existing ID at the new ID, even though that row was also going to be subsequently remapped in the same statement, as the uniqueness check would fail before the statement had a chance to move that row out of the way.

To avoid this, we now remap all old IDs to new IDs that are offset, then de-offset all the IDs at once, after shuffling them all around. We offset by a fixed 2^31, rather than querying the maximum in-use ID. This has the potential to be not enough if a cluster had more than 2 billion descriptors, however in that case the remapped descriptors would overflow the OID column type anyway. Thus we may as well just use 2B rather than incur extra complexity picking a dynamic offset.

Fixes #88008.

Release note: none (this is new 22.2 functionality).