### PR TITLE
release-22.2: colbuilder: don't use optimized IN operator for empty tuple

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2668,7 +2668,7 @@ func appendOneType(typs []*types.T, t *types.T) []*types.T {
 // require special null-handling logic).
 func useDefaultCmpOpForIn(tuple *tree.DTuple) bool {
 	tupleContents := tuple.ResolvedType().TupleContents()
-	if len(tupleContents) == 0 {
+	if len(tupleContents) == 0 || len(tuple.D) == 0 {
 		return true
 	}
 	for _, typ := range tupleContents {

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_overloads
@@ -465,3 +465,25 @@ statement ok
 SELECT * FROM t70738 AS t1
 JOIN t70738 as t2 ON t1.i8 = t2.i2
 WHERE (t2.i / t1.i8) = '1 day'
+
+# Regression test for incorrect usage of the optimized IN operator (#88141).
+statement ok
+CREATE TABLE t88141 (i INTERVAL);
+INSERT INTO t88141 (i) VALUES (NULL);
+SET testing_optimizer_random_seed = 6320964980407535657;
+SET testing_optimizer_disable_rule_probability = 0.500000;
+
+query T
+SELECT i
+FROM t88141
+WHERE NOT (i IN (
+    SELECT '1 day'::INTERVAL
+    FROM t88141 t1 JOIN t88141 t2 ON true
+    WHERE false
+));
+----
+NULL
+
+statement ok
+RESET testing_optimizer_random_seed;
+RESET testing_optimizer_disable_rule_probability;


### PR DESCRIPTION
Backport 1/1 commits from #88195.

/cc @cockroachdb/release

---

This commit makes it so that we don't use the optimized IN operator for empty tuples since they handle NULLs incorrectly. This wasn't supposed to happen already due to 9b590d39fd1de222cddc6cd1b557e6513e14c00c but there we only looked at the type and not at the actual datum. This is not a production bug since the optimizer normalizes such expressions away.

Fixes: #88141.

Release note: None

Release justification: low risk bug fix.