### PR TITLE
storage: split out and deflake `MVCCIsSpanEmpty` tests

### DIFF
--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -1,7 +1,4 @@
 
-# Populate some values. The inline value is a special case in
-# that it will cause an error if time bounds are specified.
-
 run ok
 with t=A v=abc resolve
   txn_begin ts=44
@@ -21,25 +18,6 @@ data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
 meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
-# Last test case sees inline value but does not error
-# since no time bound specified.
-run ok
-is_span_empty k=a end=+a
-is_span_empty k=a end=z
-is_span_empty k=a end=+a startTs=45
-is_span_empty k=i end=z
-----
-false
-false
-true
-false
-
-# Case in which inline value is encountered under time bounds.
-run error
-is_span_empty k=i startTs=0 ts=1
-----
-error: (*withstack.withStack:) unexpected inline value found: "i"
-
 run ok
 clear_range k=a end=+a
 ----
@@ -51,16 +29,6 @@ data: "c"/44.000000000,0 -> /BYTES/abc
 meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
-is_span_empty k=a end=+a
-----
-true
-
-run ok
-is_span_empty k=a end=-a
-----
-false
-
-run ok
 clear_range k=a end=-a
 ----
 >> at end:
@@ -68,11 +36,6 @@ data: "b"/44.000000000,0 -> /BYTES/abc
 data: "b/123"/44.000000000,0 -> /BYTES/abc
 data: "c"/44.000000000,0 -> /BYTES/abc
 meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
-
-run ok
-is_span_empty k=a end=-a
-----
-true
 
 run ok
 clear_range k=a end==b
@@ -99,23 +62,7 @@ data: "c"/44.000000000,0 -> /BYTES/abc
 meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run ok
-clear_range k=a end=-c
-----
->> at end:
-meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
-
-run ok
-is_span_empty k=a end=z
-----
-false
-
-run ok
-clear_range k=i end=+i
+clear_range k=c end=z
 ----
 >> at end:
 <no data>
-
-run ok
-is_span_empty k=a end=z
-----
-true

--- a/pkg/storage/testdata/mvcc_histories/is_span_empty
+++ b/pkg/storage/testdata/mvcc_histories/is_span_empty
@@ -1,0 +1,74 @@
+# An empty span is, well, empty.
+run ok
+is_span_empty k=a end=z
+is_span_empty k=a end=z startTs=1
+----
+true
+true
+
+# Populate with some values and an MVCC range tombstone. Inline values are
+# tested in separate file.
+run ok
+put k=a ts=2 v=a2
+put k=a ts=4 v=a4
+del k=b ts=4
+with t=A
+  txn_begin ts=10
+  put  k=c v=c10
+del_range_ts k=d end=f ts=2
+----
+del: "b": found key false
+>> at end:
+txn: "A" meta={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+rangekey: {d-f}/[2.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /BYTES/a4
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+meta: "c"/0,0 -> txn={id=00000000 key=/Min pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "c"/10.000000000,0 -> /BYTES/c10
+
+# Span is not empty.
+run ok
+is_span_empty k=a end=z
+----
+false
+
+# Empty key span.
+run ok
+is_span_empty k=+a end=b
+----
+true
+
+# Empty time span (startTs is exclusive).
+run ok
+is_span_empty k=a end=z startTs=2 ts=3
+----
+true
+
+# Intent is detected, with and without timestamp bounds.
+run ok
+is_span_empty k=c end=+c
+is_span_empty k=c end=+c startTs=9 ts=10
+----
+false
+false
+
+# Tombstone is detected, with and without timestamp bounds.
+run ok
+is_span_empty k=b end=+b
+is_span_empty k=b end=+b startTs=3 ts=4
+----
+false
+false
+
+# Range tombstone is detected, with and without timestamp bounds.
+run ok
+is_span_empty k=d end=d+
+is_span_empty k=e end=e+
+is_span_empty k=e end=e+ startTs=1 end=2
+is_span_empty k=e end=e+ startTs=2 end=3
+----
+false
+false
+false
+true

--- a/pkg/storage/testdata/mvcc_histories/is_span_empty_inline_disable_separate_engine_blocks
+++ b/pkg/storage/testdata/mvcc_histories/is_span_empty_inline_disable_separate_engine_blocks
@@ -1,0 +1,28 @@
+# Tests MVCCIsSpanEmpty with inline value. Disables separate engine blocks,
+# because the TBI may non-deterministically omit the inline value.
+run ok
+put k=i v=inline
+----
+>> at end:
+meta: "i"/0,0 -> txn={<nil>} ts=0,0 del=false klen=0 vlen=0 raw=/BYTES/inline mergeTs=<nil> txnDidNotUpdateMeta=false
+
+# Detects inline values without timestamp bounds.
+run ok
+is_span_empty k=a end=z
+is_span_empty k=a end=i
+is_span_empty k=+i end=z
+----
+false
+true
+true
+
+# Errors on inline values with timestamped bounds.
+run error
+is_span_empty k=i end=i+ startTs=1
+----
+error: (*withstack.withStack:) unexpected inline value found: "i"
+
+run error
+is_span_empty k=i end=i+ ts=1
+----
+error: (*withstack.withStack:) unexpected inline value found: "i"


### PR DESCRIPTION
Resolves #88200.

Release note: None