### PR TITLE
opt: mark SimplifyRange as essential

### DIFF
--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -1042,6 +1042,8 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		// Needed to make sure that dummy columns are pruned so that the
 		// database name is retrieved correctly.
 		int(opt.PruneScanCols),
+		// Needed to ensure that the input of a RangeExpr is always an AndExpr.
+		int(opt.SimplifyRange),
 	)
 
 	var disabledRules RuleSet


### PR DESCRIPTION
This commit marks the `SimplifyRange` normalization rule as essential during random rule-disabling tests. This is necessary because `RangeExpr` is expected to maintain the invariant that its input is always an `AndExpr`. Other rules can replace the `AndExpr` with a different expression over the course of normalization, at which point the `RangeExpr` needs to be removed. Otherwise, various code-paths that depend on the invariant may panic (for example, predicate implication).

Fixes #88352

Release note: None