### PR TITLE
opt: copy ColSet in CreateLocalityOptimizedLookupJoinPrivateIncludingCols

### DIFF
--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1237,6 +1237,9 @@ func (c *CustomFuncs) CreateLocalityOptimizedLookupJoinPrivateIncludingCols(
 	lookupExpr, remoteLookupExpr memo.FiltersExpr, private *memo.LookupJoinPrivate, cols opt.ColSet,
 ) *memo.LookupJoinPrivate {
 	newPrivate := c.CreateLocalityOptimizedLookupJoinPrivate(lookupExpr, remoteLookupExpr, private)
+	// Make a copy of the columns to avoid mutating the original
+	// LookupJoinPrivate's columns.
+	newPrivate.Cols = newPrivate.Cols.Copy()
 	newPrivate.Cols.UnionWith(cols)
 	return newPrivate
 }


### PR DESCRIPTION
`CreateLocalityOptimizedLookupJoinPrivateIncludingCols` was mutating a
`opt.ColSet` field of another `LookupJoinPrivate` because it was calling
`ColSet.UnionWith` without copying the `ColSet` first. This commit fixes
the bug.

Fixes #88126

Release note: None
