### PR TITLE
stats: make recent fix more conservative

### DIFF
--- a/pkg/sql/stats/histogram.go
+++ b/pkg/sql/stats/histogram.go
@@ -362,12 +362,12 @@ func getMinVal(
 		i := int64(*bound)
 		switch t.Width() {
 		case 16:
-			if i == math.MinInt16 {
+			if i <= math.MinInt16 { // use inequality to be conservative
 				return nil, false
 			}
 			return tree.NewDInt(tree.DInt(math.MinInt16)), true
 		case 32:
-			if i == math.MinInt32 {
+			if i <= math.MinInt32 { // use inequality to be conservative
 				return nil, false
 			}
 			return tree.NewDInt(tree.DInt(math.MinInt32)), true
@@ -397,12 +397,12 @@ func getMaxVal(
 		i := int64(*bound)
 		switch t.Width() {
 		case 16:
-			if i == math.MaxInt16 {
+			if i >= math.MaxInt16 { // use inequality to be conservative
 				return nil, false
 			}
 			return tree.NewDInt(tree.DInt(math.MaxInt16)), true
 		case 32:
-			if i == math.MaxInt32 {
+			if i >= math.MaxInt32 { // use inequality to be conservative
 				return nil, false
 			}
 			return tree.NewDInt(tree.DInt(math.MaxInt32)), true


### PR DESCRIPTION
We recently merged a fix for histograms of INT2 and INT4 types to not exceed their range, and we used an exact equality against the boundary values when determining whether "outer" buckets are needed. This commit makes that logic more bullet-proof by using an inequality. The sampled values that exceed the supported ranges for the types should not really happen, but let's be conservative.

Release note: None