### PR TITLE
backupccl: allow backupRestoreTestSetup[Empty]WithParams to test within a tenant

### DIFF
--- a/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
+++ b/pkg/ccl/backupccl/full_cluster_backup_restore_test.go
@@ -53,7 +53,12 @@ func TestFullClusterBackup(t *testing.T) {
 	settings := clustersettings.MakeTestingClusterSettings()
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
-			Settings: settings,
+			// Disabled only because backupRestoreTestSetupEmpty, another DR test
+			// helper function, that is not yet enabled to set up tenants within
+			// clusters by default. Tracking issue
+			// https://github.com/cockroachdb/cockroach/issues/76378
+			DisableDefaultTestTenant: true,
+			Settings:                 settings,
 			Knobs: base.TestingKnobs{
 				SpanConfig: &spanconfig.TestingKnobs{
 					// We compare job progress before and after a restore. Disable
@@ -351,6 +356,11 @@ func TestSingletonSpanConfigJobPostRestore(t *testing.T) {
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			// Disabled only because backupRestoreTestSetupEmpty, another DR test
+			// helper function, is not yet enabled to set up tenants within
+			// clusters by default. Tracking issue
+			// https://github.com/cockroachdb/cockroach/issues/76378
+			DisableDefaultTestTenant: true,
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},
@@ -942,6 +952,11 @@ func TestReintroduceOfflineSpans(t *testing.T) {
 			}},
 	}
 	params.ServerArgs.Knobs = knobs
+	// Disabled only because backupRestoreTestSetupEmpty, another DR test
+	// helper function, is not yet enabled to set up tenants within
+	// clusters by default. Tracking issue
+	// https://github.com/cockroachdb/cockroach/issues/76378
+	params.ServerArgs.DisableDefaultTestTenant = true
 
 	const numAccounts = 1000
 	ctx := context.Background()
@@ -1098,6 +1113,11 @@ func TestFullClusterRestoreWithUserIDs(t *testing.T) {
 
 	params := base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
+			// Disabled only because backupRestoreTestSetupEmpty, another DR test
+			// helper function, that is not yet enabled to set up tenants within
+			// clusters by default. Tracking issue
+			// https://github.com/cockroachdb/cockroach/issues/76378
+			DisableDefaultTestTenant: true,
 			Knobs: base.TestingKnobs{
 				JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 			},

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -55,7 +55,7 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 		backups[i].IntroducedSpans = make(roachpb.Spans, 0)
 		for j := range backups[i].Spans {
 			tableID := genTableID(j)
-			backups[i].Spans[j] = makeTableSpan(tableID)
+			backups[i].Spans[j] = makeTableSpan(keys.SystemSQLCodec, tableID)
 		}
 		backups[i].EndTime = ts.Add(time.Minute.Nanoseconds()*int64(i), 0)
 		if i > 0 {
@@ -66,7 +66,7 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []backuppb.Back
 				// span[spanIdxToDrop], present in the first i backups, and add a new
 				// one.
 				newTableID := genTableID(spanIdxToDrop) + 1
-				backups[i].Spans[spanIdxToDrop] = makeTableSpan(newTableID)
+				backups[i].Spans[spanIdxToDrop] = makeTableSpan(keys.SystemSQLCodec, newTableID)
 				backups[i].IntroducedSpans = append(backups[i].IntroducedSpans, backups[i].Spans[spanIdxToDrop])
 			}
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/column-families
+++ b/pkg/ccl/backupccl/testdata/backup-restore/column-families
@@ -1,4 +1,6 @@
-new-server name=s1 localities=us-east-1,us-west-1,us-west-2,eu-central-1
+# disabled to run within tenant because ALTER SPLIT cmd is not supported within tenant
+
+new-server name=s1 disable-tenant localities=us-east-1,us-west-1,us-west-2,eu-central-1
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
+++ b/pkg/ccl/backupccl/testdata/backup-restore/descriptor-conflicts
@@ -3,8 +3,11 @@
 # appropriately during a cluster restore. The conflicting system tables in the
 # restoring cluster should be copied to a descriptor ID higher than any
 # descriptor in the backup.
+#
+# disabled to run within a tenant because they cannot set zone configs
+# https://github.com/cockroachdb/cockroach/issues/49854?version=v22.2
 
-new-server name=s1
+new-server name=s1 disable-tenant
 ----
 
 exec-sql
@@ -23,7 +26,7 @@ exec-sql
 BACKUP INTO 'nodelocal://0/conflicting-descriptors';
 ----
 
-new-server name=s2 share-io-dir=s1
+new-server name=s2 share-io-dir=s1 disable-tenant
 ----
 
 # Create 4 dummy system tables that will have conflicting IDs with the database,

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-nodelocal
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-nodelocal
@@ -19,9 +19,16 @@ exec-sql
 BACKUP INTO 'external://conn-foo/cluster';
 ----
 
+# filter out the tenant_settings row to ensure the test can run within and outside a tenant
 query-sql
-SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
-'external://conn-foo/cluster'] ORDER BY object_name;
+SELECT
+  object_name, object_type, backup_type
+FROM
+ [SHOW BACKUP LATEST IN 'external://conn-foo/cluster']
+WHERE
+ object_name != 'tenant_settings'
+ORDER BY
+  object_name;
 ----
 bank table full
 comments table full
@@ -45,7 +52,6 @@ scheduled_jobs table full
 schema schema full
 settings table full
 system database full
-tenant_settings table full
 ui table full
 users table full
 zones table full

--- a/pkg/ccl/backupccl/testdata/backup-restore/external-connections-userfile
+++ b/pkg/ccl/backupccl/testdata/backup-restore/external-connections-userfile
@@ -19,9 +19,16 @@ exec-sql
 BACKUP INTO 'external://conn-foo/cluster';
 ----
 
+# filter out the tenant_settings row to ensure the test can run within and outside a tenant
 query-sql
-SELECT object_name, object_type, backup_type FROM [SHOW BACKUP LATEST IN
-'external://conn-foo/cluster'] ORDER BY object_name;
+SELECT
+  object_name, object_type, backup_type
+FROM
+ [SHOW BACKUP LATEST IN 'external://conn-foo/cluster']
+WHERE
+ object_name != 'tenant_settings'
+ORDER BY
+  object_name;
 ----
 bank table full
 comments table full
@@ -45,7 +52,6 @@ scheduled_jobs table full
 schema schema full
 settings table full
 system database full
-tenant_settings table full
 ui table full
 userfiles_root_upload_files table full
 userfiles_root_upload_payload table full

--- a/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
+++ b/pkg/ccl/backupccl/testdata/backup-restore/feature-flags
@@ -1,6 +1,8 @@
 subtest backup-feature-flags
 
-new-server name=s1
+# disabled for tenants as they can't enable/disable backup and restore features
+
+new-server name=s1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -7,7 +7,9 @@
 # - roll it back it back non-mvcc
 # - run an inc backup and ensure we reintroduce the table spans
 
-new-server name=s1
+# disabled to run within tenant as they don't have access to the
+# storage.mvcc.range_tombstones.enabled cluster setting
+new-server name=s1 disable-tenant
 ----
 
 ###########

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-imports
@@ -329,9 +329,12 @@ SELECT * FROM d.foofoo;
 # RESTORE AOST in-progress IMPORT, these tables should get thrown out.
 #
 # TODO(msbutler): cover mixed version RESTORE TABLE
+#
+# Disabled to run within tenants because version gating infra does not play nice within tenants.
+# More investigation required.
 
 
-new-server name=s4 share-io-dir=s1 allow-implicit-access beforeVersion=Start22_2
+new-server name=s4 share-io-dir=s1 allow-implicit-access beforeVersion=Start22_2 disable-tenant
 ----
 
 exec-sql
@@ -529,7 +532,7 @@ d foofoo table 3 incremental
 
 
 # Restore the backups taken from a mixed version chain
-new-server name=s5 share-io-dir=s1 allow-implicit-access
+new-server name=s5 share-io-dir=s1 allow-implicit-access disable-tenant
 ----
 
 

--- a/pkg/ccl/backupccl/testdata/backup-restore/max-row-size
+++ b/pkg/ccl/backupccl/testdata/backup-restore/max-row-size
@@ -17,10 +17,10 @@ exec-sql
 SET CLUSTER SETTING sql.guardrails.max_row_size_err = '16KiB';
 ----
 
-query-sql
+exec-sql expect-error-regex=(row larger than max row size: table 109 family 0 primary key .*/Table/109/1/2/0 size .*)
 INSERT INTO maxrow VALUES (2, repeat('x', 20000))
 ----
-pq: row larger than max row size: table 109 family 0 primary key /Table/109/1/2/0 size 20013
+regex matches error
 
 exec-sql
 BACKUP maxrow INTO 'nodelocal://1/maxrow';
@@ -39,10 +39,10 @@ SELECT i, pg_column_size(s) FROM d2.maxrow ORDER BY i;
 ----
 1 20004
 
-query-sql
+exec-sql expect-error-regex=(row larger than max row size: table 112 family 0 primary key .*/Table/112/1/2/0 size .*)
 INSERT INTO d2.maxrow VALUES (2, repeat('y', 20000));
 ----
-pq: row larger than max row size: table 112 family 0 primary key /Table/112/1/2/0 size 20014
+regex matches error
 
 exec-sql
 SET CLUSTER SETTING sql.guardrails.max_row_size_err = DEFAULT;

--- a/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
+++ b/pkg/ccl/backupccl/testdata/backup-restore/mismatched-localities
@@ -1,4 +1,6 @@
-new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1
+# disabled to run within tenant because multiregion primitives are not supported within tenant
+
+new-server name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/multiregion
@@ -1,4 +1,6 @@
-new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+# disabled to run within tenant because multiregion primitives are not supported within tenant
+
+new-server name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
 exec-sql
@@ -23,7 +25,7 @@ BACKUP INTO 'nodelocal://1/full_cluster_backup/';
 ----
 
 # A new cluster with the same locality settings.
-new-server name=s2 share-io-dir=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+new-server name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
 exec-sql
@@ -48,7 +50,7 @@ postgres root <nil> <nil> {} <nil>
 system node <nil> <nil> {} <nil>
 
 # A new cluster with different localities settings.
-new-server name=s3 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
+new-server name=s3 share-io-dir=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1
 ----
 
 exec-sql
@@ -140,7 +142,7 @@ BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';
 ----
 
 # New cluster for a cluster backup.
-new-server name=s4 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
+new-server name=s4 share-io-dir=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1
 ----
 
 exec-sql ignore-notice

--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys
@@ -1,7 +1,9 @@
 # Tests that Backups without Revisions History and Restore properly handle
 # range keys
 
-new-server name=s1
+# disabled to run within tenants because the kv request cmd only works on system tenants
+
+new-server name=s1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
+++ b/pkg/ccl/backupccl/testdata/backup-restore/rangekeys-revision-history
@@ -8,7 +8,10 @@
 # - t4: one insert in baz
 # - incremental backup
 
-new-server name=s1
+# disabled to run within tenants because the kv request cmd only works on system tenants
+
+
+new-server name=s1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-mixed-version
@@ -1,4 +1,4 @@
-new-server name=s1 beforeVersion=Start22_2
+new-server name=s1 beforeVersion=Start22_2 disable-tenant
 ----
 
 exec-sql
@@ -15,7 +15,7 @@ BACKUP INTO 'nodelocal://1/full_cluster_backup/';
 # This is a server where the cluster version is behind the binary version. Such
 # a condition only occurs when the user has upgraded the node to a new major
 # version but has not yet finalized the upgrade.
-new-server name=s2 beforeVersion=Start22_2 share-io-dir=s1
+new-server name=s2 beforeVersion=Start22_2 share-io-dir=s1 disable-tenant
 ----
 
 exec-sql expect-error-regex=pq: cluster restore not supported during major version upgrade: restore started at cluster version 22.1 but binary version is.*

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-retry
@@ -1,4 +1,5 @@
-new-server name=s1 nodes=1
+# disabled for tenants as they can't set storage.mvcc.range_tombstones.enabled
+new-server name=s1 nodes=1 disable-tenant
 ----
 
 subtest restore-retry
@@ -16,7 +17,7 @@ exec-sql
 BACKUP INTO 'nodelocal://1/cluster_backup';
 ----
 
-new-server name=s2 nodes=1 share-io-dir=s1
+new-server name=s2 nodes=1 share-io-dir=s1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-mixed-version
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-mixed-version
@@ -1,6 +1,8 @@
 # Tests that RESTORE with schema_only cannot get run in a mixed version cluster
+# Disabled to run within tenants because version gating infra does not play nice within tenants.
+# More investigation required.
 
-new-server name=s1 beforeVersion=Start22_2
+new-server name=s1 beforeVersion=Start22_2 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-schema-only-multiregion
@@ -1,7 +1,9 @@
 # Test schema only multi region restore this test is exactly the same as the 'multiregion' datadriven
 # test, except schema_only RESTORE is used
 
-new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+# disabled to run within tenant because multiregion primitives are not supported within tenant
+
+new-server name=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
 exec-sql
@@ -26,7 +28,7 @@ BACKUP INTO 'nodelocal://1/full_cluster_backup/';
 ----
 
 # A new cluster with the same locality settings.
-new-server name=s2 share-io-dir=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+new-server name=s2 share-io-dir=s1 allow-implicit-access disable-tenant localities=us-east-1,us-west-1,eu-central-1
 ----
 
 exec-sql
@@ -51,7 +53,7 @@ postgres root <nil> <nil> {} <nil>
 system node <nil> <nil> {} <nil>
 
 # A new cluster with different localities settings.
-new-server name=s3 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
+new-server name=s3 share-io-dir=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1
 ----
 
 exec-sql
@@ -143,7 +145,7 @@ BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';
 ----
 
 # New cluster for a cluster backup.
-new-server name=s4 share-io-dir=s1 allow-implicit-access localities=eu-central-1,eu-north-1
+new-server name=s4 share-io-dir=s1 allow-implicit-access disable-tenant localities=eu-central-1,eu-north-1
 ----
 
 exec-sql ignore-notice

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-tenants
@@ -1,4 +1,7 @@
-new-server name=s1
+# disabled to probabilistically run within a tenant because the test always runs from the host
+# tenant
+
+new-server name=s1 disable-tenant
 ----
 
 # Create a few tenants.
@@ -34,7 +37,7 @@ exec-sql
 BACKUP TENANT 6 INTO 'nodelocal://1/tenant6'
 ----
 
-new-server name=s2 share-io-dir=s1
+new-server name=s2 share-io-dir=s1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
+++ b/pkg/ccl/backupccl/testdata/backup-restore/show-backup-multiregion
@@ -1,6 +1,6 @@
 # These tests validate the SHOW BACKUP command for multi-region databases.
 
-new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1
+new-server name=s1 allow-implicit-access localities=us-east-1,us-west-1,eu-central-1 disable-tenant
 ----
 
 exec-sql

--- a/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
+++ b/pkg/ccl/backupccl/testdata/backup-restore/user-defined-functions
@@ -180,31 +180,14 @@ query-sql
 WITH descs AS (
   SHOW BACKUP LATEST IN 'nodelocal://0/test/'
 )
-SELECT database_name, parent_schema_name, object_name, object_type, is_full_cluster FROM descs
+SELECT
+  database_name, parent_schema_name, object_name, object_type, is_full_cluster
+FROM
+  descs
+WHERE
+  database_name = 'db1'
+
 ----
-<nil> <nil> system database true
-system public users table true
-system public zones table true
-system public settings table true
-system public ui table true
-system public locations table true
-system public role_members table true
-system public comments table true
-system public role_options table true
-system public scheduled_jobs table true
-system public database_role_settings table true
-system public role_id_seq table true
-system public tenant_settings table true
-system public privileges table true
-system public external_connections table true
-<nil> <nil> defaultdb database true
-defaultdb <nil> public schema true
-<nil> <nil> postgres database true
-postgres <nil> public schema true
-<nil> <nil> data database true
-data <nil> public schema true
-data public bank table true
-<nil> <nil> db1 database true
 db1 <nil> public schema true
 db1 <nil> sc1 schema true
 db1 sc1 tbl1 table true

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -272,6 +272,9 @@ type TestServerInterface interface {
 	// SpanConfigKVSubscriber returns the embedded spanconfig.KVSubscriber for
 	// the server.
 	SpanConfigKVSubscriber() interface{}
+
+	// TestTenants returns the test tenants associated with the server
+	TestTenants() []TestTenantInterface
 }
 
 // TestServerFactory encompasses the actual implementation of the shim

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -114,6 +114,16 @@ func (tc *TestCluster) StartedDefaultTestTenant() bool {
 	return !tc.Servers[0].Cfg.DisableDefaultTestTenant
 }
 
+// TenantOrServer returns either the ith server in the cluster or the tenant server associated with
+// the ith server if the cluster started with a default test tenant.
+func (tc *TestCluster) TenantOrServer(idx int) serverutils.TestTenantInterface {
+	s := tc.Server(idx)
+	if tc.StartedDefaultTestTenant() {
+		return s.TestTenants()[0]
+	}
+	return s
+}
+
 // stopServers stops the stoppers for each individual server in the cluster.
 // This method ensures that servers that were previously stopped explicitly are
 // not double-stopped.


### PR DESCRIPTION
Previously, all backup unit tests that called backupRestoreTestSetupWithParams
and backupRestoreTestSetupEmptyWithParams were disabled to run within tenants,
signficantly decreasing test coverage.

This patch allows tests that call these helper methods to be probabilistically
run within tenants (including most data driven tests). This patch also manually
disables some of these tests to be run within tenants. Future work should
continue to enable bulk unit tests to run within tenants by default.

Fixes https://github.com/cockroachdb/cockroach/issues/88381, https://github.com/cockroachdb/cockroach/issues/88527, https://github.com/cockroachdb/cockroach/issues/88453, https://github.com/cockroachdb/cockroach/issues/88380
Release note: None