### PR TITLE
xform: fix wrong results from locality-optimized scan of inverted index

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3079,3 +3079,69 @@ vectorized: true
             │
             └── • scan buffer
                   label: buffer 1
+
+# Regression test for #88047
+statement ok
+CREATE TABLE t88047 (
+  json_col JSONB NULL,
+  notes STRING,
+  region public.crdb_internal_region NOT NULL AS
+  (CASE WHEN ((json_col->'loc':::STRING)->>'state':::STRING) IN ('AZ':::STRING, 'CA':::STRING, 'NV':::STRING) THEN 'ap-southeast-2':::public.crdb_internal_region
+        WHEN ((json_col->'loc':::STRING)->>'state':::STRING) IN ('MI':::STRING, 'MN':::STRING, 'MO':::STRING) THEN 'ca-central-1':::public.crdb_internal_region
+        WHEN ((json_col->'loc':::STRING)->>'state':::STRING) IN ('PA':::STRING, 'VT':::STRING, 'NY':::STRING) THEN 'us-east-1':::public.crdb_internal_region END) STORED,
+  INVERTED INDEX t88047_inv_idx (json_col)
+) LOCALITY REGIONAL BY ROW AS region
+
+statement ok
+INSERT INTO t88047(json_col, notes)
+  VALUES ('{"loc": {"state": "PA"}}':::JSONB, 'Liberty Bell'),
+         ('{"loc": {"state": "PA"}}':::JSONB, 'Rocky Balboa'),
+         ('{"loc": {"state": "VT"}}':::JSONB, 'Maple Syrup'),
+         ('{"loc": {"state": "NY"}}':::JSONB, 'Big Apple'),
+         ('{"loc": {"state": "NY"}}':::JSONB, 'Statue of Liberty'),
+         ('{"loc": {"state": "CA"}}':::JSONB, 'Golden Gate Bridge'),
+         ('{"loc": {"state": "CA"}}':::JSONB, 'Yosemite'),
+         ('{"loc": {"state": "MI"}}':::JSONB, 'Go Blue!');
+
+# Expect to pick locality-optimized search from the inverted RBR index.
+query T
+EXPLAIN(OPT)
+  SELECT * FROM t88047
+WHERE json_col->'loc' @> '{"state":"NY"}'
+  LIMIT 2
+----
+index-join t88047
+ └── locality-optimized-search
+      ├── scan t88047@t88047_inv_idx
+      │    ├── constraint: /11: [/'ap-southeast-2' - /'ap-southeast-2']
+      │    ├── inverted constraint: /15/12
+      │    │    └── spans: ["7loc\x00\x02state\x00\x01\x12NY\x00\x01", "7loc\x00\x02state\x00\x01\x12NY\x00\x01"]
+      │    └── limit: 2
+      └── scan t88047@t88047_inv_idx
+           ├── constraint: /18
+           │    ├── [/'ca-central-1' - /'ca-central-1']
+           │    └── [/'us-east-1' - /'us-east-1']
+           ├── inverted constraint: /22/19
+           │    └── spans: ["7loc\x00\x02state\x00\x01\x12NY\x00\x01", "7loc\x00\x02state\x00\x01\x12NY\x00\x01"]
+           └── limit: 2
+
+# Expect to see only rows from "state":"NY".
+query TTT
+SELECT * FROM t88047
+WHERE json_col->'loc' @> '{"state":"NY"}'
+  LIMIT 2
+----
+{"loc": {"state": "NY"}}  Big Apple          us-east-1
+{"loc": {"state": "NY"}}  Statue of Liberty  us-east-1
+
+statement ok
+DROP INDEX t88047_inv_idx
+
+# Expect to see only rows from "state":"NY" after inverted index is dropped.
+query TTT
+SELECT * FROM t88047
+WHERE json_col->'loc' @> '{"state":"NY"}'
+  LIMIT 2
+----
+{"loc": {"state": "NY"}}  Big Apple          us-east-1
+{"loc": {"state": "NY"}}  Statue of Liberty  us-east-1

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -11,6 +11,7 @@
 package xform
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -211,6 +212,10 @@ func (c *CustomFuncs) GenerateLocalityOptimizedScan(
 	localConstraint.Columns = localConstraint.Columns.RemapColumns(scanPrivate.Table, localScanPrivate.Table)
 	localScanPrivate.SetConstraint(c.e.evalCtx, &localConstraint)
 	localScanPrivate.HardLimit = scanPrivate.HardLimit
+	if scanPrivate.InvertedConstraint != nil {
+		localScanPrivate.InvertedConstraint = make(inverted.Spans, len(scanPrivate.InvertedConstraint))
+		copy(localScanPrivate.InvertedConstraint, scanPrivate.InvertedConstraint)
+	}
 	localScan := c.e.f.ConstructScan(localScanPrivate)
 	if scanPrivate.HardLimit != 0 {
 		// If the local scan could never reach the hard limit, we will always have
@@ -239,6 +244,10 @@ func (c *CustomFuncs) GenerateLocalityOptimizedScan(
 	remoteConstraint.Columns = remoteConstraint.Columns.RemapColumns(scanPrivate.Table, remoteScanPrivate.Table)
 	remoteScanPrivate.SetConstraint(c.e.evalCtx, &remoteConstraint)
 	remoteScanPrivate.HardLimit = scanPrivate.HardLimit
+	if scanPrivate.InvertedConstraint != nil {
+		remoteScanPrivate.InvertedConstraint = make(inverted.Spans, len(scanPrivate.InvertedConstraint))
+		copy(remoteScanPrivate.InvertedConstraint, scanPrivate.InvertedConstraint)
+	}
 	remoteScan := c.e.f.ConstructScan(remoteScanPrivate)
 
 	// Add the LocalityOptimizedSearchExpr to the same group as the original scan.


### PR DESCRIPTION
Fixes #88047

Previously, a query which scans from a table with REGIONAL BY ROW
partitioning utilizing an inverted index with an inverted constraint
and locality-optimized search fails to apply the inverted constraint
and may return wrong results.

To address this, when locality-optimized search is built from an
inverted constrained scan, the inverted constraint is copied into the
local and remote scans of the locality-optimized search.

Release note (bug fix): This patch fixes incorrect results from queries
which utilize locality-optimized search on the inverted index of a table
with REGIONAL BY ROW partitioning.