### PR TITLE
release-22.1: codeowners, roachtest, team: rename bulk-io to disaster-recovery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,12 +70,12 @@
 
 /pkg/cli/                    @cockroachdb/cli-prs
 # last-rule-wins so bulk i/o takes userfile.go even though cli-prs takes pkg/cli
-/pkg/cli/userfile.go         @cockroachdb/bulk-io
+/pkg/cli/userfile.go         @cockroachdb/disaster-recovery
 /pkg/cli/demo*.go            @cockroachdb/cli-prs @cockroachdb/sql-experience @cockroachdb/server-prs
 /pkg/cli/debug*.go           @cockroachdb/cli-prs @cockroachdb/kv-prs
-/pkg/cli/debug_job_trace*.go @cockroachdb/bulk-io
+/pkg/cli/debug_job_trace*.go @cockroachdb/disaster-recovery
 /pkg/cli/doctor*.go          @cockroachdb/cli-prs @cockroachdb/sql-schema
-/pkg/cli/import_test.go      @cockroachdb/cli-prs @cockroachdb/bulk-io
+/pkg/cli/import_test.go      @cockroachdb/cli-prs @cockroachdb/disaster-recovery
 /pkg/cli/sql*.go             @cockroachdb/cli-prs @cockroachdb/sql-experience
 /pkg/cli/start*.go           @cockroachdb/cli-prs @cockroachdb/server-prs
 /pkg/cli/mt_proxy.go         @cockroachdb/sqlproxy-prs @cockroachdb/server-prs
@@ -91,16 +91,16 @@
 /pkg/ccl/jobsccl/            @cockroachdb/cdc-prs
 /pkg/ccl/changefeedccl/      @cockroachdb/cdc-prs
 /pkg/ccl/streamingccl/       @cockroachdb/cdc-prs
-# last-rule-wins so *after* CDC takes most of streamingccl bulk-io takes ingest pkg.
-/pkg/ccl/streamingccl/streamingest @cockroachdb/bulk-io
+# last-rule-wins so *after* CDC takes most of streamingccl disaster-recovery takes ingest pkg.
+/pkg/ccl/streamingccl/streamingest @cockroachdb/disaster-recovery
 
-/pkg/ccl/backupccl/          @cockroachdb/bulk-io
-/pkg/sql/importer/           @cockroachdb/bulk-io
-/pkg/ccl/importerccl/        @cockroachdb/bulk-io
+/pkg/ccl/backupccl/          @cockroachdb/disaster-recovery
+/pkg/sql/importer/           @cockroachdb/disaster-recovery
+/pkg/ccl/importerccl/        @cockroachdb/disaster-recovery
 /pkg/ccl/spanconfigccl/      @cockroachdb/kv-prs
-/pkg/ccl/storageccl/         @cockroachdb/bulk-io
-/pkg/cloud/                  @cockroachdb/bulk-io
-/pkg/sql/distsql_plan_csv.go @cockroachdb/bulk-io
+/pkg/ccl/storageccl/         @cockroachdb/disaster-recovery
+/pkg/cloud/                  @cockroachdb/disaster-recovery
+/pkg/sql/distsql_plan_csv.go @cockroachdb/disaster-recovery
 
 /pkg/geo/                    @cockroachdb/geospatial
 
@@ -124,7 +124,7 @@
 /pkg/base/                   @cockroachdb/server-prs
 /pkg/bench/                  @cockroachdb/sql-queries-noreview
 /pkg/bench/rttanalysis       @cockroachdb/sql-schema
-/pkg/blobs/                  @cockroachdb/bulk-io
+/pkg/blobs/                  @cockroachdb/disaster-recovery
 /pkg/build/                  @cockroachdb/dev-inf
 /pkg/ccl/baseccl/            @cockroachdb/cli-prs
 /pkg/ccl/buildccl/           @cockroachdb/dev-inf
@@ -241,7 +241,7 @@
 /pkg/roachpb/app*            @cockroachdb/sql-observability
 /pkg/roachpb/index*          @cockroachdb/sql-observability
 /pkg/roachpb/internal*       @cockroachdb/kv-prs
-/pkg/roachpb/io-formats*     @cockroachdb/bulk-io
+/pkg/roachpb/io-formats*     @cockroachdb/disaster-recovery
 /pkg/roachpb/main_test.go    @cockroachdb/kv-prs-noreview
 /pkg/roachpb/merge_spans*    @cockroachdb/kv-prs
 /pkg/roachpb/metadata*       @cockroachdb/kv-prs
@@ -256,12 +256,12 @@
 /pkg/roachpb/version*        @cockroachdb/unowned
 /pkg/roachprod/              @cockroachdb/dev-inf
 /pkg/rpc/                    @cockroachdb/server-prs
-/pkg/scheduledjobs/          @cockroachdb/bulk-io
+/pkg/scheduledjobs/          @cockroachdb/disaster-recovery
 /pkg/security/               @cockroachdb/server-prs @cockroachdb/prodsec
 /pkg/settings/               @cockroachdb/server-prs
 /pkg/spanconfig/             @cockroachdb/kv-prs
 /pkg/startupmigrations/      @cockroachdb/server-prs @cockroachdb/sql-schema
-/pkg/streaming/              @cockroachdb/bulk-io
+/pkg/streaming/              @cockroachdb/disaster-recovery
 /pkg/testutils/              @cockroachdb/test-eng-noreview
 /pkg/testutils/reduce/       @cockroachdb/sql-queries
 /pkg/testutils/sqlutils/     @cockroachdb/sql-queries

--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -53,9 +53,7 @@ cockroachdb/security:
   triage_column_id: 0 # TODO
 cockroachdb/prodsec:
   triage_column_id: 0 # TODO as well
-cockroachdb/bulk-io:
-  aliases:
-    cockroachdb/bulk-prs: other
+cockroachdb/disaster-recovery:
   triage_column_id: 3097123
 cockroachdb/cdc:
   aliases:

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -16,17 +16,17 @@ type Owner string
 
 // The allowable values of Owner.
 const (
-	OwnerSQLExperience Owner = `sql-experience`
-	OwnerBulkIO        Owner = `bulk-io`
-	OwnerCDC           Owner = `cdc`
-	OwnerKV            Owner = `kv`
-	OwnerMultiRegion   Owner = `multiregion`
-	OwnerObsInf        Owner = `obs-inf-prs`
-	OwnerServer        Owner = `server`
-	OwnerSQLQueries    Owner = `sql-queries`
-	OwnerSQLSchema     Owner = `sql-schema`
-	OwnerStorage       Owner = `storage`
-	OwnerTestEng       Owner = `test-eng`
-	OwnerDevInf        Owner = `dev-inf`
-	OwnerMultiTenant   Owner = `multi-tenant`
+	OwnerSQLExperience    Owner = `sql-experience`
+	OwnerDisasterRecovery Owner = `disaster-recovery`
+	OwnerCDC              Owner = `cdc`
+	OwnerKV               Owner = `kv`
+	OwnerMultiRegion      Owner = `multiregion`
+	OwnerObsInf           Owner = `obs-inf-prs`
+	OwnerServer           Owner = `server`
+	OwnerSQLQueries       Owner = `sql-queries`
+	OwnerSQLSchema        Owner = `sql-schema`
+	OwnerStorage          Owner = `storage`
+	OwnerTestEng          Owner = `test-eng`
+	OwnerDevInf           Owner = `dev-inf`
+	OwnerMultiTenant      Owner = `multi-tenant`
 )

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -128,7 +128,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("backup/nodeShutdown/worker/%s", backupNodeRestartSpec),
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backupNodeRestartSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -149,7 +149,7 @@ func registerBackupNodeShutdown(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("backup/nodeShutdown/coordinator/%s", backupNodeRestartSpec),
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backupNodeRestartSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -429,7 +429,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 	// that require careful consideration of mixed version states.
 	r.Add(registry.TestSpec{
 		Name:              "backup/mixed-version-basic",
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(4),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
@@ -577,7 +577,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 	// BACKUP-CHECKPOINT to lock their location.
 	r.Add(registry.TestSpec{
 		Name:              "backup/mixed-version-concurrent-backups",
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(4),
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		RequiresLicense:   true,
@@ -680,7 +680,7 @@ func registerBackup(r registry.Registry) {
 	backup2TBSpec := r.MakeClusterSpec(10)
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("backup/2TB/%s", backup2TBSpec),
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           backup2TBSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -728,7 +728,7 @@ func registerBackup(r registry.Registry) {
 		item := item
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf("backup/KMS/%s/%s", item.kmsProvider, KMSSpec.String()),
-			Owner:             registry.OwnerBulkIO,
+			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           KMSSpec,
 			EncryptionSupport: registry.EncryptionMetamorphic,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -861,7 +861,7 @@ func registerBackup(r registry.Registry) {
 	// verifies them with a fingerprint.
 	r.Add(registry.TestSpec{
 		Name:              `backupTPCC`,
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(3),
 		Timeout:           1 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -83,7 +83,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "import/nodeShutdown/worker",
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -97,7 +97,7 @@ func registerImportNodeShutdown(r registry.Registry) {
 	})
 	r.Add(registry.TestSpec{
 		Name:    "import/nodeShutdown/coordinator",
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			c.Put(ctx, t.Cockroach(), "./cockroach")
@@ -160,7 +160,7 @@ func registerImportTPCC(r registry.Registry) {
 		timeout := 5 * time.Hour
 		r.Add(registry.TestSpec{
 			Name:              testName,
-			Owner:             registry.OwnerBulkIO,
+			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           r.MakeClusterSpec(numNodes),
 			Timeout:           timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
@@ -173,7 +173,7 @@ func registerImportTPCC(r registry.Registry) {
 	const geoZones = "europe-west2-b,europe-west4-b,asia-northeast1-b,us-west1-b"
 	r.Add(registry.TestSpec{
 		Name:              fmt.Sprintf("import/tpcc/warehouses=%d/geo", geoWarehouses),
-		Owner:             registry.OwnerBulkIO,
+		Owner:             registry.OwnerDisasterRecovery,
 		Cluster:           r.MakeClusterSpec(8, spec.CPU(16), spec.Geo(), spec.Zones(geoZones)),
 		Timeout:           5 * time.Hour,
 		EncryptionSupport: registry.EncryptionMetamorphic,
@@ -205,7 +205,7 @@ func registerImportTPCH(r registry.Registry) {
 		item := item
 		r.Add(registry.TestSpec{
 			Name:              fmt.Sprintf(`import/tpch/nodes=%d`, item.nodes),
-			Owner:             registry.OwnerBulkIO,
+			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           r.MakeClusterSpec(item.nodes),
 			Timeout:           item.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
@@ -348,7 +348,7 @@ func runImportMixedVersion(
 func registerImportMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "import/mixed-versions",
-		Owner: registry.OwnerBulkIO,
+		Owner: registry.OwnerDisasterRecovery,
 		// Mixed-version support was added in 21.1.
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -392,7 +392,7 @@ func registerImportDecommissioned(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "import/decommissioned",
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(4),
 		Run:     runImportDecommissioned,
 	})

--- a/pkg/cmd/roachtest/tests/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_jobs.go
@@ -325,7 +325,7 @@ func runJobsMixedVersions(
 func registerJobsMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:  "jobs/mixed-versions",
-		Owner: registry.OwnerBulkIO,
+		Owner: registry.OwnerDisasterRecovery,
 		Skip:  "#67587",
 		// Jobs infrastructure was unstable prior to 20.1 in terms of the behavior
 		// of `PAUSE/CANCEL JOB` commands which were best effort and relied on the

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -297,7 +297,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "restore/nodeShutdown/worker",
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
@@ -311,7 +311,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 
 	r.Add(registry.TestSpec{
 		Name:    "restore/nodeShutdown/coordinator",
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(4),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			gatewayNode := 2
@@ -446,7 +446,7 @@ func registerRestore(r registry.Registry) {
 
 		r.Add(registry.TestSpec{
 			Name:              testName,
-			Owner:             registry.OwnerBulkIO,
+			Owner:             registry.OwnerDisasterRecovery,
 			Cluster:           r.MakeClusterSpec(item.nodes, clusterOpts...),
 			Timeout:           item.timeout,
 			EncryptionSupport: registry.EncryptionMetamorphic,
@@ -517,7 +517,7 @@ func registerRestore(r registry.Registry) {
 	withPauseTimeout := 3 * time.Hour
 	r.Add(registry.TestSpec{
 		Name:    withPauseTestName,
-		Owner:   registry.OwnerBulkIO,
+		Owner:   registry.OwnerDisasterRecovery,
 		Cluster: r.MakeClusterSpec(10),
 		Timeout: withPauseTimeout,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -33,8 +33,8 @@ type Team struct {
 	// Aliases is a map from additional team name to purpose for which to use
 	// them. The purpose "other" indicates a team that exists but which has no
 	// particular purpose as far as `teams` is concerned (for example, teams like
-	// the @cockroachdb/bulk-prs team which exists primarily to route, via
-	// CODEOWNERS, code reviews for the @cockroachdb/bulk-io team). This map
+	// the @cockroachdb/kv-prs team which exists primarily to route, via
+	// CODEOWNERS, code reviews for the @cockroachdb/kv team). This map
 	// does not contain TeamName.
 	Aliases map[Alias]Purpose `yaml:"aliases"`
 	// TriageColumnID is the GitHub Column ID to assign issues to.


### PR DESCRIPTION
Backport 1/1 commits from #88075.

/cc @cockroachdb/release

---

Reflecting `bulk-io` to `disaster-recovery` team rename in:
- github CODEOWNERS
- pkg/cmd/roachtest owners
- pkg/internal/team team
- TEAMS.yaml

Release note: None

Partially fixes: DEVINFHD-652

----

Release justification: Non-production code change.