### PR TITLE
valueside: break dependency on eval package

### DIFF
--- a/pkg/sql/rowenc/valueside/BUILD.bazel
+++ b/pkg/sql/rowenc/valueside/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/lex",
-        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/encoding",

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -11,7 +11,6 @@
 package valueside
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -258,7 +257,7 @@ func checkElementType(paramType *types.T, elemType *types.T) error {
 // encodeArrayElement appends the encoded form of one array element to
 // the target byte buffer.
 func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
-	switch t := eval.UnwrapDatum(nil, d).(type) {
+	switch t := tree.UnwrapDOidWrapper(d).(type) {
 	case *tree.DInt:
 		return encoding.EncodeUntaggedIntValue(b, int64(*t)), nil
 	case *tree.DString:

--- a/pkg/sql/rowenc/valueside/encode.go
+++ b/pkg/sql/rowenc/valueside/encode.go
@@ -12,7 +12,6 @@ package valueside
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -36,7 +35,7 @@ func Encode(appendTo []byte, colID ColumnIDDelta, val tree.Datum, scratch []byte
 	if val == tree.DNull {
 		return encoding.EncodeNullValue(appendTo, uint32(colID)), nil
 	}
-	switch t := eval.UnwrapDatum(nil, val).(type) {
+	switch t := tree.UnwrapDOidWrapper(val).(type) {
 	case *tree.DBitArray:
 		return encoding.EncodeBitArrayValue(appendTo, uint32(colID), t.BitArray), nil
 	case *tree.DBool:


### PR DESCRIPTION
Previously, valueside was importing eval to call eval.UnwrapDatum. It
always passed a null context to UnwrapDatum, so the eval dependency is
unnecessary. valueside can use tree.UnwrapDatum directly.

Release note: None