### PR TITLE
cli/interactive_tests: avoid running interaction tests with TERM=xterm

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -415,17 +415,7 @@ stringer(
 
 filegroup(
     name = "interactive_tests",
-    srcs = glob(
-        ["interactive_tests/**"],
-        # TODO(rail): The following tests fail under bazel.
-        # https://github.com/cockroachdb/cockroach/issues/71932, aka
-        # "broken_in_bazel"
-        exclude = [
-            "*/test_multiline_statements.tcl",
-            "*/test_pretty.tcl",
-            "*/test_server_sig.tcl",
-        ],
-    ),
+    srcs = glob(["interactive_tests/**"]),
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/cli/interactive_tests/test_bracketed_space.tcl
+++ b/pkg/cli/interactive_tests/test_bracketed_space.tcl
@@ -1,0 +1,25 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+# we force TERM to xterm, otherwise we can't
+# test bracketed paste below.
+set env(TERM) xterm
+
+spawn $argv demo --no-example-database
+
+eexpect "defaultdb>"
+
+start_test "Test that a multi-line bracketed paste is handled properly."
+send "\033\[200~"
+send "\\set display_format csv\r\n"
+send "values (1,'a'), (2,'b'), (3,'c');\r\n"
+send "\033\[201~\r\n"
+eexpect "1,a"
+eexpect "2,b"
+eexpect "3,c"
+eexpect "defaultdb>"
+end_test
+
+send_eof
+eexpect eof

--- a/pkg/cli/interactive_tests/test_multiline_statements.tcl
+++ b/pkg/cli/interactive_tests/test_multiline_statements.tcl
@@ -4,10 +4,6 @@ source [file join [file dirname $argv0] common.tcl]
 
 start_server $argv
 
-# we force TERM to xterm, otherwise we can't
-# test bracketed paste below.
-set env(TERM) xterm
-
 spawn $argv sql
 eexpect root@
 
@@ -98,18 +94,6 @@ send "commit;\r"
 eexpect COMMIT
 eexpect root@
 end_test
-
-start_test "Test that a multi-line bracketed paste is handled properly."
-send "\033\[200~"
-send "\\set display_format csv\r\n"
-send "values (1,'a'), (2,'b'), (3,'c');\r\n"
-send "\033\[201~\r\n"
-eexpect "1,a"
-eexpect "2,b"
-eexpect "3,c"
-eexpect root@
-end_test
-
 
 
 send_eof

--- a/pkg/cmd/dev/acceptance.go
+++ b/pkg/cmd/dev/acceptance.go
@@ -93,7 +93,7 @@ func (d *dev) acceptance(cmd *cobra.Command, commandLine []string) error {
 		args = append(args, "--test_arg", "-test.v")
 	}
 	args = append(args, fmt.Sprintf("--test_arg=-l=%s", logDir))
-	args = append(args, "--test_env=TZ=America/New_York")
+	args = append(args, "--test_env=TZ=America/New_York", "--test_env=TERM=vt100")
 	args = append(args, fmt.Sprintf("--test_arg=-b=%s", cockroachBin))
 	args = append(args, additionalBazelArgs...)
 


### PR DESCRIPTION
Fixes #71932.

Running the multiline / history tests with TERM=xterm causes the shell to emit xterm-specific escape syntax that in turn confuses expect/TCL.

Release note: None