### PR TITLE
build: reconfigure git ssh key

### DIFF
--- a/build/teamcity/internal/release/process/publish-cockroach-release.sh
+++ b/build/teamcity/internal/release/process/publish-cockroach-release.sh
@@ -118,6 +118,7 @@ tc_end_block "Make and push docker images"
 
 
 tc_start_block "Push release tag to GitHub"
+configure_git_ssh_key
 git_wrapped push "ssh://git@github.com/${git_repo_for_tag}.git" "$build_name"
 tc_end_block "Push release tag to GitHub"
 


### PR DESCRIPTION
The publishing of the first two 22.2 alphas has failed because the `.cockroach-teamcity-key` key for SSHing to GitHub was not present when the release tag was to be pushed to the cockroachdb/cockroach repo.

This reruns the logic to `configure_git_ssh_key` before pushing the tag.

This change was successfully tested on beta.1:
* [Publish Cockroach Release for beta.1 branch](https://teamcity.cockroachdb.com/buildConfiguration/Internal_Release_PublishCockroachRelease?branch=v22.2.0-alpha.3-357-ga33d71dcd9&mode=builds)
* See temporary change to Build Step script:
[cockroachlabs/teamcity-config@master/.teamcity/Internal_Release_Publish/buildTypes/Internal_Release_PublishCockroachRelease.xml#L150](https://github.com/cockroachlabs/teamcity-config/blob/master/.teamcity/Internal_Release_Publish/buildTypes/Internal_Release_PublishCockroachRelease.xml?rgh-link-date=2022-09-26T20%3A48%3A07Z#L150)

We will need to backport this to 22.2.

Fixes RE-270
Release note: None
Release justification: release pipeline infrastructure-only change