### PR TITLE
util/tracing: trim trace recordings in a smarter way 

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3906,7 +3906,8 @@ func (s *adminServer) GetTrace(
 		}
 		traceStillExists = true
 		if recording == nil {
-			recording = sp.GetFullRecording(tracingpb.RecordingVerbose)
+			trace := sp.GetFullRecording(tracingpb.RecordingVerbose)
+			recording = trace.Flatten()
 		}
 		return iterutil.StopIteration()
 	}); err != nil {

--- a/pkg/server/node_tenant.go
+++ b/pkg/server/node_tenant.go
@@ -28,7 +28,6 @@ import "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 func redactRecording(rec tracingpb.Recording) {
 	for i := range rec {
 		sp := &rec[i]
-		sp.Tags = nil // TODO(benbardin): Remove for 23.1.
 		sp.TagGroups = nil
 		for j := range sp.Logs {
 			record := &sp.Logs[j]

--- a/pkg/server/node_tenant_test.go
+++ b/pkg/server/node_tenant_test.go
@@ -57,7 +57,6 @@ func TestRedactRecordingForTenant(t *testing.T) {
 
 	rec := mkRec()
 	redactRecording(rec)
-	require.Zero(t, rec[0].Tags)
 	require.Zero(t, rec[0].TagGroups)
 	require.Len(t, rec[0].Logs, 1)
 	msg := rec[0].Logs[0].Msg().StripMarkers()
@@ -79,7 +78,6 @@ func TestNewSpanFields(t *testing.T) {
 		SpanID            tracingpb.SpanID
 		ParentSpanID      tracingpb.SpanID
 		Operation         string
-		Tags              map[string]string
 		TagGroups         []tracingpb.TagGroup
 		StartTime         time.Time
 		Duration          time.Duration

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1520,7 +1520,8 @@ CREATE TABLE crdb_internal.node_inflight_trace_spans (
 				"only users with the admin role are allowed to read crdb_internal.node_inflight_trace_spans")
 		}
 		return p.ExecCfg().AmbientCtx.Tracer.VisitSpans(func(span tracing.RegistrySpan) error {
-			for _, rec := range span.GetFullRecording(tracingpb.RecordingVerbose) {
+			trace := span.GetFullRecording(tracingpb.RecordingVerbose)
+			for _, rec := range trace.Flatten() {
 				traceID := rec.TraceID
 				parentSpanID := rec.ParentSpanID
 				spanID := rec.SpanID

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -2253,12 +2253,12 @@ func (p *payloadsForSpanGenerator) Start(_ context.Context, _ *kv.Txn) error {
 	p.payloadIndex = -1
 
 	rec := p.span.GetFullRecording(tracingpb.RecordingStructured)
-	if rec == nil {
+	if rec.Empty() {
 		// No structured records.
 		return nil
 	}
-	p.payloads = make([]json.JSON, len(rec[0].StructuredRecords))
-	for i, sr := range rec[0].StructuredRecords {
+	p.payloads = make([]json.JSON, len(rec.Root.StructuredRecords))
+	for i, sr := range rec.Root.StructuredRecords {
 		var err error
 		p.payloads[i], err = protoreflect.MessageToJSON(sr.Payload, protoreflect.FmtFlags{EmitDefaults: true})
 		if err != nil {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -172,7 +172,8 @@ func (tc *TestCluster) stopServers(ctx context.Context) {
 			fmt.Fprintf(&buf, "unexpectedly found %d active spans:\n", len(sps))
 			var ids []uint64
 			for _, sp := range sps {
-				rec := sp.GetFullRecording(tracingpb.RecordingVerbose)
+				trace := sp.GetFullRecording(tracingpb.RecordingVerbose)
+				rec := trace.Flatten()
 				for _, rs := range rec {
 					// NB: it would be a sight easier to just include these in the output of
 					// the string formatted recording, but making a change there presumably requires

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -152,10 +152,10 @@ type recordingState struct {
 	// notified of every StructuredEvent recording on this span.
 	notifyParentOnStructuredEvent bool
 
-	// dropped is true if the span has capped out it's memory limits for
-	// logs and structured events, and has had to drop some. It's used to
-	// annotate recordings with the _dropped tag, when applicable.
-	dropped bool
+	// droppedLogs is set if the span has capped out its memory limits for logs
+	// and structured events, and had to drop some. It's used to annotate
+	// recordings with the _dropped_logs tag, when applicable.
+	droppedLogs bool
 
 	// finishedChildren contains the recordings of finished children (and
 	// grandchildren recursively). This includes remote child span recordings
@@ -167,8 +167,11 @@ type recordingState struct {
 	// span is not in RecordingVerbose, only their structured events are copied
 	// to structured above.
 	//
-	// The spans are not maintained in a particular order.
-	finishedChildren []tracingpb.RecordedSpan
+	// It's convenient to store finishedChildren as a Trace, even though the
+	// finishedChildren.Root will only be initialized when the span finishes. The
+	// children in the trace are maintained in no particular order, so
+	// finishedChildren.sortChildren should be used before handing the trace out.
+	finishedChildren Trace
 
 	// childrenMetadata is a mapping from operation to the aggregated metadata of
 	// that operation.
@@ -197,6 +200,116 @@ type sizeLimitedBuffer struct {
 	ring.Buffer
 	bytesSize  int64
 	bytesLimit int64
+}
+
+// Trace represents the recording of a span and all its descendents.
+type Trace struct {
+	Root     tracingpb.RecordedSpan
+	Children []Trace
+	// NumSpans tracks the number of spans in the recording: 1 for the root plus
+	// the size of the child traces recursively.
+	NumSpans int
+
+	// DroppedDirectChildren maintains info about whether any direct children were
+	// omitted from Children because of recording limits.
+	//
+	// When set, DroppedDirectChildren and DroppedIndirectChildren are also
+	// reflected in corresponding tags on Root.
+	DroppedDirectChildren bool
+	// DroppedIndirectChildren maintains info about whether any indirect children
+	// were omitted from Children because of recording limits.
+	DroppedIndirectChildren bool
+}
+
+// MakeTrace constructs a Trace.
+func MakeTrace(root tracingpb.RecordedSpan) Trace {
+	return Trace{
+		Root:     root,
+		NumSpans: 1,
+	}
+}
+
+// addChild attempts to add a child's trace to t. If the child's trace is too
+// large and would cause t's trace to get over the maxRecordedSpansPerTrace
+// limit, false is returned and the call is a no-op.
+//
+// TODO(andrei): don't wholly reject the child if there's some space left in t.
+func (t *Trace) addChild(child Trace) bool {
+	if t.NumSpans+child.NumSpans > maxRecordedSpansPerTrace {
+		t.DroppedDirectChildren = true
+		t.Root.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_children", "")
+		return false
+	}
+
+	if child.DroppedDirectChildren || child.DroppedIndirectChildren {
+		t.DroppedIndirectChildren = true
+		t.Root.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_indirect_children", "")
+	}
+	t.NumSpans += child.NumSpans
+	t.Children = append(t.Children, child)
+	return true
+}
+
+func (t *Trace) addChildren(children []Trace) {
+	for i := range children {
+		t.addChild(children[i])
+	}
+}
+
+// Empty returns true if the receiver is not initialized.
+func (t *Trace) Empty() bool {
+	return len(t.Children) == 0 && t.Root.StartTime == time.Time{}
+}
+
+func (t *Trace) appendStructuredEventsRecursively(
+	buffer []tracingpb.StructuredRecord,
+) []tracingpb.StructuredRecord {
+	buffer = append(buffer, t.Root.StructuredRecords...)
+	for i := range t.Children {
+		buffer = t.Children[i].appendStructuredEventsRecursively(buffer)
+	}
+	return buffer
+}
+
+func (t *Trace) appendSpansRecursively(buffer []tracingpb.RecordedSpan) []tracingpb.RecordedSpan {
+	buffer = append(buffer, t.Root)
+	for i := range t.Children {
+		buffer = t.Children[i].appendSpansRecursively(buffer)
+	}
+	return buffer
+}
+
+// Flatten flattens the trace into a slice of spans. The root is the first span,
+// and parents come before children. Otherwise, the spans are not sorted.
+func (t *Trace) Flatten() []tracingpb.RecordedSpan {
+	return t.appendSpansRecursively(nil /* buffer */)
+}
+
+// sortChildren sorts the children in the trace by start time.
+func (t *Trace) sortChildren() {
+	toSort := sortPoolTraces.Get().(*[]Trace) // avoids allocations in sort.Sort
+	*toSort = t.Children
+	sort.Slice(*toSort, func(i, j int) bool {
+		return (*toSort)[i].Root.StartTime.Before((*toSort)[j].Root.StartTime)
+	})
+	*toSort = nil
+	sortPoolTraces.Put(toSort)
+}
+
+var sortPoolTraces = sync.Pool{
+	New: func() interface{} {
+		return &[]Trace{}
+	},
+}
+
+// Clone performs a deep copy of the trace.
+func (t *Trace) Clone() Trace {
+	r := *t
+	r.Children = make([]Trace, len(t.Children))
+	for i := range t.Children {
+		r.Children[i] = t.Children[i].Clone()
+	}
+	return r
 }
 
 // Discard zeroes out *buf. If nobody else is referencing the backing storage
@@ -356,14 +469,12 @@ func (s *crdbSpan) SpanID() tracingpb.SpanID {
 //
 // finishing indicates whether s is in the process of finishing. If it isn't,
 // the recording will include an "_unfinished" tag.
-func (s *crdbSpan) GetRecording(
-	recType tracingpb.RecordingType, finishing bool,
-) tracingpb.Recording {
+func (s *crdbSpan) GetRecording(recType tracingpb.RecordingType, finishing bool) Trace {
 	return s.getRecordingImpl(recType, false /* includeDetachedChildren */, finishing)
 }
 
 // GetFullRecording is part of the RegistrySpan interface.
-func (s *crdbSpan) GetFullRecording(recType tracingpb.RecordingType) tracingpb.Recording {
+func (s *crdbSpan) GetFullRecording(recType tracingpb.RecordingType) Trace {
 	return s.getRecordingImpl(recType, true /* includeDetachedChildren */, false /* finishing */)
 }
 
@@ -373,14 +484,14 @@ func (s *crdbSpan) GetFullRecording(recType tracingpb.RecordingType) tracingpb.R
 // the recording will include an "_unfinished" tag.
 func (s *crdbSpan) getRecordingImpl(
 	recType tracingpb.RecordingType, includeDetachedChildren bool, finishing bool,
-) tracingpb.Recording {
+) Trace {
 	switch recType {
 	case tracingpb.RecordingVerbose:
 		return s.getVerboseRecording(includeDetachedChildren, finishing)
 	case tracingpb.RecordingStructured:
-		return s.getStructuredRecording(includeDetachedChildren)
+		return MakeTrace(s.getStructuredRecording(includeDetachedChildren))
 	case tracingpb.RecordingOff:
-		return nil
+		return Trace{}
 	default:
 		panic("unreachable")
 	}
@@ -402,47 +513,43 @@ func rollupChildrenMetadata(
 //
 // finishing indicates whether s is in the process of finishing. If it isn't,
 // the recording will include an "_unfinished" tag.
-func (s *crdbSpan) getVerboseRecording(
-	includeDetachedChildren bool, finishing bool,
-) tracingpb.Recording {
+func (s *crdbSpan) getVerboseRecording(includeDetachedChildren bool, finishing bool) Trace {
 	if s == nil {
-		return nil // noop span
+		return Trace{} // noop span
 	}
 
-	var result tracingpb.Recording
+	var result Trace
 	var childrenMetadata map[string]tracingpb.OperationMetadata
 	{
 		s.mu.Lock()
-		// The capacity here is approximate since we don't know how many
-		// grandchildren there are.
-		result = make(tracingpb.Recording, 0, 1+len(s.mu.openChildren)+len(s.mu.recording.finishedChildren))
-		result = append(result, s.getRecordingNoChildrenLocked(tracingpb.RecordingVerbose, finishing))
-		result = append(result, s.mu.recording.finishedChildren...)
 
-		childrenMetadata = make(map[string]tracingpb.OperationMetadata)
+		result = s.mu.recording.finishedChildren.Clone()
+		result.Root = s.getRecordingNoChildrenLocked(tracingpb.RecordingVerbose, finishing)
 
 		// Copy over the OperationMetadata collected from s' finished children.
+		childrenMetadata = make(map[string]tracingpb.OperationMetadata)
 		rollupChildrenMetadata(childrenMetadata, s.mu.recording.childrenMetadata)
 
 		// We recurse on s' open children to get their verbose recordings, and to
 		// aggregate OperationMetadata from their children, both finished and open.
+		now := s.tracer.now()
 		for _, openChild := range s.mu.openChildren {
 			if openChild.collectRecording || includeDetachedChildren {
 				openChildSp := openChild.Span.i.crdb
 				openChildRecording := openChildSp.getVerboseRecording(includeDetachedChildren, false /* finishing */)
-				result = append(result, openChildRecording...)
+				result.addChild(openChildRecording)
 
 				// Record an entry for openChilds' OperationMetadata.
-				rootOpenChild := openChildRecording[0]
-				prevMetadata := childrenMetadata[rootOpenChild.Operation]
-				prevMetadata.Count++
-				prevMetadata.ContainsUnfinished = !rootOpenChild.Finished
-				prevMetadata.Duration += rootOpenChild.Duration
-				childrenMetadata[rootOpenChild.Operation] = prevMetadata
+				op := openChildSp.operation
+				meta := childrenMetadata[op]
+				meta.Count++
+				meta.ContainsUnfinished = true
+				meta.Duration += now.Sub(openChildSp.startTime)
+				childrenMetadata[op] = meta
 
 				// Copy over the OperationMetadata collected recursively from openChilds'
 				// children.
-				rollupChildrenMetadata(childrenMetadata, openChildRecording[0].ChildrenMetadata)
+				rollupChildrenMetadata(childrenMetadata, openChildRecording.Root.ChildrenMetadata)
 			}
 		}
 	}
@@ -452,30 +559,20 @@ func (s *crdbSpan) getVerboseRecording(
 	// Copy over the OperationMetadata collected from s' children into the root of
 	// the recording.
 	if len(childrenMetadata) != 0 {
-		rootSpan := &result[0]
-		rootSpan.ChildrenMetadata = childrenMetadata
+		result.Root.ChildrenMetadata = childrenMetadata
 	}
 
-	// Sort the spans by StartTime, except the first Span (the root of this
-	// recording) which stays in place.
-	toSort := sortPool.Get().(*tracingpb.Recording) // avoids allocations in sort.Sort
-	*toSort = result[1:]
-	sort.Sort(toSort)
-	*toSort = nil
-	sortPool.Put(toSort)
+	result.sortChildren()
 	return result
 }
 
 // getStructuredRecording returns the structured events in this span and in all
-// the children. The results are returned as a Recording for the caller's
-// convenience (and for optimizing memory allocations). The Recording will have
-// exactly one span corresponding to the receiver, with all events hanging from
-// this span (even if the events had been recorded on different spans).
-// This span will also have a `childrenMetadata` map that will contain an entry
-// for all children in s' Recording.
+// the children. The returned span will contain all structured events across the
+// receiver and all its children. The returned span will also have its
+// `childrenMetadata` populated with data for all the children.
 //
 // The caller does not take ownership of the events.
-func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) tracingpb.Recording {
+func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) tracingpb.RecordedSpan {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -486,7 +583,7 @@ func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) tracingp
 
 	// Recursively fetch the StructuredEvents for s' and its children, both
 	// finished and open.
-	res.StructuredRecords = s.getStructuredEventsRecursivelyLocked(res.StructuredRecords[:0],
+	res.StructuredRecords = s.appendStructuredEventsRecursivelyLocked(res.StructuredRecords[:0],
 		includeDetachedChildren)
 
 	// Recursively fetch the OperationMetadata for s' children, both finished and
@@ -495,27 +592,26 @@ func (s *crdbSpan) getStructuredRecording(includeDetachedChildren bool) tracingp
 	s.getChildrenMetadataRecursivelyLocked(res.ChildrenMetadata,
 		false /* includeRootMetadata */, includeDetachedChildren)
 
-	return tracingpb.Recording{res}
+	return res
 }
 
 // recordFinishedChildren adds the spans in childRecording to s' recording.
 //
 // s takes ownership of childRecording; the caller is not allowed to use them anymore.
-func (s *crdbSpan) recordFinishedChildren(childRecording tracingpb.Recording) {
-	if len(childRecording) == 0 {
+func (s *crdbSpan) recordFinishedChildren(childRecording Trace) {
+	if childRecording.Empty() {
 		return
 	}
 
 	// Notify the event listeners registered with s of the StructuredEvents on the
 	// children being added to s.
-	for _, span := range childRecording {
-		for _, record := range span.StructuredRecords {
-			var d types.DynamicAny
-			if err := types.UnmarshalAny(record.Payload, &d); err != nil {
-				continue
-			}
-			s.notifyEventListeners(d.Message.(protoutil.Message))
+	events := childRecording.appendStructuredEventsRecursively(nil)
+	for _, record := range events {
+		var d types.DynamicAny
+		if err := types.UnmarshalAny(record.Payload, &d); err != nil {
+			continue
 		}
+		s.notifyEventListeners(d.Message.(protoutil.Message))
 	}
 
 	s.mu.Lock()
@@ -525,12 +621,10 @@ func (s *crdbSpan) recordFinishedChildren(childRecording tracingpb.Recording) {
 
 // s takes ownership of childRecording; the caller is not allowed to use them
 // anymore.
-func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recording) {
-	if len(childRecording) == 0 {
+func (s *crdbSpan) recordFinishedChildrenLocked(childRec Trace) {
+	if childRec.Empty() {
 		return
 	}
-
-	rootChild := &childRecording[0]
 
 	// Depending on the type of recording, we either keep all the information
 	// received, or only the structured events.
@@ -540,10 +634,9 @@ func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recordi
 		// usually already the case, except with DistSQL traces where remote
 		// processors run in spans that FollowFrom an RPC Span that we don't
 		// collect.
-		rootChild.ParentSpanID = s.spanID
+		childRec.Root.ParentSpanID = s.spanID
 
-		if len(s.mu.recording.finishedChildren)+len(childRecording) <= maxRecordedSpansPerTrace {
-			s.mu.recording.finishedChildren = append(s.mu.recording.finishedChildren, childRecording...)
+		if s.mu.recording.finishedChildren.addChild(childRec) {
 			break
 		}
 
@@ -551,11 +644,10 @@ func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recordi
 		// records by falling through.
 		fallthrough
 	case tracingpb.RecordingStructured:
-		for ci := range childRecording {
-			child := &childRecording[ci]
-			for i := range child.StructuredRecords {
-				s.recordInternalLocked(&child.StructuredRecords[i], &s.mu.recording.structured)
-			}
+		buf := childRec.appendStructuredEventsRecursively(nil /* buffer */)
+		for i := range buf {
+			event := &buf[i]
+			s.recordInternalLocked(event, &s.mu.recording.structured)
 		}
 	case tracingpb.RecordingOff:
 		break
@@ -563,7 +655,7 @@ func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recordi
 		panic(fmt.Sprintf("unrecognized recording mode: %v", s.recordingType()))
 	}
 
-	// Update s' ChildrenMetadata to capture all the spans in `childRecording`.
+	// Update s' ChildrenMetadata to capture all the spans in childRec.
 	//
 	// As an example where we are done finishing `child`:
 	//
@@ -575,11 +667,11 @@ func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recordi
 	// {child: 2s, grandchild: 1s}
 	//
 	// Record finished rootChilds' metadata.
-	s.mu.recording.childrenMetadata[rootChild.Operation] =
-		s.mu.recording.childrenMetadata[rootChild.Operation].Combine(
+	s.mu.recording.childrenMetadata[childRec.Root.Operation] =
+		s.mu.recording.childrenMetadata[childRec.Root.Operation].Combine(
 			tracingpb.OperationMetadata{
 				Count:              1,
-				Duration:           rootChild.Duration,
+				Duration:           childRec.Root.Duration,
 				ContainsUnfinished: false,
 			})
 
@@ -587,7 +679,7 @@ func (s *crdbSpan) recordFinishedChildrenLocked(childRecording tracingpb.Recordi
 	//
 	// GetRecording(...) is responsible for recursively capturing the metadata for
 	// rootChilds' open and finished children.
-	rollupChildrenMetadata(s.mu.recording.childrenMetadata, rootChild.ChildrenMetadata)
+	rollupChildrenMetadata(s.mu.recording.childrenMetadata, childRec.Root.ChildrenMetadata)
 }
 
 func (s *crdbSpan) setTagLocked(key string, value attribute.Value) {
@@ -673,14 +765,8 @@ func (s *crdbSpan) record(msg redact.RedactableString) {
 		return
 	}
 
-	var now time.Time
-	if clock := s.tracer.testing.Clock; clock != nil {
-		now = clock.Now()
-	} else {
-		now = timeutil.Now()
-	}
 	logRecord := &tracingpb.LogRecord{
-		Time:    now,
+		Time:    s.tracer.now(),
 		Message: msg,
 	}
 
@@ -700,14 +786,8 @@ func (s *crdbSpan) recordStructured(item Structured) {
 		return
 	}
 
-	var now time.Time
-	if clock := s.tracer.testing.Clock; clock != nil {
-		now = clock.Now()
-	} else {
-		now = time.Now()
-	}
 	sr := &tracingpb.StructuredRecord{
-		Time:    now,
+		Time:    s.tracer.now(),
 		Payload: p,
 	}
 	s.recordInternal(sr, &s.mu.recording.structured)
@@ -739,13 +819,13 @@ func (s *crdbSpan) recordInternalLocked(payload memorySizable, buffer *sizeLimit
 	if size > buffer.bytesLimit {
 		// The incoming payload alone blows past the memory limit. Let's just
 		// drop it.
-		s.mu.recording.dropped = true
+		s.mu.recording.droppedLogs = true
 		return
 	}
 
 	buffer.bytesSize += size
 	if buffer.bytesSize > buffer.bytesLimit {
-		s.mu.recording.dropped = true
+		s.mu.recording.droppedLogs = true
 	}
 	for buffer.bytesSize > buffer.bytesLimit {
 		first := buffer.GetFirst().(memorySizable)
@@ -755,26 +835,22 @@ func (s *crdbSpan) recordInternalLocked(payload memorySizable, buffer *sizeLimit
 	buffer.AddLast(payload)
 }
 
-// getStructuredEventsRecursivelyLocked returns the structured events
-// accumulated by s' and its finished and still-open children.
-func (s *crdbSpan) getStructuredEventsRecursivelyLocked(
+// appendStructuredEventsRecursivelyLocked appends the structured events
+// accumulated by s' and its finished and still-open children to buffer, and
+// returns the resulting slice.
+func (s *crdbSpan) appendStructuredEventsRecursivelyLocked(
 	buffer []tracingpb.StructuredRecord, includeDetachedChildren bool,
 ) []tracingpb.StructuredRecord {
-	buffer = s.getStructuredEventsLocked(buffer)
+	buffer = s.appendStructuredEventsLocked(buffer)
 	for _, c := range s.mu.openChildren {
 		if c.collectRecording || includeDetachedChildren {
 			sp := c.Span.i.crdb
 			sp.mu.Lock()
-			buffer = sp.getStructuredEventsRecursivelyLocked(buffer, includeDetachedChildren)
+			buffer = sp.appendStructuredEventsRecursivelyLocked(buffer, includeDetachedChildren)
 			sp.mu.Unlock()
 		}
 	}
-	for _, c := range s.mu.recording.finishedChildren {
-		for i := range c.StructuredRecords {
-			buffer = append(buffer, c.StructuredRecords[i])
-		}
-	}
-	return buffer
+	return s.mu.recording.finishedChildren.appendStructuredEventsRecursively(buffer)
 }
 
 // getChildrenMetadataRecursivelyLocked populates `childrenMetadata` with
@@ -815,7 +891,7 @@ func (s *crdbSpan) getChildrenMetadataRecursivelyLocked(
 	}
 }
 
-func (s *crdbSpan) getStructuredEventsLocked(
+func (s *crdbSpan) appendStructuredEventsLocked(
 	buffer []tracingpb.StructuredRecord,
 ) []tracingpb.StructuredRecord {
 	numEvents := s.mu.recording.structured.Len()
@@ -860,26 +936,6 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 		rs.Finished = true
 	}
 
-	addTagGroup := func(name string) *tracingpb.TagGroup {
-		rs.TagGroups = append(rs.TagGroups,
-			tracingpb.TagGroup{
-				Name: name,
-			})
-		return &rs.TagGroups[len(rs.TagGroups)-1]
-	}
-
-	addTag := func(k, v string) {
-		tagGroup := rs.FindTagGroup(tracingpb.AnonymousTagGroupName)
-		if tagGroup == nil {
-			tagGroup = addTagGroup(tracingpb.AnonymousTagGroupName)
-		}
-
-		tagGroup.Tags = append(tagGroup.Tags, tracingpb.Tag{
-			Key:   k,
-			Value: v,
-		})
-	}
-
 	// If the span is not verbose, optimize by avoiding the tags.
 	// This span is likely only used to carry payloads around.
 	//
@@ -890,13 +946,19 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	wantTags := recordingType == tracingpb.RecordingVerbose
 	if wantTags {
 		if !finishing && !s.mu.finished {
-			addTag("_unfinished", "1")
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_unfinished", "1")
 		}
 		if s.recordingType() == tracingpb.RecordingVerbose {
-			addTag("_verbose", "1")
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_verbose", "1")
 		}
-		if s.mu.recording.dropped {
-			addTag("_dropped", "1")
+		if s.mu.recording.droppedLogs {
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_logs", "")
+		}
+		if s.mu.recording.finishedChildren.DroppedDirectChildren {
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_children", "")
+		}
+		if s.mu.recording.finishedChildren.DroppedIndirectChildren {
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag("_dropped_indirect_children", "")
 		}
 	}
 
@@ -911,17 +973,17 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	if wantTags {
 		if s.logTags != nil {
 			setLogTags(s.logTags.Get(), func(remappedKey string, tag *logtags.Tag) {
-				addTag(remappedKey, tag.ValueStr())
+				rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag(remappedKey, tag.ValueStr())
 			})
 		}
 		for _, kv := range s.mu.tags {
 			// We encode the tag values as strings.
-			addTag(string(kv.Key), kv.Value.Emit())
+			rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag(string(kv.Key), kv.Value.Emit())
 		}
 		for _, tg := range s.getLazyTagGroupsLocked() {
 			if tg.Name == tracingpb.AnonymousTagGroupName {
 				for _, tag := range tg.Tags {
-					addTag(tag.Key, tag.Value)
+					rs.EnsureTagGroup(tracingpb.AnonymousTagGroupName).AddTag(tag.Key, tag.Value)
 				}
 			} else {
 				rs.TagGroups = append(rs.TagGroups, *tg)
@@ -1159,12 +1221,6 @@ func (s *crdbSpan) setGoroutineID(gid int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.goroutineID = uint64(gid)
-}
-
-var sortPool = sync.Pool{
-	New: func() interface{} {
-		return &tracingpb.Recording{}
-	},
 }
 
 type atomicRecordingType tracingpb.RecordingType

--- a/pkg/util/tracing/crdbspan.go
+++ b/pkg/util/tracing/crdbspan.go
@@ -869,11 +869,6 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 	}
 
 	addTag := func(k, v string) {
-		if rs.Tags == nil {
-			rs.Tags = make(map[string]string)
-		}
-		rs.Tags[k] = v
-
 		tagGroup := rs.FindTagGroup(tracingpb.AnonymousTagGroupName)
 		if tagGroup == nil {
 			tagGroup = addTagGroup(tracingpb.AnonymousTagGroupName)
@@ -930,12 +925,6 @@ func (s *crdbSpan) getRecordingNoChildrenLocked(
 				}
 			} else {
 				rs.TagGroups = append(rs.TagGroups, *tg)
-				if rs.Tags == nil {
-					rs.Tags = make(map[string]string)
-				}
-				for _, tag := range tg.Tags {
-					rs.Tags[tag.Key] = tag.Value
-				}
 			}
 		}
 

--- a/pkg/util/tracing/grpcinterceptor/grpc_interceptor_test.go
+++ b/pkg/util/tracing/grpcinterceptor/grpc_interceptor_test.go
@@ -300,7 +300,7 @@ func TestGRPCInterceptors(t *testing.T) {
 			// immediate) in the ctx cancellation subtest.
 			testutils.SucceedsSoon(t, func() error {
 				return tr.VisitSpans(func(sp tracing.RegistrySpan) error {
-					rec := sp.GetFullRecording(tracingpb.RecordingVerbose)[0]
+					rec := sp.GetFullRecording(tracingpb.RecordingVerbose).Root
 					return errors.Newf("leaked span: %s %s", rec.Operation, rec.TagGroups)
 				})
 			})

--- a/pkg/util/tracing/service/service.go
+++ b/pkg/util/tracing/service/service.go
@@ -54,7 +54,8 @@ func (s *Service) GetSpanRecordings(
 		if span.TraceID() != request.TraceID {
 			return nil
 		}
-		recording := span.GetFullRecording(tracingpb.RecordingVerbose)
+		trace := span.GetFullRecording(tracingpb.RecordingVerbose)
+		recording := trace.Flatten()
 		if recording != nil {
 			resp.Recordings = append(resp.Recordings,
 				tracingservicepb.GetSpanRecordingsResponse_Recording{RecordedSpans: recording})

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -354,27 +354,6 @@ func (sp *Span) GetConfiguredRecording() tracingpb.Recording {
 //
 // This function is used to import a recording from another node.
 func (sp *Span) ImportRemoteRecording(remoteRecording tracingpb.Recording) {
-	// TODO(benbardin): Remove for 23.1
-	// Nodes running <= 22.1 do not support tag groups. For backwards
-	// compatibility, copy the top-level tags to tag groups. This will only be
-	// necessary for 22.2.
-	for i := range remoteRecording {
-		span := &remoteRecording[i]
-		if len(span.TagGroups) == 0 {
-			anonymousTagGroup := tracingpb.TagGroup{
-				Tags: make([]tracingpb.Tag, len(span.Tags)),
-			}
-			i := 0
-			for tagKey, tagValue := range span.Tags {
-				anonymousTagGroup.Tags[i] = tracingpb.Tag{
-					Key:   tagKey,
-					Value: tagValue,
-				}
-				i++
-			}
-			span.TagGroups = []tracingpb.TagGroup{anonymousTagGroup}
-		}
-	}
 	if !sp.detectUseAfterFinish() {
 		sp.i.ImportRemoteRecording(remoteRecording)
 	}

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -119,7 +119,7 @@ func (opts *spanOptions) recordingType() tracingpb.RecordingType {
 // otelContext returns information about the OpenTelemetry parent span. If there
 // is a local parent with an otel Span, that Span is returned. If there is a
 // RemoteParent,  a SpanContext is returned. If there's no OpenTelemetry parent,
-// both return values will be empty.
+// both return values will be Empty.
 func (opts *spanOptions) otelContext() (oteltrace.Span, oteltrace.SpanContext) {
 	if !opts.Parent.empty() && opts.Parent.i.otelSpan != nil {
 		return opts.Parent.i.otelSpan, oteltrace.SpanContext{}
@@ -213,7 +213,7 @@ func WithParent(sp *Span) SpanOption {
 	}
 
 	ref, _ /* ok */ := tryMakeSpanRef(sp)
-	// Note that ref will be empty if tryMakeSpanRef() failed. In that case, the
+	// Note that ref will be Empty if tryMakeSpanRef() failed. In that case, the
 	// resulting span will not have a parent.
 	return (parentOption)(ref)
 }

--- a/pkg/util/tracing/tracer_snapshots.go
+++ b/pkg/util/tracing/tracer_snapshots.go
@@ -148,7 +148,7 @@ func (t *Tracer) generateSnapshot() SpansSnapshot {
 	traces := make([]tracingpb.Recording, 0, 1000)
 	_ = t.SpanRegistry().VisitRoots(func(sp RegistrySpan) error {
 		rec := sp.GetFullRecording(tracingpb.RecordingVerbose)
-		traces = append(traces, rec)
+		traces = append(traces, rec.Flatten())
 		return nil
 	})
 

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -60,7 +60,7 @@ func TestTracingOffRecording(t *testing.T) {
 	noop2 := tr.StartSpan("noop2", WithParent(noop1), WithDetachedRecording())
 	require.True(t, noop2.IsNoop())
 
-	// Noop span returns empty recording.
+	// Noop span returns Empty recording.
 	require.Nil(t, noop1.GetRecording(tracingpb.RecordingVerbose))
 }
 
@@ -482,7 +482,8 @@ func getSpanOpsWithFinished(t *testing.T, tr *Tracer) map[string]bool {
 	spanOpsWithFinished := make(map[string]bool)
 
 	require.NoError(t, tr.VisitSpans(func(sp RegistrySpan) error {
-		for _, rec := range sp.GetFullRecording(tracingpb.RecordingVerbose) {
+		rec := sp.GetFullRecording(tracingpb.RecordingVerbose)
+		for _, rec := range rec.Flatten() {
 			spanOpsWithFinished[rec.Operation] = rec.Finished
 		}
 		return nil
@@ -499,7 +500,8 @@ func getSortedSpanOps(t *testing.T, tr *Tracer) []string {
 	var spanOps []string
 
 	require.NoError(t, tr.VisitSpans(func(sp RegistrySpan) error {
-		for _, rec := range sp.GetFullRecording(tracingpb.RecordingVerbose) {
+		rec := sp.GetFullRecording(tracingpb.RecordingVerbose)
+		for _, rec := range rec.Flatten() {
 			spanOps = append(spanOps, rec.Operation)
 		}
 		return nil

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -89,7 +89,7 @@ func TestTracerRecording(t *testing.T) {
 	rec := s1.GetRecording(tracingpb.RecordingStructured)
 	require.Len(t, rec, 1)
 	require.Nil(t, rec[0].Logs)
-	require.Nil(t, rec[0].Tags)
+	require.Nil(t, rec[0].TagGroups)
 	require.Empty(t, rec[0].ChildrenMetadata)
 	require.Empty(t, rec[0].StructuredRecords)
 

--- a/pkg/util/tracing/tracingpb/recorded_span.go
+++ b/pkg/util/tracing/tracingpb/recorded_span.go
@@ -82,6 +82,29 @@ func (s *RecordedSpan) FindTagGroup(name string) *TagGroup {
 	return nil
 }
 
+// EnsureTagGroup returns a reference to the tag group with the given name,
+// creating it if it doesn't exist.
+func (s *RecordedSpan) EnsureTagGroup(name string) *TagGroup {
+	if tg := s.FindTagGroup(name); tg != nil {
+		return tg
+	}
+	s.TagGroups = append(s.TagGroups, TagGroup{Name: name})
+	return &s.TagGroups[len(s.TagGroups)-1]
+}
+
+// AddTag adds a tag to the group. If a tag with the given key already exists,
+// its value is updated.
+func (tg *TagGroup) AddTag(k, v string) {
+	for i := range tg.Tags {
+		tag := &tg.Tags[i]
+		if tag.Key == k {
+			tag.Value = v
+			return
+		}
+	}
+	tg.Tags = append(tg.Tags, Tag{Key: k, Value: v})
+}
+
 // Msg extracts the message of the LogRecord, which is either in an "event" or
 // "error" field.
 func (l LogRecord) Msg() redact.RedactableString {

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -120,7 +120,6 @@ message RecordedSpan {
   //
   // A StructuredRecord wraps the Payload with a RecordedAt timestamp to expose
   // information about when this event occurred.
-  // DeprecatedInternalStructured only stores the Payloads.
   repeated StructuredRecord structured_records = 14 [(gogoproto.nullable) = false];
 
 

--- a/pkg/util/tracing/tracingpb/recorded_span.proto
+++ b/pkg/util/tracing/tracingpb/recorded_span.proto
@@ -72,11 +72,6 @@ message RecordedSpan {
   // Operation name.
   string operation = 4;
 
-  // Tags associated with the span.
-  // Deprecated. Avoid new uses. Prefer tag_groups.
-  // TODO(benbardin): Remove the tags field for 23.1.
-  map<string, string> tags = 6;
-
   // tag_groups describes tags associated with the span, potentially in a
   // shallow structured hierarchy.
   //
@@ -137,7 +132,7 @@ message RecordedSpan {
   // view of the various operations that are being traced as part of a span.
   map<string, OperationMetadata> children_metadata = 19 [(gogoproto.nullable) = false];
 
-  reserved 5,10,11,15;
+  reserved 5,6,10,11,15;
 }
 
 message TagGroup {

--- a/pkg/util/tracing/tracingui/span_registry_ui.go
+++ b/pkg/util/tracing/tracingui/span_registry_ui.go
@@ -103,11 +103,13 @@ const (
 )
 
 var hiddenTags = map[string]struct{}{
-	"_unfinished": {},
-	"_verbose":    {},
-	"_dropped":    {},
-	"node":        {},
-	"store":       {},
+	"_unfinished":                {},
+	"_verbose":                   {},
+	"_dropped_logs":              {},
+	"_dropped_children":          {},
+	"_dropped_indirect_children": {},
+	"node":                       {},
+	"store":                      {},
 }
 
 type processedSpan struct {


### PR DESCRIPTION
Before this patch, when the recording of a child span was being added to
the parent, if the number of spans in the child recording + the number
of spans in the parent's recording were greater than the span limit
(1000), then the child's recording was completely dropped (apart from
the structured events, which were still retained). So, for example, if
the parent had a recording of 1 span, and the child has a recording of
1000 spans, the whole 1000 spans were dropped.
This patch improves things by always combining the parent trace and the
child trace, and then trimming the result according to the following
arbitrary algorithm:
- start at the root of the trace and sort its children by size, desc
- drop the fattest children (including their descendents) until the
  remaining number of spans to drop becomes smaller than the size of the
  fattest non-dropped child
- recurse into that child, with an adjusted number of spans to drop

So, the idea is that, recursively, we drop parts of the largest child -
including dropping the whole child if needed.

Fixes https://github.com/cockroachdb/cockroach/issues/87536

Release note: None