### PR TITLE
sql: add missing obj_description case

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -537,6 +537,7 @@ go_test(
         "comment_on_constraint_test.go",
         "comment_on_database_test.go",
         "comment_on_index_test.go",
+        "comment_on_schema_test.go",
         "comment_on_table_test.go",
         "conn_executor_internal_test.go",
         "conn_executor_savepoints_test.go",

--- a/pkg/sql/comment_on_column_test.go
+++ b/pkg/sql/comment_on_column_test.go
@@ -181,7 +181,7 @@ func TestCommentOnColumnWhenDropColumn(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Fatal("comment remain")
+		t.Fatal("comment remaining in system.comments despite drop")
 	}
 }
 

--- a/pkg/sql/comment_on_database_test.go
+++ b/pkg/sql/comment_on_database_test.go
@@ -104,6 +104,6 @@ func TestCommentOnDatabaseWhenDrop(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Fatal("dropped comment remain comment")
+		t.Fatal("comment remaining in system.comments despite drop")
 	}
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2176,6 +2176,8 @@ func getCatalogOidForComments(catalogName string) (id int, ok bool) {
 		return catconstants.PgCatalogDescriptionTableID, true
 	case "pg_constraint":
 		return catconstants.PgCatalogConstraintTableID, true
+	case "pg_namespace":
+		return catconstants.PgCatalogNamespaceTableID, true
 	default:
 		// We currently only support comments on pg_class objects
 		// (columns, tables) in this context.


### PR DESCRIPTION
Needed for #88061.

Found bug with the following query:

```sql
COMMENT ON SCHEMA public IS 'hello';
SELECT obj_description(oid, 'pg_namespace')
FROM pg_namespace WHERE nspname = 'public';
```

Release note (sql change): The PostgreSQL compatibility function `obj_description` now supports retrieving comments on schemas.

Fixes #95322.