### PR TITLE
release-22.2: changefeedccl: avoid concurrent map access

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -409,12 +409,15 @@ func MakeStatementOptions(opts map[string]string) StatementOptions {
 	if opts == nil {
 		return MakeDefaultOptions()
 	}
+	mapCopy := make(map[string]string, len(opts))
 	for key, value := range opts {
 		if _, ok := CaseInsensitiveOpts[key]; ok {
-			opts[key] = strings.ToLower(value)
+			mapCopy[key] = strings.ToLower(value)
+		} else {
+			mapCopy[key] = value
 		}
 	}
-	return StatementOptions{m: opts}
+	return StatementOptions{m: mapCopy}
 }
 
 // MakeDefaultOptions creates the StatementOptions you'd get from

--- a/pkg/ccl/changefeedccl/sink_pubsub.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub.go
@@ -350,6 +350,10 @@ func (p *pubsubSink) Topics() []string {
 }
 
 func (p *gcpPubsubClient) getTopicClient(name string) (*pubsub.Topic, error) {
+	//TODO (zinger): Investigate whether changing topics to a sync.Map would be
+	//faster here, I think it would.
+	p.mu.Lock()
+	defer p.mu.Unlock()
 	if topic, ok := p.topics[name]; ok {
 		return topic, nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #88130.

/cc @cockroachdb/release

---

go 1.18 introduced more stringent checks for unsafe concurrent map use, surfacing some new and exciting panics in changefeed code.

Fixes #87939
Fixes #88089
Fixes #87899

Release note (bug fix): Fixed crashes in changefeed code when running on recent go versions.

Release justification: Fixes crashes in changefeed code when running on recent go versions.
