### PR TITLE
awsdms: use TC_BUILD_BRANCH as suffix if available

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -45,7 +46,10 @@ const (
 )
 
 func awsdmsVerString(v *version.Version) string {
-	ret := fmt.Sprintf("-%d-%d-%d", v.Major(), v.Minor(), v.Patch())
+	if ciBranch := os.Getenv("TC_BUILD_BRANCH"); ciBranch != "" {
+		return fmt.Sprintf("-ci-%s", ciBranch)
+	}
+	ret := fmt.Sprintf("-local-%d-%d-%d", v.Major(), v.Minor(), v.Patch())
 	if v.PreRelease() != "" {
 		ret += "-" + v.PreRelease()
 	}

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -45,7 +45,11 @@ const (
 )
 
 func awsdmsVerString(v *version.Version) string {
-	return fmt.Sprintf("-%d-%d-%d", v.Major(), v.Minor(), v.Patch())
+	ret := fmt.Sprintf("-%d-%d-%d", v.Major(), v.Minor(), v.Patch())
+	if v.PreRelease() != "" {
+		ret += "-" + v.PreRelease()
+	}
+	return ret
 }
 
 func awsdmsRoachtestRDSClusterName(v *version.Version) string {


### PR DESCRIPTION
roachtest/awsdms: include pre-release in version suffix

Apparently master can get cut but still have an older version, so we
need even more diffentiators to ensure uniqueness.

Release note: None

awsdms: use TC_BUILD_BRANCH as suffix if available

Release note: None

