### PR TITLE
kv,sql: simplify the Txn API by removing 2 cleanup functions

### DIFF
--- a/pkg/kv/db.go
+++ b/pkg/kv/db.go
@@ -951,7 +951,9 @@ func runTxn(ctx context.Context, txn *Txn, retryable func(context.Context, *Txn)
 		return retryable(ctx, txn)
 	})
 	if err != nil {
-		txn.CleanupOnError(ctx, err)
+		if rollbackErr := txn.Rollback(ctx); rollbackErr != nil {
+			log.Eventf(ctx, "failure aborting transaction: %s; abort caused by: %s", rollbackErr, err)
+		}
 	}
 	// Terminate TransactionRetryWithProtoRefreshError here, so it doesn't cause a higher-level
 	// txn to be retried. We don't do this in any of the other functions in DB; I

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints_test.go
@@ -94,7 +94,7 @@ func TestSavepoints(t *testing.T) {
 				ptxn()
 
 			case "commit":
-				if err := txn.CommitOrCleanup(ctx); err != nil {
+				if err := txn.Commit(ctx); err != nil {
 					fmt.Fprintf(&buf, "(%T) %v\n", err, err)
 				}
 

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_server_test.go
@@ -81,7 +81,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 		if err := conflictTxn.Put(ctx, key, "pusher was here"); err != nil {
 			return err
 		}
-		return conflictTxn.CommitOrCleanup(ctx)
+		return conflictTxn.Commit(ctx)
 	}
 
 	// Make a db with a short heartbeat interval.
@@ -128,7 +128,7 @@ func TestHeartbeatFindsOutAboutAbortedTransaction(t *testing.T) {
 
 	// Check that further sends through the aborted txn are rejected. The
 	// TxnCoordSender is supposed to synthesize a TransactionAbortedError.
-	if err := txn.CommitOrCleanup(ctx); !testutils.IsError(
+	if err := txn.Commit(ctx); !testutils.IsError(
 		err, "TransactionRetryWithProtoRefreshError: TransactionAbortedError",
 	) {
 		t.Fatalf("expected aborted error, got: %s", err)

--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -2505,7 +2505,7 @@ func TestDistributedTxnCleanup(t *testing.T) {
 				return errors.New("forced abort")
 			}
 			if err := txnFn(ctx, txn); err != nil {
-				txn.CleanupOnError(ctx, err)
+				require.NoError(t, txn.Rollback(ctx))
 				if !force && commit {
 					t.Fatalf("expected success with commit == true; got %v", err)
 				}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -802,7 +802,9 @@ func (r *Replica) AdminMerge(
 		err := runMergeTxn(txn)
 		if err != nil {
 			log.VEventf(ctx, 2, "merge txn failed: %s", err)
-			txn.CleanupOnError(ctx, err)
+			if rollbackErr := txn.Rollback(ctx); rollbackErr != nil {
+				log.VEventf(ctx, 2, "merge txn rollback failed: %s", rollbackErr)
+			}
 		}
 		if !errors.HasType(err, (*roachpb.TransactionRetryWithProtoRefreshError)(nil)) {
 			if err != nil {

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -771,8 +771,11 @@ func (r *meta2RangeIter) handleErr(ctx context.Context, err error) {
 	}
 	if !errIsRetriable(err) {
 		if r.txn != nil {
+			log.Eventf(ctx, "non-retriable error: %s", err)
 			// On any non-retriable error, rollback.
-			r.txn.CleanupOnError(ctx, err)
+			if rollbackErr := r.txn.Rollback(ctx); rollbackErr != nil {
+				log.Eventf(ctx, "rollback failed: %s", rollbackErr)
+			}
 			r.txn = nil
 		}
 		r.reset()

--- a/pkg/kv/txn_test.go
+++ b/pkg/kv/txn_test.go
@@ -364,9 +364,7 @@ func TestTransactionStatus(t *testing.T) {
 				}
 			}
 			if commit {
-				if pErr := txn.CommitOrCleanup(ctx); pErr != nil {
-					t.Fatal(pErr)
-				}
+				require.NoError(t, txn.Commit(ctx))
 				if a, e := txn.TestingCloneTxn().Status, roachpb.COMMITTED; a != e {
 					t.Errorf("write: %t, commit: %t transaction expected to have status %q but had %q", write, commit, e, a)
 				}

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -534,7 +534,7 @@ func cleanupAndFinishOnError(args fsm.Args) error {
 	func() {
 		ts.mu.Lock()
 		defer ts.mu.Unlock()
-		ts.mu.txn.CleanupOnError(ts.Ctx, args.Payload.(payloadWithError).errorCause())
+		_ = ts.mu.txn.Rollback(ts.Ctx)
 	}()
 	finishedTxnID := ts.finishSQLTxn()
 	ts.setAdvanceInfo(

--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -101,7 +101,10 @@ func TestDistSQLRunningInAbortedTxn(t *testing.T) {
 		if err := conflictTxn.Put(ctx, key, "pusher was here"); err != nil {
 			return err
 		}
-		return conflictTxn.CommitOrCleanup(ctx)
+		err = conflictTxn.Commit(ctx)
+		require.NoError(t, err)
+		t.Log(conflictTxn.Rollback(ctx))
+		return err
 	}
 
 	// Make a db with a short heartbeat interval, so that the aborted txn finds


### PR DESCRIPTION
Txn.CleanupOnError() basically does a rollback, and in addition takes an error only for the purpose of logging it.

Txn.CommitOrCleanup() tries to commit and if unsuccessful it tries a rollback. The error from the rollback is logged but not returned, the error from the commit is returned.

Removing these 2 functions means that the caller should call Commit and Rollback directly when needed, and handle the returned errors. For example, sql may need to log errors to a different channel from the one used but Txn, and tests may want to fail when a Rollback fails unexpectedly. This PR removes those functions.

Release note: None
Epic: None