### PR TITLE
util/growstack: increase stack growth for 1.19

### DIFF
--- a/pkg/util/growstack/growstack.s
+++ b/pkg/util/growstack/growstack.s
@@ -10,6 +10,6 @@
 
 #include "funcdata.h"
 
-TEXT ·Grow(SB),0,$16384-0
+TEXT ·Grow(SB),0,$32768-0
         NO_LOCAL_POINTERS
         RET


### PR DESCRIPTION
Now that we've adopted go 1.19, we notice that the performance is much worse (~8%) than we observed in go 1.18. Interestingly, we observe in profiles that we spend a lot more time increasing our stack size underneath request evaluation. This implied to me that some part of this is probably due to the runtime's new stack growth behavior. Perhaps what is going on is that the initial stacks are now smaller than they used to be so when we grow it, we grow it by less than we need to. I ran a benchmark that seems to indicate that this theory is true. I'd like to merge this to master and then backport it after we collect some more data.

We never released this, so no note.

Touches #88038

Release note: None