### PR TITLE
insights: make elapsed time match service latency

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -195,7 +195,7 @@ func (ex *connExecutor) recordStatementSummary(
 		IndexRecommendations: idxRecommendations,
 		Query:                stmt.StmtNoConstants,
 		StartTime:            phaseTimes.GetSessionPhaseTime(sessionphase.PlannerStartExecStmt),
-		EndTime:              phaseTimes.GetSessionPhaseTime(sessionphase.PlannerEndExecStmt),
+		EndTime:              phaseTimes.GetSessionPhaseTime(sessionphase.PlannerStartExecStmt).Add(svcLatRaw),
 		FullScan:             fullScan,
 		SessionData:          planner.SessionData(),
 		ExecStats:            queryLevelStats,


### PR DESCRIPTION
Fixes #86666.

This is a minimally-invasive fix for the lack of congruency in the insights system between statement execution elapsed time (calculated in the UI as end time - start time) and statement execution latency (service latency examined in the server for "slow" detection).

Whereas we were previously seeing elapsed times far under the 50ms and 100s insights thresholds in the UI, now the UI reflects the higher service latency values.

We may want to reconsider this implementation: is end time useful at all? If not, it may be better to remove it and add service latency to the crdb_internal tables and the UI directly. (Because the calculation for service latency is [somewhat complicated][1], we could arguably never offer two accurate start and end times to base it on.)

[1]: https://github.com/cockroachdb/cockroach/blob/f8f74599feeecc98f2b2e83554c37c4b938dc83e/pkg/sql/sessionphase/session_phase.go#L127-L160

Release justification: Bug fixes and low-risk updates to new functionality.

Release note (bug fix): For statement execution insights, the value for the end time was updated to be congruent with the start time and latency.