### PR TITLE
ui/cluster-ui: fix no most recent stmt for active txns

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
@@ -31,13 +31,20 @@ export function makeActiveTransactionsColumns(
     {
       name: "mostRecentStatement",
       title: executionsTableTitles.mostRecentStatement(execType),
-      cell: (item: ActiveTransaction) => (
-        <Tooltip placement="bottom" content={item.query}>
-          <Link to={`/execution/statement/${item.statementID}`}>
-            {limitText(item.query || "", 70)}
-          </Link>
-        </Tooltip>
-      ),
+      cell: (item: ActiveTransaction) => {
+        const queryText = limitText(item.query || "", 70);
+        return (
+          <Tooltip placement="bottom" content={item.query}>
+            {item.statementID ? (
+              <Link to={`/execution/statement/${item.statementID}`}>
+                {queryText}
+              </Link>
+            ) : (
+              queryText
+            )}
+          </Tooltip>
+        );
+      },
       sort: (item: ActiveTransaction) => item.query,
     },
     activeTransactionColumnsFromCommon.status,

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/types.ts
@@ -25,22 +25,22 @@ export const SessionStatusType =
   protos.cockroach.server.serverpb.Session.Status;
 
 export interface ActiveExecution {
-  statementID?: string; // This may not be present for a transaction.
+  statementID?: string; // Empty for transactions not currently executing a statement.
   transactionID: string;
   sessionID: string;
   status: ExecutionStatus;
   start: Moment;
   elapsedTimeMillis: number;
   application: string;
-  query?: string; // Possibly empty for a transaction.
+  query?: string; // For transactions, this is the latest query executed.
   timeSpentWaiting?: moment.Duration;
-  isFullScan: boolean;
 }
 
 export type ActiveStatement = ActiveExecution &
   Required<Pick<ActiveExecution, "statementID">> & {
     user: string;
     clientAddress: string;
+    isFullScan: boolean;
   };
 
 export type ActiveTransaction = ActiveExecution & {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/activeTransactionDetails.tsx
@@ -60,7 +60,6 @@ export const ActiveTxnInsightsLabels = {
   LAST_STATEMENT_EXEC_ID: "Most Recent Statement Execution ID",
   SESSION_ID: "Session ID",
   PRIORITY: "Priority",
-  FULL_SCAN: "Full Scan",
 };
 
 export const RECENT_STATEMENT_NOT_FOUND_MESSAGE =
@@ -142,10 +141,6 @@ export const ActiveTransactionDetails: React.FC<
                     <SummaryCardItem
                       label={ActiveTxnInsightsLabels.PRIORITY}
                       value={capitalize(transaction.priority)}
-                    />
-                    <SummaryCardItem
-                      label={ActiveTxnInsightsLabels.FULL_SCAN}
-                      value={transaction.isFullScan.toString()}
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
Fixes #87738

Previously, active txns could have an empty 'Most Recent Statement' column, even if their executed statement count was non-zero. This was due to the most recent query text being populated by the active stmt, which could be empty at the time of querying. This commit populates the last statement text for a txn even when it is not currently executing a query.

This commit also removes the `isFullScan` field from active txn pages, as we cannot fill this field out without all stmts in the txn.

Release note (ui change): Full scan field is removed from active txn details page.

Release note (bug fix): active txns with non-zero
executed statement count now always have populated stmt text, even when no stmt is being executed.