### PR TITLE
ui/cluster-ui: fix jobs page polling

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
@@ -73,6 +73,9 @@ export function isRetrying(status: string): boolean {
 export function isRunning(status: string): boolean {
   return [JOB_STATUS_RUNNING, JOB_STATUS_RETRY_RUNNING].includes(status);
 }
+export function isTerminalState(status: string): boolean {
+  return [JOB_STATUS_SUCCEEDED, JOB_STATUS_FAILED].includes(status);
+}
 
 export const statusOptions = [
   { value: "", name: "All" },

--- a/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/jobs/jobs.sagas.spec.ts
@@ -18,11 +18,7 @@ import * as matchers from "redux-saga-test-plan/matchers";
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 
 import { getJobs } from "src/api/jobsApi";
-import {
-  refreshJobsSaga,
-  requestJobsSaga,
-  receivedJobsSaga,
-} from "./jobs.sagas";
+import { refreshJobsSaga, requestJobsSaga } from "./jobs.sagas";
 import { actions, reducer, JobsState } from "./jobs.reducer";
 import {
   allJobsFixture,
@@ -81,28 +77,6 @@ describe("jobs sagas", () => {
           inFlight: false,
         })
         .run();
-    });
-  });
-
-  describe("receivedJobsSaga", () => {
-    it("sets valid status to false after specified period of time", () => {
-      const timeout = 500;
-      return expectSaga(receivedJobsSaga, timeout)
-        .delay(timeout)
-        .put(actions.invalidated())
-        .withReducer(reducer, {
-          data: jobsResponse,
-          lastError: null,
-          valid: true,
-          inFlight: false,
-        })
-        .hasFinalState<JobsState>({
-          data: jobsResponse,
-          lastError: null,
-          valid: false,
-          inFlight: false,
-        })
-        .run(1000);
     });
   });
 });

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -194,7 +194,7 @@ const jobsReducerObj = new KeyedCachedDataReducer(
   api.getJobs,
   "jobs",
   jobsRequestKey,
-  moment.duration(10, "s"),
+  null,
   moment.duration(1, "minute"),
 );
 export const refreshJobs = jobsReducerObj.refresh;
@@ -206,7 +206,7 @@ const jobReducerObj = new KeyedCachedDataReducer(
   api.getJob,
   "job",
   jobRequestKey,
-  moment.duration(10, "s"),
+  null,
 );
 export const refreshJob = jobReducerObj.refresh;
 

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobsPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobsPage.tsx
@@ -77,7 +77,9 @@ const mapStateToProps = (
   const key = jobsKey(status, type, parseInt(show, 10));
   const jobsState = selectJobsState(state, key);
   const jobs = jobsState ? jobsState.data : null;
-  const jobsLoading = jobsState ? jobsState.inFlight : false;
+  const jobsLoading = jobsState
+    ? jobsState.inFlight && !jobsState.valid
+    : false;
   const jobsError = jobsState ? jobsState.lastError : null;
   return {
     sort,


### PR DESCRIPTION
Fixes #68109

Previously, the jobs page would not poll for new data until a re-render was triggered. This commit updates the jobs page polling to every 10s regardless of
whether or not the rest of the page has changed.

Release note (bug fix): jobs page refreshes page data at an interval of 10s