### PR TITLE
sql: clean up the instrumentation a little

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -451,7 +451,7 @@ func (ih *instrumentationHelper) ShouldCollectExecStats() bool {
 
 // ShouldSaveMemo returns true if we should save the memo and catalog in planTop.
 func (ih *instrumentationHelper) ShouldSaveMemo() bool {
-	return ih.ShouldBuildExplainPlan()
+	return ih.collectBundle
 }
 
 // RecordExplainPlan records the explain.Plan for this query.


### PR DESCRIPTION
This commit removes the duplication of some logic after the execbuilding as well as makes it so that we save the memo and the catalog only when needed (when collecting the stmt bundle).

Release note: None