### PR TITLE
storage: remove Engine interface cruft

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -155,6 +155,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
@@ -1039,7 +1040,7 @@ func TestEvalAddSSTable(t *testing.T) {
 							require.Nil(t, result.Replicated.AddSSTable)
 						} else {
 							require.NotNil(t, result.Replicated.AddSSTable)
-							require.NoError(t, engine.WriteFile("sst", result.Replicated.AddSSTable.Data))
+							require.NoError(t, fs.WriteFile(engine, "sst", result.Replicated.AddSSTable.Data))
 							require.NoError(t, engine.IngestExternalFiles(ctx, []string{"sst"}))
 						}
 
@@ -1443,7 +1444,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, &resp)
 	require.NoError(t, err)
 
-	require.NoError(t, engine.WriteFile("sst", sst))
+	require.NoError(t, fs.WriteFile(engine, "sst", sst))
 	require.NoError(t, engine.IngestExternalFiles(ctx, []string{"sst"}))
 
 	statsEvaled := statsBefore

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -3874,7 +3875,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		var mismatchedSstsIdx []int
 		// Iterate over all the tested SSTs and check that they're byte-by-byte equal.
 		for i := range sstNamesSubset {
-			actualSST, err := receivingEng.ReadFile(sstNamesSubset[i])
+			actualSST, err := fs.ReadFile(receivingEng, sstNamesSubset[i])
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -12,7 +12,6 @@ package kvserver
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"time"
 	"unsafe"
@@ -483,64 +482,47 @@ func addSSTablePreApply(
 	eng.PreIngestDelay(ctx)
 	tEndDelayed = timeutil.Now()
 
-	copied := false
-	if eng.InMem() {
-		// Ingest a copy of the SST. Otherwise, Pebble will claim and mutate the
-		// sst.Data byte slice, which will also be used later by e.g. rangefeeds.
-		data := make([]byte, len(sst.Data))
-		copy(data, sst.Data)
-		path = fmt.Sprintf("%x", checksum)
-		if err := eng.WriteFile(path, data); err != nil {
-			log.Fatalf(ctx, "unable to write sideloaded SSTable at term %d, index %d: %s", term, index, err)
-		}
-	} else {
-		ingestPath := path + ".ingested"
+	ingestPath := path + ".ingested"
 
-		// The SST may already be on disk, thanks to the sideloading
-		// mechanism.  If so we can try to add that file directly, via a new
-		// hardlink if the filesystem supports it, rather than writing a new
-		// copy of it.  We cannot pass it the path in the sideload store as
-		// the engine deletes the passed path on success.
-		if linkErr := eng.Link(path, ingestPath); linkErr == nil {
-			ingestErr := eng.IngestExternalFiles(ctx, []string{ingestPath})
-			if ingestErr != nil {
-				log.Fatalf(ctx, "while ingesting %s: %v", ingestPath, ingestErr)
-			}
-			// Adding without modification succeeded, no copy necessary.
-			log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
-			return false
+	// The SST may already be on disk, thanks to the sideloading mechanism.  If
+	// so we can try to add that file directly, via a new hardlink if the
+	// filesystem supports it, rather than writing a new copy of it.  We cannot
+	// pass it the path in the sideload store as the engine deletes the passed
+	// path on success.
+	if linkErr := eng.Link(path, ingestPath); linkErr == nil {
+		ingestErr := eng.IngestExternalFiles(ctx, []string{ingestPath})
+		if ingestErr != nil {
+			log.Fatalf(ctx, "while ingesting %s: %v", ingestPath, ingestErr)
 		}
-
-		path = ingestPath
-
-		log.Eventf(ctx, "copying SSTable for ingestion at index %d, term %d: %s", index, term, path)
-
-		// TODO(tschottdorf): remove this once sideloaded storage guarantees its
-		// existence.
-		if err := eng.MkdirAll(filepath.Dir(path)); err != nil {
-			panic(err)
-		}
-		if _, err := eng.Stat(path); err == nil {
-			// The file we want to ingest exists. This can happen since the
-			// ingestion may apply twice (we ingest before we mark the Raft
-			// command as committed). Just unlink the file (the storage engine
-			// created a hard link); after that we're free to write it again.
-			if err := eng.Remove(path); err != nil {
-				log.Fatalf(ctx, "while removing existing file during ingestion of %s: %+v", path, err)
-			}
-		}
-
-		if err := writeFileSyncing(ctx, path, sst.Data, eng, 0600, st, limiter); err != nil {
-			log.Fatalf(ctx, "while ingesting %s: %+v", path, err)
-		}
-		copied = true
+		// Adding without modification succeeded, no copy necessary.
+		log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
+		return false /* copied */
 	}
 
-	if err := eng.IngestExternalFiles(ctx, []string{path}); err != nil {
-		log.Fatalf(ctx, "while ingesting %s: %+v", path, err)
+	log.Eventf(ctx, "copying SSTable for ingestion at index %d, term %d: %s", index, term, ingestPath)
+
+	// TODO(tschottdorf): remove this once sideloaded storage guarantees its
+	// existence.
+	if err := eng.MkdirAll(filepath.Dir(ingestPath)); err != nil {
+		panic(err)
 	}
-	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, path)
-	return copied
+	if _, err := eng.Stat(ingestPath); err == nil {
+		// The file we want to ingest exists. This can happen since the
+		// ingestion may apply twice (we ingest before we mark the Raft
+		// command as committed). Just unlink the file (the storage engine
+		// created a hard link); after that we're free to write it again.
+		if err := eng.Remove(ingestPath); err != nil {
+			log.Fatalf(ctx, "while removing existing file during ingestion of %s: %+v", ingestPath, err)
+		}
+	}
+	if err := writeFileSyncing(ctx, ingestPath, sst.Data, eng, 0600, st, limiter); err != nil {
+		log.Fatalf(ctx, "while ingesting %s: %+v", ingestPath, err)
+	}
+	if err := eng.IngestExternalFiles(ctx, []string{ingestPath}); err != nil {
+		log.Fatalf(ctx, "while ingesting %s: %+v", ingestPath, err)
+	}
+	log.Eventf(ctx, "ingested SSTable at index %d, term %d: %s", index, term, ingestPath)
+	return true /* copied */
 }
 
 func (r *Replica) handleReadWriteLocalEvalResult(ctx context.Context, lResult result.LocalResult) {

--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -156,7 +157,7 @@ func (ss *diskSideloadStorage) Put(ctx context.Context, index, term uint64, cont
 // Get implements SideloadStorage.
 func (ss *diskSideloadStorage) Get(ctx context.Context, index, term uint64) ([]byte, error) {
 	filename := ss.filename(ctx, index, term)
-	b, err := ss.eng.ReadFile(filename)
+	b, err := fs.ReadFile(ss.eng, filename)
 	if oserror.IsNotExist(err) {
 		return nil, errSideloadedFileNotFound
 	}

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -297,7 +298,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	var actualSSTs [][]byte
 	fileNames := msstw.scratch.SSTs()
 	for _, file := range fileNames {
-		sst, err := eng.ReadFile(file)
+		sst, err := fs.ReadFile(eng, file)
 		require.NoError(t, err)
 		actualSSTs = append(actualSSTs, sst)
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -914,8 +914,6 @@ type Engine interface {
 	RegisterFlushCompletedCallback(cb func())
 	// Filesystem functionality.
 	fs.FS
-	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
-	ReadFile(filename string) ([]byte, error)
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -916,8 +916,6 @@ type Engine interface {
 	fs.FS
 	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
 	ReadFile(filename string) ([]byte, error)
-	// WriteFile writes data to a file in this RocksDB's env.
-	WriteFile(filename string, data []byte) error
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -905,13 +905,6 @@ type Engine interface {
 	// CompactRange ensures that the specified range of key value pairs is
 	// optimized for space efficiency.
 	CompactRange(start, end roachpb.Key) error
-	// InMem returns true if the receiver is an in-memory engine and false
-	// otherwise.
-	//
-	// TODO(peter): This is a bit of a wart in the interface. It is used by
-	// addSSTablePreApply to select alternate code paths, but really there should
-	// be a unified code path there.
-	InMem() bool
 	// RegisterFlushCompletedCallback registers a callback that will be run for
 	// every successful flush. Only one callback can be registered at a time, so
 	// registering again replaces the previous callback. The callback must

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1227,7 +1227,6 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 	if err := db.Remove("/non/existent/file"); !oserror.IsNotExist(err) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 	}
-
 	// Verify RemoveAll returns nil if path does not exist.
 	if err := db.RemoveAll("/non/existent/file"); err != nil {
 		t.Fatalf("expected nil, but got %v (%T)", err, err)
@@ -1250,7 +1249,7 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 		}
 	}
 
-	if b, err := db.ReadFile(fname); err != nil {
+	if b, err := fs.ReadFile(db, fname); err != nil {
 		t.Errorf("unable to read file with filename %s, got err %v", fname, err)
 	} else if string(b) != data {
 		t.Errorf("expected content in %s is '%s', got '%s'", fname, data, string(b))
@@ -1261,7 +1260,7 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 	}
 
 	// Verify ReadFile returns os.ErrNotExist if reading an already deleted file.
-	if _, err := db.ReadFile(fname); !oserror.IsNotExist(err) {
+	if _, err := fs.ReadFile(db, fname); !oserror.IsNotExist(err) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 	}
 

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -82,3 +82,13 @@ func WriteFile(fs FS, filename string, data []byte) error {
 	}
 	return err
 }
+
+// ReadFile reads data from a file named by filename.
+func ReadFile(fs FS, filename string) ([]byte, error) {
+	file, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1347,7 +1348,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		if err := sst.Finish(); err != nil {
 			t.Fatal(err)
 		}
-		if err := db2.WriteFile(`ingest`, memFile.Data()); err != nil {
+		if err := fs.WriteFile(db2, `ingest`, memFile.Data()); err != nil {
 			t.Fatal(err)
 		}
 		if err := db2.IngestExternalFiles(ctx, []string{`ingest`}); err != nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1708,18 +1708,6 @@ func (p *Pebble) ReadFile(filename string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
-// WriteFile writes data to a file in this RocksDB's env.
-func (p *Pebble) WriteFile(filename string, data []byte) error {
-	file, err := p.fs.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, bytes.NewReader(data))
-	return err
-}
-
 // Remove implements the FS interface.
 func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1697,17 +1697,6 @@ func (p *Pebble) RegisterFlushCompletedCallback(cb func()) {
 	p.mu.Unlock()
 }
 
-// ReadFile implements the Engine interface.
-func (p *Pebble) ReadFile(filename string) ([]byte, error) {
-	file, err := p.fs.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return io.ReadAll(file)
-}
-
 // Remove implements the FS interface.
 func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1690,12 +1690,6 @@ func (p *Pebble) CompactRange(start, end roachpb.Key) error {
 	return p.db.Compact(bufStart, bufEnd, true /* parallel */)
 }
 
-// InMem returns true if the receiver is an in-memory engine and false
-// otherwise.
-func (p *Pebble) InMem() bool {
-	return p.path == ""
-}
-
 // RegisterFlushCompletedCallback implements the Engine interface.
 func (p *Pebble) RegisterFlushCompletedCallback(cb func()) {
 	p.mu.Lock()


### PR DESCRIPTION
Remove a few methods from the `Engine` interface type that don't belong.

**storage: remove Engine.InMem**

Remove storage.Engine's InMem method. This method was a hole in the
abstraction. Clients should not need to distinguish between on-disk and
in-memory engines.

**storage: remove Engine.WriteFile**

Remove the WriteFile method on the Engine interface, converting call sites to
use the storage/fs.WriteFile function. The Engine itself should only expose
primitives, and higher-level utilities like a WriteFile routine can be
implemented in terms of those primitives.

**storage/fs: move Engine.ReadFile to fs.ReadFile**

Move the Engine's ReadFile method off of the Engine interface and into a
storage/fs helper function written it terms of existing Engine methods.