### PR TITLE
builtins: Add a `crdb_internal.pb_def` function

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2922,6 +2922,12 @@ select crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor, 
 ----
 system
 
+query B
+select length(crdb_internal.pb_def('cockroach.sql.sqlbase.Descriptor')) > 0
+----
+true
+
+
 query error pq: crdb_internal.pb_to_json\(\): invalid protocol message: unknown proto message type cockroach.sql.sqlbase.descriptor
 select crdb_internal.pb_to_json('cockroach.sql.sqlbase.descriptor', descriptor)->'database'->>'name' from system.descriptor where id=1
 

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -117,6 +117,8 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_gogo_protobuf//proto",
+        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor",
         "@com_github_golang_geo//s1",
         "@com_github_knz_strtime//:strtime",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -445,6 +445,7 @@ var builtinOidsBySignature = map[string]oid.Oid{
 	`crdb_internal.pb_to_json(pbname: string, data: bytes) -> jsonb`:                                                                    1270,
 	`crdb_internal.pb_to_json(pbname: string, data: bytes, emit_defaults: bool) -> jsonb`:                                               1271,
 	`crdb_internal.pb_to_json(pbname: string, data: bytes, emit_defaults: bool, emit_redacted: bool) -> jsonb`:                          1272,
+	`crdb_internal.pb_def(pbname: string) -> string`:                                                                                    2036,
 	`crdb_internal.pretty_key(raw_key: bytes, skip_fields: int) -> string`:                                                              1323,
 	`crdb_internal.pretty_span(raw_key_start: bytes, raw_key_end: bytes, skip_fields: int) -> string`:                                   1324,
 	`crdb_internal.probe_ranges(timeout: interval, probe_type: unknown_enum) -> tuple{int AS range_id, string AS error, int AS end_to_end_latency_ms, string AS verbose_trace}`: 356,

--- a/pkg/util/protoutil/marshal.go
+++ b/pkg/util/protoutil/marshal.go
@@ -20,6 +20,7 @@ type Message interface {
 	MarshalToSizedBuffer(data []byte) (int, error)
 	Unmarshal(data []byte) error
 	Size() int
+	Descriptor() ([]byte, []int)
 }
 
 // Interceptor will be called with every proto before it is marshaled.


### PR DESCRIPTION
Add a `crdb_internal.pb_def` function which, given the protocol message name, returns a protocol buffer defition as it exists in the binary.

Release note: None
Release justification: low impact, debug only function.