### PR TITLE
opt: mark FoldInEmpty and FoldNotInEmpty as essential

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1001,6 +1001,9 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		// Needed to make sure that dummy columns are pruned so that the
 		// database name is retrieved correctly.
 		int(opt.PruneScanCols),
+		// TODO(#88141): Needed until a bug in the vectorized engine is fixed.
+		int(opt.FoldInEmpty),
+		int(opt.FoldNotInEmpty),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
These normalization rules are essential for costfuzz and unoptimized-query-oracle tests until #88141 is fixed.

Release note: None