### PR TITLE
sql: fix `pg_get_viewdef` for materialized views

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2302,6 +2302,14 @@ SELECT pg_catalog.pg_get_viewdef('pg_viewdef_view'::regclass::oid, false)
 SELECT a, b FROM test.public.pg_viewdef_test
 
 statement ok
+CREATE MATERIALIZED VIEW test.pg_viewdef_mview AS SELECT b, a FROM test.pg_viewdef_test
+
+query T
+SELECT pg_catalog.pg_get_viewdef('pg_viewdef_mview'::regclass::oid)
+----
+SELECT b, a FROM test.public.pg_viewdef_test
+
+statement ok
 CREATE TABLE test.pg_constraintdef_test (
   a int,
   b int unique,

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -264,8 +264,15 @@ func makePGGetViewDef(argTypes tree.ArgTypes) tree.Overload {
 			r, err := ctx.Planner.QueryRowEx(
 				ctx.Ctx(), "pg_get_viewdef",
 				sessiondata.NoSessionDataOverride,
-				"SELECT definition FROM pg_catalog.pg_views v JOIN pg_catalog.pg_class c ON "+
-					"c.relname=v.viewname WHERE oid=$1", args[0])
+				`SELECT definition
+ FROM pg_catalog.pg_views v
+ JOIN pg_catalog.pg_class c ON c.relname=v.viewname
+WHERE c.oid=$1
+UNION ALL
+SELECT definition
+ FROM pg_catalog.pg_matviews v
+ JOIN pg_catalog.pg_class c ON c.relname=v.matviewname
+WHERE c.oid=$1`, args[0])
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Epic: CRDB-23454
Fixes #88109.

Release note (bug fix): The function `pg_catalog.pg_get_viewdef` now works properly for materialized views.