### PR TITLE
bazel,ci: find `compare_test` binary under `bazel-bin`

### DIFF
--- a/build/teamcity/cockroach/nightlies/compose.sh
+++ b/build/teamcity/cockroach/nightlies/compose.sh
@@ -15,7 +15,7 @@ BAZCI=$BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci
 bazel build //pkg/cmd/cockroach //pkg/compose/compare/compare:compare_test --config=ci --config=crosslinux --config=test --config=with_ui
 CROSSBIN=$(bazel info bazel-bin --config=ci --config=crosslinux --config=test --config=with_ui)
 COCKROACH=$CROSSBIN/pkg/cmd/cockroach/cockroach_/cockroach
-COMPAREBIN=$(bazel run //pkg/compose/compare/compare:compare_test --config=ci --config=crosslinux --config=test --config=with_ui --run_under=realpath | grep '^/' | tail -n1)
+COMPAREBIN=$CROSSBIN/pkg/compose/compare/compare/compare_test_/compare_test
 ARTIFACTS_DIR=$PWD/artifacts
 mkdir -p $ARTIFACTS_DIR
 GO_TEST_JSON_OUTPUT_FILE=$ARTIFACTS_DIR/test.json.txt


### PR DESCRIPTION
Since the Go 1.19 upgrade this has been broken as `realpath` has been getting the `-test.timeout` argument and been getting confused. Also since Go 1.19 it is must easier to find this binary which is right under the normal `bazel-bin`.

Release note: None