### PR TITLE
changefeedccl: Improve JSON encoder performance 

### DIFF
--- a/pkg/ccl/changefeedccl/bench_test.go
+++ b/pkg/ccl/changefeedccl/bench_test.go
@@ -210,7 +210,7 @@ func createBenchmarkChangefeed(
 	}
 	initialHighWater := hlc.Timestamp{}
 	encodingOpts := changefeedbase.EncodingOptions{Format: changefeedbase.OptFormatJSON, Envelope: changefeedbase.OptEnvelopeRow}
-	encoder, err := makeJSONEncoder(encodingOpts, AllTargets(details))
+	encoder, err := makeJSONEncoder(encodingOpts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdcevent/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "event.go",
         "projection.go",
         "rowfetcher_cache.go",
+        "version_cache.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent",
     visibility = ["//visibility:public"],

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -577,4 +578,58 @@ func MakeRowFromTuple(evalCtx *eval.Context, t *tree.DTuple) Row {
 		}
 	}
 	return Row(r)
+}
+
+// TestingMakeEventRowFromEncDatums creates event row from specified  enc datum row.
+// encRow assumed to contain *already decoded* datums.
+// The first numKeyCols are assumed to be primary key columns.
+// Columns names are generated based on the datum types.
+func TestingMakeEventRowFromEncDatums(
+	encRow rowenc.EncDatumRow, colTypes []*types.T, numKeyCols int, deleted bool,
+) Row {
+	if len(encRow) != len(colTypes) {
+		panic("unexpected length mismatch")
+	}
+	intRange := func(start, end int) (res []int) {
+		for i := 0; i < end; i++ {
+			res = append(res, i)
+		}
+		return res
+	}
+	ed := &EventDescriptor{
+		Metadata: Metadata{
+			TableID:    42,
+			TableName:  "randtbl",
+			FamilyName: "primary",
+		},
+		cols: func() (cols []ResultColumn) {
+			names := make(map[string]int, len(encRow))
+			for i, typ := range colTypes {
+				colName := fmt.Sprintf("col_%s", typ.String())
+				names[colName]++
+				if names[colName] > 1 {
+					colName += fmt.Sprintf("_%d", names[colName]-1)
+				}
+				cols = append(cols, ResultColumn{
+					ResultColumn: colinfo.ResultColumn{
+						Name:    colName,
+						Typ:     typ,
+						TableID: 42,
+					},
+					ord: i,
+				})
+			}
+			return cols
+		}(),
+		keyCols:   intRange(0, numKeyCols),
+		valueCols: intRange(0, len(encRow)),
+	}
+
+	var alloc tree.DatumAlloc
+	return Row{
+		EventDescriptor: ed,
+		datums:          encRow,
+		deleted:         deleted,
+		alloc:           &alloc,
+	}
 }

--- a/pkg/ccl/changefeedccl/cdcevent/event.go
+++ b/pkg/ccl/changefeedccl/cdcevent/event.go
@@ -349,7 +349,7 @@ func getEventDescriptorCached(
 	schemaTS hlc.Timestamp,
 	cache *cache.UnorderedCache,
 ) (*EventDescriptor, error) {
-	idVer := idVersion{id: desc.GetID(), version: desc.GetVersion(), family: family.ID}
+	idVer := CacheKey{ID: desc.GetID(), Version: desc.GetVersion(), FamilyID: family.ID}
 
 	if v, ok := cache.Get(idVer); ok {
 		ed := v.(*EventDescriptor)
@@ -385,7 +385,7 @@ func NewEventDecoder(
 		return nil, err
 	}
 
-	eventDescriptorCache := cache.NewUnorderedCache(defaultCacheConfig)
+	eventDescriptorCache := cache.NewUnorderedCache(DefaultCacheConfig)
 	getEventDescriptor := func(
 		desc catalog.TableDescriptor,
 		family *descpb.ColumnFamilyDescriptor,

--- a/pkg/ccl/changefeedccl/cdcevent/version_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/version_cache.go
@@ -1,0 +1,42 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Licensed as a CockroachDB Enterprise file under the Cockroach Community
+// License (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+//     https://github.com/cockroachdb/cockroach/blob/master/licenses/CCL.txt
+
+package cdcevent
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
+)
+
+// DefaultCacheConfig is the default configuration for unordered cache.
+var DefaultCacheConfig = cache.Config{
+	Policy: cache.CacheFIFO,
+	// TODO: If we find ourselves thrashing here in changefeeds on many tables,
+	// we can improve performance by eagerly evicting versions using Resolved notifications.
+	// A old Version with a timestamp entirely before a notification can be safely evicted.
+	ShouldEvict: func(size int, _ interface{}, _ interface{}) bool { return size > 1024 },
+}
+
+// CacheKey is the key for the event caches.
+type CacheKey struct {
+	ID       descpb.ID
+	Version  descpb.DescriptorVersion
+	FamilyID descpb.FamilyID
+}
+
+// GetCachedOrCreate returns cached object, or creates and caches new one.
+func GetCachedOrCreate(
+	k CacheKey, c *cache.UnorderedCache, creator func() interface{},
+) interface{} {
+	if v, ok := c.Get(k); ok {
+		return v
+	}
+	v := creator()
+	c.Add(k, v)
+	return v
+}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -504,7 +504,8 @@ func createChangefeedJobRecord(
 	//   the default error to avoid claiming the user set an option they didn't
 	//   explicitly set. Fortunately we know the only way to cause this is to
 	//   set envelope.
-	if isCloudStorageSink(parsedSink) || isWebhookSink(parsedSink) {
+	if (isCloudStorageSink(parsedSink) || isWebhookSink(parsedSink)) &&
+		encodingOpts.Envelope != changefeedbase.OptEnvelopeBare {
 		if err = opts.ForceKeyInValue(); err != nil {
 			return nil, errors.Errorf(`this sink is incompatible with envelope=%s`, encodingOpts.Envelope)
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1103,7 +1103,7 @@ func TestChangefeedProjectionDelete(t *testing.T) {
 			`foo: [0]->{}`,
 		})
 	}
-	cdcTest(t, testFn)
+	cdcTest(t, testFn, feedTestForceSink("cloudstorage"))
 }
 
 // If we drop columns which are not targeted by the changefeed, it should not backfill.
@@ -2529,9 +2529,7 @@ func TestChangefeedBareJSON(t *testing.T) {
 		sqlDB.Exec(t, `INSERT INTO foo values (0, 'dog')`)
 		foo := feed(t, f, `CREATE CHANGEFEED WITH schema_change_policy=stop AS SELECT * FROM foo`)
 		defer closeFeed(t, foo)
-		assertPayloads(t, foo, []string{
-			`foo: [0]->{"a": 0, "b": "dog"}`,
-		})
+		assertPayloads(t, foo, []string{`foo: [0]->{"a": 0, "b": "dog"}`})
 	}
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 	cdcTest(t, testFn, feedTestForceSink("enterprise"))

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -46,7 +46,7 @@ func getEncoder(
 ) (Encoder, error) {
 	switch opts.Format {
 	case changefeedbase.OptFormatJSON:
-		return makeJSONEncoder(opts, targets)
+		return makeJSONEncoder(opts)
 	case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
 		return newConfluentAvroEncoder(opts, targets)
 	case changefeedbase.OptFormatCSV:

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -405,7 +405,7 @@ func makeCloudStorageSink(
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
-	if !encodingOpts.KeyInValue {
+	if encodingOpts.Envelope != changefeedbase.OptEnvelopeBare && !encodingOpts.KeyInValue {
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -162,7 +162,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// NB: compression added in single-node subtest.
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e, err := makeJSONEncoder(opts, changefeedbase.Targets{})
+	e, err := makeJSONEncoder(opts)
 	require.NoError(t, err)
 
 	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)

--- a/pkg/ccl/changefeedccl/sink_webhook.go
+++ b/pkg/ccl/changefeedccl/sink_webhook.go
@@ -295,7 +295,7 @@ func makeWebhookSink(
 			changefeedbase.OptEnvelope, encodingOpts.Envelope)
 	}
 
-	if !encodingOpts.KeyInValue {
+	if encodingOpts.Envelope != changefeedbase.OptEnvelopeBare && !encodingOpts.KeyInValue {
 		return nil, errors.Errorf(`this sink requires the WITH %s option`, changefeedbase.OptKeyInValue)
 	}
 

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -122,7 +122,7 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	opts, err := getGenericWebhookSinkOptions().GetEncodingOptions()
 	require.NoError(t, err)
-	enc, err := makeJSONEncoder(opts, changefeedbase.Targets{})
+	enc, err := makeJSONEncoder(opts)
 	require.NoError(t, err)
 
 	// test a resolved timestamp entry

--- a/pkg/util/json/BUILD.bazel
+++ b/pkg/util/json/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/inverted",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/util",
         "//pkg/util/encoding",
         "//pkg/util/syncutil",
         "//pkg/util/unique",


### PR DESCRIPTION
Rewrite JSON encoder to improve its performance.

Prior to this change JSON encoder was very inefficient.
This inefficiency had multiple underlying reasons:
  * New Go map objects were constructed for each event.
  * Underlying json conversion functions had inefficiencies
    (tracked in https://github.com/cockroachdb/cockroach/pull/87968)
  * Conversion of Go maps to JSON incurs the cost
    of sorting the keys -- for each row. Sorting,
    particularly when rows are wide, has significant cost.
  * Each conversion to JSON allocated new array builder
    (to encode keys) and new object builder; that too has cost.
  * Underlying code structure, while attempting to reuse
    code when constructing different "envelope" formats,
    cause the code to be more inefficient.

This PR addresses all of the above.  In particular, since
a schema version for the table is guaranteed to have
the same set of primary key and value columns, we can construct
JSON builders once.  The expensive sort operation can be performed
once per version; builders can be memoized and cached.

The performance impact is significant:
  * Key encoding speed up is 5-30%, depending on the number of primary
    keys.
  * Value encoding 30% - 60% faster (slowest being "wrapped" envelope
    with diff -- which effectively encodes 2x values)
  * Byte allocations per row reduces by over 70%, with the number
    of allocations reduced similarly.

Release note (enterprise change): Changefeed JSON encoder
performance improved by 50%.
Release justification: performance improvement