### PR TITLE
keys: refactor PrettyPrint function to use safeFormatInternal

### DIFF
--- a/pkg/ccl/partitionccl/zone_test.go
+++ b/pkg/ccl/partitionccl/zone_test.go
@@ -332,8 +332,8 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 				// Verify that we're always doing the space savings when we can.
 				if span.Key.PrefixEnd().Equal(span.EndKey) {
 					t.Errorf("endKey should be omitted when equal to key.PrefixEnd [%s, %s)",
-						encoding.PrettyPrintValue(directions, span.Key, "/"),
-						encoding.PrettyPrintValue(directions, span.EndKey, "/"))
+						encoding.PrettyPrintValue(directions, span.Key, "/").StripMarkers(),
+						encoding.PrettyPrintValue(directions, span.EndKey, "/").StripMarkers())
 				}
 				if len(span.EndKey) == 0 {
 					span.EndKey = span.Key.PrefixEnd()
@@ -342,8 +342,8 @@ func TestGenerateSubzoneSpans(t *testing.T) {
 				// TODO(dan): Check that spans are sorted.
 
 				actual = append(actual, fmt.Sprintf("%s %s-%s", subzoneShort,
-					encoding.PrettyPrintValue(directions, span.Key, "/"),
-					encoding.PrettyPrintValue(directions, span.EndKey, "/")))
+					encoding.PrettyPrintValue(directions, span.Key, "/").StripMarkers(),
+					encoding.PrettyPrintValue(directions, span.EndKey, "/").StripMarkers()))
 			}
 
 			if len(actual) != len(test.parsed.generatedSpans) {

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -44,11 +44,10 @@ const (
 // DictEntry contains info on pretty-printing and pretty-scanning keys in a
 // region of the key space.
 type DictEntry struct {
-	Name   string
+	Name   redact.SafeString
 	prefix roachpb.Key
 	// print the key's pretty value, key has been removed prefix data
-	// TODO: update return type to be a redactable string so we can at least mark the `/` chars as "safe"
-	ppFunc func(valDirs []encoding.Direction, key roachpb.Key) string
+	ppFunc func(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString
 	// safe format the key's pretty value into a RedactableString
 	sfFunc func(valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt) redact.RedactableString
 	// PSFunc parses the relevant prefix of the input into a roachpb.Key,
@@ -67,7 +66,7 @@ func parseUnsupported(_ string) (string, roachpb.Key) {
 // KeyComprehensionTable contains information about how to decode pretty-printed
 // keys, split by key spans.
 type KeyComprehensionTable []struct {
-	Name    string
+	Name    redact.SafeString
 	start   roachpb.Key
 	end     roachpb.Key
 	Entries []DictEntry
@@ -81,7 +80,7 @@ var (
 	// ConstKeyOverrides provides overrides that define how to translate specific
 	// pretty-printed keys.
 	ConstKeyOverrides = []struct {
-		Name  string
+		Name  redact.SafeString
 		Value roachpb.Key
 	}{
 		{"/Max", MaxKey},
@@ -93,7 +92,7 @@ var (
 	// keyofKeyDict means the key of suffix which is itself a key,
 	// should recursively pretty print it, see issue #3228
 	keyOfKeyDict = []struct {
-		name   string
+		name   redact.SafeString
 		prefix []byte
 	}{
 		{name: "/Meta2", prefix: Meta2Prefix},
@@ -163,27 +162,33 @@ func cachedSettingsKeyPrint(key roachpb.Key) string {
 	return settingKey.String()
 }
 
-func localStoreKeyPrint(_ []encoding.Direction, key roachpb.Key) string {
+func localStoreKeyPrint(_ []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
 	for _, v := range constSubKeyDict {
 		if bytes.HasPrefix(key, v.key) {
+			storeKeyStr := v.name + "/"
 			if v.key.Equal(localStoreNodeTombstoneSuffix) {
-				return v.name + "/" + nodeTombstoneKeyPrint(
+				buf.Print(storeKeyStr + nodeTombstoneKeyPrint(
 					append(roachpb.Key(nil), append(LocalStorePrefix, key...)...),
-				)
+				))
+				return buf.RedactableString()
 			} else if v.key.Equal(localStoreCachedSettingsSuffix) {
-				return v.name + "/" + cachedSettingsKeyPrint(
+				buf.Print(storeKeyStr + cachedSettingsKeyPrint(
 					append(roachpb.Key(nil), append(LocalStorePrefix, key...)...),
-				)
+				))
+				return buf.RedactableString()
 			} else if v.key.Equal(localStoreUnsafeReplicaRecoverySuffix) {
-				return v.name + "/" + lossOfQuorumRecoveryEntryKeyPrint(
+				buf.Print(storeKeyStr + lossOfQuorumRecoveryEntryKeyPrint(
 					append(roachpb.Key(nil), append(LocalStorePrefix, key...)...),
-				)
+				))
+				return buf.RedactableString()
 			}
-			return v.name
+			buf.Print(v.name)
+			return buf.RedactableString()
 		}
 	}
-
-	return fmt.Sprintf("%q", []byte(key))
+	buf.Printf("%q", []byte(key))
+	return buf.RedactableString()
 }
 
 func lossOfQuorumRecoveryEntryKeyPrint(key roachpb.Key) string {
@@ -390,23 +395,25 @@ func localRangeIDKeyParse(input string) (remainder string, key roachpb.Key) {
 	panic(&ErrUglifyUnsupported{errors.New("unhandled general range key")})
 }
 
-func localRangeIDKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
-	var buf bytes.Buffer
+func localRangeIDKeyPrint(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
 	if encoding.PeekType(key) != encoding.Int {
-		return fmt.Sprintf("/err<%q>", []byte(key))
+		buf.Printf("/err<%q>", []byte(key))
+		return buf.RedactableString()
 	}
 
 	// Get the rangeID.
 	key, i, err := encoding.DecodeVarintAscending(key)
 	if err != nil {
-		return fmt.Sprintf("/err<%v:%q>", err, []byte(key))
+		buf.Printf("/err<%v:%q>", err, []byte(key))
+		return buf.RedactableString()
 	}
 
-	fmt.Fprintf(&buf, "/%d", i)
+	buf.Printf("/%d", i)
 
 	// Print and remove the rangeID infix specifier.
 	if len(key) != 0 {
-		fmt.Fprintf(&buf, "/%s", string(key[0]))
+		buf.Printf("/%s", string(key[0]))
 		key = key[1:]
 	}
 
@@ -414,11 +421,11 @@ func localRangeIDKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string 
 	hasSuffix := false
 	for _, s := range rangeIDSuffixDict {
 		if bytes.HasPrefix(key, s.suffix) {
-			fmt.Fprintf(&buf, "/%s", s.name)
+			buf.Printf("/%s", s.name)
 			key = key[len(s.suffix):]
 			if s.ppFunc != nil && len(key) != 0 {
-				fmt.Fprintf(&buf, "%s", s.ppFunc(key))
-				return buf.String()
+				buf.Printf("%s", s.ppFunc(key))
+				return buf.RedactableString()
 			}
 			hasSuffix = true
 			break
@@ -427,28 +434,27 @@ func localRangeIDKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string 
 
 	// Get the encode values.
 	if hasSuffix {
-		fmt.Fprintf(&buf, "%s", decodeKeyPrint(valDirs, key))
+		buf.Printf("%s", decodeKeyPrint(valDirs, key))
 	} else {
-		fmt.Fprintf(&buf, "%q", []byte(key))
+		buf.Printf("%q", []byte(key))
 	}
 
-	return buf.String()
+	return buf.RedactableString()
 }
 
-func localRangeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
-	var buf bytes.Buffer
-
+func localRangeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
 	for _, s := range rangeSuffixDict {
 		if s.atEnd {
 			if bytes.HasSuffix(key, s.suffix) {
 				key = key[:len(key)-len(s.suffix)]
 				_, decodedKey, err := encoding.DecodeBytesAscending([]byte(key), nil)
 				if err != nil {
-					fmt.Fprintf(&buf, "%s/%s", decodeKeyPrint(valDirs, key), s.name)
+					buf.Printf("%s/%s", decodeKeyPrint(valDirs, key), redact.Safe(s.name))
 				} else {
-					fmt.Fprintf(&buf, "%s/%s", roachpb.Key(decodedKey), s.name)
+					buf.Printf("%s/%s", roachpb.Key(decodedKey), redact.Safe(s.name))
 				}
-				return buf.String()
+				return buf.RedactableString()
 			}
 		} else {
 			begin := bytes.Index(key, s.suffix)
@@ -456,56 +462,58 @@ func localRangeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
 				addrKey := key[:begin]
 				_, decodedAddrKey, err := encoding.DecodeBytesAscending([]byte(addrKey), nil)
 				if err != nil {
-					fmt.Fprintf(&buf, "%s/%s", decodeKeyPrint(valDirs, addrKey), s.name)
+					buf.Printf("%s/%s", decodeKeyPrint(valDirs, addrKey), redact.Safe(s.name))
 				} else {
-					fmt.Fprintf(&buf, "%s/%s", roachpb.Key(decodedAddrKey), s.name)
+					buf.Printf("%s/%s", roachpb.Key(decodedAddrKey), redact.Safe(s.name))
 				}
 				if bytes.Equal(s.suffix, LocalTransactionSuffix) {
 					txnID, err := uuid.FromBytes(key[(begin + len(s.suffix)):])
 					if err != nil {
-						return fmt.Sprintf("/%q/err:%v", key, err)
+						buf.Printf(fmt.Sprintf("/%q/err:%v", key, err))
+						return buf.RedactableString()
 					}
-					fmt.Fprintf(&buf, "/%q", txnID)
+					buf.Printf("/%q", txnID)
 				} else {
 					id := key[(begin + len(s.suffix)):]
-					fmt.Fprintf(&buf, "/%q", []byte(id))
+					buf.Printf("/%q", []byte(id))
 				}
-				return buf.String()
+				return buf.RedactableString()
 			}
 		}
 	}
 
 	_, decodedKey, err := encoding.DecodeBytesAscending([]byte(key), nil)
 	if err != nil {
-		fmt.Fprintf(&buf, "%s", decodeKeyPrint(valDirs, key))
+		buf.Printf("%s", decodeKeyPrint(valDirs, key))
 	} else {
-		fmt.Fprintf(&buf, "%s", roachpb.Key(decodedKey))
+		buf.Printf("%s", roachpb.Key(decodedKey))
 	}
-
-	return buf.String()
+	return buf.RedactableString()
 }
 
 // lockTablePrintLockedKey is initialized to prettyPrintInternal in init() to break an
 // initialization loop.
 var lockTablePrintLockedKey func(
-	valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt, skipOverrides bool,
-) string
+	valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt,
+) redact.RedactableString
 
-func localRangeLockTablePrint(valDirs []encoding.Direction, key roachpb.Key) string {
-	var buf bytes.Buffer
+func localRangeLockTablePrint(
+	valDirs []encoding.Direction, key roachpb.Key,
+) redact.RedactableString {
+	buf := redact.StringBuilder{}
 	if !bytes.HasPrefix(key, LockTableSingleKeyInfix) {
-		fmt.Fprintf(&buf, "/\"%x\"", key)
-		return buf.String()
+		buf.Printf("/\"%x\"", redact.Safe(key))
+		return buf.RedactableString()
 	}
-	buf.WriteString("/Intent")
+	buf.Print(redact.Safe("/Intent"))
 	key = key[len(LockTableSingleKeyInfix):]
 	b, lockedKey, err := encoding.DecodeBytesAscending(key, nil)
 	if err != nil || len(b) != 0 {
-		fmt.Fprintf(&buf, "/\"%x\"", key)
-		return buf.String()
+		buf.Printf("/\"%x\"", redact.Safe(key))
+		return buf.RedactableString()
 	}
-	buf.WriteString(lockTablePrintLockedKey(valDirs, lockedKey, QuoteRaw, false /*skipOverrides*/))
-	return buf.String()
+	buf.Print(lockTablePrintLockedKey(valDirs, lockedKey, QuoteRaw))
+	return buf.RedactableString()
 }
 
 // ErrUglifyUnsupported is returned when UglyPrint doesn't know how to process a
@@ -546,109 +554,35 @@ func abortSpanKeyPrint(key roachpb.Key) string {
 	return fmt.Sprintf("/%q", txnID)
 }
 
-func print(_ []encoding.Direction, key roachpb.Key) string {
-	return fmt.Sprintf("/%q", []byte(key))
+func print(_ []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
+	buf.Printf("/%q", []byte(key))
+	return buf.RedactableString()
 }
 
-func decodeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
+func decodeKeyPrint(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
 	return encoding.PrettyPrintValue(valDirs, key, "/")
 }
 
-func timeseriesKeyPrint(_ []encoding.Direction, key roachpb.Key) string {
-	return PrettyPrintTimeseriesKey(key)
+func timeseriesKeyPrint(_ []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
+	buf.Print(PrettyPrintTimeseriesKey(key))
+	return buf.RedactableString()
 }
 
-func tenantKeyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
+func tenantKeyPrint(valDirs []encoding.Direction, key roachpb.Key) redact.RedactableString {
+	buf := redact.StringBuilder{}
 	key, tID, err := DecodeTenantPrefix(key)
 	if err != nil {
-		return fmt.Sprintf("/err:%v", err)
+		buf.Printf("/err:%v", err)
+		return buf.RedactableString()
 	}
 	if len(key) == 0 {
-		return fmt.Sprintf("/%s", tID)
+		buf.Printf("/%s", redact.Safe(tID))
+		return buf.RedactableString()
 	}
-	return fmt.Sprintf("/%s%s", tID, key.StringWithDirs(valDirs))
-}
-
-// prettyPrintInternal parse key with prefix in KeyDict.
-// For table keys, valDirs correspond to the encoding direction of each encoded
-// value in key.
-// If valDirs is unspecified, the default encoding direction for each value
-// type is used (see encoding.go:prettyPrintFirstValue).
-// If the key doesn't match any prefix in KeyDict, return its byte value with
-// quotation and false, or else return its human readable value and true.
-//
-// skipOverrides provides a way to skip the usage of ConstKeyOverrides. This is
-// configurable to enable recursive printing of keys (e.g. from SafeFormat) a way
-// to avoid treating the remainder as a potential match for the overrides in
-// ConstKeyOverrides, which in general, should not apply to the remainder of any key.
-// For example: The key `/Meta1/""` would have `/Meta1` trimmed from the key, and
-// prettyPrintInternal may be called to print the remainder of `""`. This would
-// incorrectly be interpreted as `/Min` if we didn't skip the usage of ConstKeyOverrides.
-func prettyPrintInternal(
-	valDirs []encoding.Direction, key roachpb.Key, quoteRawKeys QuoteOpt, skipOverrides bool,
-) string {
-	if !skipOverrides {
-		for _, k := range ConstKeyOverrides {
-			if key.Equal(k.Value) {
-				return k.Name
-			}
-		}
-	}
-
-	helper := func(key roachpb.Key) (string, bool) {
-		var b strings.Builder
-		for _, k := range KeyDict {
-			if key.Compare(k.start) >= 0 && (k.end == nil || key.Compare(k.end) <= 0) {
-				b.WriteString(k.Name)
-				if k.end != nil && k.end.Compare(key) == 0 {
-					b.WriteString("/Max")
-					return b.String(), true
-				}
-
-				hasPrefix := false
-				for _, e := range k.Entries {
-					if bytes.HasPrefix(key, e.prefix) {
-						hasPrefix = true
-						key = key[len(e.prefix):]
-						b.WriteString(e.Name)
-						b.WriteString(e.ppFunc(valDirs, key))
-						break
-					}
-				}
-				if !hasPrefix {
-					key = key[len(k.start):]
-					if quoteRawKeys {
-						b.WriteByte('/')
-						b.WriteByte('"')
-					}
-					b.Write([]byte(key))
-					if quoteRawKeys {
-						b.WriteByte('"')
-					}
-				}
-
-				return b.String(), true
-			}
-		}
-
-		if quoteRawKeys {
-			return fmt.Sprintf("%q", []byte(key)), false
-		}
-		return string(key), false
-	}
-
-	for _, k := range keyOfKeyDict {
-		if bytes.HasPrefix(key, k.prefix) {
-			key = key[len(k.prefix):]
-			str, formatted := helper(key)
-			if formatted {
-				return k.name + str
-			}
-			return k.name + "/" + str
-		}
-	}
-	str, _ := helper(key)
-	return str
+	buf.Printf("/%s%s", redact.Safe(tID), redact.Safe(key.StringWithDirs(valDirs)))
+	return buf.RedactableString()
 }
 
 // PrettyPrint prints the key in a human readable format, see TestPrettyPrint.
@@ -665,7 +599,6 @@ func prettyPrintInternal(
 //
 // See SafeFormat for a redaction-safe implementation.
 func PrettyPrint(valDirs []encoding.Direction, key roachpb.Key) string {
-	//return prettyPrintInternal(valDirs, key, QuoteRaw, false /*skipOverrides*/)
 	return safeFormatInternal(valDirs, key, QuoteRaw).StripMarkers()
 }
 
@@ -745,16 +678,15 @@ func safeFormatInternal(
 ) redact.RedactableString {
 	for _, k := range ConstKeyOverrides {
 		if key.Equal(k.Value) {
-			return redact.Sprint(redact.Safe(k.Name))
+			return redact.Sprint(k.Name)
 		}
 	}
 
-	// ""
 	helper := func(key roachpb.Key) redact.RedactableString {
 		var b redact.StringBuilder
 		for _, k := range KeyDict {
 			if key.Compare(k.start) >= 0 && (k.end == nil || key.Compare(k.end) <= 0) {
-				b.Print(redact.Safe(k.Name))
+				b.Print(k.Name)
 				if k.end != nil && k.end.Compare(key) == 0 {
 					b.Print(redact.Safe("/Max"))
 					return b.RedactableString()
@@ -764,7 +696,7 @@ func safeFormatInternal(
 				for _, e := range k.Entries {
 					if bytes.HasPrefix(key, e.prefix) && e.sfFunc != nil {
 						key = key[len(e.prefix):]
-						b.Print(redact.Safe(e.Name))
+						b.Print(e.Name)
 						b.Print(e.sfFunc(valDirs, key, quoteRawKeys))
 						safeFormatted = true
 					}
@@ -788,23 +720,26 @@ func safeFormatInternal(
 							b.Print("/")
 							b.Print(`"`)
 						}
-						// Caution: using b.Print here might not print the bytes the way we want :|
-						// might have to use b.Write([]byte), but this requires error handling so
-						// ideally we don't have to use it since we don't have error handling anywhere
-						// else
-						b.Print([]byte(key))
+						//Block in testing phase
+						// TODO @santamaura remove comment block when tests pass.
+						if _, ok := b.Write([]byte(key)); ok != nil {
+							b.Print([]byte(key))
+						}
 						if quoteRawKeys {
 							b.Print(`"`)
 						}
 					}
-
 				}
 				return b.RedactableString()
 			}
 		}
 		// If we reach this point, the key is not recognized based on KeyDict.
 		// Print the raw bytes instead.
-		b.Print(key)
+		if quoteRawKeys {
+			b.Printf("%q", []byte(key))
+			return b.RedactableString()
+		}
+		b.Print(string(key))
 		return b.RedactableString()
 	}
 
@@ -813,9 +748,9 @@ func safeFormatInternal(
 			key = key[len(k.prefix):]
 			str := helper(key)
 			if len(str) > 0 && strings.Index(str.StripMarkers(), "/") != 0 {
-				return redact.Sprintf("%v/%v", redact.Sprint(k.name), str)
+				return redact.Sprintf("%v/%v", k.name, str)
 			}
-			return redact.Sprintf("%v%v", redact.Sprint(k.name), str)
+			return redact.Sprintf("%v%v", k.name, str)
 		}
 	}
 	return helper(key)
@@ -825,7 +760,7 @@ func init() {
 	roachpb.PrettyPrintKey = PrettyPrint
 	roachpb.SafeFormatKey = SafeFormat
 	roachpb.PrettyPrintRange = PrettyPrintRange
-	lockTablePrintLockedKey = prettyPrintInternal
+	lockTablePrintLockedKey = safeFormatInternal
 
 	// KeyDict drives the pretty-printing and pretty-scanning of the key space.
 	KeyDict = KeyComprehensionTable{
@@ -920,7 +855,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 	if maxChars < 8 {
 		maxChars = 8
 	}
-	prettyStart := prettyPrintInternal(nil /* valDirs */, start, DontQuoteRaw, false /*skipOverrides*/)
+	prettyStart := safeFormatInternal(nil /* valDirs */, start, DontQuoteRaw).StripMarkers()
 	if len(end) == 0 {
 		if len(prettyStart) <= maxChars {
 			return prettyStart
@@ -929,7 +864,7 @@ func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
 		b.WriteRune('…')
 		return b.String()
 	}
-	prettyEnd := prettyPrintInternal(nil /* valDirs */, end, DontQuoteRaw, false /*skipOverrides*/)
+	prettyEnd := safeFormatInternal(nil /* valDirs */, end, DontQuoteRaw).StripMarkers()
 	i := 0
 	// Find the common prefix.
 	for ; i < len(prettyStart) && i < len(prettyEnd) && prettyStart[i] == prettyEnd[i]; i++ {

--- a/pkg/keys/printer_test.go
+++ b/pkg/keys/printer_test.go
@@ -69,7 +69,7 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 		{
 			"namespace table handled as standard system tenant table",
 			keys.NamespaceTableMin,
-			"/Table/30",
+			"/NamespaceTable/30",
 		},
 		{
 			"table index without index key",
@@ -105,6 +105,14 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 			makeKey(tenSysCodec.TablePrefix(42), []byte{0x12, 'a', 0x00, 0x03}),
 			`/Table/42/‹???›`,
 		},
+		{
+			"marks safe reserved key prefix",
+			makeKey(keys.Meta1Prefix,
+				tenSysCodec.TablePrefix(42),
+				encoding.EncodeStringAscending(nil, "California"),
+				encoding.EncodeStringAscending(nil, "Los Angeles")),
+			`/Meta1/Table/42/‹"California"›/‹"Los Angeles"›`,
+		},
 	}
 
 	for _, test := range testCases {
@@ -114,17 +122,16 @@ func TestSafeFormatKey_SystemTenant(t *testing.T) {
 	}
 }
 
-func TestSafeFormatKey_UnsupportedKeyspace(t *testing.T) {
-	ten5Codec := keys.MakeSQLCodec(roachpb.MakeTenantID(5))
+func TestSafeFormatKey_Basic(t *testing.T) {
 	testCases := []struct {
 		name string
 		key  roachpb.Key
 		exp  string
 	}{
 		{
-			"key-spaces without a safe format function implementation are fully redacted",
-			keys.MakeRangeKeyPrefix(roachpb.RKey(ten5Codec.TablePrefix(42))),
-			`‹/Local/Range/Tenant/5/Table/42›`,
+			"ensure constants get redacted",
+			makeKey(keys.Meta2Prefix, roachpb.Key("foo")),
+			`/Meta2/‹"foo"›`,
 		},
 	}
 

--- a/pkg/ts/keys.go
+++ b/pkg/ts/keys.go
@@ -119,7 +119,7 @@ func prettyPrintKey(key roachpb.Key) string {
 	if err != nil {
 		// Not a valid timeseries key, fall back to doing the best we can to display
 		// it.
-		return encoding.PrettyPrintValue(nil /* dirs */, key, "/")
+		return encoding.PrettyPrintValue(nil /* dirs */, key, "/").StripMarkers()
 	}
 	return fmt.Sprintf("/%s/%s/%s/%s", name, resolution,
 		timeutil.Unix(0, timestamp).Format(time.RFC3339Nano), source)

--- a/pkg/util/encoding/BUILD.bazel
+++ b/pkg/util/encoding/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -1985,11 +1985,13 @@ func prettyPrintValueImpl(valDirs []Direction, b []byte, sep string) (string, bo
 			// to continue - it's possible we can still decode the
 			// remainder of the key bytes.
 			allDecoded = false
+			// Mark the separator as safe
 			buf.WriteString(sep)
 			buf.WriteByte('?')
 			buf.WriteByte('?')
 			buf.WriteByte('?')
 		} else {
+			// Mark the separator as safe
 			buf.WriteString(sep)
 			buf.WriteString(s)
 		}

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -912,7 +912,7 @@ func TestPrettyPrintValue(t *testing.T) {
 			dirStr = "Desc"
 		}
 		t.Run(test.exp[1:]+"/"+dirStr, func(t *testing.T) {
-			got := PrettyPrintValue([]Direction{test.dir}, test.key, "/")
+			got := PrettyPrintValue([]Direction{test.dir}, test.key, "/").StripMarkers()
 			if got != test.exp {
 				t.Errorf("expected %q, got %q", test.exp, got)
 			}

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -1275,7 +1275,7 @@ func TestEncodeDecodeJSONInvertedIndex(t *testing.T) {
 		}
 
 		for j, path := range enc {
-			str := encoding.PrettyPrintValue(nil, path, "/")
+			str := encoding.PrettyPrintValue(nil, path, "/").StripMarkers()
 			if str != c.expEnc[j] {
 				t.Errorf("unexpected encoding mismatch for %v. expected [%s], got [%s]",
 					c.value, c.expEnc[j], str)

--- a/pkg/util/keysutil/keys.go
+++ b/pkg/util/keysutil/keys.go
@@ -117,7 +117,7 @@ outer:
 	for len(input) > 0 {
 		if entries != nil {
 			for _, v := range entries {
-				if strings.HasPrefix(input, v.Name) {
+				if strings.HasPrefix(input, string(v.Name)) {
 					input = input[len(v.Name):]
 					if v.PSFunc == nil {
 						return mkErr(nil)
@@ -134,14 +134,14 @@ outer:
 			}
 		}
 		for _, v := range keys.ConstKeyOverrides {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				output = append(output, v.Value...)
 				input = input[len(v.Name):]
 				continue outer
 			}
 		}
 		for _, v := range s.keyComprehension {
-			if strings.HasPrefix(input, v.Name) {
+			if strings.HasPrefix(input, string(v.Name)) {
 				// No appending to output yet, the dictionary will take care of
 				// it.
 				input = input[len(v.Name):]


### PR DESCRIPTION
Previously the `PrettyPrint` function called the `prettyPrintInternal`
function which had similar logic to `safeFormatInternal`. This patch
modifies `safeFormatInternal` such that `PrettyPrint` can use it and
`prettyPrintInternal` has been removed. As part of this refactor,
all `ppFunc` functions have been updated to return
`redact.RedactableString`. Changes from #87952 are also included.

Resolves https://github.com/cockroachdb/cockroach/issues/88060

Release note: None