### PR TITLE
schematelemetry: add unit tests for descriptor redaction

### DIFF
--- a/pkg/sql/catalog/schematelemetry/BUILD.bazel
+++ b/pkg/sql/catalog/schematelemetry/BUILD.bazel
@@ -4,6 +4,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "schematelemetry",
     srcs = [
+        "redact.go",
         "scheduled_job_executor.go",
         "schema_telemetry_event.go",
         "schema_telemetry_job.go",
@@ -48,18 +49,23 @@ go_test(
     name = "schematelemetry_test",
     srcs = [
         "main_test.go",
+        "redact_test.go",
         "schema_telemetry_test.go",
     ],
     args = ["-test.timeout=295s"],
     deps = [
+        ":schematelemetry",
         "//pkg/base",
         "//pkg/jobs",
         "//pkg/jobs/jobstest",
+        "//pkg/keys",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/schematelemetry/schematelemetrycontroller",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/sem/builtins/builtinconstants",
         "//pkg/sql/sem/tree",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/catalog/schematelemetry/redact_test.go
+++ b/pkg/sql/catalog/schematelemetry/redact_test.go
@@ -1,0 +1,58 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package schematelemetry_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schematelemetry"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactQueries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, db, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	tdb := sqlutils.MakeSQLRunner(db)
+	tdb.Exec(t, "CREATE TABLE kv (k INT PRIMARY KEY, v STRING)")
+	tdb.Exec(t, "CREATE VIEW view AS SELECT k, v FROM kv WHERE v <> 'constant literal'")
+	tdb.Exec(t, "CREATE TABLE ctas AS SELECT k, v FROM kv WHERE v <> 'constant literal'")
+
+	t.Run("view", func(t *testing.T) {
+		view := desctestutils.TestingGetTableDescriptor(
+			kvDB, keys.SystemSQLCodec, "defaultdb", "public", "view",
+		)
+		mut := tabledesc.NewBuilder(view.TableDesc()).BuildCreatedMutableTable()
+		require.Empty(t, schematelemetry.Redact(mut))
+		require.Equal(t, `SELECT k, v FROM defaultdb.public.kv WHERE v != '_'`, mut.ViewQuery)
+	})
+
+	t.Run("create table as", func(t *testing.T) {
+		ctas := desctestutils.TestingGetTableDescriptor(
+			kvDB, keys.SystemSQLCodec, "defaultdb", "public", "ctas",
+		)
+		mut := tabledesc.NewBuilder(ctas.TableDesc()).BuildCreatedMutableTable()
+		require.Empty(t, schematelemetry.Redact(mut))
+		require.Equal(t, `SELECT k, v FROM defaultdb.public.kv WHERE v != '_'`, mut.CreateQuery)
+	})
+}

--- a/pkg/sql/catalog/schematelemetry/schema_telemetry_event.go
+++ b/pkg/sql/catalog/schematelemetry/schema_telemetry_event.go
@@ -17,15 +17,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
-	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
@@ -91,25 +85,15 @@ func CollectClusterSchemaForTelemetry(
 		}
 		ev := newEvent(rd.GetID())
 		redacted[rd.GetID()] = ev
-		var redactErrs []error
 		// Redact parts of the catalog which may contain PII.
-		{
-			mut := rd.NewBuilder().BuildCreatedMutable()
-			switch d := mut.(type) {
-			case *tabledesc.Mutable:
-				redactErrs = redactTableDescriptor(d.TableDesc())
-			case *typedesc.Mutable:
-				redactTypeDescriptor(d.TypeDesc())
-			}
-			ev.Desc = mut.DescriptorProto()
-		}
+		mut := rd.NewBuilder().BuildCreatedMutable()
+		redactErrs := Redact(mut)
+		ev.Desc = mut.DescriptorProto()
 		// Add all errors to the snapshot metadata event.
 		for _, err := range redactErrs {
-			if err != nil {
-				err = errors.Wrapf(err, " %s %q (%d)", rd.DescriptorType(), rd.GetName(), rd.GetID())
-				log.Errorf(ctx, "error during schema telemetry event generation: %v", err)
-				meta.Errors = append(meta.Errors, err.Error())
-			}
+			err = errors.Wrapf(err, " %s %q (%d)", rd.DescriptorType(), rd.GetName(), rd.GetID())
+			log.Errorf(ctx, "error during schema telemetry event generation: %v", err)
+			meta.Errors = append(meta.Errors, err.Error())
 		}
 		return nil
 	})
@@ -194,174 +178,4 @@ func truncatedCatalogKeys(
 		}
 	}
 	return namespaceKeys, orphanedDescIDs, descIDsInSnapshot
-}
-
-func redactTableDescriptor(d *descpb.TableDescriptor) (errs []error) {
-	handleErr := func(err error) {
-		errs = append(errs, err)
-	}
-	if d.ViewQuery != "" {
-		handleErr(errors.Wrap(redactQuery(&d.ViewQuery), "view query"))
-	}
-	if d.CreateQuery != "" {
-		handleErr(errors.Wrap(redactQuery(&d.CreateQuery), "create query"))
-	}
-	handleErr(redactIndex(&d.PrimaryIndex))
-	for i := range d.Indexes {
-		idx := &d.Indexes[i]
-		handleErr(errors.Wrapf(redactIndex(idx), "index #%d", idx.ID))
-	}
-	for i := range d.Columns {
-		col := &d.Columns[i]
-		for _, err := range redactColumn(col) {
-			handleErr(errors.Wrapf(err, "column #%d", col.ID))
-		}
-	}
-	for i := range d.Checks {
-		chk := d.Checks[i]
-		handleErr(errors.Wrapf(redactCheckConstraints(chk), "constraint #%d", chk.ConstraintID))
-	}
-	for i := range d.UniqueWithoutIndexConstraints {
-		uwi := &d.UniqueWithoutIndexConstraints[i]
-		handleErr(errors.Wrapf(redactUniqueWithoutIndexConstraint(uwi), "constraint #%d", uwi.ConstraintID))
-	}
-	for _, m := range d.Mutations {
-		if idx := m.GetIndex(); idx != nil {
-			handleErr(errors.Wrapf(redactIndex(idx), "index #%d", idx.ID))
-		} else if col := m.GetColumn(); col != nil {
-			for _, err := range redactColumn(col) {
-				handleErr(errors.Wrapf(err, "column #%d", col.ID))
-			}
-		} else if ctu := m.GetConstraint(); ctu != nil {
-			switch ctu.ConstraintType {
-			case descpb.ConstraintToUpdate_CHECK:
-				chk := &ctu.Check
-				handleErr(errors.Wrapf(redactCheckConstraints(chk), "constraint #%d", chk.ConstraintID))
-			case descpb.ConstraintToUpdate_UNIQUE_WITHOUT_INDEX:
-				uwi := &ctu.UniqueWithoutIndexConstraint
-				handleErr(errors.Wrapf(redactUniqueWithoutIndexConstraint(uwi), "constraint #%d", uwi.ConstraintID))
-			}
-		}
-	}
-	if scs := d.DeclarativeSchemaChangerState; scs != nil {
-		for i := range scs.RelevantStatements {
-			stmt := &scs.RelevantStatements[i]
-			stmt.Statement.Statement = stmt.Statement.RedactedStatement
-		}
-		for i := range scs.Targets {
-			t := &scs.Targets[i]
-			handleErr(errors.Wrapf(redactElement(t.Element()), "element #%d", i))
-		}
-	}
-	return errs
-}
-
-func redactQuery(sql *string) error {
-	q, err := parser.ParseOne(*sql)
-	if err != nil {
-		*sql = "_"
-		return err
-	}
-	fmtCtx := tree.NewFmtCtx(tree.FmtHideConstants)
-	q.AST.Format(fmtCtx)
-	*sql = fmtCtx.String()
-	return nil
-}
-
-func redactIndex(idx *descpb.IndexDescriptor) error {
-	redactPartitioning(&idx.Partitioning)
-	return errors.Wrap(redactExprStr(&idx.Predicate), "partial predicate")
-}
-
-func redactColumn(col *descpb.ColumnDescriptor) (errs []error) {
-	handleErr := func(err error) {
-		errs = append(errs, err)
-	}
-	if ce := col.ComputeExpr; ce != nil {
-		handleErr(errors.Wrap(redactExprStr(ce), "compute expr"))
-	}
-	if de := col.DefaultExpr; de != nil {
-		handleErr(errors.Wrap(redactExprStr(de), "default expr"))
-	}
-	if ue := col.OnUpdateExpr; ue != nil {
-		handleErr(errors.Wrap(redactExprStr(ue), "on-update expr"))
-	}
-	return errs
-}
-
-func redactCheckConstraints(chk *descpb.TableDescriptor_CheckConstraint) error {
-	return redactExprStr(&chk.Expr)
-}
-
-func redactUniqueWithoutIndexConstraint(uwi *descpb.UniqueWithoutIndexConstraint) error {
-	return redactExprStr(&uwi.Predicate)
-}
-
-func redactTypeDescriptor(d *descpb.TypeDescriptor) {
-	for i := range d.EnumMembers {
-		e := &d.EnumMembers[i]
-		e.LogicalRepresentation = "_"
-		e.PhysicalRepresentation = []byte("_")
-	}
-}
-
-// redactElement redacts literals which may contain PII from elements.
-func redactElement(element scpb.Element) error {
-	switch e := element.(type) {
-	case *scpb.EnumTypeValue:
-		e.LogicalRepresentation = "_"
-		e.PhysicalRepresentation = []byte("_")
-	case *scpb.IndexPartitioning:
-		redactPartitioning(&e.PartitioningDescriptor)
-	case *scpb.SecondaryIndexPartial:
-		return redactExpr(&e.Expression.Expr)
-	case *scpb.CheckConstraint:
-		return redactExpr(&e.Expression.Expr)
-	case *scpb.ColumnDefaultExpression:
-		return redactExpr(&e.Expression.Expr)
-	case *scpb.ColumnOnUpdateExpression:
-		return redactExpr(&e.Expression.Expr)
-	case *scpb.ColumnType:
-		if e.ComputeExpr != nil {
-			return redactExpr(&e.ComputeExpr.Expr)
-		}
-	}
-	return nil
-}
-
-func redactPartitioning(p *catpb.PartitioningDescriptor) {
-	for i := range p.List {
-		l := &p.List[i]
-		for j := range l.Values {
-			l.Values[j] = []byte("_")
-		}
-		redactPartitioning(&l.Subpartitioning)
-	}
-	for i := range p.Range {
-		r := &p.Range[i]
-		r.FromInclusive = []byte("_")
-		r.ToExclusive = []byte("_")
-	}
-}
-
-func redactExpr(expr *catpb.Expression) error {
-	str := string(*expr)
-	err := redactExprStr(&str)
-	*expr = catpb.Expression(str)
-	return err
-}
-
-func redactExprStr(expr *string) error {
-	if *expr == "" {
-		return nil
-	}
-	parsedExpr, err := parser.ParseExpr(*expr)
-	if err != nil {
-		*expr = "_"
-		return err
-	}
-	fmtCtx := tree.NewFmtCtx(tree.FmtHideConstants)
-	parsedExpr.Format(fmtCtx)
-	*expr = fmtCtx.String()
-	return nil
 }


### PR DESCRIPTION
This commit moves code around to make it testable but otherwise does not alter any functionality.

Informs #85787.

Release note: none