### PR TITLE
release-22.2: schema comment fixes

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -537,6 +537,7 @@ go_test(
         "comment_on_constraint_test.go",
         "comment_on_database_test.go",
         "comment_on_index_test.go",
+        "comment_on_schema_test.go",
         "comment_on_table_test.go",
         "conn_executor_internal_test.go",
         "conn_executor_savepoints_test.go",

--- a/pkg/sql/comment_on_column_test.go
+++ b/pkg/sql/comment_on_column_test.go
@@ -181,7 +181,7 @@ func TestCommentOnColumnWhenDropColumn(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Fatal("comment remain")
+		t.Fatal("comment remaining in system.comments despite drop")
 	}
 }
 

--- a/pkg/sql/comment_on_database_test.go
+++ b/pkg/sql/comment_on_database_test.go
@@ -104,6 +104,6 @@ func TestCommentOnDatabaseWhenDrop(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		t.Fatal("dropped comment remain comment")
+		t.Fatal("comment remaining in system.comments despite drop")
 	}
 }

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -344,7 +344,9 @@ https://www.postgresql.org/docs/9.5/infoschema-check-constraints.html`,
 				// uses the format <namespace_oid>_<table_oid>_<col_idx>_not_null.
 				// We might as well do the same.
 				conNameStr := tree.NewDString(fmt.Sprintf(
-					"%s_%s_%d_not_null", h.NamespaceOid(db.GetID(), scName), tableOid(table.GetID()), column.Ordinal()+1,
+					"%s_%s_%d_not_null",
+					h.NamespaceOid(db, scName),
+					tableOid(table.GetID()), column.Ordinal()+1,
 				))
 				chkExprStr := tree.NewDString(fmt.Sprintf(
 					"%s IS NOT NULL", column.GetName(),
@@ -1308,7 +1310,9 @@ https://www.postgresql.org/docs/9.5/infoschema-table-constraints.html`,
 					}
 					// NOT NULL column constraints are implemented as a CHECK in postgres.
 					conNameStr := tree.NewDString(fmt.Sprintf(
-						"%s_%s_%d_not_null", h.NamespaceOid(db.GetID(), scName), tableOid(table.GetID()), col.Ordinal()+1,
+						"%s_%s_%d_not_null",
+						h.NamespaceOid(db, scName),
+						tableOid(table.GetID()), col.Ordinal()+1,
 					))
 					if err := addRow(
 						dbNameStr,                // constraint_catalog

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -1983,25 +1983,25 @@ SELECT *
 FROM information_schema.table_constraints
 ORDER BY TABLE_NAME, CONSTRAINT_TYPE, CONSTRAINT_NAME
 ----
-constraint_catalog  constraint_schema  constraint_name            table_catalog  table_schema  table_name  constraint_type  is_deferrable  initially_deferred
-constraint_db       public             3864823197_118_1_not_null  constraint_db  public        t1          CHECK            NO             NO
-constraint_db       public             c2                         constraint_db  public        t1          CHECK            NO             NO
-constraint_db       public             check_a                    constraint_db  public        t1          CHECK            NO             NO
-constraint_db       public             t1_pkey                    constraint_db  public        t1          PRIMARY KEY      NO             NO
-constraint_db       public             t1_a_key                   constraint_db  public        t1          UNIQUE           NO             NO
-constraint_db       public             3864823197_119_2_not_null  constraint_db  public        t2          CHECK            NO             NO
-constraint_db       public             fk                         constraint_db  public        t2          FOREIGN KEY      NO             NO
-constraint_db       public             t2_pkey                    constraint_db  public        t2          PRIMARY KEY      NO             NO
+constraint_catalog  constraint_schema  constraint_name     table_catalog  table_schema  table_name  constraint_type  is_deferrable  initially_deferred
+constraint_db       public             117_118_1_not_null  constraint_db  public        t1          CHECK            NO             NO
+constraint_db       public             c2                  constraint_db  public        t1          CHECK            NO             NO
+constraint_db       public             check_a             constraint_db  public        t1          CHECK            NO             NO
+constraint_db       public             t1_pkey             constraint_db  public        t1          PRIMARY KEY      NO             NO
+constraint_db       public             t1_a_key            constraint_db  public        t1          UNIQUE           NO             NO
+constraint_db       public             117_119_2_not_null  constraint_db  public        t2          CHECK            NO             NO
+constraint_db       public             fk                  constraint_db  public        t2          FOREIGN KEY      NO             NO
+constraint_db       public             t2_pkey             constraint_db  public        t2          PRIMARY KEY      NO             NO
 
 query TTTT colnames
 SELECT *
 FROM information_schema.check_constraints
 ORDER BY CONSTRAINT_CATALOG, CONSTRAINT_NAME
 ----
-constraint_catalog  constraint_schema  constraint_name            check_clause
-constraint_db       public             3864823197_118_1_not_null  p IS NOT NULL
-constraint_db       public             c2                         ((a < 99:::INT8))
-constraint_db       public             check_a                    ((a > 4:::INT8))
+constraint_catalog  constraint_schema  constraint_name     check_clause
+constraint_db       public             117_118_1_not_null  p IS NOT NULL
+constraint_db       public             c2                  ((a < 99:::INT8))
+constraint_db       public             check_a             ((a > 4:::INT8))
 
 query TTTTTTT colnames
 SELECT *
@@ -2026,10 +2026,10 @@ USING (constraint_catalog, constraint_schema, constraint_name)
 WHERE tc.table_schema in ('public')
 ORDER BY tc.table_schema, tc.table_name, cc.constraint_name
 ----
-table_schema  table_name  constraint_name            check_clause
-public        t1          3864823197_118_1_not_null  p IS NOT NULL
-public        t1          c2                         ((a < 99:::INT8))
-public        t1          check_a                    ((a > 4:::INT8))
+table_schema  table_name  constraint_name     check_clause
+public        t1          117_118_1_not_null  p IS NOT NULL
+public        t1          c2                  ((a < 99:::INT8))
+public        t1          check_a             ((a > 4:::INT8))
 
 statement ok
 DROP DATABASE constraint_db CASCADE

--- a/pkg/sql/logictest/testdata/logic_test/orms
+++ b/pkg/sql/logictest/testdata/logic_test/orms
@@ -358,7 +358,7 @@ SELECT
   typdefaultbin
 FROM pg_type WHERE typname = 'regression_66576'
 ----
-regression_66576  4101115737  c  C  false  0  -1  0  -1  NULL
+regression_66576  105  c  C  false  0  -1  0  -1  NULL
 
 query T
 SELECT reltype FROM pg_class WHERE relname = 'regression_65576'

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -430,7 +430,7 @@ oid         nspname             nspowner    nspacl
 155990598   information_schema  NULL        NULL
 2154378761  pg_catalog          NULL        NULL
 1098122499  pg_extension        NULL        NULL
-4101115737  public              2310524507  NULL
+105         public              2310524507  NULL
 
 # Verify that we can still see the schemas even if we don't have any privilege
 # on the current database.
@@ -449,7 +449,7 @@ oid         nspname             nspowner    nspacl
 155990598   information_schema  NULL        NULL
 2154378761  pg_catalog          NULL        NULL
 1098122499  pg_extension        NULL        NULL
-4101115737  public              2310524507  NULL
+105         public              2310524507  NULL
 
 user root
 
@@ -564,31 +564,31 @@ JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
 WHERE n.nspname = 'public'
 ----
 oid         relname            relnamespace  reltype  reloftype  relowner    relam       relfilenode  reltablespace
-110         t1                 3082627813    100110   0          1546506610  2631952481  0            0
-3687884466  t1_pkey            3082627813    0        0          1546506610  2631952481  0            0
-3687884465  t1_a_key           3082627813    0        0          1546506610  2631952481  0            0
-3687884464  index_key          3082627813    0        0          1546506610  2631952481  0            0
-111         t1_m_seq           3082627813    100111   0          1546506610  0           0            0
-112         t1_n_seq           3082627813    100112   0          1546506610  0           0            0
-113         t2                 3082627813    100113   0          1546506610  2631952481  0            0
-2955071325  t2_pkey            3082627813    0        0          1546506610  2631952481  0            0
-2955071326  t2_t1_id_idx       3082627813    0        0          1546506610  2631952481  0            0
-114         t3                 3082627813    100114   0          1546506610  2631952481  0            0
-2695335054  t3_pkey            3082627813    0        0          1546506610  2631952481  0            0
-2695335053  t3_a_b_idx         3082627813    0        0          1546506610  2631952481  0            0
-115         v1                 3082627813    100115   0          1546506610  0           0            0
-116         t4                 3082627813    100116   0          1546506610  2631952481  0            0
-3214807592  t4_pkey            3082627813    0        0          1546506610  2631952481  0            0
-117         t5                 3082627813    100117   0          1546506610  2631952481  0            0
-1869730585  t5_pkey            3082627813    0        0          1546506610  2631952481  0            0
-120         t6                 3082627813    100120   0          1546506610  2631952481  0            0
-2129466852  t6_pkey            3082627813    0        0          1546506610  2631952481  0            0
-2129466855  t6_expr_idx        3082627813    0        0          1546506610  2631952481  0            0
-2129466854  t6_expr_expr1_idx  3082627813    0        0          1546506610  2631952481  0            0
-2129466848  t6_expr_key        3082627813    0        0          1546506610  2631952481  0            0
-2129466850  t6_expr_idx1       3082627813    0        0          1546506610  2631952481  0            0
-121         mv1                3082627813    100121   0          1546506610  0           0            0
-784389845   mv1_pkey           3082627813    0        0          1546506610  2631952481  0            0
+110         t1                 109           100110   0          1546506610  2631952481  0            0
+3687884466  t1_pkey            109           0        0          1546506610  2631952481  0            0
+3687884465  t1_a_key           109           0        0          1546506610  2631952481  0            0
+3687884464  index_key          109           0        0          1546506610  2631952481  0            0
+111         t1_m_seq           109           100111   0          1546506610  0           0            0
+112         t1_n_seq           109           100112   0          1546506610  0           0            0
+113         t2                 109           100113   0          1546506610  2631952481  0            0
+2955071325  t2_pkey            109           0        0          1546506610  2631952481  0            0
+2955071326  t2_t1_id_idx       109           0        0          1546506610  2631952481  0            0
+114         t3                 109           100114   0          1546506610  2631952481  0            0
+2695335054  t3_pkey            109           0        0          1546506610  2631952481  0            0
+2695335053  t3_a_b_idx         109           0        0          1546506610  2631952481  0            0
+115         v1                 109           100115   0          1546506610  0           0            0
+116         t4                 109           100116   0          1546506610  2631952481  0            0
+3214807592  t4_pkey            109           0        0          1546506610  2631952481  0            0
+117         t5                 109           100117   0          1546506610  2631952481  0            0
+1869730585  t5_pkey            109           0        0          1546506610  2631952481  0            0
+120         t6                 109           100120   0          1546506610  2631952481  0            0
+2129466852  t6_pkey            109           0        0          1546506610  2631952481  0            0
+2129466855  t6_expr_idx        109           0        0          1546506610  2631952481  0            0
+2129466854  t6_expr_expr1_idx  109           0        0          1546506610  2631952481  0            0
+2129466848  t6_expr_key        109           0        0          1546506610  2631952481  0            0
+2129466850  t6_expr_idx1       109           0        0          1546506610  2631952481  0            0
+121         mv1                109           100121   0          1546506610  0           0            0
+784389845   mv1_pkey           109           0        0          1546506610  2631952481  0            0
 
 query TIRIOBBT colnames
 SELECT relname, relpages, reltuples, relallvisible, reltoastrelid, relhasindex, relisshared, relpersistence
@@ -1305,27 +1305,27 @@ WHERE n.nspname = 'public'
 ORDER BY con.oid
 ----
 oid         conname        connamespace  contype  condef
-36403682    check_b        3082627813    c        CHECK ((b > 11))
-108480825   uwi_b_c        3082627813    u        UNIQUE WITHOUT INDEX (b, c)
-180431994   t5_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
-192087236   fk_b_c         3082627813    f        FOREIGN KEY (b, c) REFERENCES t4(b, c) MATCH FULL ON UPDATE RESTRICT
-296187876   check_c        3082627813    c        CHECK ((c != ''::STRING))
-1002858066  t6_expr_key    3082627813    u        UNIQUE (lower(c) ASC)
-1034567609  uwi_b_partial  3082627813    u        UNIQUE WITHOUT INDEX (b) WHERE (c = 'foo'::STRING)
-1265772734  t2_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
-1525509005  t3_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
-1568726274  index_key      3082627813    u        UNIQUE (b ASC, c ASC)
-1568726275  t1_a_key       3082627813    u        UNIQUE (a ASC)
-1622172050  unique_a       3082627813    u        UNIQUE WITHOUT INDEX (a)
-2044981543  t6_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
-2061447344  fk             3082627813    f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
-2610849745  t1_pkey        3082627813    p        PRIMARY KEY (p ASC)
-3130322283  t4_pkey        3082627813    p        PRIMARY KEY (rowid ASC)
-3390058550  mv1_pkey       3082627813    p        PRIMARY KEY (rowid ASC)
-3764151187  t5_a_fkey      3082627813    f        FOREIGN KEY (a) REFERENCES t4(a) ON DELETE CASCADE
-3836426375  fk             3082627813    f        FOREIGN KEY (t1_id) REFERENCES t1(a)
-3955926752  primary        3082627813    p        PRIMARY KEY (value ASC)
-4215663023  primary        3082627813    p        PRIMARY KEY (value ASC)
+36403682    check_b        109           c        CHECK ((b > 11))
+108480825   uwi_b_c        109           u        UNIQUE WITHOUT INDEX (b, c)
+180431994   t5_pkey        109           p        PRIMARY KEY (rowid ASC)
+192087236   fk_b_c         109           f        FOREIGN KEY (b, c) REFERENCES t4(b, c) MATCH FULL ON UPDATE RESTRICT
+296187876   check_c        109           c        CHECK ((c != ''::STRING))
+1002858066  t6_expr_key    109           u        UNIQUE (lower(c) ASC)
+1034567609  uwi_b_partial  109           u        UNIQUE WITHOUT INDEX (b) WHERE (c = 'foo'::STRING)
+1265772734  t2_pkey        109           p        PRIMARY KEY (rowid ASC)
+1525509005  t3_pkey        109           p        PRIMARY KEY (rowid ASC)
+1568726274  index_key      109           u        UNIQUE (b ASC, c ASC)
+1568726275  t1_a_key       109           u        UNIQUE (a ASC)
+1622172050  unique_a       109           u        UNIQUE WITHOUT INDEX (a)
+2044981543  t6_pkey        109           p        PRIMARY KEY (rowid ASC)
+2061447344  fk             109           f        FOREIGN KEY (a, b) REFERENCES t1(b, c)
+2610849745  t1_pkey        109           p        PRIMARY KEY (p ASC)
+3130322283  t4_pkey        109           p        PRIMARY KEY (rowid ASC)
+3390058550  mv1_pkey       109           p        PRIMARY KEY (rowid ASC)
+3764151187  t5_a_fkey      109           f        FOREIGN KEY (a) REFERENCES t4(a) ON DELETE CASCADE
+3836426375  fk             109           f        FOREIGN KEY (t1_id) REFERENCES t1(a)
+3955926752  primary        109           p        PRIMARY KEY (value ASC)
+4215663023  primary        109           p        PRIMARY KEY (value ASC)
 
 query TTBBBOOO colnames
 SELECT conname, contype, condeferrable, condeferred, convalidated, conrelid, contypid, conindid
@@ -1680,25 +1680,25 @@ oid         typname                                typnamespace  typowner    typ
 90003       _geography                             591606261     NULL        -1      false     b
 90004       box2d                                  591606261     NULL        32      true      b
 90005       _box2d                                 591606261     NULL        -1      false     b
-100110      t1                                     3082627813    1546506610  -1      false     c
-100111      t1_m_seq                               3082627813    1546506610  -1      false     c
-100112      t1_n_seq                               3082627813    1546506610  -1      false     c
-100113      t2                                     3082627813    1546506610  -1      false     c
-100114      t3                                     3082627813    1546506610  -1      false     c
-100115      v1                                     3082627813    1546506610  -1      false     c
-100116      t4                                     3082627813    1546506610  -1      false     c
-100117      t5                                     3082627813    1546506610  -1      false     c
-100118      mytype                                 3082627813    1546506610  -1      false     e
-100119      _mytype                                3082627813    1546506610  -1      false     b
-100120      t6                                     3082627813    1546506610  -1      false     c
-100121      mv1                                    3082627813    1546506610  -1      false     c
-100128      source_table                           3082627813    1546506610  -1      false     c
-100129      depend_view                            3082627813    1546506610  -1      false     c
-100130      view_dependingon_view                  3082627813    1546506610  -1      false     c
-100131      newtype1                               3082627813    1546506610  -1      false     e
-100132      _newtype1                              3082627813    1546506610  -1      false     b
-100133      newtype2                               3082627813    1546506610  -1      false     e
-100134      _newtype2                              3082627813    1546506610  -1      false     b
+100110      t1                                     109           1546506610  -1      false     c
+100111      t1_m_seq                               109           1546506610  -1      false     c
+100112      t1_n_seq                               109           1546506610  -1      false     c
+100113      t2                                     109           1546506610  -1      false     c
+100114      t3                                     109           1546506610  -1      false     c
+100115      v1                                     109           1546506610  -1      false     c
+100116      t4                                     109           1546506610  -1      false     c
+100117      t5                                     109           1546506610  -1      false     c
+100118      mytype                                 109           1546506610  -1      false     e
+100119      _mytype                                109           1546506610  -1      false     b
+100120      t6                                     109           1546506610  -1      false     c
+100121      mv1                                    109           1546506610  -1      false     c
+100128      source_table                           109           1546506610  -1      false     c
+100129      depend_view                            109           1546506610  -1      false     c
+100130      view_dependingon_view                  109           1546506610  -1      false     c
+100131      newtype1                               109           1546506610  -1      false     e
+100132      _newtype1                              109           1546506610  -1      false     b
+100133      newtype2                               109           1546506610  -1      false     e
+100134      _newtype2                              109           1546506610  -1      false     b
 4294967002  spatial_ref_sys                        1700435119    2310524507  -1      false     c
 4294967003  geometry_columns                       1700435119    2310524507  -1      false     c
 4294967004  geography_columns                      1700435119    2310524507  -1      false     c
@@ -3593,7 +3593,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'newtype1'
 ----
 oid     typname   typnamespace  typowner    typlen  typbyval  typtype
-100131  newtype1  3082627813    1546506610  -1      false     e
+100131  newtype1  109           1546506610  -1      false     e
 
 query OTOOIBT colnames
 SELECT oid, typname, typnamespace, typowner, typlen, typbyval, typtype
@@ -3615,7 +3615,7 @@ FROM pg_catalog.pg_type
 WHERE typname = 'source_table'
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  3082627813    1546506610  -1      false     c
+100128  source_table  109           1546506610  -1      false     c
 
 let $sourceid
 SELECT oid
@@ -3629,7 +3629,7 @@ FROM pg_catalog.pg_type
 WHERE oid = $sourceid
 ----
 oid     typname       typnamespace  typowner    typlen  typbyval  typtype
-100128  source_table  3082627813    1546506610  -1      false     c
+100128  source_table  109           1546506610  -1      false     c
 
 ## pg_catalog.pg_proc
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -124,7 +124,7 @@ array_in  array_in  array_in  array_in
 query OO
 SELECT 'public'::REGNAMESPACE, 'public'::REGNAMESPACE::OID
 ----
-public  4101115737
+public  105
 
 query OO
 SELECT 'root'::REGROLE, 'root'::REGROLE::OID

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -168,9 +168,9 @@ query TTTTTBBBTITTTTT
 SELECT oid, proname, pronamespace, proowner, prolang, proleakproof, proisstrict, proretset, provolatile, pronargs, prorettype, proargtypes, proargmodes, proargnames, prosrc
 FROM pg_catalog.pg_proc WHERE proname IN ('proc_f', 'proc_f_2');
 ----
-100118  proc_f    4101115737  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    SELECT 1;
-100119  proc_f    4101115737  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
-100121  proc_f_2  131273696   1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
+100118  proc_f    105  1546506610  14  false  false  false  v  1  20  20     {i}    NULL    SELECT 1;
+100119  proc_f    105  1546506610  14  true   true   false  i  2  25  25 20  {i,i}  {"",b}  SELECT 'hello';
+100121  proc_f_2  120  1546506610  14  false  false  false  v  1  25  25     {i}    NULL    SELECT 'hello';
 
 statement ok
 USE defaultdb;

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -660,7 +660,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 		if err != nil {
 			return err
 		}
-		namespaceOid := h.NamespaceOid(db.GetID(), scName)
+		namespaceOid := h.NamespaceOid(db, scName)
 		if err := addRow(
 			tableOid(table.GetID()),        // oid
 			tree.NewDName(table.GetName()), // relname
@@ -771,7 +771,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-collation.html`,
 	populate: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false /* requiresPrivileges */, func(db catalog.DatabaseDescriptor) error {
-			namespaceOid := h.NamespaceOid(db.GetID(), pgCatalogName)
+			namespaceOid := h.NamespaceOid(db, pgCatalogName)
 			add := func(collName string) error {
 				return addRow(
 					h.CollationOid(collName),  // oid
@@ -854,7 +854,7 @@ func populateTableConstraints(
 	if err != nil {
 		return err
 	}
-	namespaceOid := h.NamespaceOid(db.GetID(), scName)
+	namespaceOid := h.NamespaceOid(db, scName)
 	tblOid := tableOid(table.GetID())
 	for conName, con := range conInfo {
 		conoid := tree.DNull
@@ -2093,10 +2093,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-namespace.html`,
 						ownerOID = h.UserOid(username.MakeSQLUsernameFromPreNormalizedString("admin"))
 					}
 					return addRow(
-						h.NamespaceOid(db.GetID(), sc.GetName()), // oid
-						tree.NewDString(sc.GetName()),            // nspname
-						ownerOID,                                 // nspowner
-						tree.DNull,                               // nspacl
+						h.NamespaceOid(db, sc.GetName()), // oid
+						tree.NewDString(sc.GetName()),    // nspname
+						ownerOID,                         // nspowner
+						tree.DNull,                       // nspacl
 					)
 				})
 			})
@@ -2128,7 +2128,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-operator.html`,
 	schema: vtable.PGCatalogOperator,
 	populate: func(ctx context.Context, p *planner, db catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
 		h := makeOidHasher()
-		nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
+		nspOid := h.NamespaceOid(db, pgCatalogName)
 		addOp := func(opName string, kind tree.Datum, params tree.TypeList, returnTyper tree.ReturnTyper) error {
 			var leftType, rightType *tree.DOid
 			switch params.Length() {
@@ -2297,7 +2297,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 		// builtin function since they don't really belong to any database.
 		err := forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
-				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
+				nspOid := h.NamespaceOid(db, pgCatalogName)
 				for _, name := range builtins.AllBuiltinNames {
 					// parser.Builtins contains duplicate uppercase and lowercase keys.
 					// Only return the lowercase ones for compatibility with postgres.
@@ -2462,10 +2462,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-proc.html`,
 						}
 
 						return addRow(
-							tree.NewDOid(catid.FuncIDToOID(fnDesc.GetID())),  // oid
-							tree.NewDName(fnDesc.GetName()),                  // proname
-							h.NamespaceOid(dbDesc.GetID(), scDesc.GetName()), // pronamespace
-							h.UserOid(fnDesc.GetPrivileges().Owner()),        // proowner
+							tree.NewDOid(catid.FuncIDToOID(fnDesc.GetID())), // oid
+							tree.NewDName(fnDesc.GetName()),                 // proname
+							h.NamespaceOid(dbDesc, scDesc.GetName()),        // pronamespace
+							h.UserOid(fnDesc.GetPrivileges().Owner()),       // proowner
 							// In postgres oid of sql language is 14, need to add a mapping if
 							// we are going to support more languages.
 							tree.NewDOid(14), // prolang
@@ -2957,7 +2957,7 @@ func addPGTypeRowForTable(
 	table catalog.TableDescriptor,
 	addRow func(...tree.Datum) error,
 ) error {
-	nspOid := h.NamespaceOid(db.GetID(), scName)
+	nspOid := h.NamespaceOid(db, scName)
 	ownerOID, err := getOwnerOID(ctx, p, table)
 	if err != nil {
 		return err
@@ -3113,7 +3113,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 		h := makeOidHasher()
 		return forEachDatabaseDesc(ctx, p, dbContext, false, /* requiresPrivileges */
 			func(db catalog.DatabaseDescriptor) error {
-				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
+				nspOid := h.NamespaceOid(db, pgCatalogName)
 
 				// Generate rows for all predefined types.
 				for _, typ := range types.OidToType {
@@ -3141,7 +3141,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 					p,
 					db,
 					func(_ catalog.DatabaseDescriptor, scName string, typDesc catalog.TypeDescriptor) error {
-						nspOid := h.NamespaceOid(db.GetID(), scName)
+						nspOid := h.NamespaceOid(db, scName)
 						typ, err := typDesc.MakeTypesT(ctx, tree.NewQualifiedTypeName(db.GetName(), scName, typDesc.GetName()), p)
 						if err != nil {
 							return err
@@ -3163,7 +3163,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 				addRow func(...tree.Datum) error) (bool, error) {
 
 				h := makeOidHasher()
-				nspOid := h.NamespaceOid(db.GetID(), pgCatalogName)
+				nspOid := h.NamespaceOid(db, pgCatalogName)
 				coid := tree.MustBeDOid(unwrappedConstraint)
 				ooid := coid.Oid
 
@@ -3231,7 +3231,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-type.html`,
 					return true, nil
 				}
 
-				nspOid = h.NamespaceOid(db.GetID(), scName)
+				nspOid = h.NamespaceOid(db, scName)
 				typ, err = typDesc.MakeTypesT(ctx, tree.NewUnqualifiedTypeName(typDesc.GetName()), p)
 				if err != nil {
 					return false, err
@@ -4504,9 +4504,12 @@ func (h oidHasher) writeForeignKeyConstraint(fk *descpb.ForeignKeyConstraint) {
 	h.writeStr(fk.Name)
 }
 
-func (h oidHasher) NamespaceOid(dbID descpb.ID, scName string) *tree.DOid {
+func (h oidHasher) NamespaceOid(db catalog.DatabaseDescriptor, scName string) *tree.DOid {
+	if scID := db.GetSchemaID(scName); scID != 0 {
+		return tree.NewDOid(oid.Oid(scID))
+	}
 	h.writeTypeTag(namespaceTypeTag)
-	h.writeDB(dbID)
+	h.writeDB(db.GetID())
 	h.writeSchema(scName)
 	return h.getOid()
 }

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -2176,6 +2176,8 @@ func getCatalogOidForComments(catalogName string) (id int, ok bool) {
 		return catconstants.PgCatalogDescriptionTableID, true
 	case "pg_constraint":
 		return catconstants.PgCatalogConstraintTableID, true
+	case "pg_namespace":
+		return catconstants.PgCatalogNamespaceTableID, true
 	default:
 		// We currently only support comments on pg_class objects
 		// (columns, tables) in this context.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql: use schema desc ID for OIDs in pg_catalog" (#88009)
  * 1/1 commits from "sql: add missing obj_description case" (#88098)

Please see individual PRs for details.

/cc @cockroachdb/release

----
Release justification: bug fix