### PR TITLE
release-22.1: server: return all completed stmt diag requests

### DIFF
--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -118,7 +118,7 @@ func (s *statusServer) CancelStatementDiagnosticsReport(
 
 // StatementDiagnosticsRequests retrieves all statement diagnostics
 // requests in the `system.statement_diagnostics_requests` table that
-// have not yet expired.
+// have either completed or have not yet expired.
 func (s *statusServer) StatementDiagnosticsRequests(
 	ctx context.Context, _ *serverpb.StatementDiagnosticsReportsRequest,
 ) (*serverpb.StatementDiagnosticsReportsResponse, error) {
@@ -182,7 +182,7 @@ func (s *statusServer) StatementDiagnosticsRequests(
 			if expiresAt, ok := row[6].(*tree.DTimestampTZ); ok {
 				req.ExpiresAt = expiresAt.Time
 				// Don't return already expired requests.
-				if req.ExpiresAt.Before(timeutil.Now()) {
+				if !completed && req.ExpiresAt.Before(timeutil.Now()) {
 					continue
 				}
 			}


### PR DESCRIPTION
Backport 1/1 commits from #88138.

/cc @cockroachdb/release

---

Fixes #80104

Previously, we only return statement diagnostics requests that have not yet expired. Since we use the results of this request to populate completed statement diagnostics bundles in addition to outstanding requests, completed statement diag bundles would disappear from the UI after the request expired.

This commit ensures that `StatementDiagnosticsRequests` returns all completed stmt diag requests so that we can display the complete history of completed bundles in the UI.

Release note (bug fix): completed stmt diagnostics bundles now persist in the UI in stmt diag bundle pages
Release justification: bug fix