### PR TITLE
sql: execute subqueries only once for CTAS

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -765,6 +765,12 @@ type PlanningCtx struct {
 	// mode.
 	planDepth int
 
+	// doNotRunSubqueries, when set, indicates that the subqueries should not be
+	// run before running the main query. This is needed when evaluating CREATE
+	// TABLE AS statements in order to not run the same subqueries twice (the
+	// backfill of CTAS will execute them).
+	doNotRunSubqueries bool
+
 	// If set, the DistSQL diagram is **not** generated and not added to the
 	// trace (when the tracing is enabled). We generally want to include it, but
 	// on the main query path the overhead becomes too large while we also have

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -1313,7 +1313,7 @@ func (dsp *DistSQLPlanner) PlanAndRunAll(
 	recv *DistSQLReceiver,
 	evalCtxFactory func() *extendedEvalContext,
 ) error {
-	if len(planner.curPlan.subqueryPlans) != 0 {
+	if len(planner.curPlan.subqueryPlans) != 0 && !planCtx.doNotRunSubqueries {
 		// Create a separate memory account for the results of the subqueries.
 		// Note that we intentionally defer the closure of the account until we
 		// return from this method (after the main query is executed).

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1016,6 +1016,8 @@ func (e *distSQLSpecExecFactory) ConstructCreateTable(
 func (e *distSQLSpecExecFactory) ConstructCreateTableAs(
 	input exec.Node, schema cat.Schema, ct *tree.CreateTable,
 ) (exec.Node, error) {
+	// TODO(yuzefovich): make sure this doesn't execute the subqueries twice
+	// when implemented (see #78457).
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: create table")
 }
 

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -986,3 +986,35 @@ tbl  CREATE TABLE public.tbl (
      CONSTRAINT tbl_pkey PRIMARY KEY (i ASC),
      FAMILY f1 (i, j)
 )
+
+# Regression tests for executing the subqueries of the CTAS source twice
+# (#78457).
+statement ok
+CREATE TABLE t78457_1 (c INT);
+CREATE TABLE t78457_2 AS WITH t AS (INSERT INTO t78457_1 VALUES (1) RETURNING 1) SELECT * FROM t78457_1;
+
+# We need a retry since the backfill process is asynchronous.
+query I retry
+SELECT * FROM t78457_1
+----
+1
+
+query I
+SELECT * FROM t78457_2
+----
+1
+
+statement ok
+CREATE TABLE t78457_3 (c INT PRIMARY KEY);
+CREATE TABLE t78457_4 AS WITH t AS (INSERT INTO t78457_3 VALUES (1) RETURNING 1) SELECT * FROM t78457_3;
+
+# We need a retry since the backfill process is asynchronous.
+query I retry
+SELECT * FROM t78457_3
+----
+1
+
+query I
+SELECT * FROM t78457_4
+----
+1

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -305,6 +305,14 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 		}
 		defer localPlanner.curPlan.close(ctx)
 
+		// There should be no postqueries.
+		if plan := localPlanner.curPlan; len(plan.checkPlans) != 0 || len(plan.cascades) != 0 {
+			return errors.AssertionFailedf(
+				"unexpectedly CTAS has %d checks and %d cascades (none expected)",
+				len(plan.checkPlans), len(plan.cascades),
+			)
+		}
+
 		res := roachpb.BulkOpSummary{}
 		rw := NewCallbackResultWriter(func(ctx context.Context, row tree.Datums) error {
 			// TODO(adityamaru): Use the BulkOpSummary for either telemetry or to


### PR DESCRIPTION
Previously if CREATE TABLE AS statement had any subqueries in the "source" query, those subqueries would get executed twice (once when evaluating the statement and then the second time in the asynchronous backfill schema change). If those subqueries included any mutations, this would lead to executing the write operations twice (possibly leading to errors if duplicate write violated constraints). This is now fixed by skipping the subqueries when running the statement.

Fixes: #78457.

Release note (bug fix): Previously, CockroachDB would evaluate subqueries twice if they were part of the "source" query of the `CREATE TABLE ... AS <source>` statement. If those subqueries included any write operations, they would be performed twice either leading to duplicate writes or errors due to constraint violations. This is now fixed.