### PR TITLE
opt: fix node-crashing panics with correlated With exprs

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -578,3 +578,29 @@ WHERE
         )
           AS tab_397813 (col_664948, col_664949) ON (tab_397806.col_664940) = (tab_397813.col_664948)
   );
+
+subtest regression_87733
+
+statement ok
+CREATE TABLE t87733a (a INT);
+CREATE TABLE t87733b (b INT);
+INSERT INTO t87733a VALUES (1)
+
+# Regression test for #87733. Do not panic when planning the RHS of an
+# apply-join that refers to a With expression transitively through another With
+# expression.
+query T
+WITH
+  t1 AS (SELECT a FROM t87733a),
+  t2 AS MATERIALIZED (SELECT a, b FROM t1 JOIN t87733b ON true)
+SELECT NULL
+FROM t1
+LEFT JOIN LATERAL (
+  WITH t3 AS (SELECT * FROM t2 WHERE t2.a = t1.a)
+  SELECT array_agg(CASE WHEN v = '' THEN b END)
+  FROM (
+    SELECT '' AS v, b FROM t3 ORDER BY b DESC
+  )
+) ON true;
+----
+NULL

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1054,6 +1054,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 
 		// Copy the right expression into a new memo, replacing each bound column
 		// with the corresponding value from the left row.
+		addedWithBindings := false
 		var replaceFn norm.ReplaceFunc
 		replaceFn = func(e opt.Expr) opt.Expr {
 			switch t := e.(type) {
@@ -1063,15 +1064,26 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 				}
 
 			case *memo.WithScanExpr:
-				// Allow referring to "outer" With expressions. The bound expressions
-				// are not part of this Memo but they are used only for their relational
-				// properties, which should be valid.
-				for i := range withExprs {
-					if withExprs[i].id == t.With {
-						memoExpr := b.mem.Metadata().WithBinding(t.With)
-						f.Metadata().AddWithBinding(t.With, memoExpr)
-						break
+				// Allow referring to "outer" With expressions. The bound
+				// expressions are not part of this Memo, but they are used only
+				// for their relational properties, which should be valid.
+				//
+				// We must add all With expressions to the metadata even if they
+				// aren't referred to directly because they might be referred to
+				// transitively through other With expressions. For example, if
+				// the RHS refers to With expression &1, and &1 refers to With
+				// expression &2, we must include &2 in the metadata so that
+				// its relational properties are available. See #87733.
+				//
+				// We lazily add these With expressions to the metadata here
+				// because the call to Factory.CopyAndReplace below clears With
+				// expressions in the metadata.
+				if !addedWithBindings {
+					for i, n := opt.WithID(1), b.mem.MaxWithID(); i <= n; i++ {
+						memoExpr := b.mem.Metadata().WithBinding(i)
+						f.Metadata().AddWithBinding(i, memoExpr)
 					}
+					addedWithBindings = true
 				}
 				// Fall through.
 			}

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -41,7 +41,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -1024,7 +1026,29 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	//
 	// Note: we put o outside of the function so we allocate it only once.
 	var o xform.Optimizer
-	planRightSideFn := func(ctx context.Context, ef exec.Factory, leftRow tree.Datums) (exec.Plan, error) {
+	planRightSideFn := func(ctx context.Context, ef exec.Factory, leftRow tree.Datums) (_ exec.Plan, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				// This code allows us to propagate internal errors without having to add
+				// error checks everywhere throughout the code. This is only possible
+				// because the code does not update shared state and does not manipulate
+				// locks.
+				//
+				// This is the same panic-catching logic that exists in
+				// o.Optimize() below. It's required here because it's possible
+				// for factory functions to panic below, like
+				// CopyAndReplaceDefault.
+				if ok, e := errorutil.ShouldCatch(r); ok {
+					err = e
+					log.VEventf(ctx, 1, "%v", err)
+				} else {
+					// Other panic objects can't be considered "safe" and thus are
+					// propagated as crashes that terminate the session.
+					panic(r)
+				}
+			}
+		}()
+
 		o.Init(ctx, b.evalCtx, b.catalog)
 		f := o.Factory()
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -466,6 +466,12 @@ func (m *Memo) NextWithID() opt.WithID {
 	return m.curWithID
 }
 
+// MaxWithID returns the current maximum assigned identifier for a WITH
+// expression.
+func (m *Memo) MaxWithID() opt.WithID {
+	return m.curWithID
+}
+
 // Detach is used when we detach a memo that is to be reused later (either for
 // execbuilding or with AssignPlaceholders). New expressions should no longer be
 // constructed in this memo.


### PR DESCRIPTION
#### opt: prevent apply-join panics from crashing nodes

Previously, it was possible for the execution of an apply-join to crash
a node due to an uncaught optimizer panic when calling the
`planRightSideFn` closure. This closure is invoked for every input row
to the apply-join. It replaces variables in the expression on the right
side of the join with constants using `Factory.CopyAndReplace`, which
can panic. This panic won't be caught by the panic-catching logic in
`Optimizer.Optimize` because the closure is invoked outside the context
of `Optimizer.Optimize` - it's occurring during execution instead.

This commit copies the panic-catching logic of `Optimizer.Optimize` to
the apply-join's `planRightSideFn` closure to ensure that any panics are
caught.

Release Note (bug fix): A bug has been fixed that could cause nodes to
crash in rare cases when executing apply-joins in query plans.

#### opt: fix transitive references to With exprs in RHS of apply-join

This commit fixes an error that could occur when the RHS of an
apply-join referenced a With expression transitive through another With
expression. The error occurred because the optimizer could not access
the relational properties of the transitively referenced With expression
because the With was not added to the metadata. The commit fixes the
issue by adding all With expressions to the metadata if any With
expressions are referenced.

Fixes #87733

Release note (bug fix): A bug has been fixed that caused errors in rare
cases when executing queries with correlated WITH expressions. This bug
was present since correlated WITH expressions were introduced in
v21.2.0.
