### PR TITLE
release-21.2: kvserver: log when raft send/recv queue fills up

### DIFF
--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -592,6 +592,9 @@ func (t *RaftTransport) SendAsync(req *RaftMessageRequest, class rpc.ConnectionC
 		}
 		return true
 	default:
+		if logRaftSendQueueFullEvery.ShouldLog() {
+			log.Warningf(t.AnnotateCtx(context.Background()), "raft send queue to n%d is full", toNodeID)
+		}
 		req.release()
 		return false
 	}


### PR DESCRIPTION
Backport 1/1 commits from #86645.

/cc @cockroachdb/release

---

Inspired by https://github.com/cockroachlabs/support/issues/1770.

If either the raft send or receive queue fills up, wide-spread outages
can occur as replication progress stalls. We have metrics that can
indicate this, but straightforward logging is also appropriate to direct
attention to the fact, which this commit achieves.

Touches https://github.com/cockroachdb/cockroach/issues/79755

Release justification: important logging improvement
Release note: None

