### PR TITLE
cfetcher: correctly update the limit hint

### DIFF
--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -854,15 +854,17 @@ func (cf *cFetcher) NextBatch(ctx context.Context) (coldata.Batch, error) {
 				// make sure that we don't bother filling in extra data if we
 				// don't need to.
 				emitBatch = true
-				// Update the limit hint to track the expected remaining rows to
-				// be fetched.
-				//
-				// Note that limitHint might become negative at which point we
-				// will start ignoring it.
-				cf.machine.limitHint -= cf.machine.rowIdx
 			}
 
 			if emitBatch {
+				if cf.machine.limitHint > 0 {
+					// Update the limit hint to track the expected remaining
+					// rows to be fetched.
+					//
+					// Note that limitHint might become negative at which point
+					// we will start ignoring it.
+					cf.machine.limitHint -= cf.machine.rowIdx
+				}
 				cf.pushState(stateResetBatch)
 				cf.finalizeBatch()
 				return cf.machine.batch, nil


### PR DESCRIPTION
In 41fa8b62d9b6824c8d55a70253070f2c47494b0b (which was supposed to be a "noop" refactor) we introduced a bug which made it so that we no longer update the remaining limit hint correctly. As a result, the cFetcher might no longer respect the limit hint. What makes things worse is the fact that the KV layer still does everything correctly, so when the cFetcher asks for more rows that exceed the limit, the KV layer does a BatchRequest with 10x of the original limit. This is now fixed by correctly updating the limit hint right before emitting the batch.

Addresses: #88382.

Epic: CRDB-20535

Release note (bug fix): CockroachDB no longer fetches unnecessary rows for queries with LIMITs. The bug was introduced in 22.1.7.