### PR TITLE
sql: hide number of placeholder

### DIFF
--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -67,7 +67,7 @@ BACKUP TABLE foo INTO $1 IN $2
 ----
 BACKUP TABLE foo INTO $1 IN $2
 BACKUP TABLE (foo) INTO ($1) IN ($2) -- fully parenthesized
-BACKUP TABLE foo INTO $1 IN $2 -- literals removed
+BACKUP TABLE foo INTO $1 IN $1 -- literals removed
 BACKUP TABLE _ INTO $1 IN $2 -- identifiers removed
 
 parse
@@ -171,7 +171,7 @@ SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
 ----
 SHOW BACKUP FROM $1 IN $2 WITH foo = 'bar'
 SHOW BACKUP FROM ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP FROM $1 IN $2 WITH foo = '_' -- literals removed
+SHOW BACKUP FROM $1 IN $1 WITH foo = '_' -- literals removed
 SHOW BACKUP FROM $1 IN $2 WITH _ = 'bar' -- identifiers removed
 
 parse
@@ -203,7 +203,7 @@ SHOW BACKUP $1 IN $2 WITH foo = 'bar'
 ----
 SHOW BACKUP $1 IN $2 WITH foo = 'bar'
 SHOW BACKUP ($1) IN ($2) WITH foo = ('bar') -- fully parenthesized
-SHOW BACKUP $1 IN $2 WITH foo = '_' -- literals removed
+SHOW BACKUP $1 IN $1 WITH foo = '_' -- literals removed
 SHOW BACKUP $1 IN $2 WITH _ = 'bar' -- identifiers removed
 
 parse
@@ -227,7 +227,7 @@ BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
 ----
 BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
 BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
-BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $2, '_' -- literals removed
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
 BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
 
 parse
@@ -235,7 +235,7 @@ BACKUP foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz'
 ----
 BACKUP TABLE foo TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- normalized!
 BACKUP TABLE (foo) TO ($1) INCREMENTAL FROM ('bar'), ($2), ('baz') -- fully parenthesized
-BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $2, '_' -- literals removed
+BACKUP TABLE foo TO $1 INCREMENTAL FROM '_', $1, '_' -- literals removed
 BACKUP TABLE _ TO $1 INCREMENTAL FROM 'bar', $2, 'baz' -- identifiers removed
 
 parse
@@ -301,7 +301,7 @@ BACKUP DATABASE foo TO ($1, $2)
 ----
 BACKUP DATABASE foo TO ($1, $2)
 BACKUP DATABASE foo TO (($1), ($2)) -- fully parenthesized
-BACKUP DATABASE foo TO ($1, $2) -- literals removed
+BACKUP DATABASE foo TO ($1, $1) -- literals removed
 BACKUP DATABASE _ TO ($1, $2) -- identifiers removed
 
 parse
@@ -309,7 +309,7 @@ BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
 ----
 BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM 'baz'
 BACKUP DATABASE foo TO (($1), ($2)) INCREMENTAL FROM ('baz') -- fully parenthesized
-BACKUP DATABASE foo TO ($1, $2) INCREMENTAL FROM '_' -- literals removed
+BACKUP DATABASE foo TO ($1, $1) INCREMENTAL FROM '_' -- literals removed
 BACKUP DATABASE _ TO ($1, $2) INCREMENTAL FROM 'baz' -- identifiers removed
 
 parse
@@ -400,7 +400,7 @@ RESTORE TABLE foo FROM $2 IN $1
 ----
 RESTORE TABLE foo FROM $2 IN $1
 RESTORE TABLE (foo) FROM ($2) IN ($1) -- fully parenthesized
-RESTORE TABLE foo FROM $2 IN $1 -- literals removed
+RESTORE TABLE foo FROM $1 IN $1 -- literals removed
 RESTORE TABLE _ FROM $2 IN $1 -- identifiers removed
 
 parse
@@ -408,7 +408,7 @@ RESTORE TABLE foo FROM $1, $2, 'bar'
 ----
 RESTORE TABLE foo FROM $1, $2, 'bar'
 RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
-RESTORE TABLE foo FROM $1, $2, '_' -- literals removed
+RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
 RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -416,7 +416,7 @@ RESTORE foo FROM $1, $2, 'bar'
 ----
 RESTORE TABLE foo FROM $1, $2, 'bar' -- normalized!
 RESTORE TABLE (foo) FROM ($1), ($2), ('bar') -- fully parenthesized
-RESTORE TABLE foo FROM $1, $2, '_' -- literals removed
+RESTORE TABLE foo FROM $1, $1, '_' -- literals removed
 RESTORE TABLE _ FROM $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -424,7 +424,7 @@ RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
 ----
 RESTORE TABLE foo FROM 'abc' IN $1, $2, 'bar'
 RESTORE TABLE (foo) FROM ('abc') IN ($1), ($2), ('bar') -- fully parenthesized
-RESTORE TABLE foo FROM '_' IN $1, $2, '_' -- literals removed
+RESTORE TABLE foo FROM '_' IN $1, $1, '_' -- literals removed
 RESTORE TABLE _ FROM 'abc' IN $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -432,7 +432,7 @@ RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
 ----
 RESTORE TABLE foo FROM $4 IN $1, $2, 'bar'
 RESTORE TABLE (foo) FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
-RESTORE TABLE foo FROM $4 IN $1, $2, '_' -- literals removed
+RESTORE TABLE foo FROM $1 IN $1, $1, '_' -- literals removed
 RESTORE TABLE _ FROM $4 IN $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -547,7 +547,7 @@ RESTORE DATABASE foo FROM ($1, $2)
 ----
 RESTORE DATABASE foo FROM ($1, $2)
 RESTORE DATABASE foo FROM (($1), ($2)) -- fully parenthesized
-RESTORE DATABASE foo FROM ($1, $2) -- literals removed
+RESTORE DATABASE foo FROM ($1, $1) -- literals removed
 RESTORE DATABASE _ FROM ($1, $2) -- identifiers removed
 
 parse
@@ -555,7 +555,7 @@ RESTORE DATABASE foo FROM ($1), ($2)
 ----
 RESTORE DATABASE foo FROM $1, $2 -- normalized!
 RESTORE DATABASE foo FROM ($1), ($2) -- fully parenthesized
-RESTORE DATABASE foo FROM $1, $2 -- literals removed
+RESTORE DATABASE foo FROM $1, $1 -- literals removed
 RESTORE DATABASE _ FROM $1, $2 -- identifiers removed
 
 parse
@@ -563,7 +563,7 @@ RESTORE DATABASE foo FROM ($1), ($2, $3)
 ----
 RESTORE DATABASE foo FROM $1, ($2, $3) -- normalized!
 RESTORE DATABASE foo FROM ($1), (($2), ($3)) -- fully parenthesized
-RESTORE DATABASE foo FROM $1, ($2, $3) -- literals removed
+RESTORE DATABASE foo FROM $1, ($1, $1) -- literals removed
 RESTORE DATABASE _ FROM $1, ($2, $3) -- identifiers removed
 
 parse
@@ -571,7 +571,7 @@ RESTORE DATABASE foo FROM ($1, $2), $3
 ----
 RESTORE DATABASE foo FROM ($1, $2), $3
 RESTORE DATABASE foo FROM (($1), ($2)), ($3) -- fully parenthesized
-RESTORE DATABASE foo FROM ($1, $2), $3 -- literals removed
+RESTORE DATABASE foo FROM ($1, $1), $1 -- literals removed
 RESTORE DATABASE _ FROM ($1, $2), $3 -- identifiers removed
 
 parse
@@ -579,7 +579,7 @@ RESTORE DATABASE foo FROM $1, ($2, $3)
 ----
 RESTORE DATABASE foo FROM $1, ($2, $3)
 RESTORE DATABASE foo FROM ($1), (($2), ($3)) -- fully parenthesized
-RESTORE DATABASE foo FROM $1, ($2, $3) -- literals removed
+RESTORE DATABASE foo FROM $1, ($1, $1) -- literals removed
 RESTORE DATABASE _ FROM $1, ($2, $3) -- identifiers removed
 
 parse
@@ -587,7 +587,7 @@ RESTORE DATABASE foo FROM ($1, $2), ($3, $4)
 ----
 RESTORE DATABASE foo FROM ($1, $2), ($3, $4)
 RESTORE DATABASE foo FROM (($1), ($2)), (($3), ($4)) -- fully parenthesized
-RESTORE DATABASE foo FROM ($1, $2), ($3, $4) -- literals removed
+RESTORE DATABASE foo FROM ($1, $1), ($1, $1) -- literals removed
 RESTORE DATABASE _ FROM ($1, $2), ($3, $4) -- identifiers removed
 
 parse
@@ -595,7 +595,7 @@ RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
 ----
 RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
 RESTORE DATABASE foo FROM (($1), ($2)), (($3), ($4)) AS OF SYSTEM TIME ('1') -- fully parenthesized
-RESTORE DATABASE foo FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE DATABASE foo FROM ($1, $1), ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
 RESTORE DATABASE _ FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1' -- identifiers removed
 
 parse
@@ -603,7 +603,7 @@ RESTORE FROM ($1, $2)
 ----
 RESTORE FROM ($1, $2)
 RESTORE FROM (($1), ($2)) -- fully parenthesized
-RESTORE FROM ($1, $2) -- literals removed
+RESTORE FROM ($1, $1) -- literals removed
 RESTORE FROM ($1, $2) -- identifiers removed
 
 parse
@@ -611,7 +611,7 @@ RESTORE FROM ($1, $2), $3
 ----
 RESTORE FROM ($1, $2), $3
 RESTORE FROM (($1), ($2)), ($3) -- fully parenthesized
-RESTORE FROM ($1, $2), $3 -- literals removed
+RESTORE FROM ($1, $1), $1 -- literals removed
 RESTORE FROM ($1, $2), $3 -- identifiers removed
 
 parse
@@ -619,7 +619,7 @@ RESTORE FROM $1, ($2, $3)
 ----
 RESTORE FROM $1, ($2, $3)
 RESTORE FROM ($1), (($2), ($3)) -- fully parenthesized
-RESTORE FROM $1, ($2, $3) -- literals removed
+RESTORE FROM $1, ($1, $1) -- literals removed
 RESTORE FROM $1, ($2, $3) -- identifiers removed
 
 parse
@@ -627,7 +627,7 @@ RESTORE FROM ($1, $2), ($3, $4)
 ----
 RESTORE FROM ($1, $2), ($3, $4)
 RESTORE FROM (($1), ($2)), (($3), ($4)) -- fully parenthesized
-RESTORE FROM ($1, $2), ($3, $4) -- literals removed
+RESTORE FROM ($1, $1), ($1, $1) -- literals removed
 RESTORE FROM ($1, $2), ($3, $4) -- identifiers removed
 
 parse
@@ -635,7 +635,7 @@ RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
 ----
 RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1'
 RESTORE FROM (($1), ($2)), (($3), ($4)) AS OF SYSTEM TIME ('1') -- fully parenthesized
-RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE FROM ($1, $1), ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
 RESTORE FROM ($1, $2), ($3, $4) AS OF SYSTEM TIME '1' -- identifiers removed
 
 parse
@@ -643,7 +643,7 @@ RESTORE FROM $1, $2, 'bar'
 ----
 RESTORE FROM $1, $2, 'bar'
 RESTORE FROM ($1), ($2), ('bar') -- fully parenthesized
-RESTORE FROM $1, $2, '_' -- literals removed
+RESTORE FROM $1, $1, '_' -- literals removed
 RESTORE FROM $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -651,7 +651,7 @@ RESTORE FROM $4 IN $1, $2, 'bar'
 ----
 RESTORE FROM $4 IN $1, $2, 'bar'
 RESTORE FROM ($4) IN ($1), ($2), ('bar') -- fully parenthesized
-RESTORE FROM $4 IN $1, $2, '_' -- literals removed
+RESTORE FROM $1 IN $1, $1, '_' -- literals removed
 RESTORE FROM $4 IN $1, $2, 'bar' -- identifiers removed
 
 parse
@@ -659,7 +659,7 @@ RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign
 ----
 RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign_keys
 RESTORE FROM ($4) IN ($1), ($2), ('bar') AS OF SYSTEM TIME ('1') WITH skip_missing_foreign_keys -- fully parenthesized
-RESTORE FROM $4 IN $1, $2, '_' AS OF SYSTEM TIME '_' WITH skip_missing_foreign_keys -- literals removed
+RESTORE FROM $1 IN $1, $1, '_' AS OF SYSTEM TIME '_' WITH skip_missing_foreign_keys -- literals removed
 RESTORE FROM $4 IN $1, $2, 'bar' AS OF SYSTEM TIME '1' WITH skip_missing_foreign_keys -- identifiers removed
 
 parse
@@ -702,7 +702,7 @@ RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'
 ----
 RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1'
 RESTORE TENANT 36 FROM (($1), ($2)) AS OF SYSTEM TIME ('1') -- fully parenthesized
-RESTORE TENANT _ FROM ($1, $2) AS OF SYSTEM TIME '_' -- literals removed
+RESTORE TENANT _ FROM ($1, $1) AS OF SYSTEM TIME '_' -- literals removed
 RESTORE TENANT 36 FROM ($1, $2) AS OF SYSTEM TIME '1' -- identifiers removed
 
 parse
@@ -710,7 +710,7 @@ RESTORE TENANT 36 FROM ($1, $2) WITH tenant = '5'
 ----
 RESTORE TENANT 36 FROM ($1, $2) WITH tenant = '5'
 RESTORE TENANT 36 FROM (($1), ($2)) WITH tenant = ('5') -- fully parenthesized
-RESTORE TENANT _ FROM ($1, $2) WITH tenant = '_' -- literals removed
+RESTORE TENANT _ FROM ($1, $1) WITH tenant = '_' -- literals removed
 RESTORE TENANT 36 FROM ($1, $2) WITH tenant = '5' -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/prepared_stmts
+++ b/pkg/sql/parser/testdata/prepared_stmts
@@ -27,7 +27,7 @@ PREPARE a (STRING, STRING) AS SELECT $1, $2
 ----
 PREPARE a (STRING, STRING) AS SELECT $1, $2
 PREPARE a (STRING, STRING) AS SELECT ($1), ($2) -- fully parenthesized
-PREPARE a (STRING, STRING) AS SELECT $1, $2 -- literals removed
+PREPARE a (STRING, STRING) AS SELECT $1, $1 -- literals removed
 PREPARE _ (STRING, STRING) AS SELECT $1, $2 -- identifiers removed
 
 parse
@@ -251,7 +251,7 @@ PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA ($2) WITH temp = $3
 ----
 PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA ($2) WITH temp = $3
 PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA (($2)) WITH temp = ($3) -- fully parenthesized
-PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA ($2) WITH temp = $3 -- literals removed
+PREPARE a (STRING, STRING, STRING) AS IMPORT INTO a CSV DATA ($1) WITH temp = $1 -- literals removed
 PREPARE _ (STRING, STRING, STRING) AS IMPORT INTO _ CSV DATA ($2) WITH _ = $3 -- identifiers removed
 
 parse

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -195,7 +195,7 @@ SELECT $1, $2 FROM t
 ----
 SELECT $1, $2 FROM t
 SELECT ($1), ($2) FROM t -- fully parenthesized
-SELECT $1, $2 FROM t -- literals removed
+SELECT $1, $1 FROM t -- literals removed
 SELECT $1, $2 FROM _ -- identifiers removed
 
 parse
@@ -2801,7 +2801,7 @@ SELECT a FROM t FETCH FIRST $1 ROWS ONLY OFFSET $2 ROWS
 ----
 SELECT a FROM t LIMIT $1 OFFSET $2 -- normalized!
 SELECT (a) FROM t LIMIT ($1) OFFSET ($2) -- fully parenthesized
-SELECT a FROM t LIMIT $1 OFFSET $2 -- literals removed
+SELECT a FROM t LIMIT $1 OFFSET $1 -- literals removed
 SELECT _ FROM _ LIMIT $1 OFFSET $2 -- identifiers removed
 
 parse

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -481,7 +481,7 @@ func TestFormatNodeSummary(t *testing.T) {
 		},
 		{
 			stmt:     `UPDATE system.jobs SET status = $2, payload = $3, last_run = $4, num_runs = $5 WHERE internal_table_id = $1`,
-			expected: `UPDATE system.jobs SET status = $2, pa... WHERE internal_table_...`,
+			expected: `UPDATE system.jobs SET status = $1, pa... WHERE internal_table_...`,
 		},
 		{
 			stmt:     `UPDATE system.extra_extra_long_table_name SET (schedule_state, next_run) = ($1, $2) WHERE schedule_id = 'name'`,

--- a/pkg/sql/sem/tree/hide_constants.go
+++ b/pkg/sql/sem/tree/hide_constants.go
@@ -34,7 +34,10 @@ func (ctx *FmtCtx) formatNodeOrHideConstants(n NodeFormatter) {
 			return
 		case *Placeholder:
 			// Placeholders should be printed as placeholder markers.
-			// Deliberately empty so we format as normal.
+			// Using always '$1' so we limit the amount of different
+			// fingerprints created.
+			ctx.WriteString("$1")
+			return
 		case *StrVal:
 			ctx.WriteString("'_'")
 			return


### PR DESCRIPTION
Previously, placeholder values were kept as is
for fingerprint creation, meaning `IN ($1, $2)`
would be a different fingerprint than `IN ($2, $1)` even though they should be the same.
This commit replace all placeholder values with `$1`, so we
can still know it was a placeholder, but we don't care about the
number of the placeholder itself.
This is the simplest solution to solve this problem. Other
options (e.g. replace with `$_` or `p_`) were considered but
ultimately they would require other modification on the parser code
to accept these values.

Previously:
`SELECT * FROM t WHERE v IN ($1, $2)` -> `SELECT * FROM t WHERE v IN ($1, $2)`
`SELECT * FROM t WHERE v IN ($2, $1)` -> `SELECT * FROM t WHERE v IN ($2, $1)`

Now:
`SELECT * FROM t WHERE v IN ($1, $2)` -> `SELECT * FROM t WHERE v IN ($1, $1)`
`SELECT * FROM t WHERE v IN ($2, $1)` -> `SELECT * FROM t WHERE v IN ($1, $1)`

Fixes #88074

Release note (sql change): The index of a placeholder
is now replaced to always be `$1` to limit fingerprint creations.