### PR TITLE
release-22.1: scplan: decorating error with plan details !=> assertion failure

### DIFF
--- a/pkg/sql/schemachanger/scplan/plan.go
+++ b/pkg/sql/schemachanger/scplan/plan.go
@@ -89,6 +89,7 @@ func MakePlan(initial scpb.CurrentState, params Params) (p Plan, err error) {
 			}
 			err = p.DecorateErrorWithPlanDetails(rAsErr)
 		}
+		err = errors.WithAssertionFailure(err)
 	}()
 
 	{

--- a/pkg/sql/schemachanger/scplan/plan_explain.go
+++ b/pkg/sql/schemachanger/scplan/plan_explain.go
@@ -63,7 +63,7 @@ func (p Plan) DecorateErrorWithPlanDetails(err error) error {
 		}
 	}
 
-	return errors.WithAssertionFailure(err)
+	return err
 }
 
 // DependenciesURL returns a URL to render the dependency graph in the Plan.


### PR DESCRIPTION
Backport 1/1 commits from #88250.

/cc @cockroachdb/release

---

Fixes #85659.

Release note: None
Release justification: high-value low-risk bug fix
