### PR TITLE
sql: fix bug of dropping temporary tables / sequences

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -687,6 +687,13 @@ func TestTenantLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestTenantLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestTenantLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -870,11 +870,7 @@ func (p *planner) HasOwnershipOnSchema(
 		}
 	case catalog.SchemaVirtual:
 		// Cannot drop on virtual schemas.
-	case catalog.SchemaTemporary:
-		// The user owns all the temporary schemas that they created in the session.
-		hasOwnership = p.SessionData() != nil &&
-			p.SessionData().IsTemporarySchemaID(uint32(scDesc.GetID()))
-	case catalog.SchemaUserDefined:
+	case catalog.SchemaTemporary, catalog.SchemaUserDefined:
 		hasOwnership, err = p.HasOwnership(ctx, scDesc)
 		if err != nil {
 			return false, err

--- a/pkg/sql/logictest/testdata/logic_test/drop_temp
+++ b/pkg/sql/logictest/testdata/logic_test/drop_temp
@@ -1,0 +1,44 @@
+subtest drop_temp_tables_seqs
+
+user root
+
+statement ok
+SET experimental_enable_temp_tables=on;
+
+statement ok
+CREATE TEMP TABLE t_tmp(X int);
+
+statement ok
+CREATE TEMP SEQUENCE s_tmp START 1 INCREMENT 1;
+
+statement ok
+CREATE USER tmp_dropper;
+
+statement ok
+SET ROLE tmp_dropper;
+
+statement error pq: user tmp_dropper does not have DROP privilege on relation t_tmp
+DROP TABLE t_tmp;
+
+statement error pq: user tmp_dropper does not have DROP privilege on relation s_tmp
+DROP SEQUENCE s_tmp;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT DROP ON TABLE t_tmp to tmp_dropper;
+GRANT DROP ON SEQUENCE s_tmp to tmp_dropper;
+
+
+statement ok
+SET ROLE tmp_dropper;
+
+statement ok
+DROP TABLE t_tmp;
+
+statement ok
+DROP SEQUENCE s_tmp;
+
+statement ok
+SET ROLE root;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -660,6 +660,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -660,6 +660,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -660,6 +660,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -653,6 +653,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -660,6 +660,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -674,6 +674,13 @@ func TestLogic_drop_table(
 	runLogicTest(t, "drop_table")
 }
 
+func TestLogic_drop_temp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "drop_temp")
+}
+
 func TestLogic_drop_type(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Previously, any users can always drop temporary table and sequence, even though they don't have the `DROP` privilege on them. This is inconsistent with Postgres14's behavior. This commit is to fix this.

fixes #86802

Release note (bug fix): dropping temporary tables and sequences should check privilege too.