### PR TITLE
admission: enable elastic cpu control by default

### DIFF
--- a/pkg/util/admission/elastic_cpu_work_queue.go
+++ b/pkg/util/admission/elastic_cpu_work_queue.go
@@ -32,8 +32,8 @@ var (
 	elasticCPUControlEnabled = settings.RegisterBoolSetting(
 		settings.SystemOnly,
 		"admission.elastic_cpu.enabled",
-		"when true, backup work performed by the KV layer is subject to admission control",
-		false,
+		"when true, elastic work (like backups) performed by the KV layer is subject to admission control",
+		true,
 	)
 )
 


### PR DESCRIPTION
We want to have this bake through the 23.1 development cycle.

Release note: None (not being backported)