### PR TITLE
release-22.1: colexecdisk: add cancel checking for disk-spilling operators

### DIFF
--- a/pkg/sql/colcontainer/BUILD.bazel
+++ b/pkg/sql/colcontainer/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/sql/colexecerror",
         "//pkg/sql/types",
         "//pkg/storage/fs",
+        "//pkg/util/cancelchecker",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/uuid",


### PR DESCRIPTION
Backport 1/1 commits from #88302.

/cc @cockroachdb/release

---

This commit adds the cancel checking to the methods of the disk queue as well as to the external operators themselves.

Fixes: #87482.

Release note (bug fix): CockroachDB now more promptly reacts to query cancellations (e.g. due to statement timeout being exceeded) after the query spilled to disk.

Release justification: bug fix.