### PR TITLE
backupccl: reduce GC TTL on table during cluster restore rollback

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -2225,7 +2225,7 @@ func (r *restoreResumer) OnFailOrCancel(
 			}
 		}
 
-		if err := r.dropDescriptors(ctx, execCfg.JobRegistry, execCfg.Codec, txn, descsCol); err != nil {
+		if err := r.dropDescriptors(ctx, execCfg.JobRegistry, execCfg.Codec, txn, descsCol, ie); err != nil {
 			return err
 		}
 
@@ -2269,6 +2269,7 @@ func (r *restoreResumer) dropDescriptors(
 	codec keys.SQLCodec,
 	txn *kv.Txn,
 	descsCol *descs.Collection,
+	ie sqlutil.InternalExecutor,
 ) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 
@@ -2330,13 +2331,29 @@ func (r *restoreResumer) dropDescriptors(
 			}
 		}
 
-		// If the DropTime is set, a table uses RangeClear for fast data removal. This
-		// operation starts at DropTime + the GC TTL. If we used now() here, it would
-		// not clean up data until the TTL from the time of the error. Instead, use 1
-		// (that is, 1ns past the epoch) to allow this to be cleaned up as soon as
-		// possible. This is safe since the table data was never visible to users,
-		// and so we don't need to preserve MVCC semantics.
+		// Arrange for fast GC of table data.
+		//
+		// The new (09-2022) GC job uses range deletion tombstones to clear data and
+		// then waits for the MVCC GC process to clear the data before removing any
+		// descriptors. To ensure that this happens quickly, we install a zone
+		// configuration for every table that we are going to drop with a small GC TTL.
+		//
+		// NB: We can't set GC TTLs for non-system tenants currently.
+		if codec.ForSystemTenant() {
+			if err := setGCTTLForDroppingTable(ctx, txn, descsCol, tableToDrop, ie); err != nil {
+				return errors.Wrapf(err, "setting low GC TTL for table %q", tableToDrop.GetName())
+			}
+		}
+
+		// In the legacy GC job, setting DropTime ensures a table uses RangeClear
+		// for fast data removal. This operation starts at DropTime + the GC TTL. If
+		// we used now() here, it would not clean up data until the TTL from the
+		// time of the error. Instead, use 1 (that is, 1ns past the epoch) to allow
+		// this to be cleaned up as soon as possible. This is safe since the table
+		// data was never visible to users, and so we don't need to preserve MVCC
+		// semantics.
 		tableToDrop.DropTime = dropTime
+
 		b.Del(catalogkeys.EncodeNameKey(codec, tableToDrop))
 		descsCol.NotifyOfDeletedDescriptor(tableToDrop.GetID())
 	}
@@ -2558,6 +2575,66 @@ func (r *restoreResumer) dropDescriptors(
 	}
 
 	return nil
+}
+
+func setGCTTLForDroppingTable(
+	ctx context.Context,
+	txn *kv.Txn,
+	descsCol *descs.Collection,
+	tableToDrop *tabledesc.Mutable,
+	ie sqlutil.InternalExecutor,
+) error {
+	log.VInfof(ctx, 2, "lowering TTL for table %q (%d)", tableToDrop.GetName(), tableToDrop.GetID())
+	// We get a mutable descriptor here because we are going to construct a
+	// synthetic descriptor collection in which they are online.
+	_, dbDesc, err := descsCol.GetImmutableDatabaseByID(ctx, txn, tableToDrop.GetParentID(),
+		tree.DatabaseLookupFlags{
+			Required:       true,
+			IncludeOffline: true,
+			IncludeDropped: true,
+			AvoidLeased:    true,
+		})
+	if err != nil {
+		return err
+	}
+
+	schemaDesc, err := descsCol.GetImmutableSchemaByID(ctx, txn, tableToDrop.GetParentSchemaID(),
+		tree.SchemaLookupFlags{
+			Required:       true,
+			IncludeDropped: true,
+			IncludeOffline: true,
+			AvoidLeased:    true,
+		})
+	if err != nil {
+		return err
+	}
+	tableName := tree.NewTableNameWithSchema(
+		tree.Name(dbDesc.GetName()),
+		tree.Name(schemaDesc.GetName()),
+		tree.Name(tableToDrop.GetName()))
+
+	// Set the db and table to public so that we can use ALTER TABLE below.  At
+	// this point,they may be offline.
+	mutDBDesc := dbdesc.NewBuilder(dbDesc.DatabaseDesc()).BuildCreatedMutable()
+	mutTableDesc := tabledesc.NewBuilder(tableToDrop.TableDesc()).BuildCreatedMutable()
+	mutDBDesc.SetPublic()
+	mutTableDesc.SetPublic()
+
+	syntheticDescriptors := []catalog.Descriptor{
+		mutTableDesc,
+		mutDBDesc,
+	}
+	if schemaDesc.SchemaKind() == catalog.SchemaUserDefined {
+		mutSchemaDesc := schemadesc.NewBuilder(schemaDesc.SchemaDesc()).BuildCreatedMutable()
+		mutSchemaDesc.SetPublic()
+		syntheticDescriptors = append(syntheticDescriptors, mutSchemaDesc)
+	}
+
+	alterStmt := fmt.Sprintf("ALTER TABLE %s CONFIGURE ZONE USING gc.ttlseconds = 1", tableName.FQString())
+	return ie.WithSyntheticDescriptors(syntheticDescriptors, func() error {
+		_, err := ie.Exec(ctx, "set-low-gcttl", txn, alterStmt)
+		return err
+	})
 }
 
 // removeExistingTypeBackReferences removes back references from types that

--- a/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
+++ b/pkg/ccl/backupccl/testdata/backup-restore/restore-on-fail-or-cancel-fast-drop
@@ -1,0 +1,88 @@
+new-server name=s1 nodes=1 disable-tenant
+----
+
+subtest restore-cleanup-with-range-tombstones
+
+exec-sql
+CREATE DATABASE restore;
+CREATE SCHEMA restore.myschema;
+CREATE TABLE foobar (pk int primary key);
+CREATE TABLE restore.myschema.table1 (pk int primary key);
+INSERT INTO restore.myschema.table1 VALUES (1);
+CREATE TYPE data.myenum AS ENUM ('hello');
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://1/cluster_backup';
+----
+
+new-server name=s2 nodes=1 share-io-dir=s1 disable-tenant
+----
+
+exec-sql
+SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = true;
+----
+
+# Restore's OnFailOrCancel deletes descriptors which requires us to wait for no
+# versions of that descriptor to be leased before proceeding. Since our test fails
+# the job after the descriptors have been published, it's possible for them to be leased
+# somewhere.
+exec-sql
+SET CLUSTER SETTING sql.catalog.descriptor_lease_duration = '1s';
+----
+
+# The GC Job sleeps between checking if a range being empty. Lowering this
+# speeds up the test.
+exec-sql
+SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '250ms';
+----
+
+# The protected timestamp poll interval controls how often our cache of
+# protected timestamps is updated. The GC threshold can only advance as far as
+# the time at which the cache was updated. We set this low so our cache is
+# fresh and our range deletions are eligible for GC faster.
+exec-sql
+SET CLUSTER SETTING kv.protectedts.poll_interval = '250ms';
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.after_publishing_descriptors';
+----
+
+restore expect-pausepoint tag=a
+RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+----
+job paused at pausepoint
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+# Cancel the job so that the cleanup hook runs.
+job cancel=a
+----
+
+# The sleep(2) here to help ensure that the protected timestamp cache is fresh before we
+# enqueue the ranges for GC. We enqueue them here, to speed up the test which would otherwise
+# need to wait for them to be enqueued naturally.
+#
+# TODO(ssd): We sleep via the test runner and not via SQL using pg_sleep because if we try to
+# execute a query too quickly we see failures. https://github.com/cockroachdb/cockroach/issues/88913
+sleep ms=2000
+----
+
+exec-sql
+SELECT crdb_internal.kv_enqueue_replica(range_id, 'mvccGC', true) FROM (SELECT range_id FROM crdb_internal.ranges);
+----
+
+# We should be able to restore as soon as the GC jobs complete. Without the many settings changes
+# above, this would take several minutes as it relies on GC completing.
+exec-sql
+SHOW JOBS WHEN COMPLETE (SELECT job_id FROM [SHOW JOBS] WHERE job_type = 'SCHEMA CHANGE GC')
+----
+
+restore
+RESTORE FROM LATEST IN 'nodelocal://0/cluster_backup';
+----
+
+subtest end


### PR DESCRIPTION
When range deletion tombstones are disabled, the GCJob uses the
DropTime set when constructing the job to manually calculate when it
should issue ClearRange requests.  Restore's OnFailOrCancel used this
to ensure that GC for a cancelled backup happened quickly.

The range deletion tombstones are enabled, the job simply waits for
the MVCC GC queue to clear the range. Thus, the Restore job's attempt
to arrange for fast cleanup of the rolled back objects doesn't work.

Here, we set a very low GC TTL to reduce the time required to clean up
the data rolled back by a restore.

Note, however, that this is not sufficient to allow users to quickly
retry a failed restore. While the lower GC TTL makes the data
eligible for cleanup more quickly, the user will still have to wait
for all of those ranges to be enqueued for GC.

Epic: None

Release note (bug fix): Fixes problem that would prevent data from a
failed restore from being cleaned up quickly.