### PR TITLE
api: increase timeout of sql api

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
@@ -9,7 +9,11 @@
 // licenses/APL.txt.
 
 import moment from "moment";
-import { executeInternalSql, SqlExecutionRequest } from "./sqlApi";
+import {
+  executeInternalSql,
+  LONG_TIMEOUT,
+  SqlExecutionRequest,
+} from "./sqlApi";
 
 export type ClusterLockState = {
   databaseName?: string;
@@ -65,6 +69,7 @@ WHERE
       },
     ],
     execute: true,
+    timeout: LONG_TIMEOUT,
   };
 
   return executeInternalSql<ClusterLockColumns>(request).then(result => {

--- a/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/indexActionsApi.ts
@@ -8,7 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { executeInternalSql, SqlExecutionRequest } from "./sqlApi";
+import {
+  executeInternalSql,
+  LONG_TIMEOUT,
+  SqlExecutionRequest,
+} from "./sqlApi";
 
 type IndexAction = {
   status: "SUCCESS" | "FAILED";
@@ -32,6 +36,7 @@ export function executeIndexRecAction(
     statements: statements,
     database: databaseName,
     execute: true,
+    timeout: LONG_TIMEOUT,
   };
   return executeInternalSql<IndexActionResponse>(request)
     .then(result => {

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -13,6 +13,8 @@ import {
   SqlExecutionRequest,
   SqlExecutionResponse,
   INTERNAL_SQL_API_APP,
+  LONG_TIMEOUT,
+  LARGE_RESULT_SIZE,
 } from "./sqlApi";
 import {
   InsightExecEnum,
@@ -187,7 +189,8 @@ export function getTransactionInsightEventState(): Promise<TransactionInsightEve
       },
     ],
     execute: true,
-    max_result_size: 50000, // 50 kib
+    max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
   };
   return executeInternalSql<TransactionContentionResponseColumns>(
     txnContentionRequest,
@@ -204,7 +207,8 @@ export function getTransactionInsightEventState(): Promise<TransactionInsightEve
         },
       ],
       execute: true,
-      max_result_size: 50000, // 50 kib
+      max_result_size: LARGE_RESULT_SIZE,
+      timeout: LONG_TIMEOUT,
     };
     return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
       txnFingerprintRequest,
@@ -224,7 +228,8 @@ export function getTransactionInsightEventState(): Promise<TransactionInsightEve
           },
         ],
         execute: true,
-        max_result_size: 50000, // 50 kib
+        max_result_size: LARGE_RESULT_SIZE,
+        timeout: LONG_TIMEOUT,
       };
       return executeInternalSql<FingerprintStmtsResponseColumns>(
         fingerprintStmtsRequest,
@@ -381,7 +386,8 @@ export function getTransactionInsightEventDetailsState(
       },
     ],
     execute: true,
-    max_result_size: 50000, // 50 kib
+    max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
   };
   return executeInternalSql<TxnContentionDetailsResponseColumns>(
     txnContentionDetailsRequest,
@@ -398,7 +404,8 @@ export function getTransactionInsightEventDetailsState(
         },
       ],
       execute: true,
-      max_result_size: 50000, // 50 kib
+      max_result_size: LARGE_RESULT_SIZE,
+      timeout: LONG_TIMEOUT,
     };
     return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
       waitingTxnFingerprintRequest,
@@ -412,7 +419,8 @@ export function getTransactionInsightEventDetailsState(
           },
         ],
         execute: true,
-        max_result_size: 50000, // 50 kib
+        max_result_size: LARGE_RESULT_SIZE,
+        timeout: LONG_TIMEOUT,
       };
       return executeInternalSql<FingerprintStmtsResponseColumns>(
         waitingFingerprintStmtsRequest,
@@ -427,7 +435,8 @@ export function getTransactionInsightEventDetailsState(
             },
           ],
           execute: true,
-          max_result_size: 50000, // 50 kib
+          max_result_size: LARGE_RESULT_SIZE,
+          timeout: LONG_TIMEOUT,
         };
         return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
           blockingTxnFingerprintRequest,
@@ -442,7 +451,8 @@ export function getTransactionInsightEventDetailsState(
               },
             ],
             execute: true,
-            max_result_size: 50000, // 50 kib
+            max_result_size: LARGE_RESULT_SIZE,
+            timeout: LONG_TIMEOUT,
           };
           return executeInternalSql<FingerprintStmtsResponseColumns>(
             blockingFingerprintStmtsRequest,
@@ -624,7 +634,8 @@ export function getStatementInsightsApi(): Promise<StatementInsights> {
       },
     ],
     execute: true,
-    max_result_size: 50000, // 50 kib
+    max_result_size: LARGE_RESULT_SIZE,
+    timeout: LONG_TIMEOUT,
   };
   return executeInternalSql<ExecutionInsightsResponseRow>(request).then(
     result => {

--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -12,6 +12,7 @@ import {
   SqlExecutionRequest,
   SqlTxnResult,
   executeInternalSql,
+  LONG_TIMEOUT,
 } from "./sqlApi";
 import {
   InsightRecommendation,
@@ -181,6 +182,7 @@ export function getSchemaInsights(): Promise<InsightRecommendation[]> {
       sql: insightQuery.query,
     })),
     execute: true,
+    timeout: LONG_TIMEOUT,
   };
   return executeInternalSql<SchemaInsightResponse>(request).then(result => {
     const results: InsightRecommendation[] = [];

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -78,6 +78,8 @@ export function executeSql<RowType>(
 }
 
 export const INTERNAL_SQL_API_APP = "$ internal-console";
+export const LONG_TIMEOUT = "300s";
+export const LARGE_RESULT_SIZE = 50000; // 50 kib
 
 /**
  * executeInternalSql executes the provided SQL statements with


### PR DESCRIPTION
Previously, some request using the sql-over-http
api were hitting a timeout, with the default value of 5s. This commit increases to 300s (5min) on the calls made from SQL Activity and Insights pages.

Fixes #88094

Release note: None