### PR TITLE
colexecdisk: add cancel checking for disk-spilling operators

### DIFF
--- a/pkg/sql/colcontainer/BUILD.bazel
+++ b/pkg/sql/colcontainer/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/sql/colexecerror",
         "//pkg/sql/types",
         "//pkg/storage/fs",
+        "//pkg/util/cancelchecker",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/uuid",

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -545,7 +546,20 @@ func (d *diskQueue) writeFooterAndFlush(ctx context.Context) (err error) {
 	return nil
 }
 
+//gcassert:inline
+func checkCancellation(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return cancelchecker.QueryCanceledError
+	default:
+		return nil
+	}
+}
+
 func (d *diskQueue) Enqueue(ctx context.Context, b coldata.Batch) error {
+	if err := checkCancellation(ctx); err != nil {
+		return err
+	}
 	if d.state == diskQueueStateDequeueing {
 		if d.cfg.CacheMode != DiskQueueCacheModeIntertwinedCalls {
 			return errors.Errorf(
@@ -719,6 +733,9 @@ func (d *diskQueue) maybeInitDeserializer(ctx context.Context) (bool, error) {
 // Dequeue dequeues a batch from disk and deserializes it into b. Note that the
 // deserialized batch is only valid until the next call to Dequeue.
 func (d *diskQueue) Dequeue(ctx context.Context, b coldata.Batch) (bool, error) {
+	if err := checkCancellation(ctx); err != nil {
+		return false, err
+	}
 	if d.serializer != nil && d.numBufferedBatches > 0 {
 		if err := d.writeFooterAndFlush(ctx); err != nil {
 			return false, err

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -113,7 +113,8 @@ const (
 // some amount of RAM for its buffer. This is determined by
 // maxNumberPartitions variable.
 type externalSorter struct {
-	colexecop.OneInputHelper
+	colexecop.OneInputNode
+	colexecop.InitHelper
 	colexecop.NonExplainable
 	colexecop.CloserHelper
 
@@ -127,6 +128,8 @@ type externalSorter struct {
 	// operation. This will be roughly a half of the total limit and is used by
 	// the dequeued batches and the output batch.
 	mergeMemoryLimit int64
+
+	cancelChecker colexecutils.CancelChecker
 
 	state      externalSorterState
 	inputTypes []*types.T
@@ -290,7 +293,7 @@ func NewExternalSorter(
 		partitionedDiskQueueSemaphore = nil
 	}
 	es := &externalSorter{
-		OneInputHelper:           colexecop.MakeOneInputHelper(inMemSorter),
+		OneInputNode:             colexecop.NewOneInputNode(inMemSorter),
 		mergeUnlimitedAllocator:  mergeUnlimitedAllocator,
 		outputUnlimitedAllocator: outputUnlimitedAllocator,
 		mergeMemoryLimit:         mergeMemoryLimit,
@@ -341,8 +344,17 @@ func (s *externalSorter) resetPartitionsInfo(i int) {
 	s.partitionsInfo.maxBatchMemSize[i] = 0
 }
 
+func (s *externalSorter) Init(ctx context.Context) {
+	if !s.InitHelper.Init(ctx) {
+		return
+	}
+	s.Input.Init(s.Ctx)
+	s.cancelChecker.Init(s.Ctx)
+}
+
 func (s *externalSorter) Next() coldata.Batch {
 	for {
+		s.cancelChecker.CheckEveryCall()
 		switch s.state {
 		case externalSorterNewPartition:
 			b := s.Input.Next()

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -135,6 +135,7 @@ type hashBasedPartitioner struct {
 		fdSemaphore semaphore.Semaphore
 		acquiredFDs int
 	}
+	cancelChecker colexecutils.CancelChecker
 
 	partitioners      []*colcontainer.PartitionedDiskQueue
 	partitionedInputs []*partitionerToOperator
@@ -321,6 +322,7 @@ func (op *hashBasedPartitioner) Init(ctx context.Context) {
 	for i := range op.inputs {
 		op.inputs[i].Init(op.Ctx)
 	}
+	op.cancelChecker.Init(op.Ctx)
 	op.partitionsToProcessUsingMain = make(map[int]*hbpPartitionInfo)
 	// If we are initializing the hash-based partitioner, it means that we had
 	// to fallback from the in-memory one since the inputs had more tuples that
@@ -405,6 +407,7 @@ func (op *hashBasedPartitioner) Next() coldata.Batch {
 	var batches [2]coldata.Batch
 StateChanged:
 	for {
+		op.cancelChecker.CheckEveryCall()
 		switch op.state {
 		case hbpInitialPartitioning:
 			allZero := true

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2031,6 +2031,7 @@ func TestLint(t *testing.T) {
 		var buf strings.Builder
 		if err := gcassert.GCAssert(&buf,
 			"../../col/coldata",
+			"../../sql/colcontainer",
 			"../../sql/colconv",
 			"../../sql/colexec",
 			"../../sql/colexec/colexecagg",


### PR DESCRIPTION
This commit adds the cancel checking to the methods of the disk queue as well as to the external operators themselves.

Fixes: #87482.

Epic: CRDB-20535

Release note (bug fix): CockroachDB now more promptly reacts to query cancellations (e.g. due to statement timeout being exceeded) after the query spilled to disk.