### PR TITLE
sql: add assertion for txn passed to internal executor

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1097,7 +1097,16 @@ func (ie *InternalExecutor) checkIfStmtIsAllowed(stmt tree.Statement, txn *kv.Tx
 
 // checkIfTxnIsConsistent returns true if the given txn is not nil and is not
 // the same txn that is used to construct the internal executor.
+// TODO(janexing): this will be deprecated soon as we will only use
+// ie.extraTxnState.txn, and the txn argument in query functions will be
+// deprecated.
 func (ie *InternalExecutor) checkIfTxnIsConsistent(txn *kv.Txn) error {
+	if txn == nil && ie.extraTxnState != nil {
+		return errors.New("the current internal executor was contructed with" +
+			"a txn. To use an internal executor without a txn, call " +
+			"sqlutil.InternalExecutorFactory.RunWithoutTxn()")
+	}
+
 	if txn != nil && ie.extraTxnState != nil && ie.extraTxnState.txn != txn {
 		return errors.New("txn is inconsistent with the one when " +
 			"constructing the internal executor")

--- a/pkg/upgrade/upgrades/update_invalid_column_ids_in_sequence_back_references.go
+++ b/pkg/upgrade/upgrades/update_invalid_column_ids_in_sequence_back_references.go
@@ -42,7 +42,7 @@ func updateInvalidColumnIDsInSequenceBackReferences(
 		) (err error) {
 			currSeqID = lastSeqID
 			for {
-				done, currSeqID, err = findNextTableToUpgrade(ctx, ie, currSeqID,
+				done, currSeqID, err = findNextTableToUpgrade(ctx, ie, txn, currSeqID,
 					func(table *descpb.TableDescriptor) bool {
 						return table.IsSequence()
 					})


### PR DESCRIPTION
If an internal executor is created with a txn binding to it, it should not be used to execute a statement with a nil txn.

Release note: None