### PR TITLE
cdc: use highwater, if set, to get table descriptors in alter changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -84,7 +84,8 @@ func init() {
 
 type annotatedChangefeedStatement struct {
 	*tree.CreateChangefeed
-	originalSpecs map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification
+	originalSpecs       map[tree.ChangefeedTarget]jobspb.ChangefeedTargetSpecification
+	alterChangefeedAsOf hlc.Timestamp
 }
 
 func getChangefeedStatement(stmt tree.Statement) *annotatedChangefeedStatement {
@@ -346,6 +347,10 @@ func createChangefeedJobRecord(
 			return nil, err
 		}
 		statementTime = initialHighWater
+	}
+
+	if !changefeedStmt.alterChangefeedAsOf.IsEmpty() {
+		statementTime = changefeedStmt.alterChangefeedAsOf
 	}
 
 	endTime := hlc.Timestamp{}


### PR DESCRIPTION
When the changefeed is started with cursor option, and then runs for a while (>gcttl time -- say 25 hours), the attempts to alter changefeed will fail due to the fact that createChangefeedJobRecord uses cursor (which is now very old) to set the time at which targets are resolved

To fix this, we will use the highwater timestamp to get the table descriptors. Targets will always be valid at highwater. Since createChangefeedJobRecord is called both during create changefeed and alter changefeed, we use cursor/statement time if highwater is not avaliable (which indicates that currently create changefeed is executing)

Resolves: #88050

Release note (bug fix): Fixed a bug which causes alter changefeed to fail if the changefeed was created with cursor option and had been running for more than gc.ttlseconds