### PR TITLE
kvserver,clusterversion: {version,feature}-gate lease upgrade logic

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -295,4 +295,4 @@ trace.jaeger.agent	string		the address of a Jaeger agent to receive traces using
 trace.opentelemetry.collector	string		address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.
 trace.span_registry.enabled	boolean	true	if set, ongoing traces can be seen at https://<ui>/#/debug/tracez
 trace.zipkin.collector	string		the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.
-version	version	1000022.1-70	set the active cluster version in the format '<major>.<minor>'
+version	version	1000022.1-72	set the active cluster version in the format '<major>.<minor>'

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -229,6 +229,6 @@
 <tr><td><code>trace.opentelemetry.collector</code></td><td>string</td><td><code></code></td><td>address of an OpenTelemetry trace collector to receive traces using the otel gRPC protocol, as <host>:<port>. If no port is specified, 4317 will be used.</td></tr>
 <tr><td><code>trace.span_registry.enabled</code></td><td>boolean</td><td><code>true</code></td><td>if set, ongoing traces can be seen at https://<ui>/#/debug/tracez</td></tr>
 <tr><td><code>trace.zipkin.collector</code></td><td>string</td><td><code></code></td><td>the address of a Zipkin instance to receive traces, as <host>:<port>. If no port is specified, 9411 will be used.</td></tr>
-<tr><td><code>version</code></td><td>version</td><td><code>1000022.1-70</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
+<tr><td><code>version</code></td><td>version</td><td><code>1000022.1-72</code></td><td>set the active cluster version in the format '<major>.<minor>'</td></tr>
 </tbody>
 </table>

--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -288,6 +288,16 @@ const (
 	// version is enabled, the receiver will look at the priority of snapshots
 	// using the fields added in 22.2.
 	PrioritizeSnapshots
+	// EnableLeaseUpgrade version gates a change in the lease transfer protocol
+	// whereby we only ever transfer expiration-based leases (and have
+	// recipients later upgrade them to the more efficient epoch based ones).
+	// This was done to limit the effects of ill-advised lease transfers since
+	// the incoming leaseholder would need to recognize itself as such within a
+	// few seconds. This needs version gating so that in mixed-version clusters,
+	// as part of lease transfers, we don't start sending out expiration based
+	// leases to nodes that (i) don't expect them for certain keyspans, and (ii)
+	// don't know to upgrade them to efficient epoch-based ones.
+	EnableLeaseUpgrade
 
 	// *************************************************
 	// Step (1): Add new versions here.
@@ -466,6 +476,10 @@ var rawVersionsSingleton = keyedVersions{
 	{
 		Key:     PrioritizeSnapshots,
 		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 70},
+	},
+	{
+		Key:     EnableLeaseUpgrade,
+		Version: roachpb.Version{Major: 22, Minor: 1, Internal: 72},
 	},
 
 	// *************************************************

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -48,12 +48,14 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/constraint"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -63,6 +65,13 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
+)
+
+var transferExpirationLeasesFirstEnabled = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.transfer_expiration_leases_first.enabled",
+	"controls whether we transfer expiration-based leases that are later upgraded to epoch-based ones",
+	true,
 )
 
 var leaseStatusLogLimiter = func() *log.EveryN {
@@ -246,7 +255,10 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		ProposedTS: &status.Now,
 	}
 
-	if p.repl.requiresExpiringLeaseRLocked() || transfer {
+	if p.repl.requiresExpiringLeaseRLocked() ||
+		(transfer &&
+			transferExpirationLeasesFirstEnabled.Get(&p.repl.store.ClusterSettings().SV) &&
+			p.repl.store.ClusterSettings().Version.IsActive(ctx, clusterversion.EnableLeaseUpgrade)) {
 		// In addition to ranges that unconditionally require expiration-based
 		// leases (node liveness and earlier), we also use them during lease
 		// transfers for all other ranges. After acquiring these expiration

--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -463,7 +463,7 @@ var LogicTestConfigs = []TestClusterConfig{
 		NumNodes:                    1,
 		OverrideDistSQLMode:         "off",
 		BootstrapVersion:            clusterversion.ByKey(clusterversion.V22_1),
-		BinaryVersion:               clusterversion.ByKey(clusterversion.PrioritizeSnapshots), //TODO: switch to 22.2.
+		BinaryVersion:               clusterversion.ByKey(clusterversion.EnableLeaseUpgrade), // TODO(dt): switch to 22.2.
 		DisableUpgrade:              true,
 		DeclarativeCorpusCollection: true,
 	},


### PR DESCRIPTION
Informs #88301. EnableLeaseUpgrade version gates a change in the lease transfer protocol whereby we only ever transfer expiration-based leases (and have recipients later upgrade them to the more efficient epoch based ones). This was done to limit the effects of ill-advised lease transfers since the incoming leaseholder would need to recognize itself as such within a few seconds. This needs version gating so that in mixed-version clusters, as part of lease transfers, we don't start sending out expiration based leases to nodes that (i) don't expect them for certain keyspans, and (ii) don't know to upgrade them to efficient epoch-based ones.

While here, we also introduce a (hidden, default=true) cluster setting kv.transfer_expiration_leases_first.enabled to feature gate this protocol change.