### PR TITLE
sql: pg_proc should respect context db for udf

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -156,6 +156,17 @@ FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
 100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
 
+statement ok
+USE defaultdb;
+
+query TTTTTBBBTITTTTT
+SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
+FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
+----
+
+statement ok
+USE test;
+
 subtest create_function_statements
 
 query TITITIT

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2422,7 +2422,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 		if err != nil {
 			return err
 		}
-		return forEachDatabaseDesc(ctx, p, nil /* dbContext */, false, /* requiresPrivileges */
+		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(dbDesc catalog.DatabaseDescriptor) error {
 				return forEachSchema(ctx, p, dbDesc, func(scDesc catalog.SchemaDescriptor) error {
 					return scDesc.ForEachFunctionOverload(func(overload descpb.SchemaDescriptor_FunctionOverload) error {


### PR DESCRIPTION
`pg_proc` table should only return udf in the context db if it's not nil.

Release note: None
Release justification: low risk virtual table improvement.
