### PR TITLE
kvserver: mvcc gc queue - use gc full range hint

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -1274,7 +1274,7 @@ func mergeTrigger(
 		if err != nil {
 			return result.Result{}, err
 		}
-		if lhsHint.Merge(rhsHint) {
+		if lhsHint.Merge(rhsHint, rec.GetMVCCStats().HasNoUserData(), merge.RightMVCCStats.HasNoUserData()) {
 			updated, err := lhsLoader.SetGCHint(ctx, batch, ms, lhsHint, merge.WriteGCHint)
 			if err != nil {
 				return result.Result{}, err

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -5125,69 +5125,124 @@ func TestStoreMergeGCHint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-	serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				DisableMergeQueue: true,
-				DisableSplitQueue: true,
-			},
+	for _, d := range []struct {
+		name                string
+		dataLeft, dataRight bool
+		delLeft, delRight   bool
+		expectHint          bool
+	}{
+		{
+			name:       "merge similar ranges",
+			dataLeft:   true,
+			dataRight:  true,
+			delLeft:    true,
+			delRight:   true,
+			expectHint: true,
 		},
-	})
-	s := serv.(*server.TestServer)
-	defer s.Stopper().Stop(ctx)
-	store, err := s.Stores().GetStore(s.GetFirstStoreID())
-	require.NoError(t, err)
+		{
+			name:       "merge with data on right",
+			dataLeft:   true,
+			dataRight:  true,
+			delLeft:    true,
+			expectHint: false,
+		},
+		{
+			name:       "merge with data on left",
+			dataLeft:   true,
+			dataRight:  true,
+			delRight:   true,
+			expectHint: false,
+		},
+		{
+			name:       "merge with empty on left",
+			dataRight:  true,
+			delRight:   true,
+			expectHint: true,
+		},
+		{
+			name:       "merge with empty on right",
+			dataLeft:   true,
+			delLeft:    true,
+			expectHint: true,
+		},
+	} {
+		t.Run(d.name, func(t *testing.T) {
+			ctx := context.Background()
+			serv, _, _ := serverutils.StartServer(t, base.TestServerArgs{
+				Knobs: base.TestingKnobs{
+					Store: &kvserver.StoreTestingKnobs{
+						DisableMergeQueue: true,
+						DisableSplitQueue: true,
+					},
+				},
+			})
+			s := serv.(*server.TestServer)
+			defer s.Stopper().Stop(ctx)
+			store, err := s.Stores().GetStore(s.GetFirstStoreID())
+			require.NoError(t, err)
 
-	leftKey := roachpb.Key("a")
-	splitKey := roachpb.Key("b")
-	rightKey := roachpb.Key("c")
-	content := []byte("test")
+			leftKey := roachpb.Key("a")
+			splitKey := roachpb.Key("b")
+			rightKey := roachpb.Key("c")
+			content := []byte("test")
 
-	put := func(key roachpb.Key) {
-		pArgs := putArgs(key, content)
-		_, pErr := kv.SendWrapped(ctx, store.TestSender(), pArgs)
-		require.NoError(t, pErr.GoError(), "failed to put value")
+			put := func(key roachpb.Key) {
+				pArgs := putArgs(key, content)
+				_, pErr := kv.SendWrapped(ctx, store.TestSender(), pArgs)
+				require.NoError(t, pErr.GoError(), "failed to put value")
+			}
+
+			delRange := func(key roachpb.Key) (wallTime int64) {
+				repl := store.LookupReplica(roachpb.RKey(key))
+				gcHint := repl.GetGCHint()
+				require.True(t, gcHint.IsEmpty(), "GC hint is not empty by default")
+
+				drArgs := &roachpb.DeleteRangeRequest{
+					UpdateRangeDeleteGCHint: true,
+					UseRangeTombstone:       true,
+					RequestHeader: roachpb.RequestHeader{
+						Key:    repl.Desc().StartKey.AsRawKey(),
+						EndKey: repl.Desc().EndKey.AsRawKey(),
+					},
+				}
+				_, pErr := kv.SendWrapped(ctx, store.TestSender(), drArgs)
+				require.NoError(t, pErr.GoError(), "failed to send delete range request")
+
+				return timeutil.Now().UnixNano()
+			}
+
+			splitArgs := adminSplitArgs(splitKey)
+			_, pErr := kv.SendWrapped(ctx, store.TestSender(), splitArgs)
+			require.NoError(t, pErr.GoError(), "failed to send admin split")
+
+			if d.dataLeft {
+				put(leftKey)
+			}
+			if d.dataRight {
+				put(rightKey)
+			}
+			var beforeSecondDel int64
+			if d.delLeft {
+				beforeSecondDel = delRange(leftKey)
+			}
+			if d.delRight {
+				delRange(rightKey)
+			}
+
+			r, err := s.LookupRange(leftKey)
+			require.NoError(t, err, "failed to lookup range")
+			mergeArgs := adminMergeArgs(r.StartKey.AsRawKey())
+			_, pErr = kv.SendWrapped(ctx, store.TestSender(), mergeArgs)
+			require.NoError(t, pErr.GoError(), "failed to send admin merge")
+
+			repl := store.LookupReplica(roachpb.RKey(leftKey))
+			gcHint := repl.GetGCHint()
+			require.Equal(t, d.expectHint, !gcHint.IsEmpty(), "GC hint is empty after range delete")
+			if d.expectHint && d.delLeft && d.delRight {
+				require.Greater(t, gcHint.LatestRangeDeleteTimestamp.WallTime, beforeSecondDel,
+					"highest timestamp wasn't picked up")
+			}
+			repl.AssertState(ctx, store.Engine())
+		})
 	}
-
-	delRange := func(key roachpb.Key) (wallTime int64) {
-		repl := store.LookupReplica(roachpb.RKey(key))
-		gcHint := repl.GetGCHint()
-		require.True(t, gcHint.IsEmpty(), "GC hint is not empty by default")
-
-		drArgs := &roachpb.DeleteRangeRequest{
-			UpdateRangeDeleteGCHint: true,
-			UseRangeTombstone:       true,
-			RequestHeader: roachpb.RequestHeader{
-				Key:    repl.Desc().StartKey.AsRawKey(),
-				EndKey: repl.Desc().EndKey.AsRawKey(),
-			},
-		}
-		_, pErr := kv.SendWrapped(ctx, store.TestSender(), drArgs)
-		require.NoError(t, pErr.GoError(), "failed to send delete range request")
-
-		return timeutil.Now().UnixNano()
-	}
-
-	splitArgs := adminSplitArgs(splitKey)
-	_, pErr := kv.SendWrapped(ctx, store.TestSender(), splitArgs)
-	require.NoError(t, pErr.GoError(), "failed to send admin split")
-
-	put(leftKey)
-	put(rightKey)
-	beforeSecondDel := delRange(leftKey)
-	delRange(rightKey)
-
-	r, err := s.LookupRange(leftKey)
-	require.NoError(t, err, "failed to lookup range")
-	mergeArgs := adminMergeArgs(r.StartKey.AsRawKey())
-	_, pErr = kv.SendWrapped(ctx, store.TestSender(), mergeArgs)
-	require.NoError(t, pErr.GoError(), "failed to send admin merge")
-
-	repl := store.LookupReplica(roachpb.RKey(leftKey))
-	gcHint := repl.GetGCHint()
-	require.False(t, gcHint.IsEmpty(), "GC hint is empty after range delete")
-	require.Greater(t, gcHint.LatestRangeDeleteTimestamp.WallTime, beforeSecondDel, "highest timestamp wasn't picked up")
-
-	repl.AssertState(ctx, store.Engine())
 }

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -89,6 +89,8 @@ type consistencyQueue struct {
 	replicaCountFn func() int
 }
 
+var _ queueImpl = &consistencyQueue{}
+
 // A data wrapper to allow for the shouldQueue method to be easier to test.
 type consistencyShouldQueueData struct {
 	desc                      *roachpb.RangeDescriptor
@@ -219,6 +221,11 @@ func (q *consistencyQueue) process(
 		fn(resp)
 	}
 	return true, nil
+}
+
+func (*consistencyQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (q *consistencyQueue) timer(duration time.Duration) time.Duration {

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -89,6 +89,8 @@ type mergeQueue struct {
 	purgChan <-chan time.Time
 }
 
+var _ queueImpl = &mergeQueue{}
+
 func newMergeQueue(store *Store, db *kv.DB) *mergeQueue {
 	mq := &mergeQueue{
 		db:       db,
@@ -424,6 +426,11 @@ func (mq *mergeQueue) process(
 		lhsRepl.loadBasedSplitter.RecordMax(mq.store.Clock().PhysicalTime(), mergedQPS)
 	}
 	return true, nil
+}
+
+func (*mergeQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (mq *mergeQueue) timer(time.Duration) time.Duration {

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1397,6 +1397,12 @@ sub-level and file counts.`,
 		Measurement: "Requests",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaGCEnqueueHighPriority = metric.Metadata{
+		Name:        "queue.gc.info.enqueuehighpriority",
+		Help:        "Number of replicas enqueued for GC with high priority",
+		Measurement: "Replicas",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Slow request metrics.
 	metaLatchRequests = metric.Metadata{
@@ -1862,6 +1868,7 @@ type StoreMetrics struct {
 	GCTxnIntentsResolveFailed *metric.Counter
 	GCUsedClearRange          *metric.Counter
 	GCFailedClearRange        *metric.Counter
+	GCEnqueueHighPriority     *metric.Counter
 
 	// Slow request counts.
 	SlowLatchRequests *metric.Gauge
@@ -2390,6 +2397,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		GCTxnIntentsResolveFailed:    metric.NewCounter(metaGCTxnIntentsResolveFailed),
 		GCUsedClearRange:             metric.NewCounter(metaGCUsedClearRange),
 		GCFailedClearRange:           metric.NewCounter(metaGCFailedClearRange),
+		GCEnqueueHighPriority:        metric.NewCounter(metaGCEnqueueHighPriority),
 
 		// Wedge request counters.
 		SlowLatchRequests: metric.NewGauge(metaLatchRequests),

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/contextutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -39,6 +40,10 @@ const (
 	// mvccGCQueueDefaultTimerDuration is the default duration between MVCC GCs
 	// of queued replicas.
 	mvccGCQueueDefaultTimerDuration = 1 * time.Second
+	// mvccHiPriGCQueueDefaultTimerDuration is default duration between MVCC GCs
+	// of queued replicas when replicas contain only garbage removed by range
+	// tombstone completely.
+	mvccHiPriGCQueueDefaultTimerDuration = 0 * time.Second
 	// mvccGCQueueTimeout is the timeout for a single MVCC GC run.
 	mvccGCQueueTimeout = 10 * time.Minute
 	// mvccGCQueueIntentBatchTimeout is the timeout for resolving a single batch
@@ -64,6 +69,20 @@ const (
 
 	probablyLargeAbortSpanSysCountThreshold = 10000
 	largeAbortSpanBytesThreshold            = 16 * (1 << 20) // 16mb
+
+	// deleteRangePriority is used to indicate replicas that needs to be processed
+	// out of band quickly to enable storage compaction optimization because all
+	// data in them was removed.
+	deleteRangePriority = math.MaxFloat64
+	// gcHintScannerTimeout determines how long hint scanner can hold mvcc gc queue
+	// from progressing. We don't want to scanner to fail if timeout is too short
+	// as it may miss some high priority replicas and increase compaction load,
+	// but at the same time if something goes wrong and we can't obtain read locks
+	// on replica, we can tolerate so much time. 5 minutes shouldn't delay GC
+	// excessively and we wouldn't retry scan at least until we process all
+	// found replicas and do a normal scanner cycle that uses
+	// server.defaultScanInterval rescan period.
+	gcHintScannerTimeout = 5 * time.Minute
 )
 
 // mvccGCQueueInterval is a setting that controls how long the mvcc GC queue
@@ -73,6 +92,15 @@ var mvccGCQueueInterval = settings.RegisterDurationSetting(
 	"kv.mvcc_gc.queue_interval",
 	"how long the mvcc gc queue waits between processing replicas",
 	mvccGCQueueDefaultTimerDuration,
+	settings.NonNegativeDuration,
+)
+
+// mvccGCQueueHighPriInterval
+var mvccGCQueueHighPriInterval = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"kv.mvcc_gc.queue_high_priority_interval",
+	"how long the mvcc gc queue waits between processing high priority replicas (e.g. after table drops)",
+	mvccHiPriGCQueueDefaultTimerDuration,
 	settings.NonNegativeDuration,
 )
 
@@ -118,11 +146,22 @@ func largeAbortSpan(ms enginepb.MVCCStats) bool {
 // single priority. If any task is overdue, shouldQueue returns true.
 type mvccGCQueue struct {
 	*baseQueue
+
+	// Set to true when GC finds range that has a hint indicating that range is
+	// completely cleared.
+	lastRangeWasHighPriority bool
+	// leaseholderCheckInterceptor is a leasholder check used by high priority replica scanner
+	// its only purpose is to allow test function injection.
+	leaseholderCheckInterceptor func(ctx context.Context, replica *Replica, now hlc.ClockTimestamp) bool
 }
+
+var _ queueImpl = &mvccGCQueue{}
 
 // newMVCCGCQueue returns a new instance of mvccGCQueue.
 func newMVCCGCQueue(store *Store) *mvccGCQueue {
-	mgcq := &mvccGCQueue{}
+	mgcq := &mvccGCQueue{
+		leaseholderCheckInterceptor: store.TestingKnobs().MVCCGCQueueLeaseCheckInterceptor,
+	}
 	mgcq.baseQueue = newBaseQueue(
 		"mvccGC", mgcq, store,
 		queueConfig{
@@ -187,11 +226,11 @@ func (r mvccGCQueueScore) String() string {
 // in the event that the cumulative ages of GC'able bytes or extant
 // intents exceed thresholds.
 func (mgcq *mvccGCQueue) shouldQueue(
-	ctx context.Context, now hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
+	ctx context.Context, _ hlc.ClockTimestamp, repl *Replica, _ spanconfig.StoreReader,
 ) (bool, float64) {
 	// Consult the protected timestamp state to determine whether we can GC and
 	// the timestamp which can be used to calculate the score.
-	_, conf := repl.DescAndSpanConfig()
+	conf := repl.SpanConfig()
 	canGC, _, gcTimestamp, oldThreshold, newThreshold, err := repl.checkProtectedTimestampsForGC(ctx, conf.TTL())
 	if err != nil {
 		log.VErrEventf(ctx, 2, "failed to check protected timestamp for gc: %v", err)
@@ -206,6 +245,7 @@ func (mgcq *mvccGCQueue) shouldQueue(
 		log.VErrEventf(ctx, 2, "failed to fetch last processed time: %v", err)
 		return false, 0
 	}
+
 	r := makeMVCCGCQueueScore(ctx, repl, gcTimestamp, lastGC, conf.TTL(), canAdvanceGCThreshold)
 	return r.ShouldQueue, r.FinalScore
 }
@@ -231,7 +271,7 @@ func makeMVCCGCQueueScore(
 	// trigger GC at the same time.
 	r := makeMVCCGCQueueScoreImpl(
 		ctx, int64(repl.RangeID), now, ms, gcTTL, lastGC, canAdvanceGCThreshold,
-		gc.TxnCleanupThreshold.Get(&repl.ClusterSettings().SV),
+		repl.GetGCHint(), gc.TxnCleanupThreshold.Get(&repl.ClusterSettings().SV),
 	)
 	return r
 }
@@ -335,6 +375,7 @@ func makeMVCCGCQueueScoreImpl(
 	gcTTL time.Duration,
 	lastGC hlc.Timestamp,
 	canAdvanceGCThreshold bool,
+	hint roachpb.GCHint,
 	txnCleanupThreshold time.Duration,
 ) mvccGCQueueScore {
 	ms.Forward(now.WallTime)
@@ -423,13 +464,32 @@ func makeMVCCGCQueueScoreImpl(
 		r.FinalScore++
 	}
 
-	// If range was deleted, lower score threshold to allow faster cleanup as
-	// most of the garbage is concentrated at the ttl threshold.
-	if !r.ShouldQueue && suspectedFullRangeDeletion(ms) {
+	maybeRangeDel := suspectedFullRangeDeletion(ms)
+	hasActiveGCHint := gcHintedRangeDelete(hint, gcTTL, now)
+
+	if hasActiveGCHint && (maybeRangeDel || ms.ContainsEstimates > 0) {
+		// We have GC hint allowing us to collect range and we either satisfy
+		// heuristic that indicate no live data or we have estimates and we assume
+		// hint is correct.
+		r.ShouldQueue = canAdvanceGCThreshold
+		r.FinalScore = deleteRangePriority
+	}
+
+	if !r.ShouldQueue && maybeRangeDel {
+		// If we don't have GC hint, but range del heuristic is satisfied, then
+		// check with lowered score threshold as all the data is deleted.
 		r.ShouldQueue = canAdvanceGCThreshold && r.FuzzFactor*valScore > mvccGCDropRangeKeyScoreThreshold
 	}
 
 	return r
+}
+
+func gcHintedRangeDelete(hint roachpb.GCHint, ttl time.Duration, now hlc.Timestamp) bool {
+	deleteTimestamp := hint.LatestRangeDeleteTimestamp
+	if deleteTimestamp.IsEmpty() {
+		return false
+	}
+	return deleteTimestamp.Add(ttl.Nanoseconds(), 0).Less(now)
 }
 
 // suspectedFullRangeDeletion checks for ranges where there's no live data and
@@ -700,6 +760,7 @@ func (mgcq *mvccGCQueue) process(
 			log.Errorf(ctx, "failed to recompute stats with error=%s", err)
 		}
 	}
+
 	return true, nil
 }
 
@@ -722,9 +783,82 @@ func updateStoreMetricsWithGCInfo(metrics *StoreMetrics, info gc.Info) {
 	metrics.GCFailedClearRange.Inc(int64(info.ClearRangeKeyFailures))
 }
 
+func (mgcq *mvccGCQueue) postProcessScheduled(
+	ctx context.Context, processedReplica replicaInQueue, priority float64,
+) {
+	if priority < deleteRangePriority {
+		mgcq.lastRangeWasHighPriority = false
+		return
+	}
+
+	if !mgcq.lastRangeWasHighPriority {
+		// We are most likely processing first range that has a GC hint notifying
+		// that multiple range deletions happen.
+		if err := contextutil.RunWithTimeout(ctx, "gc-check-hinted-hi-pri-replicas", gcHintScannerTimeout, func(ctx context.Context) error {
+			mgcq.scanReplicasForHiPriGCHints(ctx, processedReplica.GetRangeID())
+			return ctx.Err()
+		}); err != nil {
+			log.Infof(ctx, "failed to start mvcc gc scan for range delete hints, error: %s", err)
+		}
+		// Set flag indicating that we are already collecting high priority to avoid
+		// rescanning and re-enqueueing ranges multiple times.
+		mgcq.lastRangeWasHighPriority = true
+	}
+}
+
+// scanReplicasForHiPriGCHints scans replicas in random order which makes
+// single bad replica that could cause scan to time out be less disruptive
+// in case we need to retry.
+func (mgcq *mvccGCQueue) scanReplicasForHiPriGCHints(
+	ctx context.Context, triggerRange roachpb.RangeID,
+) {
+	var foundReplicas int
+	clockNow := mgcq.store.Clock().NowAsClockTimestamp()
+	now := clockNow.ToTimestamp()
+	v := newStoreReplicaVisitor(mgcq.store)
+	v.Visit(func(replica *Replica) bool {
+		if replica.GetRangeID() == triggerRange {
+			return true
+		}
+		if ctx.Err() != nil {
+			return false
+		}
+		gCHint := replica.GetGCHint()
+		if !gCHint.LatestRangeDeleteTimestamp.IsEmpty() {
+			desc, spanConfig := replica.DescAndSpanConfig()
+			gcThreshold := now.Add(-int64(spanConfig.GCPolicy.TTLSeconds)*1e9,
+				0)
+			if gCHint.LatestRangeDeleteTimestamp.Less(gcThreshold) {
+				// If replica has a hint we also need to check if this replica is a
+				// leaseholder as mvcc gc queue only works with leaseholder replicas.
+				var isLeaseHolder bool
+				if mgcq.leaseholderCheckInterceptor != nil {
+					isLeaseHolder = mgcq.leaseholderCheckInterceptor(ctx, replica, clockNow)
+				} else {
+					l := replica.LeaseStatusAt(ctx, clockNow)
+					isLeaseHolder = l.IsValid() && l.OwnedBy(replica.StoreID())
+				}
+				if !isLeaseHolder {
+					return true
+				}
+				added, _ := mgcq.addInternal(ctx, desc, replica.ReplicaID(), deleteRangePriority)
+				if added {
+					mgcq.store.metrics.GCEnqueueHighPriority.Inc(1)
+					foundReplicas++
+				}
+			}
+		}
+		return true
+	})
+	log.Infof(ctx, "mvcc gc scan for range delete hints found %d replicas", foundReplicas)
+}
+
 // timer returns a constant duration to space out GC processing
 // for successive queued replicas.
 func (mgcq *mvccGCQueue) timer(_ time.Duration) time.Duration {
+	if mgcq.lastRangeWasHighPriority {
+		return mvccGCQueueHighPriInterval.Get(&mgcq.store.ClusterSettings().SV)
+	}
 	return mvccGCQueueInterval.Get(&mgcq.store.ClusterSettings().SV)
 }
 

--- a/pkg/kv/kvserver/queue_concurrency_test.go
+++ b/pkg/kv/kvserver/queue_concurrency_test.go
@@ -131,6 +131,8 @@ type fakeQueueImpl struct {
 	pr func(context.Context, *Replica, spanconfig.StoreReader) (processed bool, err error)
 }
 
+var _ queueImpl = &fakeQueueImpl{}
+
 func (fakeQueueImpl) shouldQueue(
 	context.Context, hlc.ClockTimestamp, *Replica, spanconfig.StoreReader,
 ) (shouldQueue bool, priority float64) {
@@ -141,6 +143,11 @@ func (fq fakeQueueImpl) process(
 	ctx context.Context, repl *Replica, confReader spanconfig.StoreReader,
 ) (bool, error) {
 	return fq.pr(ctx, repl, confReader)
+}
+
+func (fakeQueueImpl) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (fakeQueueImpl) timer(time.Duration) time.Duration {

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -151,6 +151,8 @@ type raftLogQueue struct {
 	logSnapshots util.EveryN
 }
 
+var _ queueImpl = &raftLogQueue{}
+
 // newRaftLogQueue returns a new instance of raftLogQueue. Replicas are passed
 // to the queue both proactively (triggered by write load) and periodically
 // (via the scanner). When processing a replica, the queue decides whether the
@@ -729,6 +731,11 @@ func (rlq *raftLogQueue) process(
 	}
 	r.store.metrics.RaftLogTruncated.Inc(int64(decision.NumTruncatableIndexes()))
 	return true, nil
+}
+
+func (*raftLogQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 // timer returns interval between processing successive queued truncations.

--- a/pkg/kv/kvserver/raft_snapshot_queue.go
+++ b/pkg/kv/kvserver/raft_snapshot_queue.go
@@ -37,6 +37,8 @@ type raftSnapshotQueue struct {
 	*baseQueue
 }
 
+var _ queueImpl = &raftSnapshotQueue{}
+
 // newRaftSnapshotQueue returns a new instance of raftSnapshotQueue.
 func newRaftSnapshotQueue(store *Store) *raftSnapshotQueue {
 	rq := &raftSnapshotQueue{}
@@ -162,6 +164,11 @@ func (rq *raftSnapshotQueue) processRaftSnapshot(
 	// make sure that log truncations won't require snapshots for healthy
 	// followers.
 	return err == nil /* processed */, err
+}
+
+func (*raftSnapshotQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (*raftSnapshotQueue) timer(_ time.Duration) time.Duration {

--- a/pkg/kv/kvserver/replica_gc_queue.go
+++ b/pkg/kv/kvserver/replica_gc_queue.go
@@ -83,6 +83,8 @@ type replicaGCQueue struct {
 	db      *kv.DB
 }
 
+var _ queueImpl = &replicaGCQueue{}
+
 // newReplicaGCQueue returns a new instance of replicaGCQueue.
 func newReplicaGCQueue(store *Store, db *kv.DB) *replicaGCQueue {
 	rgcq := &replicaGCQueue{
@@ -363,6 +365,11 @@ func (rgcq *replicaGCQueue) process(
 		}
 	}
 	return true, nil
+}
+
+func (*replicaGCQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (*replicaGCQueue) timer(_ time.Duration) time.Duration {

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -524,6 +524,8 @@ type replicateQueue struct {
 	logTracesThresholdFunc queueProcessTimeoutFunc
 }
 
+var _ queueImpl = &replicateQueue{}
+
 // newReplicateQueue returns a new instance of replicateQueue.
 func newReplicateQueue(store *Store, allocator allocatorimpl.Allocator) *replicateQueue {
 	rq := &replicateQueue{
@@ -1933,6 +1935,11 @@ func (rq *replicateQueue) canTransferLeaseFrom(ctx context.Context, repl *Replic
 		return timeutil.Since(lastLeaseTransfer.(time.Time)) > minInterval
 	}
 	return true
+}
+
+func (*replicateQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (*replicateQueue) timer(_ time.Duration) time.Duration {

--- a/pkg/kv/kvserver/scanner.go
+++ b/pkg/kv/kvserver/scanner.go
@@ -31,7 +31,7 @@ type replicaQueue interface {
 	// Start launches a goroutine to process the contents of the queue.
 	// The provided stopper is used to signal that the goroutine should exit.
 	Start(*stop.Stopper)
-	// MaybeAdd adds the replica to the queue if the replica meets
+	// MaybeAddAsync adds the replica to the queue if the replica meets
 	// the queue's inclusion criteria and the queue is not already
 	// too full, etc.
 	MaybeAddAsync(context.Context, replicaInQueue, hlc.ClockTimestamp)

--- a/pkg/kv/kvserver/split_queue.go
+++ b/pkg/kv/kvserver/split_queue.go
@@ -56,6 +56,8 @@ type splitQueue struct {
 	loadBasedCount telemetry.Counter
 }
 
+var _ queueImpl = &splitQueue{}
+
 // newSplitQueue returns a new instance of splitQueue.
 func newSplitQueue(store *Store, db *kv.DB) *splitQueue {
 	var purgChan <-chan time.Time
@@ -263,6 +265,11 @@ func (sq *splitQueue) processAttempt(
 		return true, nil
 	}
 	return false, nil
+}
+
+func (*splitQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 // timer returns interval between processing successive queued splits.

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -438,6 +438,10 @@ type StoreTestingKnobs struct {
 	// LeaseUpgradeInterceptor intercepts leases that get upgraded to
 	// epoch-based ones.
 	LeaseUpgradeInterceptor func(*roachpb.Lease)
+
+	// MVCCGCQueueLeaseCheckInterceptor intercepts calls to Replica.LeaseStatusAt when
+	// making high priority replica scans.
+	MVCCGCQueueLeaseCheckInterceptor func(ctx context.Context, replica *Replica, now hlc.ClockTimestamp) bool
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -84,6 +84,8 @@ type timeSeriesMaintenanceQueue struct {
 	mem            *mon.BytesMonitor
 }
 
+var _ queueImpl = &timeSeriesMaintenanceQueue{}
+
 // newTimeSeriesMaintenanceQueue returns a new instance of
 // timeSeriesMaintenanceQueue.
 func newTimeSeriesMaintenanceQueue(
@@ -159,6 +161,11 @@ func (q *timeSeriesMaintenanceQueue) process(
 		log.VErrEventf(ctx, 2, "failed to update last processed time: %v", err)
 	}
 	return true, nil
+}
+
+func (*timeSeriesMaintenanceQueue) postProcessScheduled(
+	ctx context.Context, replica replicaInQueue, priority float64,
+) {
 }
 
 func (q *timeSeriesMaintenanceQueue) timer(duration time.Duration) time.Duration {

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -103,6 +103,14 @@ func (ms MVCCStats) GCBytes() int64 {
 	return ms.Total() - ms.LiveBytes
 }
 
+// HasNoUserData returns true if there is no user data in the range.
+// User data includes RangeKeyCount, KeyCount and IntentCount as those keys
+// are user writable. ContainsEstimates must also be zero to avoid false
+// positives where range actually has data.
+func (ms MVCCStats) HasNoUserData() bool {
+	return ms.ContainsEstimates == 0 && ms.RangeKeyCount == 0 && ms.KeyCount == 0 && ms.IntentCount == 0
+}
+
 // AvgIntentAge returns the average age of outstanding intents,
 // based on current wall time specified via nowNanos.
 func (ms MVCCStats) AvgIntentAge(nowNanos int64) float64 {

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -912,6 +912,12 @@ var charts = []sectionDescription{
 					"queue.gc.info.clearrangefailed",
 				},
 			},
+			{
+				Title: "GC Enqueue with High Priority",
+				Metrics: []string{
+					"queue.gc.info.enqueuehighpriority",
+				},
+			},
 		},
 	},
 	{


### PR DESCRIPTION
Previously ranges deleted as part of DDL operations that set a full range delete GC hint were processed like normal ranges. This commit changes mvcc gc to expedite processing of all replicas on which hint is set as soon as first is processed without waiting for replica scanner to enqueue the rest.

Release note: None
