### PR TITLE
release-22.1: roachtest: update django test skips

### DIFF
--- a/pkg/cmd/roachtest/tests/blocklist_test.go
+++ b/pkg/cmd/roachtest/tests/blocklist_test.go
@@ -36,7 +36,7 @@ func TestBlocklists(t *testing.T) {
 		"hibernate":    hibernateBlockList20_2,
 		"pgjdbc":       pgjdbcBlockList20_2,
 		"psycopg":      psycopgBlockList20_2,
-		"django":       djangoBlocklist20_2,
+		"django":       djangoBlocklist,
 		"sqlAlchemy":   sqlAlchemyBlocklist20_2,
 		"libpq":        libPQBlocklist20_2,
 		"gopg":         gopgBlockList20_2,

--- a/pkg/cmd/roachtest/tests/django.go
+++ b/pkg/cmd/roachtest/tests/django.go
@@ -28,7 +28,7 @@ var djangoReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)(
 var djangoCockroachDBReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)\.(?P<minor>\d+)$`)
 
 var djangoSupportedTag = "cockroach-4.1.x"
-var djangoCockroachDBSupportedTag = "4.1"
+var djangoCockroachDBSupportedTag = "4.1.*"
 
 func registerDjango(r registry.Registry) {
 	runDjango := func(
@@ -188,13 +188,7 @@ func registerDjango(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		blocklistName, expectedFailureList, ignoredlistName, ignoredlist := djangoBlocklists.getLists(version)
-		if expectedFailureList == nil {
-			t.Fatalf("No django blocklist defined for cockroach version %s", version)
-		}
-		if ignoredlist == nil {
-			t.Fatalf("No django ignorelist defined for cockroach version %s", version)
-		}
+		blocklistName, ignoredlistName := "djangoBlocklist", "djangoIgnoreList"
 		t.L().Printf("Running cockroach version %s, using blocklist %s, using ignoredlist %s",
 			version, blocklistName, ignoredlistName)
 
@@ -231,9 +225,9 @@ func registerDjango(r registry.Registry) {
 		t.Status("collating test results")
 
 		results := newORMTestsResults()
-		results.parsePythonUnitTestOutput(fullTestResults, expectedFailureList, ignoredlist)
+		results.parsePythonUnitTestOutput(fullTestResults, djangoBlocklist, djangoIgnoreList)
 		results.summarizeAll(
-			t, "django" /* ormName */, blocklistName, expectedFailureList, version, djangoSupportedTag,
+			t, "django" /* ormName */, blocklistName, djangoBlocklist, version, djangoSupportedTag,
 		)
 	}
 

--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -161,55 +161,10 @@ var enabledDjangoTests = []string{
 	"view_tests",
 }
 
-var djangoBlocklists = blocklistsForVersion{
-	{"v20.2", "djangoBlocklist20_2", djangoBlocklist20_2, "djangoIgnoreList20_2", djangoIgnoreList20_2},
-	{"v21.1", "djangoBlocklist21_1", djangoBlocklist21_1, "djangoIgnoreList21_1", djangoIgnoreList21_1},
-	{"v21.2", "djangoBlocklist21_2", djangoBlocklist21_2, "djangoIgnoreList21_2", djangoIgnoreList21_2},
-	{"v22.1", "djangoBlocklist22_1", djangoBlocklist22_1, "djangoIgnoreList22_1", djangoIgnoreList22_1},
-}
-
 // Maintain that this list is alphabetized.
-var djangoBlocklist22_1 = djangoBlocklist21_2
+var djangoBlocklist = blocklist{}
 
-var djangoBlocklist21_2 = djangoBlocklist21_1
-
-var djangoBlocklist21_1 = djangoBlocklist20_2
-
-var djangoBlocklist20_2 = blocklist{}
-
-var djangoIgnoreList22_1 = djangoIgnoreList21_2
-
-var djangoIgnoreList21_2 = blocklist{
-	"migrations.test_operations.OperationTests.test_alter_fk_non_fk":  "will be fixed in django-cockroachdb v3.2.2",
-	"schema.tests.SchemaTests.test_alter_field_db_collation":          "will be fixed in django-cockroachdb v3.2.2",
-	"schema.tests.SchemaTests.test_alter_field_type_and_db_collation": "will be fixed in django-cockroachdb v3.2.2",
-}
-
-var djangoIgnoreList21_1 = blocklist{
-	"schema.tests.SchemaTests.test_alter_field_db_collation":          "will be fixed in django-cockroachdb v3.2.2",
-	"schema.tests.SchemaTests.test_alter_field_type_and_db_collation": "will be fixed in django-cockroachdb v3.2.2",
-}
-
-var djangoIgnoreList20_2 = blocklist{
-	"expressions.tests.BasicExpressionsTests.test_boolean_expression_combined":   "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_attribute_name_not_python_keyword":   "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_digits_column_name_introspection":    "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_field_types":                         "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_managed_models":                      "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_number_field_types":                  "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_special_column_name_introspection":   "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_stealth_table_name_filter_option":    "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_table_name_introspection":            "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_table_option":                        "unknown",
-	"inspectdb.tests.InspectDBTestCase.test_unique_together_meta":                "unknown",
-	"introspection.tests.IntrospectionTests.test_get_constraints_indexes_orders": "unknown",
-	"introspection.tests.IntrospectionTests.test_get_table_description_types":    "unknown",
-	"schema.tests.SchemaTests.test_add_field_temp_default":                       "unknown",
-	"schema.tests.SchemaTests.test_alter":                                        "unknown",
-	"schema.tests.SchemaTests.test_alter_field_fk_keeps_index":                   "unknown",
-	"schema.tests.SchemaTests.test_alter_field_fk_to_o2o":                        "unknown",
-	"schema.tests.SchemaTests.test_alter_numeric_field_keep_null_status":         "unknown",
-	"schema.tests.SchemaTests.test_alter_smallint_pk_to_smallautofield_pk":       "unknown",
-	"schema.tests.SchemaTests.test_db_table":                                     "unknown",
-	"schema.tests.SchemaTests.test_foreign_key_index_long_names_regression":      "unknown",
+var djangoIgnoreList = blocklist{
+	"schema.tests.SchemaTests.test_add_auto_field":   "unneeded once django-cockroachdb 4.1.1 is released",
+	"schema.tests.SchemaTests.test_autofield_to_o2o": "unneeded once django-cockroachdb 4.1.1 is released",
 }


### PR DESCRIPTION
Backport 1/1 commits from #87597.

/cc @cockroachdb/release

fixes https://github.com/cockroachdb/cockroach/issues/87676

---

Fixes #87368, fixes #87576, fixes #87250

Release justification: test only

Release note: None
