### PR TITLE
release-22.2: scplan: decorating error with plan details !=> assertion failure

### DIFF
--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -95,6 +95,7 @@ func makePlan(p *Plan) (err error) {
 			}
 			err = rAsErr
 		}
+		err = errors.WithAssertionFailure(err)
 	}()
 	{
 		start := timeutil.Now()

--- a/pkg/sql/schemachanger/scplan/plan_explain.go
+++ b/pkg/sql/schemachanger/scplan/plan_explain.go
@@ -41,7 +41,7 @@ func (p Plan) DecorateErrorWithPlanDetails(err error) (retErr error) {
 	if p.Graph != nil {
 		err = addDetail(err, "dependencies graphviz URL", "dependencies graphviz: ", p.DependenciesURL)
 	}
-	return errors.WithAssertionFailure(err)
+	return err
 }
 
 func addDetail(


### PR DESCRIPTION
Backport 1/1 commits from #88250.

/cc @cockroachdb/release

---

Fixes #85659.

Release note: None
Release justification: low-risk high-value change
