### PR TITLE
rowenc: fix needed column families computation for secondary indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_index
+++ b/pkg/sql/logictest/testdata/logic_test/select_index
@@ -703,3 +703,20 @@ query I
 SELECT c2 FROM t76289_2@t76289_2_pk2_idx WHERE pk2 = 0;
 ----
 NULL
+
+# Regression test for incorrectly splitting a row to scan (with NULL values in
+# the row) into family spans when reading from the secondary index if the KV
+# is omitted for some column families (#88110).
+statement ok
+CREATE TABLE t88110 (
+  _i INT8 NOT NULL, _bool BOOL, _int INT8,
+  UNIQUE (_bool) STORING(_int),
+  FAMILY (_bool),
+  FAMILY (_i, _int)
+);
+INSERT INTO t88110 (_i, _bool, _int) VALUES (0, false, NULL);
+
+query I
+SELECT DISTINCT _int FROM t88110 WHERE NOT _bool;
+----
+NULL

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -236,6 +236,8 @@ func NeededColumnFamilyIDs(
 		return families
 	}
 
+	secondaryStoredColumnIDs := index.CollectSecondaryStoredColumnIDs()
+
 	// Iterate over the column families to find which ones contain needed columns.
 	// We also keep track of whether all of the needed families' columns are
 	// nullable, since this means we need column family 0 as a sentinel, even if
@@ -263,10 +265,21 @@ func NeededColumnFamilyIDs(
 				needed = true
 			}
 			if !columns[columnOrdinal].IsNullable() && !indexedCols.Contains(columnOrdinal) {
-				// This column is non-nullable and is not indexed, thus, it must
-				// be stored in the value part of the KV entry. As a result,
-				// this column family is non-nullable too.
-				nullable = false
+				// This column is non-nullable and is not indexed, thus, if it
+				// is stored in the value part of the KV entry (which is the
+				// case for the primary indexes as well as when the column is
+				// included in STORING clause of the secondary index), the
+				// column family is non-nullable too.
+				//
+				// Note that for unique secondary indexes more columns might be
+				// included in the value part (namely "key suffix" columns when
+				// the indexed columns have a NULL value), but we choose to
+				// ignore those here. This is needed for correctness, and as a
+				// result we might fetch the zeroth column family when it turns
+				// out to be not needed.
+				if index.Primary() || secondaryStoredColumnIDs.Contains(columnID) {
+					nullable = false
+				}
 			}
 		}
 		if needed {


### PR DESCRIPTION
Previously, when determining the "minimal set of column families" required to retrieve all of the needed columns for the scan operation we could incorrectly not include the special zeroth family into the set. The KV for the zeroth column family is always present, so it might need to be fetched even when it's not explicitly needed when the "needed" column families are all nullable. Before this patch the code for determining whether all of the needed column families are nullable incorrectly assumed that all columns in a family are stored, but this is only true for the primary indexes - for the secondary indexes only those columns mentioned in `STORING` clause are actually stored (apart from the indexed and PK columns). As a result we could incorrectly not fetch a row if:
- the unique secondary index is used
- the needed column has a NULL value
- all non-nullable columns from the same column family as the needed column are not stored in the index
- other column families are not fetched.

This is now fixed by considering only the set of stored columns.

The bug seems relatively minor since it requires a multitude of conditions to be met, so I don't think it's a TA worthy.

Fixes: #88110.

Epic: CRDB-20535

Release note (bug fix): Previously, CockroachDB could incorrectly not fetch rows with NULL values when reading from the unique secondary index when multiple column families are defined for the table and the index doesn't store some of the NOT NULL columns.