### PR TITLE
release-22.2: storage: remove Engine interface cruft

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -155,6 +155,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/fs",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
@@ -1039,7 +1040,7 @@ func TestEvalAddSSTable(t *testing.T) {
 							require.Nil(t, result.Replicated.AddSSTable)
 						} else {
 							require.NotNil(t, result.Replicated.AddSSTable)
-							require.NoError(t, engine.WriteFile("sst", result.Replicated.AddSSTable.Data))
+							require.NoError(t, fs.WriteFile(engine, "sst", result.Replicated.AddSSTable.Data))
 							require.NoError(t, engine.IngestExternalFiles(ctx, []string{"sst"}))
 						}
 
@@ -1443,7 +1444,7 @@ func TestAddSSTableMVCCStats(t *testing.T) {
 	_, err := batcheval.EvalAddSSTable(ctx, engine, cArgs, &resp)
 	require.NoError(t, err)
 
-	require.NoError(t, engine.WriteFile("sst", sst))
+	require.NoError(t, fs.WriteFile(engine, "sst", sst))
 	require.NoError(t, engine.IngestExternalFiles(ctx, []string{"sst"}))
 
 	statsEvaled := statsBefore

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -3880,7 +3881,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		var mismatchedSstsIdx []int
 		// Iterate over all the tested SSTs and check that they're byte-by-byte equal.
 		for i := range sstNamesSubset {
-			actualSST, err := receivingEng.ReadFile(sstNamesSubset[i])
+			actualSST, err := fs.ReadFile(receivingEng, sstNamesSubset[i])
 			if err != nil {
 				return err
 			}

--- a/pkg/kv/kvserver/replica_sideload_disk.go
+++ b/pkg/kv/kvserver/replica_sideload_disk.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
@@ -156,7 +157,7 @@ func (ss *diskSideloadStorage) Put(ctx context.Context, index, term uint64, cont
 // Get implements SideloadStorage.
 func (ss *diskSideloadStorage) Get(ctx context.Context, index, term uint64) ([]byte, error) {
 	filename := ss.filename(ctx, index, term)
-	b, err := ss.eng.ReadFile(filename)
+	b, err := fs.ReadFile(ss.eng, filename)
 	if oserror.IsNotExist(err) {
 		return nil, errSideloadedFileNotFound
 	}

--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -297,7 +298,7 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	var actualSSTs [][]byte
 	fileNames := msstw.scratch.SSTs()
 	for _, file := range fileNames {
-		sst, err := eng.ReadFile(file)
+		sst, err := fs.ReadFile(eng, file)
 		require.NoError(t, err)
 		actualSSTs = append(actualSSTs, sst)
 	}

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -916,8 +916,6 @@ type Engine interface {
 	RegisterFlushCompletedCallback(cb func())
 	// Filesystem functionality.
 	fs.FS
-	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
-	ReadFile(filename string) ([]byte, error)
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -918,8 +918,6 @@ type Engine interface {
 	fs.FS
 	// ReadFile reads the content from the file with the given filename int this RocksDB's env.
 	ReadFile(filename string) ([]byte, error)
-	// WriteFile writes data to a file in this RocksDB's env.
-	WriteFile(filename string, data []byte) error
 	// CreateCheckpoint creates a checkpoint of the engine in the given directory,
 	// which must not exist. The directory should be on the same file system so
 	// that hard links can be used.

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -907,13 +907,6 @@ type Engine interface {
 	// CompactRange ensures that the specified range of key value pairs is
 	// optimized for space efficiency.
 	CompactRange(start, end roachpb.Key) error
-	// InMem returns true if the receiver is an in-memory engine and false
-	// otherwise.
-	//
-	// TODO(peter): This is a bit of a wart in the interface. It is used by
-	// addSSTablePreApply to select alternate code paths, but really there should
-	// be a unified code path there.
-	InMem() bool
 	// RegisterFlushCompletedCallback registers a callback that will be run for
 	// every successful flush. Only one callback can be registered at a time, so
 	// registering again replaces the previous callback. The callback must

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1249,22 +1249,19 @@ func TestEngineFSFileNotFoundError(t *testing.T) {
 			t.Fatalf("error closing file %s, got err %v", fname, err)
 		}
 	}
-
-	if b, err := db.ReadFile(fname); err != nil {
+	if b, err := fs.ReadFile(db, fname); err != nil {
 		t.Errorf("unable to read file with filename %s, got err %v", fname, err)
 	} else if string(b) != data {
 		t.Errorf("expected content in %s is '%s', got '%s'", fname, data, string(b))
 	}
-
 	if err := db.Remove(fname); err != nil {
 		t.Errorf("unable to delete file with filename %s, got err %v", fname, err)
 	}
 
 	// Verify ReadFile returns os.ErrNotExist if reading an already deleted file.
-	if _, err := db.ReadFile(fname); !oserror.IsNotExist(err) {
+	if _, err := fs.ReadFile(db, fname); !oserror.IsNotExist(err) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)
 	}
-
 	// Verify Remove returns os.ErrNotExist if deleting an already deleted file.
 	if err := db.Remove(fname); !oserror.IsNotExist(err) {
 		t.Fatalf("expected IsNotExist, but got %v (%T)", err, err)

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -82,3 +82,13 @@ func WriteFile(fs FS, filename string, data []byte) error {
 	}
 	return err
 }
+
+// ReadFile reads data from a file named by filename.
+func ReadFile(fs FS, filename string) ([]byte, error) {
+	file, err := fs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	return io.ReadAll(file)
+}

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -1347,7 +1348,7 @@ func TestMVCCIncrementalIteratorIntentStraddlesSStables(t *testing.T) {
 		if err := sst.Finish(); err != nil {
 			t.Fatal(err)
 		}
-		if err := db2.WriteFile(`ingest`, memFile.Data()); err != nil {
+		if err := fs.WriteFile(db2, `ingest`, memFile.Data()); err != nil {
 			t.Fatal(err)
 		}
 		if err := db2.IngestExternalFiles(ctx, []string{`ingest`}); err != nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1708,18 +1708,6 @@ func (p *Pebble) ReadFile(filename string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
-// WriteFile writes data to a file in this RocksDB's env.
-func (p *Pebble) WriteFile(filename string, data []byte) error {
-	file, err := p.fs.Create(filename)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, bytes.NewReader(data))
-	return err
-}
-
 // Remove implements the FS interface.
 func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1697,17 +1697,6 @@ func (p *Pebble) RegisterFlushCompletedCallback(cb func()) {
 	p.mu.Unlock()
 }
 
-// ReadFile implements the Engine interface.
-func (p *Pebble) ReadFile(filename string) ([]byte, error) {
-	file, err := p.fs.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-
-	return io.ReadAll(file)
-}
-
 // Remove implements the FS interface.
 func (p *Pebble) Remove(filename string) error {
 	return p.fs.Remove(filename)

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1690,12 +1690,6 @@ func (p *Pebble) CompactRange(start, end roachpb.Key) error {
 	return p.db.Compact(bufStart, bufEnd, true /* parallel */)
 }
 
-// InMem returns true if the receiver is an in-memory engine and false
-// otherwise.
-func (p *Pebble) InMem() bool {
-	return p.path == ""
-}
-
 // RegisterFlushCompletedCallback implements the Engine interface.
 func (p *Pebble) RegisterFlushCompletedCallback(cb func()) {
 	p.mu.Lock()


### PR DESCRIPTION
Backport 3/3 commits from #88063.

/cc @cockroachdb/release

---

Remove a few methods from the `Engine` interface type that don't belong.

**storage: remove Engine.InMem**

Remove storage.Engine's InMem method. This method was a hole in the
abstraction. Clients should not need to distinguish between on-disk and
in-memory engines.

**storage: remove Engine.WriteFile**

Remove the WriteFile method on the Engine interface, converting call sites to
use the storage/fs.WriteFile function. The Engine itself should only expose
primitives, and higher-level utilities like a WriteFile routine can be
implemented in terms of those primitives.

**storage/fs: move Engine.ReadFile to fs.ReadFile**

Move the Engine's ReadFile method off of the Engine interface and into a
storage/fs helper function written it terms of existing Engine methods.

Release justification: Non-production code changes and low-risk bug fix