### PR TITLE
ttl: Schedule TTL job when ttl_expiration_expression is set after table creation

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1333,9 +1333,7 @@ func NewTableDesc(
 	); err != nil {
 		return nil, err
 	}
-	if updatedRowLevelTTL := setter.UpdatedRowLevelTTL; updatedRowLevelTTL != nil {
-		setter.TableDesc.RowLevelTTL = updatedRowLevelTTL
-	}
+	setter.TableDesc.RowLevelTTL = setter.UpdatedRowLevelTTL
 
 	indexEncodingVersion := descpb.StrictIndexColumnIDGuaranteesVersion
 	isRegionalByRow := n.Locality != nil && n.Locality.LocalityLevel == tree.LocalityLevelRow
@@ -1491,6 +1489,7 @@ func NewTableDesc(
 						hasRowLevelTTLColumn = true
 						break
 					}
+
 				}
 			}
 			if !hasRowLevelTTLColumn {

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,22 +1,46 @@
-subtest todo_add_subtests
+subtest ttl_expire_after_must_be_interval
 
 statement error value of "ttl_expire_after" must be an interval
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = ' xx invalid interval xx')
 
+subtest end
+
+subtest ttl_expire_after_must_be_at_least_zero
+
 statement error value of "ttl_expire_after" must be at least zero
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expire_after = '-10 minutes')
+
+subtest end
+
+subtest ttl_expiration_expression_must_be_string
 
 statement error parameter "ttl_expiration_expression" requires a string value
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 0)
 
+subtest end
+
+subtest ttl_expiration_expression_must_be_valid_expression
+
 statement error ttl_expiration_expression "; DROP DATABASE defaultdb" must be a valid expression: at or near "EOF": syntax error
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = '; DROP DATABASE defaultdb')
+
+subtest end
+
+subtest ttl_expiration_expression_must_be_timestamptz
 
 statement error expected ttl_expiration_expression expression to have type timestamptz, but 'text' has type string
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl_expiration_expression = 'text')
 
+subtest end
+
+subtest ttl_expire_after_or_ttl_expiration_expression_must_be_set
+
 statement error "ttl_expire_after" and/or "ttl_expiration_expression" must be set
 CREATE TABLE tbl (id INT PRIMARY KEY, text TEXT) WITH (ttl = 'on')
+
+subtest end
+
+subtest todo_add_subtests
 
 query T noticetrace
 CREATE TABLE tbl_ttl_automatic_column (id INT PRIMARY KEY, text TEXT) WITH (ttl_automatic_column = 'on')
@@ -875,21 +899,35 @@ statement ok
 ROLLBACK
 
 statement ok
-ALTER TABLE tbl SET (ttl_expire_after = '10 minutes', ttl_select_batch_size = 200)
+DROP TABLE tbl
+
+subtest end
+
+subtest create_table_no_ttl_set_ttl_expire_after
+
+statement ok
+CREATE TABLE create_table_no_ttl_set_ttl_expire_after (
+   id INT PRIMARY KEY,
+   text TEXT,
+   FAMILY (id, text)
+)
+
+statement ok
+ALTER TABLE create_table_no_ttl_set_ttl_expire_after SET (ttl_expire_after = '10 minutes')
 
 query T
-SELECT create_statement FROM [SHOW CREATE TABLE tbl]
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expire_after]
 ----
-CREATE TABLE public.tbl (
-                                                                                                                                                   id INT8 NOT NULL,
-                                                                                                                                                   text STRING NULL,
-                                                                                                                                                   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
-                                                                                                                                                   CONSTRAINT tbl_pkey PRIMARY KEY (id ASC),
-                                                                                                                                                   FAMILY fam_0_id_text (id, text, crdb_internal_expiration)
-) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly', ttl_select_batch_size = 200)
+CREATE TABLE public.create_table_no_ttl_set_ttl_expire_after (
+                                                                                         id INT8 NOT NULL,
+                                                                                         text STRING NULL,
+                                                                                         crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+                                                                                         CONSTRAINT create_table_no_ttl_set_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+                                                                                         FAMILY fam_0_id_text (id, text, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@hourly')
 
 let $table_id
-SELECT oid FROM pg_class WHERE relname = 'tbl'
+SELECT oid FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expire_after'
 
 query TTT
 SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
@@ -898,9 +936,60 @@ WHERE label = 'row-level-ttl-$table_id'
 ACTIVE  @hourly  root
 
 statement ok
-DROP TABLE tbl
+ALTER TABLE create_table_no_ttl_set_ttl_expire_after RESET (ttl)
 
-# Special table name.
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl-$table_id'
+----
+
+subtest end
+
+subtest create_table_no_ttl_set_ttl_expiration_expression
+
+statement ok
+CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression (
+   id INT PRIMARY KEY,
+   text TEXT,
+   expire_at TIMESTAMPTZ,
+   FAMILY (id, text)
+)
+
+statement ok
+ALTER TABLE create_table_no_ttl_set_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at')
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
+                                                                                        id INT8 NOT NULL,
+                                                                                        text STRING NULL,
+                                                                                        expire_at TIMESTAMPTZ NULL,
+                                                                                        CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+                                                                                        FAMILY fam_0_id_text_expire_at (id, text, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')
+
+let $table_id
+SELECT oid FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expiration_expression'
+
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl-$table_id'
+----
+ACTIVE  @hourly  root
+
+statement ok
+ALTER TABLE create_table_no_ttl_set_ttl_expiration_expression RESET (ttl)
+
+query TTT
+SELECT schedule_status, recurrence, owner FROM [SHOW SCHEDULES]
+WHERE label = 'row-level-ttl-$table_id'
+----
+
+subtest end
+
+subtest special_table_name
+
 statement ok
 CREATE TABLE "Table-Name" (id INT PRIMARY KEY) WITH (ttl_expire_after = '10 hours')
 

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1513,7 +1513,7 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 
 			// If we are modifying TTL, then make sure the schedules are created
 			// or dropped as appropriate.
-			if modify := m.AsModifyRowLevelTTL(); modify != nil {
+			if modify := m.AsModifyRowLevelTTL(); modify != nil && !modify.IsRollback() {
 				if fn := sc.testingKnobs.RunBeforeModifyRowLevelTTL; fn != nil {
 					if err := fn(); err != nil {
 						return err

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -7625,109 +7625,169 @@ CREATE INDEX idx_test_split_b ON t.test_split (b) USING HASH WITH (bucket_count=
 `)
 }
 
+func createFailOnceFunc() func() error {
+	var once sync.Once
+	return func() error {
+		var err error
+		once.Do(func() {
+			err = errors.AssertionFailedf("fail!")
+		})
+		return err
+	}
+}
+
+func verifyTableSchema(t *testing.T, sqlDB *gosql.DB, expectedSchema string) {
+	var actualSchema string
+	require.NoError(t, sqlDB.QueryRow(`SELECT create_statement FROM [SHOW CREATE TABLE t.test]`).Scan(&actualSchema))
+	require.Equal(t, expectedSchema, actualSchema)
+}
+
 func TestTTLAutomaticColumnSchemaChangeFailures(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 
-	var shouldFail bool
-	failFunc := func() error {
-		if shouldFail {
-			shouldFail = false
-			return errors.AssertionFailedf("fail!")
-		}
-		return nil
-	}
-
 	const (
 		createNonTTLTable = `CREATE DATABASE t;
-	CREATE TABLE t.test (id TEXT PRIMARY KEY);`
+	CREATE TABLE t.test (id TEXT PRIMARY KEY, expire_at TIMESTAMPTZ);`
 		expectNonTTLTable = `CREATE TABLE public.test (
 	id STRING NOT NULL,
+	expire_at TIMESTAMPTZ NULL,
 	CONSTRAINT test_pkey PRIMARY KEY (id ASC)
 )`
 
-		createTTLTable = `CREATE DATABASE t;
-CREATE TABLE t.test (id TEXT PRIMARY KEY) WITH (ttl_expire_after = '10 hours');`
-		expectTTLTable = `CREATE TABLE public.test (
+		createTTLExpireAfterTable = `CREATE DATABASE t;
+CREATE TABLE t.test (id TEXT PRIMARY KEY, expire_at TIMESTAMPTZ) WITH (ttl_expire_after = '10 hours');`
+		expectTTLExpireAfterTable = `CREATE TABLE public.test (
 	id STRING NOT NULL,
+	expire_at TIMESTAMPTZ NULL,
 	crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '10:00:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '10:00:00':::INTERVAL,
 	CONSTRAINT test_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '10:00:00':::INTERVAL, ttl_job_cron = '@hourly')`
+
+		createTTLExpirationExpressionTable = `CREATE DATABASE t;
+CREATE TABLE t.test (id TEXT PRIMARY KEY, expire_at TIMESTAMPTZ) WITH (ttl_expiration_expression = 'expire_at');`
+		expectTTLExpirationExpressionTable = `CREATE TABLE public.test (
+	id STRING NOT NULL,
+	expire_at TIMESTAMPTZ NULL,
+	CONSTRAINT test_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', ttl_job_cron = '@hourly')`
 	)
 
 	testCases := []struct {
-		desc                    string
-		setup                   string
-		schemaChange            string
-		knobs                   *sql.SchemaChangerTestingKnobs
-		expectedShowCreateTable string
-		expectSchedule          bool
+		desc                       string
+		setup                      string
+		schemaChange               string
+		runBeforeBackfill          func() error
+		runBeforeModifyRowLevelTTL func() error
+		expectedShowCreateTable    string
+		expectSchedule             bool
 	}{
+		// ttl_expire_after
 		{
-			desc:         "error during ALTER TABLE ... SET (ttl_expire_after ...) during add mutation",
-			setup:        createNonTTLTable,
-			schemaChange: `ALTER TABLE t.test SET (ttl_expire_after = '10 hours')`,
-			knobs: &sql.SchemaChangerTestingKnobs{
-				RunBeforeBackfill: failFunc,
-			},
+			desc:                    "error during ALTER TABLE x SET ttl_expire_after x during add mutation",
+			setup:                   createNonTTLTable,
+			schemaChange:            `ALTER TABLE t.test SET (ttl_expire_after = '10 hours')`,
+			runBeforeBackfill:       createFailOnceFunc(),
 			expectedShowCreateTable: expectNonTTLTable,
 			expectSchedule:          false,
 		},
 		{
-			desc:         "error during ALTER TABLE ... SET (ttl_expire_after ...) during modify row-level-ttl mutation",
-			setup:        createNonTTLTable,
-			schemaChange: `ALTER TABLE t.test SET (ttl_expire_after = '10 hours')`,
-			knobs: &sql.SchemaChangerTestingKnobs{
-				RunBeforeModifyRowLevelTTL: failFunc,
-			},
+			desc:                       "error during ALTER TABLE x SET ttl_expire_after x during modify row-level-ttl mutation",
+			setup:                      createNonTTLTable,
+			schemaChange:               `ALTER TABLE t.test SET (ttl_expire_after = '10 hours')`,
+			runBeforeModifyRowLevelTTL: createFailOnceFunc(),
+			expectedShowCreateTable:    expectNonTTLTable,
+			expectSchedule:             false,
+		},
+		{
+			desc:                    "error during ALTER TABLE x RESET ttl_expire_after during delete column mutation",
+			setup:                   createTTLExpireAfterTable,
+			schemaChange:            `ALTER TABLE t.test RESET (ttl)`,
+			runBeforeBackfill:       createFailOnceFunc(),
+			expectedShowCreateTable: expectTTLExpireAfterTable,
+			expectSchedule:          true,
+		},
+		{
+			desc:                       "error during ALTER TABLE x RESET ttl_expire_after during modify row-level-ttl mutation",
+			setup:                      createTTLExpireAfterTable,
+			schemaChange:               `ALTER TABLE t.test RESET (ttl)`,
+			runBeforeModifyRowLevelTTL: createFailOnceFunc(),
+			expectedShowCreateTable:    expectTTLExpireAfterTable,
+			expectSchedule:             true,
+		},
+		// ttl_expiration_expression
+		{
+			desc:                    "error during ALTER TABLE x SET ttl_expiration_expression x during add mutation",
+			setup:                   createNonTTLTable,
+			schemaChange:            `ALTER TABLE t.test SET (ttl_expiration_expression = 'expire_at')`,
+			runBeforeBackfill:       createFailOnceFunc(),
 			expectedShowCreateTable: expectNonTTLTable,
 			expectSchedule:          false,
 		},
 		{
-			desc:         "error during ALTER TABLE ... RESET (ttl) during delete column mutation",
-			setup:        createTTLTable,
-			schemaChange: `ALTER TABLE t.test RESET (ttl)`,
-			knobs: &sql.SchemaChangerTestingKnobs{
-				RunBeforeBackfill: failFunc,
-			},
-			expectedShowCreateTable: expectTTLTable,
+			desc:                       "error during ALTER TABLE x SET ttl_expiration_expression x during modify row-level-ttl mutation",
+			setup:                      createNonTTLTable,
+			schemaChange:               `ALTER TABLE t.test SET (ttl_expiration_expression = 'expire_at')`,
+			runBeforeModifyRowLevelTTL: createFailOnceFunc(),
+			expectedShowCreateTable:    expectNonTTLTable,
+			expectSchedule:             false,
+		},
+		{
+			desc:                    "error during ALTER TABLE x RESET ttl_expiration_expression during delete column mutation",
+			setup:                   createTTLExpirationExpressionTable,
+			schemaChange:            `ALTER TABLE t.test RESET (ttl)`,
+			runBeforeBackfill:       createFailOnceFunc(),
+			expectedShowCreateTable: expectTTLExpirationExpressionTable,
 			expectSchedule:          true,
 		},
 		{
-			desc:         "error during ALTER TABLE ... SET (ttl_expire_after ...) during modify row-level-ttl mutation",
-			setup:        createTTLTable,
-			schemaChange: `ALTER TABLE t.test RESET (ttl)`,
-			knobs: &sql.SchemaChangerTestingKnobs{
-				RunBeforeModifyRowLevelTTL: failFunc,
-			},
-			expectedShowCreateTable: expectTTLTable,
-			expectSchedule:          true,
+			desc:                       "error during ALTER TABLE x RESET ttl_expiration_expression during modify row-level-ttl mutation",
+			setup:                      createTTLExpirationExpressionTable,
+			schemaChange:               `ALTER TABLE t.test RESET (ttl)`,
+			runBeforeModifyRowLevelTTL: createFailOnceFunc(),
+			expectedShowCreateTable:    expectTTLExpirationExpressionTable,
+			expectSchedule:             true,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+
+			knobs := &sql.SchemaChangerTestingKnobs{}
+
 			params, _ := tests.CreateTestServerParams()
-			params.Knobs.SQLSchemaChanger = tc.knobs
+			params.Knobs.SQLSchemaChanger = knobs
 			s, sqlDB, kvDB := serverutils.StartServer(t, params)
 			defer s.Stopper().Stop(ctx)
 
 			_, err := sqlDB.Exec(tc.setup)
 			require.NoError(t, err)
 
-			shouldFail = true
-			defer func() {
-				shouldFail = false
-			}()
+			// Set test knobs before schema change
+			knobs.RunBeforeBackfill = func() error {
+				// TODO(ewall): uncomment during https://github.com/cockroachdb/cockroach/issues/88560 resolution
+				// verifyTableSchema(t, sqlDB, tc.expectedShowCreateTable)
+				if tc.runBeforeBackfill != nil {
+					return tc.runBeforeBackfill()
+				}
+				return nil
+			}
+			knobs.RunBeforeModifyRowLevelTTL = func() error {
+				// TODO(ewall): uncomment during https://github.com/cockroachdb/cockroach/issues/88560 resolution
+				// verifyTableSchema(t, sqlDB, tc.expectedShowCreateTable)
+				if tc.runBeforeModifyRowLevelTTL != nil {
+					return tc.runBeforeModifyRowLevelTTL()
+				}
+				return nil
+			}
+
 			_, err = sqlDB.Exec(tc.schemaChange)
 			require.Error(t, err)
 
 			// Ensure CREATE TABLE is the same.
-			var actualSchema string
-			require.NoError(t, sqlDB.QueryRow(`SELECT create_statement FROM [SHOW CREATE TABLE t.test]`).Scan(&actualSchema))
-			require.Equal(t, tc.expectedShowCreateTable, actualSchema)
+			verifyTableSchema(t, sqlDB, tc.expectedShowCreateTable)
 
 			// Ensure the schedule is still there.
 			desc := desctestutils.TestingGetPublicTableDescriptor(


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/88254
refs https://github.com/cockroachdb/cockroach/issues/88560
    
Previously a TTL mutation was added for the schema changer only when
ttl_expire_after was set. Now a TTL mutation is also added when
ttl_expiration_expression is set.

Release note: None