### PR TITLE
roachtest: use n1-standard for 16-core GCE machines

### DIFF
--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -37,11 +37,11 @@ func AWSMachineType(cpus int) string {
 
 // GCEMachineType selects a machine type given the desired number of CPUs.
 func GCEMachineType(cpus int) string {
-	// TODO(peter): This is awkward: below 16 cpus, use n1-standard so that the
-	// machines have a decent amount of RAM. We could use customer machine
+	// TODO(peter): This is awkward: at or below 16 cpus, use n1-standard so that
+	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
 	// determined (you can't request any arbitrary amount of RAM).
-	if cpus < 16 {
+	if cpus <= 16 {
 		return fmt.Sprintf("n1-standard-%d", cpus)
 	}
 	return fmt.Sprintf("n1-highcpu-%d", cpus)


### PR DESCRIPTION
Roachtest used `n1-highcpu` machines at 16 cores and beyond. However, this causes a memory cliff, because a `n1-standard-8` machine has ~30 GB memory (3.75 GB per core), but a `n1-highcpu-16` machine only has 14 GB memory (0.9 GB per core).

This patch makes 16-core machines use `n1-standard` as well, with 60 GB memory, and only switches to `n1-highcpu` at 32 cores (with 29 GB memory).

Touches #87809.

Release note: None