### PR TITLE
sql: version gate idx recommendations in insert-stmt-stats

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/kv",


### PR DESCRIPTION
This commit version gates index recommendation insert in insert-stmt-stats.

Fixes #88140.

Release note: None