### PR TITLE
kvserver: drop unnecessary log message during drain

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1540,10 +1540,7 @@ func (s *Store) SetDraining(drain bool, reporter func(int, redact.SafeString), v
 					// manually to a non-draining replica.
 
 					if !needsLeaseTransfer {
-						if verbose || log.V(1) {
-							// This logging is useful to troubleshoot incomplete drains.
-							log.Info(ctx, "not moving out")
-						}
+						// Skip this replica.
 						atomic.AddInt32(&numTransfersAttempted, -1)
 						return
 					}


### PR DESCRIPTION
When draining, we print a message for each replica that we are not going to drain, because, for example, the current store does not own the lease.

This message is confusing because it sounds like the drain is stuck until we can get those leases off, but actually all is good.

This PR drops that message.

Alternatively we can add a few words to make this message sound better, if we think it's needed.

Related to issue #https://github.com/cockroachlabs/support/issues/1799

Release note: None