### PR TITLE
vendor etcd/raft from PR

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -1715,11 +1715,9 @@ def go_deps():
         name = "com_github_coreos_etcd",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/coreos/etcd",
-        sha256 = "c32b3fc5dba0eeb8533d628489cf862c4eb360644d79c597bcc6290f3d74b046",
-        strip_prefix = "github.com/coreos/etcd@v3.3.13+incompatible",
-        urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/coreos/etcd/com_github_coreos_etcd-v3.3.13+incompatible.zip",
-        ],
+        vcs = "git",
+        remote = "https://github.com/tbg/etcd",
+        commit = "raft-single-voter",
     )
     go_repository(
         name = "com_github_coreos_go_etcd",
@@ -8761,11 +8759,9 @@ def go_deps():
         ],
         build_file_proto_mode = "default",
         importpath = "go.etcd.io/etcd/raft/v3",
-        sha256 = "62faedd81e10061a4e0d7476865a62b84121ea462514afeaa1b9d66cc53b5a4b",
-        strip_prefix = "go.etcd.io/etcd/raft/v3@v3.0.0-20210320072418-e51c697ec6e8",
-        urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/go.etcd.io/etcd/raft/v3/io_etcd_go_etcd_raft_v3-v3.0.0-20210320072418-e51c697ec6e8.zip",
-        ],
+	vcs = "git",
+        remote = "https://github.com/tbg/etcd",
+        commit = "raft-single-voter",
     )
     go_repository(
         name = "io_goji",


### PR DESCRIPTION
> ERROR: /Users/tobias/go/src/github.com/cockroachdb/cockroach/pkg/kv/kvserver/BUILD.bazel:7:11: no such package '@io_etcd_go_etcd_raft_v3//tracker': BUILD file not found in directory 'tracker' of external repository @io_etcd_go_etcd_raft_v3. Add a BUILD file to a directory to mark it as a package. and referenced by '//pkg/kv/kvserver:kvserver'

Same problem when specifying the commit SHA so I don't think it's that.

Release note: None
