### PR TITLE
cdc: fix assignment to nil map panic in json encoder

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1086,6 +1086,26 @@ func TestNoStopAfterNonTargetColumnDrop(t *testing.T) {
 	cdcTest(t, testFn)
 }
 
+func TestChangefeedProjectionDelete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (id int primary key, a string)`)
+		sqlDB.Exec(t, `INSERT INTO foo values (0, 'a')`)
+		foo := feed(t, f, `CREATE CHANGEFEED WITH schema_change_policy='stop' AS SELECT * FROM foo`)
+		defer closeFeed(t, foo)
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{"a": "a", "id": 0}`,
+		})
+		sqlDB.Exec(t, `DELETE FROM foo WHERE id = 0`)
+		assertPayloads(t, foo, []string{
+			`foo: [0]->{}`,
+		})
+	}
+	cdcTest(t, testFn)
+}
+
 // If we drop columns which are not targeted by the changefeed, it should not backfill.
 func TestNoBackfillAfterNonTargetColumnDrop(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -158,7 +158,11 @@ func (e *jsonEncoder) EncodeValue(
 			meta = jsonEntries
 		} else {
 			meta = make(map[string]interface{}, 1)
-			jsonEntries = after
+			if after != nil {
+				jsonEntries = after
+			} else {
+				jsonEntries = map[string]interface{}{}
+			}
 			jsonEntries[jsonMetaSentinel] = meta
 		}
 		if e.beforeField {


### PR DESCRIPTION
JSON encoding a delete message for a deleted row was panicking. This fixes that.

Release note (bug fix): Fixed a crash in changefeed expressions when JSON encoding an empty projection.