### PR TITLE
changefeedccl: add metric for size based flushes

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -480,6 +480,7 @@ func (s *cloudStorageSink) EmitRow(
 	}
 
 	if int64(file.buf.Len()) > s.targetMaxFileSize {
+		s.metrics.recordSizeBasedFlush()
 		if err := s.flushTopicVersions(ctx, file.topic, file.schemaID); err != nil {
 			return err
 		}

--- a/pkg/ts/catalog/chart_catalog.go
+++ b/pkg/ts/catalog/chart_catalog.go
@@ -1386,6 +1386,12 @@ var charts = []sectionDescription{
 				},
 			},
 			{
+				Title: "Size Based Flushes",
+				Metrics: []string{
+					"changefeed.size_based_flushes",
+				},
+			},
+			{
 				Title: "Max Behind Nanos",
 				Metrics: []string{
 					"changefeed.max_behind_nanos",


### PR DESCRIPTION
Add metric to track when the cloud storage sink has to flush
data due to the file size limit being reached.

Fixes: https://github.com/cockroachdb/cockroach/issues/84435
Release note: None

