### PR TITLE
backupccl: add regions column to SHOW BACKUP

### DIFF
--- a/pkg/ccl/backupccl/show.go
+++ b/pkg/ccl/backupccl/show.go
@@ -10,6 +10,7 @@ package backupccl
 
 import (
 	"context"
+	"fmt"
 	"path"
 	"sort"
 	"strings"
@@ -36,6 +37,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descbuilder"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/doctor"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
@@ -629,6 +631,7 @@ func backupShowerHeaders(showSchemas bool, opts map[string]string) colinfo.Resul
 		{Name: "size_bytes", Typ: types.Int},
 		{Name: "rows", Typ: types.Int},
 		{Name: "is_full_cluster", Typ: types.Bool},
+		{Name: "regions", Typ: types.String},
 	}
 	if showSchemas {
 		baseHeaders = append(baseHeaders, colinfo.ResultColumn{Name: "create_statement", Typ: types.String})
@@ -670,14 +673,20 @@ func backupShowerDefault(
 				// Map database ID to descriptor name.
 				dbIDToName := make(map[descpb.ID]string)
 				schemaIDToName := make(map[descpb.ID]string)
+				typeIDToTypeDescriptor := make(map[descpb.ID]catalog.TypeDescriptor)
 				schemaIDToName[keys.PublicSchemaIDForBackup] = catconstants.PublicSchemaName
 				for i := range manifest.Descriptors {
-					_, db, _, schema, _ := descpb.FromDescriptor(&manifest.Descriptors[i])
-					if db != nil {
+					_, db, typ, schema, _ := descpb.FromDescriptor(&manifest.Descriptors[i])
+					switch {
+					case db != nil:
 						if _, ok := dbIDToName[db.ID]; !ok {
 							dbIDToName[db.ID] = db.Name
 						}
-					} else if schema != nil {
+					case typ != nil:
+						if _, ok := schemaIDToName[typ.ID]; !ok {
+							typeIDToTypeDescriptor[typ.ID] = typedesc.NewBuilder(typ).BuildImmutableType()
+						}
+					case schema != nil:
 						if _, ok := schemaIDToName[schema.ID]; !ok {
 							schemaIDToName[schema.ID] = schema.Name
 						}
@@ -721,6 +730,7 @@ func backupShowerDefault(
 					dataSizeDatum := tree.DNull
 					rowCountDatum := tree.DNull
 					fileSizeDatum := tree.DNull
+					regionsDatum := tree.DNull
 
 					desc := descbuilder.NewBuilder(descriptor).BuildExistingMutable()
 
@@ -728,6 +738,13 @@ func backupShowerDefault(
 					switch desc := desc.(type) {
 					case catalog.DatabaseDescriptor:
 						descriptorType = "database"
+						if desc.IsMultiRegion() {
+							regions, err := showRegions(typeIDToTypeDescriptor[desc.GetRegionConfig().RegionEnumID], desc.GetName())
+							if err != nil {
+								return nil, errors.Wrapf(err, "cannot generate regions column")
+							}
+							regionsDatum = nullIfEmpty(regions)
+						}
 					case catalog.SchemaDescriptor:
 						descriptorType = "schema"
 						dbName = dbIDToName[desc.GetParentID()]
@@ -776,6 +793,7 @@ func backupShowerDefault(
 						dataSizeDatum,
 						rowCountDatum,
 						tree.MakeDBool(manifest.DescriptorCoverage == tree.AllDescriptors),
+						regionsDatum,
 					}
 					if showSchemas {
 						row = append(row, createStmtDatum)
@@ -816,6 +834,7 @@ func backupShowerDefault(
 						tree.DNull, // DataSize
 						tree.DNull, // RowCount
 						tree.DNull, // Descriptor Coverage
+						tree.DNull, // Regions
 					}
 					if showSchemas {
 						row = append(row, tree.DNull)
@@ -924,6 +943,40 @@ func nullIfZero(i descpb.ID) tree.Datum {
 		return tree.DNull
 	}
 	return tree.NewDInt(tree.DInt(i))
+}
+
+// showRegions constructs a string containing the ALTER DATABASE
+// commands that create the multi region specifications for a backed up database.
+func showRegions(typeDesc catalog.TypeDescriptor, dbname string) (string, error) {
+	var regionsStringBuilder strings.Builder
+	if typeDesc == nil {
+		return "", fmt.Errorf("type descriptor for %s is nil", dbname)
+	}
+
+	primaryRegionName, err := typeDesc.PrimaryRegionName()
+	if err != nil {
+		return "", err
+	}
+	regionsStringBuilder.WriteString("ALTER DATABASE ")
+	regionsStringBuilder.WriteString(dbname)
+	regionsStringBuilder.WriteString(" SET PRIMARY REGION ")
+	regionsStringBuilder.WriteString("\"" + primaryRegionName.String() + "\"")
+	regionsStringBuilder.WriteString(";")
+
+	regionNames, err := typeDesc.RegionNames()
+	if err != nil {
+		return "", err
+	}
+	for _, regionName := range regionNames {
+		if regionName != primaryRegionName {
+			regionsStringBuilder.WriteString(" ALTER DATABASE ")
+			regionsStringBuilder.WriteString(dbname)
+			regionsStringBuilder.WriteString(" ADD REGION ")
+			regionsStringBuilder.WriteString("\"" + regionName.String() + "\"")
+			regionsStringBuilder.WriteString(";")
+		}
+	}
+	return regionsStringBuilder.String(), nil
 }
 
 func showPrivileges(descriptor *descpb.Descriptor) string {

--- a/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
@@ -1,0 +1,41 @@
+# These tests validate the SHOW BACKUP command for multi-region databases.
+
+new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+----
+
+exec-sql
+CREATE DATABASE d PRIMARY REGION "us-east-1" REGIONS "us-west-1", "eu-central-1";
+CREATE TABLE d.t (x INT);
+INSERT INTO d.t VALUES (1), (2), (3);
+----
+
+exec-sql
+CREATE DATABASE foo;
+CREATE TABLE foo.t (x INT);
+INSERT INTO foo.t VALUES (1), (2), (3);
+----
+
+exec-sql
+BACKUP DATABASE d, foo INTO 'nodelocal://1/database_backup/';
+----
+
+query-sql
+SELECT object_name, regions FROM [SELECT * FROM [SHOW BACKUP LATEST IN 'nodelocal://1/database_backup/'] WHERE object_type='database'];
+----
+d ALTER DATABASE d SET PRIMARY REGION "us-east-1"; ALTER DATABASE d ADD REGION "eu-central-1"; ALTER DATABASE d ADD REGION "us-west-1";
+foo <nil>
+
+# Here we copied the output of SHOW BACKUP to see if it creates an identical multi-region database.
+
+exec-sql
+DROP DATABASE d CASCADE;
+CREATE DATABASE d;
+ALTER DATABASE d SET PRIMARY REGION "us-east-1"; ALTER DATABASE d ADD REGION "eu-central-1"; ALTER DATABASE d ADD REGION "us-west-1";
+----
+
+query-sql
+SELECT * FROM [SHOW REGIONS FROM DATABASE d] ORDER BY region;
+----
+d eu-central-1 false false {eu-central-1}
+d us-east-1 true false {us-east1}
+d us-west-1 false false {us-west1}


### PR DESCRIPTION
Fixes #79681

Add regions column to display multi-region information for backup databases.

Release note (sql change): Previously, the user did not have an easy way to see if a backed up database is multi-region. This change adds the `regions` column to the `SHOW BACKUP` command which will output a string of `ALTER DATABASE` commands if the database is a multi-region database and `NULL` for everything else.