### PR TITLE
cdc: avoid deadlock on error in pubsub sink

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1804,7 +1804,7 @@ func (p *fakePubsubSink) Flush(ctx context.Context) error {
 	return p.Sink.Flush(ctx)
 }
 
-func (p *fakePubsubClient) connectivityError() error {
+func (p *fakePubsubClient) connectivityErrorLocked() error {
 	return nil
 }
 


### PR DESCRIPTION
https://github.com/cockroachdb/cockroach/pull/88130 introduced a deadlock when an attempt to create a
topic fails -- the goroutine tries to acquire a lock in order to record the error, but it already has it in order to write to the map. This PR releases the lock while creating the topic, which should also help with performance a bit on startup.

Fixes #85374

Release note (bug fix): Fixed a bug preventing pubsub changefeeds from retrying.