### PR TITLE
release-22.2: opt: mark FoldInEmpty and FoldNotInEmpty as essential

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -998,6 +998,9 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		// Needed to prevent rule cycles that lead to timeouts and OOMs.
 		int(opt.EliminateProject),
 		int(opt.EliminateSelect),
+		// TODO(#88141): Needed until a bug in the vectorized engine is fixed.
+		int(opt.FoldInEmpty),
+		int(opt.FoldNotInEmpty),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
Backport 1/1 commits from #88152.

/cc @cockroachdb/release

---

These normalization rules are essential for costfuzz and unoptimized-query-oracle tests until #88141 is fixed.

Release note: None

Release justification: This is a test-only change.
