### PR TITLE
release-21.2: sql: fix bug of dropping temporary tables / sequences

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -787,11 +787,7 @@ func (p *planner) HasOwnershipOnSchema(
 		}
 	case catalog.SchemaVirtual:
 		// Cannot drop on virtual schemas.
-	case catalog.SchemaTemporary:
-		// The user owns all the temporary schemas that they created in the session.
-		hasOwnership = p.SessionData() != nil &&
-			p.SessionData().IsTemporarySchemaID(uint32(scDesc.GetID()))
-	case catalog.SchemaUserDefined:
+	case catalog.SchemaTemporary, catalog.SchemaUserDefined:
 		hasOwnership, err = p.HasOwnership(ctx, scDesc)
 		if err != nil {
 			return false, err

--- a/pkg/sql/logictest/testdata/logic_test/drop_temp
+++ b/pkg/sql/logictest/testdata/logic_test/drop_temp
@@ -1,0 +1,44 @@
+subtest drop_temp_tables_seqs
+
+user root
+
+statement ok
+SET experimental_enable_temp_tables=on;
+
+statement ok
+CREATE TEMP TABLE t_tmp(X int);
+
+statement ok
+CREATE TEMP SEQUENCE s_tmp START 1 INCREMENT 1;
+
+statement ok
+CREATE USER tmp_dropper;
+
+statement ok
+SET ROLE tmp_dropper;
+
+statement error pq: user tmp_dropper does not have DROP privilege on relation t_tmp
+DROP TABLE t_tmp;
+
+statement error pq: user tmp_dropper does not have DROP privilege on relation s_tmp
+DROP SEQUENCE s_tmp;
+
+statement ok
+SET ROLE root;
+
+statement ok
+GRANT DROP ON TABLE t_tmp to tmp_dropper;
+GRANT DROP ON SEQUENCE s_tmp to tmp_dropper;
+
+
+statement ok
+SET ROLE tmp_dropper;
+
+statement ok
+DROP TABLE t_tmp;
+
+statement ok
+DROP SEQUENCE s_tmp;
+
+statement ok
+SET ROLE root;


### PR DESCRIPTION
Backport 1/1 commits from #88201.

/cc @cockroachdb/release

Release justification: bug fix

---

Previously, any users can always drop temporary table and sequence, even though they don't have the `DROP` privilege on them. This is inconsistent with Postgres14's behavior. This commit is to fix this.

fixes #86802

Release note (bug fix): dropping temporary tables and sequences should check privilege too.
