### PR TITLE
pkg/ui: add first stage of redesigned tracez page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -19,3 +19,4 @@ export * from "./indexActionsApi";
 export * from "./schemaInsightsApi";
 export * from "./schedulesApi";
 export * from "./sqlApi";
+export * from "./tracezApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/tracezApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/tracezApi.ts
@@ -1,0 +1,77 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import { fetchData } from "src/api";
+import TakeTracingSnapshotRequest = cockroach.server.serverpb.TakeTracingSnapshotRequest;
+
+export type ListTracingSnapshotsRequestMessage =
+  cockroach.server.serverpb.ListTracingSnapshotsRequest;
+export type ListTracingSnapshotsResponseMessage =
+  cockroach.server.serverpb.ListTracingSnapshotsResponse;
+
+export type TakeTracingSnapshotRequestMessage = TakeTracingSnapshotRequest;
+export type TakeTracingSnapshotResponseMessage =
+  cockroach.server.serverpb.TakeTracingSnapshotResponse;
+
+export type GetTracingSnapshotRequestMessage =
+  cockroach.server.serverpb.GetTracingSnapshotRequest;
+export type GetTracingSnapshotResponseMessage =
+  cockroach.server.serverpb.GetTracingSnapshotResponse;
+
+export type Span = cockroach.server.serverpb.ITracingSpan;
+export type Snapshot = cockroach.server.serverpb.ITracingSnapshot;
+
+export type GetTraceRequestMessage = cockroach.server.serverpb.GetTraceRequest;
+export type GetTraceResponseMessage =
+  cockroach.server.serverpb.GetTraceResponse;
+
+const API_PREFIX = "_admin/v1";
+
+export function listTracingSnapshots(): Promise<ListTracingSnapshotsResponseMessage> {
+  return fetchData(
+    cockroach.server.serverpb.ListTracingSnapshotsResponse,
+    `${API_PREFIX}/trace_snapshots`,
+    null,
+    null,
+  );
+}
+
+export function takeTracingSnapshot(): Promise<TakeTracingSnapshotResponseMessage> {
+  const req = new TakeTracingSnapshotRequest();
+  return fetchData(
+    cockroach.server.serverpb.TakeTracingSnapshotResponse,
+    `${API_PREFIX}/trace_snapshots`,
+    req as any,
+    null,
+  );
+}
+
+export function getTracingSnapshot(
+  snapshotID: number,
+): Promise<GetTracingSnapshotResponseMessage> {
+  return fetchData(
+    cockroach.server.serverpb.GetTracingSnapshotResponse,
+    `${API_PREFIX}/trace_snapshots/${snapshotID}`,
+    null,
+    null,
+  );
+}
+
+export function getTraceForSnapshot(
+  req: GetTraceRequestMessage,
+): Promise<GetTraceResponseMessage> {
+  return fetchData(
+    cockroach.server.serverpb.GetTraceResponse,
+    `${API_PREFIX}/traces`,
+    req as any,
+    null,
+  );
+}

--- a/pkg/ui/workspaces/cluster-ui/src/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/index.ts
@@ -46,6 +46,7 @@ export * from "./store";
 export * from "./transactionsPage";
 export * from "./transactionDetails";
 export * from "./text";
+export * from "./tracez";
 export { util, api };
 export * from "./sessions";
 export * from "./timeScaleDropdown";

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/index.ts
@@ -8,17 +8,4 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as React from "react";
-
-interface IconProps {
-  className: string;
-  viewBox?: string;
-}
-
-export function CircleFilled(props: IconProps): React.ReactElement {
-  return (
-    <svg {...props}>
-      <circle cx="5" cy="5" r="5" />
-    </svg>
-  );
-}
+export * from "./snapshot";

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot.module.scss
@@ -1,0 +1,110 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+@import "src/core/index.module.scss";
+
+.snapshots-page {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+.no-results {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
+.table-row {
+  vertical-align: top;
+  height: 37px; // Override the default row-wrapper height of 70px.
+}
+
+.table-cell {
+  padding: 4px 0px 4px 16px; // For vertical, override default of 16px.
+}
+
+.operation-cell {
+  padding: 4px 0px 4px 0px; // For vertical, override default of 16px.
+}
+
+.tag {
+  padding: 4px;
+  border-radius: 6px;
+  color: $colors--primary-blue-4;
+  background-color: $colors--primary-blue-1;
+  align-self: start;
+  justify-self: start;
+}
+
+.single-tags-row {
+  display: flex;
+  flex-flow: row;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.icon-cell {
+  padding: 4px 4px 4px 0px;
+  margin: 0px;
+  display: flex;
+  justify-content: right;
+}
+
+.table-cell-time {
+  padding: 4px 16px; // For vertical, override default of 16px.
+  display: flex;
+  justify-content: right;
+}
+
+.table-title-time {
+  width: 20ch;
+}
+
+.tag-group {
+  display: flex;
+  flex-direction: row;
+}
+
+.tag-cell {
+  gap: 4px;
+  display: flex;
+  flex-direction: column;
+}
+
+.plus-minus {
+  border-style: solid;
+  border-width: 1px;
+  height: 13px;
+  width: 13px;
+  margin-top: 4px;
+  fill: $colors--primary-blue-4;
+  border-color: $colors--primary-blue-4;
+  border-radius: 2px;
+}
+
+.icon-red {
+  fill: red;
+  height: 10px;
+  width: 10px;
+  padding-top: 1px;
+}
+
+.icon-green {
+  fill: green;
+  height: 10px;
+  width: 10px;
+  padding-top: 1px;
+}
+
+.section {
+  flex: 0 0 auto;
+  padding: 12px 24px 140px 0px;
+}

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/index.ts
@@ -8,17 +8,5 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import * as React from "react";
-
-interface IconProps {
-  className: string;
-  viewBox?: string;
-}
-
-export function CircleFilled(props: IconProps): React.ReactElement {
-  return (
-    <svg {...props}>
-      <circle cx="5" cy="5" r="5" />
-    </svg>
-  );
-}
+export * from "./snapshotPage";
+export * from "./spanTable";

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.spec.tsx
@@ -1,0 +1,69 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SnapshotPage, SnapshotPageProps } from "./snapshotPage";
+import { render } from "@testing-library/react";
+import React from "react";
+import { MemoryRouter } from "react-router-dom";
+import * as H from "history";
+
+import { SortSetting } from "../../sortedtable";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import GetTracingSnapshotResponse = cockroach.server.serverpb.GetTracingSnapshotResponse;
+
+const getMockSnapshotPageProps = (): SnapshotPageProps => {
+  const history = H.createHashHistory();
+  return {
+    location: history.location,
+    history,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: {},
+    },
+    refreshSnapshot: (id: number): void => {},
+    refreshSnapshots: (): void => {},
+    setSort: (value: SortSetting): void => {},
+    snapshotError: undefined,
+    snapshotLoading: false,
+    snapshots: undefined,
+    snapshotsError: undefined,
+    snapshotsLoading: false,
+    sort: undefined,
+    snapshot: null,
+  };
+};
+
+describe("Snapshot", () => {
+  it("renders expected snapshot table columns", () => {
+    const props = getMockSnapshotPageProps();
+    props.snapshot = GetTracingSnapshotResponse.fromObject({
+      snapshot: {
+        spans: [{ span_id: 1 }],
+      },
+    });
+    const { getAllByText } = render(
+      <MemoryRouter>
+        <SnapshotPage {...props} />
+      </MemoryRouter>,
+    );
+    const expectedColumnTitles = [
+      "Span",
+      "Start Time (UTC)",
+      "Duration",
+      "Tags",
+    ];
+
+    for (const columnTitle of expectedColumnTitles) {
+      getAllByText(columnTitle);
+    }
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/snapshotPage.tsx
@@ -1,0 +1,165 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React, { useEffect } from "react";
+import { Helmet } from "react-helmet";
+import { RouteComponentProps } from "react-router-dom";
+import {
+  ListTracingSnapshotsResponseMessage,
+  GetTracingSnapshotResponseMessage,
+} from "src/api/tracezApi";
+import { Dropdown } from "src/dropdown";
+import { Loading } from "src/loading";
+import { PageConfig, PageConfigItem } from "src/pageConfig";
+import { SortSetting } from "src/sortedtable";
+import { getMatchParamByName, TimestampToMoment } from "src/util";
+import { syncHistory } from "src/util";
+
+import { SpanTable } from "./spanTable";
+
+import { commonStyles } from "src/common";
+import styles from "../snapshot.module.scss";
+import classNames from "classnames/bind";
+
+const cx = classNames.bind(styles);
+
+export interface SnapshotPageStateProps {
+  sort: SortSetting;
+  snapshotsError: Error | null;
+  snapshotsLoading: boolean;
+  snapshots: ListTracingSnapshotsResponseMessage;
+  snapshot: GetTracingSnapshotResponseMessage;
+  snapshotError: Error | null;
+  snapshotLoading: boolean;
+}
+
+export interface SnapshotPageDispatchProps {
+  setSort: (value: SortSetting) => void;
+  refreshSnapshots: () => void;
+  refreshSnapshot: (id: number) => void;
+}
+
+export type SnapshotPageProps = SnapshotPageStateProps &
+  SnapshotPageDispatchProps &
+  RouteComponentProps;
+
+export const SnapshotPage: React.FC<SnapshotPageProps> = props => {
+  const {
+    history,
+    match,
+    refreshSnapshots,
+    refreshSnapshot,
+    snapshots,
+    snapshot,
+    sort,
+    setSort,
+  } = props;
+
+  const searchParams = new URLSearchParams(history.location.search);
+
+  // Sort Settings.
+  const ascending = (searchParams.get("ascending") || undefined) === "true";
+  const columnTitle = searchParams.get("columnTitle") || "";
+
+  const snapshotIDStr = getMatchParamByName(match, "snapshotID");
+
+  useEffect(() => {
+    refreshSnapshots();
+  });
+
+  useEffect(() => {
+    if (snapshotIDStr || !snapshots) {
+      return;
+    }
+    const snapArray = snapshots.snapshots;
+    const lastSnapshotID = snapArray[snapArray.length - 1].snapshot_id;
+    history.location.pathname = "/debug/tracez_v2/snapshot/" + lastSnapshotID;
+    history.replace(history.location);
+  }, [snapshots, snapshotIDStr, history]);
+
+  useEffect(() => {
+    if (!columnTitle) {
+      return;
+    }
+    setSort({ columnTitle, ascending });
+  }, [setSort, columnTitle, ascending]);
+
+  useEffect(() => {
+    if (!snapshotIDStr) {
+      return;
+    }
+    refreshSnapshot(parseInt(snapshotIDStr));
+  }, [snapshotIDStr, refreshSnapshot]);
+
+  const onSnapshotSelected = (item: string) => {
+    history.location.pathname = "/debug/tracez_v2/snapshot/" + item;
+    history.push(history.location);
+  };
+
+  const changeSortSetting = (ss: SortSetting): void => {
+    setSort(ss);
+    syncHistory(
+      {
+        ascending: ss.ascending.toString(),
+        columnTitle: ss.columnTitle,
+      },
+      history,
+    );
+  };
+
+  const snapshotItems = !snapshots
+    ? []
+    : snapshots.snapshots.map(snapshotInfo => {
+        const id = snapshotInfo.snapshot_id.toString();
+        const time = TimestampToMoment(snapshotInfo.captured_at).format(
+          "MMM D, YYYY [at] HH:mm:ss",
+        );
+        return {
+          name: "Snapshot " + id + ": " + time,
+          value: id,
+        };
+      });
+
+  const isLoading = props.snapshotsLoading || props.snapshotLoading;
+  const error = props.snapshotsError || props.snapshotError;
+  return (
+    <div className={cx("snapshots-page")}>
+      <Helmet title="Snapshots" />
+      <h3 className={commonStyles("base-heading")}>Snapshots</h3>
+      <div>
+        <PageConfig>
+          <PageConfigItem>
+            <Dropdown items={snapshotItems} onChange={onSnapshotSelected}>
+              {snapshotIDStr &&
+                snapshotItems.length &&
+                snapshotItems.find(option => option["value"] === snapshotIDStr)[
+                  "name"
+                ]}
+            </Dropdown>
+          </PageConfigItem>
+        </PageConfig>
+      </div>
+      <section className={cx("section")}>
+        <Loading
+          loading={isLoading}
+          page={"snapshots"}
+          error={error}
+          render={() => (
+            <SpanTable
+              snapshot={snapshot?.snapshot}
+              setSort={changeSortSetting}
+              sort={sort}
+            />
+          )}
+        />
+      </section>
+    </div>
+  );
+};

--- a/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/tracez/snapshot/spanTable.tsx
@@ -1,0 +1,254 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+import moment from "moment";
+import React, { useState } from "react";
+import { Nodes, Caution, Plus, Minus } from "@cockroachlabs/icons";
+import { Span, Snapshot } from "src/api/tracezApi";
+import { EmptyTable } from "src/empty";
+import { ColumnDescriptor, SortSetting, SortedTable } from "src/sortedtable";
+
+import styles from "../snapshot.module.scss";
+import classNames from "classnames/bind";
+import { TimestampToMoment } from "src/util";
+import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import ISpanTag = cockroach.server.serverpb.ISpanTag;
+import RecordingMode = cockroach.util.tracing.tracingpb.RecordingMode;
+import { CircleFilled } from "../../icon";
+import { Dropdown } from "src/dropdown";
+import "antd/lib/switch/style";
+const cx = classNames.bind(styles);
+
+class SpanSortedTable extends SortedTable<Span> {}
+
+interface TagRowProps {
+  t: ISpanTag;
+}
+const Tag = ({ t }: TagRowProps) => {
+  let highlight = null;
+  if (t.highlight) {
+    highlight = <Caution />;
+  }
+  let arrow = null;
+  if (t.inherited) {
+    arrow = " ↓";
+  } else if (t.copied_from_child) {
+    arrow = " ↑";
+  }
+  return (
+    <div className={cx("tag")}>
+      {highlight}
+      {t.key}
+      {arrow}
+      {t.val && ": "}
+      {t.val}
+    </div>
+  );
+};
+
+const TagCell = (props: { span: Span }) => {
+  const tagGroups = props.span.processed_tags.filter(
+    tag => tag?.children?.length,
+  );
+  const tags = props.span.processed_tags.filter(tag => !tag?.children?.length);
+
+  let hiddenTagGroup = null;
+  if (tagGroups.length && tagGroups[tagGroups.length - 1].key === "...") {
+    // This should always be present, and always be last, but wrap it in the check just in case.
+    hiddenTagGroup = tagGroups.pop();
+  }
+
+  return (
+    <div className={cx("tag-cell")}>
+      <div className={cx("single-tags-row")}>
+        {tags.map((t, i) => (
+          <Tag t={t} key={i} />
+        ))}
+        {hiddenTagGroup && <TagGroup tag={hiddenTagGroup} />}
+      </div>
+      {tagGroups.map((t, i) => (
+        <TagGroup tag={t} key={i} />
+      ))}
+    </div>
+  );
+};
+
+const TagGroup = (props: { tag: ISpanTag }) => {
+  const { tag } = props;
+  const [isExpanded, setExpanded] = useState(false);
+  const { children } = tag;
+  return (
+    <div className={cx("tag")}>
+      {!isExpanded && (
+        <div className={cx("tag-group")}>
+          <Plus
+            className={cx("plus-minus")}
+            onClick={() => {
+              setExpanded(!isExpanded);
+            }}
+          />
+          <div>
+            &nbsp;
+            {tag.key + " (" + tag.children.length + ")"}
+          </div>
+        </div>
+      )}
+      {isExpanded && (
+        <div className={cx("tag-group")}>
+          <Minus
+            className={cx("plus-minus")}
+            onClick={() => {
+              setExpanded(!isExpanded);
+            }}
+          />
+          <div>
+            &nbsp;
+            {tag.key + " (" + tag.children.length + ")"}
+            <table>
+              <tbody>
+                {children.map((child, i) => (
+                  <tr key={i}>
+                    <td>
+                      <strong>{child.key + ":"}</strong>&nbsp;
+                    </td>
+                    <td>{child.val}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const formatDuration = (d: moment.Duration): string => {
+  const hours = Math.floor(d.asHours());
+  const hourStr = hours ? hours + "h " : "";
+  const minutes = d.minutes();
+  let minuteStr = "";
+  if (hourStr) {
+    minuteStr = minutes.toFixed(0).padStart(2, "0") + "m ";
+  } else if (minutes) {
+    minuteStr = minutes + "m ";
+  }
+  const secondPadNum = hourStr || minuteStr ? 2 : 1;
+  const secondStr = d.seconds().toFixed(0).padStart(secondPadNum, "0");
+  const msStr = "." + d.milliseconds().toFixed(0).padEnd(3, "0") + "s";
+  return hourStr + minuteStr + secondStr + msStr;
+};
+const makeColumns = (
+  snapshot: Snapshot,
+  relativeTimeMode: boolean,
+  setRelativeTimeMode: (value: boolean) => void,
+): ColumnDescriptor<Span>[] => {
+  const startTime = TimestampToMoment(snapshot.captured_at);
+
+  const timeModes = [
+    {
+      name: "Start Time (UTC)",
+      value: false,
+    },
+    {
+      name: "Duration",
+      value: true,
+    },
+  ];
+  return [
+    {
+      name: "icons",
+      title: "",
+      cell: span => {
+        return span.current_recording_mode != RecordingMode.OFF ? (
+          // Use a viewbox to shrink the icon just a bit while leaving it centered.
+          <CircleFilled className={cx("icon-red")} viewBox={"-1 -1 12 12"} />
+        ) : span.current ? (
+          <CircleFilled className={cx("icon-green")} viewBox={"-1 -1 12 12"} />
+        ) : null;
+      },
+      className: cx("icon-cell"),
+    },
+    {
+      name: "span",
+      title: "Span",
+      titleAlign: "left",
+      cell: span => span.operation,
+      sort: span => span.operation,
+      hideTitleUnderline: true,
+      className: cx("operation-cell"),
+    },
+    {
+      name: "time",
+      title: (
+        <div
+          onClick={e => {
+            e.stopPropagation();
+          }}
+          className={cx("table-title-time")}
+        >
+          <Dropdown<boolean>
+            items={timeModes}
+            onChange={value => {
+              setRelativeTimeMode(value);
+            }}
+          >
+            {relativeTimeMode ? "Duration" : "Start Time (UTC)"}
+          </Dropdown>
+        </div>
+      ),
+      titleAlign: "right",
+      cell: span => {
+        return relativeTimeMode
+          ? formatDuration(
+              moment.duration(startTime.diff(TimestampToMoment(span.start))),
+            )
+          : TimestampToMoment(span.start).format("YYYY-MM-DD HH:mm:ss");
+      },
+      // This sort is backwards in duration mode, but toggling between sort keys within a column really trips things up.
+      sort: span => TimestampToMoment(span.start).unix(),
+      hideTitleUnderline: true,
+      className: cx("table-cell-time"),
+    },
+    {
+      name: "tags",
+      title: "Tags",
+      titleAlign: "left",
+      cell: span => <TagCell span={span} />,
+      hideTitleUnderline: true,
+      className: cx("table-cell"),
+    },
+  ];
+};
+
+export interface SpanTableProps {
+  sort: SortSetting;
+  setSort: (value: SortSetting) => void;
+  snapshot: Snapshot;
+}
+
+export const SpanTable: React.FC<SpanTableProps> = props => {
+  const { snapshot, sort, setSort } = props;
+  const spans = snapshot?.spans;
+
+  const [relativeTimeMode, setRelativeTimeMode] = useState(false);
+  if (!spans) {
+    return <EmptyTable title="No spans to show" icon={<Nodes />} />;
+  }
+
+  return (
+    <SpanSortedTable
+      data={spans}
+      sortSetting={sort}
+      onChangeSortSetting={setSort}
+      columns={makeColumns(snapshot, relativeTimeMode, setRelativeTimeMode)}
+      rowClass={() => cx("table-row")}
+    />
+  );
+};

--- a/pkg/ui/workspaces/db-console/src/app.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.spec.tsx
@@ -43,6 +43,7 @@ stubComponentInModule(
 stubComponentInModule("src/views/insights/schemaInsightsPage", "default");
 stubComponentInModule("src/views/schedules/schedulesPage", "default");
 stubComponentInModule("src/views/schedules/scheduleDetails", "default");
+stubComponentInModule("src/views/tracez_v2/snapshotPage", "default");
 
 import React from "react";
 import { Action, Store } from "redux";
@@ -494,6 +495,13 @@ describe("Routing to", () => {
       screen.getByText(ENQUEUE_RANGE_HEADER, {
         selector: "h1",
       });
+    });
+  });
+
+  describe("'/debug/tracez_v2/snapshot/:id' path", () => {
+    test("routes to <ScheduleDetails> component", () => {
+      navigateToPath("/debug/tracez_v2/snapshot/12345");
+      screen.getByTestId("snapshotPage");
     });
   });
 

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -80,6 +80,7 @@ import ActiveStatementDetails from "./views/statements/activeStatementDetailsCon
 import ActiveTransactionDetails from "./views/transactions/activeTransactionDetailsConnected";
 import "styl/app.styl";
 import { Tracez } from "src/views/tracez/tracez";
+import SnapshotPage from "src/views/tracez_v2/snapshotPage";
 import InsightsOverviewPage from "./views/insights/insightsOverview";
 import TransactionInsightDetailsPage from "./views/insights/transactionInsightDetailsPage";
 import StatementInsightDetailsPage from "./views/insights/statementInsightDetailsPage";
@@ -322,6 +323,16 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
                   {/* debug pages */}
                   <Route exact path="/debug" component={Debug} />
                   <Route exact path="/debug/tracez" component={Tracez} />
+                  <Route
+                    exact
+                    path="/debug/tracez_v2"
+                    component={SnapshotPage}
+                  />
+                  <Route
+                    exact
+                    path="/debug/tracez_v2/snapshot/:snapshotID"
+                    component={SnapshotPage}
+                  />
                   <Route exact path="/debug/redux" component={ReduxDebug} />
                   <Route exact path="/debug/chart" component={CustomChart} />
                   <Route

--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -455,6 +455,24 @@ const scheduleReducerObj = new KeyedCachedDataReducer(
 );
 export const refreshSchedule = scheduleReducerObj.refresh;
 
+const snapshotsReducerObj = new CachedDataReducer(
+  clusterUiApi.listTracingSnapshots,
+  "snapshots",
+  moment.duration(1, "s"),
+);
+export const refreshSnapshots = snapshotsReducerObj.refresh;
+
+export const snapshotKey = (snapshotID: number): string =>
+  snapshotID.toString();
+
+const snapshotReducerObj = new KeyedCachedDataReducer(
+  clusterUiApi.getTracingSnapshot,
+  "snapshot",
+  snapshotKey,
+  moment.duration(1, "s"),
+);
+export const refreshSnapshot = snapshotReducerObj.refresh;
+
 export interface APIReducersState {
   cluster: CachedDataReducerState<api.ClusterResponseMessage>;
   events: CachedDataReducerState<api.EventsResponseMessage>;
@@ -496,6 +514,8 @@ export interface APIReducersState {
   schemaInsights: CachedDataReducerState<clusterUiApi.InsightRecommendation[]>;
   schedules: KeyedCachedDataReducerState<clusterUiApi.Schedules>;
   schedule: KeyedCachedDataReducerState<clusterUiApi.Schedule>;
+  snapshots: CachedDataReducerState<clusterUiApi.ListTracingSnapshotsResponseMessage>;
+  snapshot: KeyedCachedDataReducerState<clusterUiApi.GetTracingSnapshotResponseMessage>;
 }
 
 export const apiReducersReducer = combineReducers<APIReducersState>({
@@ -546,6 +566,8 @@ export const apiReducersReducer = combineReducers<APIReducersState>({
   [schemaInsightsReducerObj.actionNamespace]: schemaInsightsReducerObj.reducer,
   [schedulesReducerObj.actionNamespace]: schedulesReducerObj.reducer,
   [scheduleReducerObj.actionNamespace]: scheduleReducerObj.reducer,
+  [snapshotsReducerObj.actionNamespace]: snapshotsReducerObj.reducer,
+  [snapshotReducerObj.actionNamespace]: snapshotReducerObj.reducer,
 });
 
 export { CachedDataReducerState, KeyedCachedDataReducerState };

--- a/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotPage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/tracez_v2/snapshotPage.tsx
@@ -1,0 +1,59 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import {
+  SnapshotPage,
+  SnapshotPageStateProps,
+  SortSetting,
+} from "@cockroachlabs/cluster-ui";
+import { connect } from "react-redux";
+import { RouteComponentProps, withRouter } from "react-router-dom";
+import { refreshSnapshot, refreshSnapshots } from "src/redux/apiReducers";
+import { LocalSetting } from "src/redux/localsettings";
+import { AdminUIState } from "src/redux/state";
+import { getMatchParamByName } from "src/util/query";
+
+export const sortSetting = new LocalSetting<AdminUIState, SortSetting>(
+  "sortSetting/spans",
+  s => s.localSettings,
+  { columnTitle: "creationTime", ascending: false },
+);
+
+const mapStateToProps = (
+  state: AdminUIState,
+  props: RouteComponentProps,
+): SnapshotPageStateProps => {
+  const snapshotsState = state.cachedData.snapshots;
+
+  const snapshotID = getMatchParamByName(props.match, "snapshotID");
+  const snapshotState = state.cachedData.snapshot[snapshotID];
+
+  return {
+    sort: sortSetting.selector(state),
+
+    snapshots: snapshotsState ? snapshotsState.data : null,
+    snapshotsLoading: snapshotsState ? snapshotsState.inFlight : false,
+    snapshotsError: snapshotsState ? snapshotsState.lastError : null,
+
+    snapshot: snapshotState ? snapshotState.data : null,
+    snapshotLoading: snapshotState ? snapshotState.inFlight : false,
+    snapshotError: snapshotState ? snapshotState.lastError : null,
+  };
+};
+
+const mapDispatchToProps = {
+  setSort: sortSetting.set,
+  refreshSnapshots,
+  refreshSnapshot,
+};
+
+export default withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(SnapshotPage),
+);


### PR DESCRIPTION
Begins to implement

https://www.figma.com/file/LUptGAxt5x1idq6eZLA50o/BulkIO-Traces?node-id=59%3A7958

When complete, the new pages will offer:
- A robust route structure and full redux integration for better
navigation.
- Denser information display.
- More information display, i.e. start time/duration, and expanding mutliple
tag groups.
- A new span details page, which will include child span information.

For now, this page is behind a new route with no entrypoint.
It implements the core route structure, redux selectors and
API calls.
Left for later PRs are Take Snapshot, the Span Details page, pagination,
search filtering, and View Raw JSON.

Part of https://github.com/cockroachdb/cockroach/issues/83679

Release note: None

![Screen Shot 2022-10-04 at 12 46 07 PM](https://user-images.githubusercontent.com/261508/193897216-dd6f811e-c6da-4916-8f2f-a8042040e6ba.png)
![Screen Shot 2022-10-04 at 12 45 53 PM](https://user-images.githubusercontent.com/261508/193897217-61f41cb3-1341-4f42-be31-07035ccf6dea.png)
![Screen Shot 2022-10-04 at 12 45 37 PM](https://user-images.githubusercontent.com/261508/193897218-975bf6ec-d5ae-4a1f-9522-494500426b1e.png)
![Screen Shot 2022-10-04 at 12 45 27 PM](https://user-images.githubusercontent.com/261508/193897220-0c0b5028-1f00-4d90-afed-2697f9d47056.png)
![Screen Shot 2022-10-04 at 12 45 17 PM](https://user-images.githubusercontent.com/261508/193897223-c6f92740-67af-4b1e-a69e-5f536d9759c8.png)

