### PR TITLE
changefeedccl: avoid concurrent map access

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -434,15 +434,15 @@ func MakeStatementOptions(opts map[string]string) StatementOptions {
 	if opts == nil {
 		return MakeDefaultOptions()
 	}
-	stmtOpts := make(map[string]string)
+	mapCopy := make(map[string]string, len(opts))
 	for key, value := range opts {
 		if _, ok := CaseInsensitiveOpts[key]; ok {
-			stmtOpts[key] = strings.ToLower(value)
+			mapCopy[key] = strings.ToLower(value)
 		} else {
-			stmtOpts[key] = value
+			mapCopy[key] = value
 		}
 	}
-	return StatementOptions{m: stmtOpts}
+	return StatementOptions{m: mapCopy}
 }
 
 // MakeDefaultOptions creates the StatementOptions you'd get from

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -350,6 +350,10 @@ func (p *pubsubSink) Topics() []string {
 }
 
 func (p *gcpPubsubClient) getTopicClient(name string) (*pubsub.Topic, error) {
+	//TODO (zinger): Investigate whether changing topics to a sync.Map would be
+	//faster here, I think it would.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if topic, ok := p.topics[name]; ok {
 		return topic, nil
 	}


### PR DESCRIPTION
go 1.18 introduced more stringent checks for unsafe concurrent map use, surfacing some new and exciting panics in changefeed code.

When backported, fixes #87939
When backported, fixes #88089
When backported, fixes #87899

Release note (bug fix): Fixed crashes in changefeed code when running on recent go versions.