### PR TITLE
opt: run sqlsmith roachtest queries with EXPLAIN

### DIFF
--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -228,6 +228,11 @@ INSERT INTO seed_mr_table DEFAULT VALUES;`, regionList[0]),
 					_, err := conn.Exec(stmt)
 					if err == nil {
 						logStmt(stmt)
+						stmt = "EXPLAIN " + stmt
+						_, err = conn.Exec(stmt)
+						if err == nil {
+							logStmt(stmt)
+						}
 					}
 					done <- err
 				}(ctx)


### PR DESCRIPTION
This commit modifies the SqlSmith roachtest to run each generated query with explain. This should allow the test to catch planning errors that do not happen during normal execution.

Informs #88037

Release note: None