### PR TITLE
cli/sql: delay writing the history file to the end

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -280,12 +280,10 @@ func (c *cliState) addHistory(line string) {
 		return
 	}
 
-	// ins.AddHistory will push command into memory and try to
-	// persist to disk (if ins's history file is set). err can
-	// be not nil only if it got a IO error while trying to persist.
+	// ins.AddHistory will push command into memory. err can
+	// be not nil only if it got a memory error.
 	if err := c.ins.AddHistory(line); err != nil {
-		fmt.Fprintf(c.iCtx.stderr, "warning: cannot save command-line history: %v\n", err)
-		c.ins.SetAutoSaveHistory("", false)
+		fmt.Fprintf(c.iCtx.stderr, "warning: cannot add entry to history: %v\n", err)
 	}
 }
 
@@ -2172,7 +2170,22 @@ func (c *cliState) configurePreShellDefaults(
 					fmt.Fprintf(c.iCtx.stderr, "warning: cannot load the command-line history (file corrupted?): %v\n", err)
 					fmt.Fprintf(c.iCtx.stderr, "note: the history file will be cleared upon first entry\n")
 				}
-				c.ins.SetAutoSaveHistory(histFile, true)
+				// SetAutoSaveHistory() does two things:
+				// - it preserves the name of the history file, for use
+				//   by the final SaveHistory() call.
+				// - it decides whether to save the history to file upon
+				//   every new command.
+				// We disable the latter, since a history file can grow somewhat
+				// large and we don't want the excess I/O latency to be interleaved
+				// in-between every command.
+				c.ins.SetAutoSaveHistory(histFile, false)
+				prevCleanup := cleanupFn
+				cleanupFn = func() {
+					if err := c.ins.SaveHistory(); err != nil {
+						fmt.Fprintf(c.iCtx.stderr, "warning: cannot save command-line history: %v\n", err)
+					}
+					prevCleanup()
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #54679.

Previously, the shell would write to the history file in-between each input.

This was incurring noticeable delays if the history file was large.

This patch fixes that by delaying the file write until the end. This is akin to the behavior of unix shell.

There is no user-visible change except in the case of a crash of the shell itself, which at this point has become extremely rare.

Release note: None