### PR TITLE
{bazci,dev}: send build events to beaver hub

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=61
+DEV_VERSION=62
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/BUILD.bazel
+++ b/pkg/cmd/dev/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/build/util",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
+        "//pkg/util/buildutil",
         "@com_github_alessio_shellescape//:shellescape",
         "@com_github_google_shlex//:shlex",
         "@com_github_spf13_cobra//:cobra",
@@ -68,6 +69,7 @@ disallowed_imports_test(
     "dev_lib",
     allowlist = [
         "//pkg/build/util",
+        "//pkg/util/buildutil",
         "//pkg/cmd/dev/io/exec",
         "//pkg/cmd/dev/io/os",
         "@com_github_alessio_shellescape//:shellescape",

--- a/pkg/cmd/dev/main.go
+++ b/pkg/cmd/dev/main.go
@@ -16,6 +16,11 @@ import (
 	"os/exec"
 )
 
+const (
+	beaverHubServerEndpoint = "https://beaver-hub-server-jjd2v2r2dq-uk.a.run.app/process"
+	bepFileBasename         = "build_event_binary_file"
+)
+
 func main() {
 	log.SetFlags(0)
 	log.SetPrefix("")

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -1,7 +1,7 @@
 exec
 dev build cockroach-short
 ----
-bazel build //pkg/cmd/cockroach-short:cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -13,7 +13,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build cockroach-short --cpus=12
 ----
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short
+bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -25,7 +25,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build --debug short
 ----
-bazel build //pkg/cmd/cockroach-short:cockroach-short
+bazel build //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -37,7 +37,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build short -- -s
 ----
-bazel build //pkg/cmd/cockroach-short:cockroach-short -s
+bazel build //pkg/cmd/cockroach-short:cockroach-short -s --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -49,7 +49,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build -- --verbose_failures --sandbox_debug
 ----
-bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug
+bazel build //pkg/cmd/cockroach:cockroach --config=with_ui --verbose_failures --sandbox_debug --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -59,7 +59,7 @@ cp sandbox/pkg/cmd/cockroach/cockroach_/cockroach crdb-checkout/cockroach
 exec
 dev build stress
 ----
-bazel build @com_github_cockroachdb_stress//:stress --//build/toolchains:nogo_disable_flag
+bazel build @com_github_cockroachdb_stress//:stress --//build/toolchains:nogo_disable_flag --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no
@@ -69,7 +69,7 @@ cp sandbox/external/com_github_cockroachdb_stress/stress_/stress crdb-checkout/b
 exec
 dev build tests
 ----
-bazel build //pkg:all_tests --config=test
+bazel build //pkg:all_tests --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/datadriven/test
+++ b/pkg/cmd/dev/testdata/datadriven/test
@@ -1,152 +1,152 @@
 exec
 dev test pkg/util/tracing
 ----
-bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/util/tracing/...
 ----
-bazel test pkg/util/tracing/... --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/util/tracing/... --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/util/tracing -f TestStartChild*
 ----
-bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/util/tracing -f TestStartChild* -v --show-logs
 ----
-bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_arg -test.v --test_arg -show-logs --test_sharding_strategy=disabled --test_output all
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_arg -test.v --test_arg -show-logs --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/util/tracing -f TestStartChild* --ignore-cache
 ----
-bazel test pkg/util/tracing:all --nocache_test_results --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors
+bazel test pkg/util/tracing:all --nocache_test_results --test_env=GOTRACEBACK=all '--test_filter=TestStartChild*' --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test //pkg/testutils --timeout=10s
 ----
-bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_timeout=15 --test_arg -test.timeout=10s --test_output errors
+bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_timeout=15 --test_arg -test.timeout=10s --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/util/tracing -- -s
 ----
-bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_output errors -s
+bazel test pkg/util/tracing:all --test_env=GOTRACEBACK=all --test_output errors -s --build_event_binary_file=/tmp/path
 
 exec
 dev test ./pkg/roachpb
 ----
-bazel test pkg/roachpb:all --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/roachpb:all --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/roachpb:string_test
 ----
-bazel test pkg/roachpb:string_test --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/roachpb:string_test --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test //pkg/testutils
 ----
-bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/testutils:all --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test //pkg/testutils pkg/util/limit
 ----
-bazel test pkg/testutils:all pkg/util/limit:all --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/testutils:all pkg/util/limit:all --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig --count 5 --race
 ----
-bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_output errors
+bazel test --config=race pkg/spanconfig:all --test_env=GOTRACEBACK=all --test_arg -test.count=5 --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/cmd/dev -f TestDataDriven/test --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_arg -test.v --test_sharding_strategy=disabled --test_output all
+bazel test pkg/cmd/dev:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/cmd/dev --test_filter=TestDataDriven/test --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/server -f=TestSpanStatsResponse -v --count=5 --vmodule=raft=1
 ----
-bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --test_arg -test.count=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all
+bazel test pkg/server:all --test_env=GOTRACEBACK=all --test_filter=TestSpanStatsResponse --test_arg -test.v --test_arg -test.count=5 --test_arg -vmodule=raft=1 --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test --short
 ----
-bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_arg -test.short --test_output errors
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_arg -test.short --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/kv/kvserver -f TestStoreRangeSplitMergeGeneration --test-args '-test.memprofile=mem.out'
 ----
 bazel info workspace --color=no
-bazel test pkg/kv/kvserver:all --test_env=GOTRACEBACK=all --test_filter=TestStoreRangeSplitMergeGeneration --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_sharding_strategy=disabled --test_output errors
+bazel test pkg/kv/kvserver:all --test_env=GOTRACEBACK=all --test_filter=TestStoreRangeSplitMergeGeneration --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/ccl/logictestccl -f=TestTenantLogic/3node-tenant/system -v --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --sandbox_writable_path=crdb-checkout/pkg/sql/opt/exec/execbuilder --test_filter=TestTenantLogic/3node-tenant/system --test_arg -test.v --test_sharding_strategy=disabled --test_output all
+bazel test pkg/ccl/logictestccl:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/ccl/logictestccl --sandbox_writable_path=crdb-checkout/pkg/sql/logictest --sandbox_writable_path=crdb-checkout/pkg/sql/opt/exec/execbuilder --test_filter=TestTenantLogic/3node-tenant/system --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigkvsubscriber -f=TestDecodeSpanTargets -v --stream-output
 ----
-bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_arg -test.v --test_sharding_strategy=disabled --test_output streamed
+bazel test pkg/spanconfig/spanconfigkvsubscriber:all --test_env=GOTRACEBACK=all --test_filter=TestDecodeSpanTargets --test_arg -test.v --test_sharding_strategy=disabled --test_output streamed --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/schemachanger pkg/sql/schemachanger/scplan -- --test_sharding_strategy=disabled
 ----
-bazel test pkg/sql/schemachanger:all pkg/sql/schemachanger/scplan:all --test_env=GOTRACEBACK=all --test_output errors --test_sharding_strategy=disabled
+bazel test pkg/sql/schemachanger:all pkg/sql/schemachanger/scplan:all --test_env=GOTRACEBACK=all --test_output errors --test_sharding_strategy=disabled --build_event_binary_file=/tmp/path
 
 exec
 dev test
 ----
-bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/...
 ----
-bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors
+bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/... pkg/ccl/spanconfigccl/...
 ----
-bazel test pkg/spanconfig/... pkg/ccl/spanconfigccl/... --test_env=GOTRACEBACK=all --test_output errors
+bazel test pkg/spanconfig/... pkg/ccl/spanconfigccl/... --test_env=GOTRACEBACK=all --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/schemachanger --rewrite -v
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/schemachanger:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/schemachanger --test_arg -test.v --test_sharding_strategy=disabled --test_output all
+bazel test pkg/sql/schemachanger:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/schemachanger --test_arg -test.v --test_sharding_strategy=disabled --test_output all --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/opt/xform --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/opt/xform:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/opt/xform --sandbox_writable_path=crdb-checkout/pkg/sql/opt/testutils/opttester/testfixtures --test_sharding_strategy=disabled --test_output errors
+bazel test pkg/sql/opt/xform:all --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql/opt/xform --sandbox_writable_path=crdb-checkout/pkg/sql/opt/testutils/opttester/testfixtures --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/sql/... --rewrite
 ----
 bazel info workspace --color=no
-bazel test pkg/sql/... --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql --test_sharding_strategy=disabled --test_output errors
+bazel test pkg/sql/... --nocache_test_results --test_env=GOTRACEBACK=all --test_env=COCKROACH_WORKSPACE=crdb-checkout --test_arg -rewrite --sandbox_writable_path=crdb-checkout/pkg/sql --test_sharding_strategy=disabled --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --test-args '-test.timeout=0.5s'
 ----
 bazel info workspace --color=no
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --timeout 30s --test-args '-test.timeout=0.5s'
 ----
 bazel info workspace --color=no
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=35 --test_arg -test.timeout=30s --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=35 --test_arg -test.timeout=30s --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.timeout=0.5s --test_output errors --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore -- --test_arg '-test.timeout=0.5s'
 ----
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_output errors --test_arg -test.timeout=0.5s
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_output errors --test_arg -test.timeout=0.5s --build_event_binary_file=/tmp/path
 
 exec
 dev test pkg/spanconfig/spanconfigstore --timeout=40s -- --test_arg '-test.timeout=0.5s'
 ----
-bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=45 --test_arg -test.timeout=40s --test_output errors --test_arg -test.timeout=0.5s
+bazel test pkg/spanconfig/spanconfigstore:all --test_env=GOTRACEBACK=all --test_timeout=45 --test_arg -test.timeout=40s --test_output errors --test_arg -test.timeout=0.5s --build_event_binary_file=/tmp/path

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build
@@ -1,7 +1,7 @@
 dev build pkg/roachpb:roachpb_test
 ----
 bazel query pkg/roachpb:roachpb_test --output=label_kind
-bazel build //pkg/roachpb:roachpb_test --config=test
+bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/dev-build.rec
@@ -2,7 +2,7 @@ bazel query pkg/roachpb:roachpb_test --output=label_kind
 ----
 go_test rule //pkg/roachpb:roachpb_test
 
-bazel build //pkg/roachpb:roachpb_test --config=test
+bazel build //pkg/roachpb:roachpb_test --config=test --build_event_binary_file=/tmp/path
 ----
 
 mkdir crdb-checkout/bin


### PR DESCRIPTION
This code change lets `bazci` and `dev` send build events to beaver hub so
we can start collecting data about builds in CI and locally.

Release note: None
Epic: [CRDB-8350](https://cockroachlabs.atlassian.net/browse/CRDB-8350)