### PR TITLE
colexec: use tree.DNull when projection is called on null input

### DIFF
--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -76,15 +76,13 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -99,7 +97,7 @@ func (p projBitandInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -160,15 +158,13 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -183,7 +179,7 @@ func (p projBitandInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -244,15 +240,13 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -267,7 +261,7 @@ func (p projBitandInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -328,15 +322,13 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -351,7 +343,7 @@ func (p projBitandInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -412,15 +404,13 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -435,7 +425,7 @@ func (p projBitandInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -496,15 +486,13 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -519,7 +507,7 @@ func (p projBitandInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -580,15 +568,13 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -603,7 +589,7 @@ func (p projBitandInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -664,15 +650,13 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -687,7 +671,7 @@ func (p projBitandInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -748,15 +732,13 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -771,7 +753,7 @@ func (p projBitandInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -834,20 +816,23 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -865,11 +850,17 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -883,7 +874,9 @@ func (p projBitandDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -943,15 +936,13 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -966,7 +957,7 @@ func (p projBitorInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1027,15 +1018,13 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1050,7 +1039,7 @@ func (p projBitorInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1111,15 +1100,13 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1134,7 +1121,7 @@ func (p projBitorInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1195,15 +1182,13 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1218,7 +1203,7 @@ func (p projBitorInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1279,15 +1264,13 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1302,7 +1285,7 @@ func (p projBitorInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1363,15 +1346,13 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1386,7 +1367,7 @@ func (p projBitorInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1447,15 +1428,13 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1470,7 +1449,7 @@ func (p projBitorInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1531,15 +1510,13 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1554,7 +1531,7 @@ func (p projBitorInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1615,15 +1592,13 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1638,7 +1613,7 @@ func (p projBitorInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1701,20 +1676,23 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -1732,11 +1710,17 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -1750,7 +1734,9 @@ func (p projBitorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1810,15 +1796,13 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1833,7 +1817,7 @@ func (p projBitxorInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1894,15 +1878,13 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -1917,7 +1899,7 @@ func (p projBitxorInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -1978,15 +1960,13 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2001,7 +1981,7 @@ func (p projBitxorInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2062,15 +2042,13 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2085,7 +2063,7 @@ func (p projBitxorInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2146,15 +2124,13 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2169,7 +2145,7 @@ func (p projBitxorInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2230,15 +2206,13 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2253,7 +2227,7 @@ func (p projBitxorInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2314,15 +2288,13 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2337,7 +2309,7 @@ func (p projBitxorInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2398,15 +2370,13 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2421,7 +2391,7 @@ func (p projBitxorInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2482,15 +2452,13 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2505,7 +2473,7 @@ func (p projBitxorInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2568,20 +2536,23 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -2599,11 +2570,17 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -2617,7 +2594,9 @@ func (p projBitxorDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2677,15 +2656,13 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2707,7 +2684,7 @@ func (p projPlusDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2789,15 +2766,13 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2819,7 +2794,7 @@ func (p projPlusDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -2901,15 +2876,13 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -2931,7 +2904,7 @@ func (p projPlusDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3013,15 +2986,13 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3042,7 +3013,7 @@ func (p projPlusDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3121,15 +3092,13 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3150,7 +3119,7 @@ func (p projPlusInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3229,15 +3198,13 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3258,7 +3225,7 @@ func (p projPlusInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3337,15 +3304,13 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3366,7 +3331,7 @@ func (p projPlusInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3445,15 +3410,13 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3476,7 +3439,7 @@ func (p projPlusInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3563,15 +3526,13 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3597,7 +3558,7 @@ func (p projPlusInt16DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3689,15 +3650,13 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3718,7 +3677,7 @@ func (p projPlusInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3797,15 +3756,13 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3826,7 +3783,7 @@ func (p projPlusInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -3905,15 +3862,13 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -3934,7 +3889,7 @@ func (p projPlusInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4013,15 +3968,13 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4044,7 +3997,7 @@ func (p projPlusInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4131,15 +4084,13 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4165,7 +4116,7 @@ func (p projPlusInt32DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4257,15 +4208,13 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4286,7 +4235,7 @@ func (p projPlusInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4365,15 +4314,13 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4394,7 +4341,7 @@ func (p projPlusInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4473,15 +4420,13 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4502,7 +4447,7 @@ func (p projPlusInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4581,15 +4526,13 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4612,7 +4555,7 @@ func (p projPlusInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4699,15 +4642,13 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4733,7 +4674,7 @@ func (p projPlusInt64DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4825,15 +4766,13 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4851,7 +4790,7 @@ func (p projPlusFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -4921,15 +4860,13 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -4947,7 +4884,7 @@ func (p projPlusTimestampIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5017,15 +4954,13 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5043,7 +4978,7 @@ func (p projPlusIntervalTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5113,15 +5048,13 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5134,7 +5067,7 @@ func (p projPlusIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5191,15 +5124,13 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5225,7 +5156,7 @@ func (p projPlusIntervalDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5319,15 +5250,13 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5353,7 +5282,7 @@ func (p projPlusDatumIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5447,15 +5376,13 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5481,7 +5408,7 @@ func (p projPlusDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5575,15 +5502,13 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5609,7 +5534,7 @@ func (p projPlusDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5703,15 +5628,13 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5737,7 +5660,7 @@ func (p projPlusDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5829,15 +5752,13 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5859,7 +5780,7 @@ func (p projMinusDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -5941,15 +5862,13 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -5971,7 +5890,7 @@ func (p projMinusDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6053,15 +5972,13 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6083,7 +6000,7 @@ func (p projMinusDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6165,15 +6082,13 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6194,7 +6109,7 @@ func (p projMinusDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6273,15 +6188,13 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6302,7 +6215,7 @@ func (p projMinusInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6381,15 +6294,13 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6410,7 +6321,7 @@ func (p projMinusInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6489,15 +6400,13 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6518,7 +6427,7 @@ func (p projMinusInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6597,15 +6506,13 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6628,7 +6535,7 @@ func (p projMinusInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6715,15 +6622,13 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6749,7 +6654,7 @@ func (p projMinusInt16DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6841,15 +6746,13 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6870,7 +6773,7 @@ func (p projMinusInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -6949,15 +6852,13 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -6978,7 +6879,7 @@ func (p projMinusInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7057,15 +6958,13 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7086,7 +6985,7 @@ func (p projMinusInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7165,15 +7064,13 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7196,7 +7093,7 @@ func (p projMinusInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7283,15 +7180,13 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7317,7 +7212,7 @@ func (p projMinusInt32DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7409,15 +7304,13 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7438,7 +7331,7 @@ func (p projMinusInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7517,15 +7410,13 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7546,7 +7437,7 @@ func (p projMinusInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7625,15 +7516,13 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7654,7 +7543,7 @@ func (p projMinusInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7733,15 +7622,13 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7764,7 +7651,7 @@ func (p projMinusInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7851,15 +7738,13 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -7885,7 +7770,7 @@ func (p projMinusInt64DatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -7977,15 +7862,13 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8003,7 +7886,7 @@ func (p projMinusFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8073,15 +7956,13 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8097,7 +7978,7 @@ func (p projMinusTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8161,15 +8042,13 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8187,7 +8066,7 @@ func (p projMinusTimestampIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8257,15 +8136,13 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8278,7 +8155,7 @@ func (p projMinusIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8335,15 +8212,13 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8369,7 +8244,7 @@ func (p projMinusIntervalDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -8461,15 +8336,13 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8491,7 +8364,7 @@ func (p projMinusJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8569,15 +8442,13 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8595,7 +8466,7 @@ func (p projMinusJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8663,15 +8534,13 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8689,7 +8558,7 @@ func (p projMinusJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8757,15 +8626,13 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8783,7 +8650,7 @@ func (p projMinusJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8853,20 +8720,23 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -8884,11 +8754,17 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -8902,7 +8778,9 @@ func (p projMinusDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8964,15 +8842,13 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -8998,7 +8874,7 @@ func (p projMinusDatumIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9092,15 +8968,13 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9126,7 +9000,7 @@ func (p projMinusDatumBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9218,15 +9092,13 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9252,7 +9124,7 @@ func (p projMinusDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9346,15 +9218,13 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9380,7 +9250,7 @@ func (p projMinusDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9474,15 +9344,13 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9508,7 +9376,7 @@ func (p projMinusDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9600,15 +9468,13 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9630,7 +9496,7 @@ func (p projMultDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -9712,15 +9578,13 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9742,7 +9606,7 @@ func (p projMultDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -9824,15 +9688,13 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9854,7 +9716,7 @@ func (p projMultDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -9936,15 +9798,13 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -9965,7 +9825,7 @@ func (p projMultDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10044,15 +9904,13 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10070,7 +9928,7 @@ func (p projMultDecimalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10140,15 +9998,13 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10177,7 +10033,7 @@ func (p projMultInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10280,15 +10136,13 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10317,7 +10171,7 @@ func (p projMultInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10420,15 +10274,13 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10457,7 +10309,7 @@ func (p projMultInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10560,15 +10412,13 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10591,7 +10441,7 @@ func (p projMultInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10676,15 +10526,13 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10697,7 +10545,7 @@ func (p projMultInt16IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10752,15 +10600,13 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10789,7 +10635,7 @@ func (p projMultInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -10892,15 +10738,13 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -10929,7 +10773,7 @@ func (p projMultInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11032,15 +10876,13 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11069,7 +10911,7 @@ func (p projMultInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11172,15 +11014,13 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11203,7 +11043,7 @@ func (p projMultInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11288,15 +11128,13 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11309,7 +11147,7 @@ func (p projMultInt32IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11364,15 +11202,13 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11401,7 +11237,7 @@ func (p projMultInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11504,15 +11340,13 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11541,7 +11375,7 @@ func (p projMultInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11644,15 +11478,13 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11681,7 +11513,7 @@ func (p projMultInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11784,15 +11616,13 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11815,7 +11645,7 @@ func (p projMultInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11900,15 +11730,13 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -11921,7 +11749,7 @@ func (p projMultInt64IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -11976,15 +11804,13 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12002,7 +11828,7 @@ func (p projMultFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12072,15 +11898,13 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12093,7 +11917,7 @@ func (p projMultFloat64IntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12148,15 +11972,13 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12169,7 +11991,7 @@ func (p projMultIntervalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12224,15 +12046,13 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12245,7 +12065,7 @@ func (p projMultIntervalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12300,15 +12120,13 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12321,7 +12139,7 @@ func (p projMultIntervalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12376,15 +12194,13 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12397,7 +12213,7 @@ func (p projMultIntervalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12452,15 +12268,13 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12478,7 +12292,7 @@ func (p projMultIntervalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12548,15 +12362,13 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12582,7 +12394,7 @@ func (p projDivDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12676,15 +12488,13 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12710,7 +12520,7 @@ func (p projDivDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12804,15 +12614,13 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12838,7 +12646,7 @@ func (p projDivDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -12932,15 +12740,13 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -12965,7 +12771,7 @@ func (p projDivDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13056,15 +12862,13 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13089,7 +12893,7 @@ func (p projDivInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13180,15 +12984,13 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13213,7 +13015,7 @@ func (p projDivInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13304,15 +13106,13 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13337,7 +13137,7 @@ func (p projDivInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13428,15 +13228,13 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13463,7 +13261,7 @@ func (p projDivInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13560,15 +13358,13 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13593,7 +13389,7 @@ func (p projDivInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13684,15 +13480,13 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13717,7 +13511,7 @@ func (p projDivInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13808,15 +13602,13 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13841,7 +13633,7 @@ func (p projDivInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -13932,15 +13724,13 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -13967,7 +13757,7 @@ func (p projDivInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14064,15 +13854,13 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14097,7 +13885,7 @@ func (p projDivInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14188,15 +13976,13 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14221,7 +14007,7 @@ func (p projDivInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14312,15 +14098,13 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14345,7 +14129,7 @@ func (p projDivInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14436,15 +14220,13 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14471,7 +14253,7 @@ func (p projDivInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14568,15 +14350,13 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14598,7 +14378,7 @@ func (p projDivFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14680,15 +14460,13 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14705,7 +14483,7 @@ func (p projDivIntervalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14772,15 +14550,13 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14797,7 +14573,7 @@ func (p projDivIntervalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14864,15 +14640,13 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14889,7 +14663,7 @@ func (p projDivIntervalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -14956,15 +14730,13 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -14981,7 +14753,7 @@ func (p projDivIntervalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15048,15 +14820,13 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15082,7 +14852,7 @@ func (p projFloorDivDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15176,15 +14946,13 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15210,7 +14978,7 @@ func (p projFloorDivDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15304,15 +15072,13 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15338,7 +15104,7 @@ func (p projFloorDivDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15432,15 +15198,13 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15465,7 +15229,7 @@ func (p projFloorDivDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15556,15 +15320,13 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15584,7 +15346,7 @@ func (p projFloorDivInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15660,15 +15422,13 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15688,7 +15448,7 @@ func (p projFloorDivInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15764,15 +15524,13 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15792,7 +15550,7 @@ func (p projFloorDivInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -15868,15 +15626,13 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -15903,7 +15659,7 @@ func (p projFloorDivInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16000,15 +15756,13 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16028,7 +15782,7 @@ func (p projFloorDivInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16104,15 +15858,13 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16132,7 +15884,7 @@ func (p projFloorDivInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16208,15 +15960,13 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16236,7 +15986,7 @@ func (p projFloorDivInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16312,15 +16062,13 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16347,7 +16095,7 @@ func (p projFloorDivInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16444,15 +16192,13 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16472,7 +16218,7 @@ func (p projFloorDivInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16548,15 +16294,13 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16576,7 +16320,7 @@ func (p projFloorDivInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16652,15 +16396,13 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16680,7 +16422,7 @@ func (p projFloorDivInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16756,15 +16498,13 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16791,7 +16531,7 @@ func (p projFloorDivInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -16888,15 +16628,13 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -16918,7 +16656,7 @@ func (p projFloorDivFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17000,15 +16738,13 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17034,7 +16770,7 @@ func (p projModDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17128,15 +16864,13 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17162,7 +16896,7 @@ func (p projModDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17256,15 +16990,13 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17290,7 +17022,7 @@ func (p projModDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17384,15 +17116,13 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17417,7 +17147,7 @@ func (p projModDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17508,15 +17238,13 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17536,7 +17264,7 @@ func (p projModInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17612,15 +17340,13 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17640,7 +17366,7 @@ func (p projModInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17716,15 +17442,13 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17744,7 +17468,7 @@ func (p projModInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17820,15 +17544,13 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17855,7 +17577,7 @@ func (p projModInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -17952,15 +17674,13 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -17980,7 +17700,7 @@ func (p projModInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18056,15 +17776,13 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18084,7 +17802,7 @@ func (p projModInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18160,15 +17878,13 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18188,7 +17904,7 @@ func (p projModInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18264,15 +17980,13 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18299,7 +18013,7 @@ func (p projModInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18396,15 +18110,13 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18424,7 +18136,7 @@ func (p projModInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18500,15 +18212,13 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18528,7 +18238,7 @@ func (p projModInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18604,15 +18314,13 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18632,7 +18340,7 @@ func (p projModInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18708,15 +18416,13 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18743,7 +18449,7 @@ func (p projModInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18840,15 +18546,13 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18870,7 +18574,7 @@ func (p projModFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -18952,15 +18656,13 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -18982,7 +18684,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19064,15 +18766,13 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19094,7 +18794,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19176,15 +18876,13 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19206,7 +18904,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19288,15 +18986,13 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19317,7 +19013,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19396,15 +19092,13 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19431,7 +19125,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19528,15 +19222,13 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19563,7 +19255,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19660,15 +19352,13 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19695,7 +19385,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19792,15 +19482,13 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19823,7 +19511,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -19908,15 +19596,13 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -19943,7 +19629,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20040,15 +19726,13 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20075,7 +19759,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20172,15 +19856,13 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20207,7 +19889,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20304,15 +19986,13 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20335,7 +20015,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20420,15 +20100,13 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20455,7 +20133,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20552,15 +20230,13 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20587,7 +20263,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20684,15 +20360,13 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20719,7 +20393,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20816,15 +20490,13 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20847,7 +20519,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -20932,15 +20604,13 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -20958,7 +20628,7 @@ func (p projPowFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21028,15 +20698,13 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21056,7 +20724,7 @@ func (p projConcatBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21128,15 +20796,13 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21155,7 +20821,7 @@ func (p projConcatJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21226,20 +20892,23 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -21257,11 +20926,17 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg1.(tree.Datum), arg2.(tree.Datum))
 						if err != nil {
@@ -21275,7 +20950,9 @@ func (p projConcatDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -21335,15 +21012,13 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21364,7 +21039,7 @@ func (p projLShiftInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21443,15 +21118,13 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21472,7 +21145,7 @@ func (p projLShiftInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21551,15 +21224,13 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21580,7 +21251,7 @@ func (p projLShiftInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21659,15 +21330,13 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21688,7 +21357,7 @@ func (p projLShiftInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21767,15 +21436,13 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21796,7 +21463,7 @@ func (p projLShiftInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21875,15 +21542,13 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -21904,7 +21569,7 @@ func (p projLShiftInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -21983,15 +21648,13 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22012,7 +21675,7 @@ func (p projLShiftInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22091,15 +21754,13 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22120,7 +21781,7 @@ func (p projLShiftInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22199,15 +21860,13 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22228,7 +21887,7 @@ func (p projLShiftInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22309,15 +21968,13 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22343,7 +22000,7 @@ func (p projLShiftDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22437,15 +22094,13 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22471,7 +22126,7 @@ func (p projLShiftDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22565,15 +22220,13 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22599,7 +22252,7 @@ func (p projLShiftDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22691,15 +22344,13 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22720,7 +22371,7 @@ func (p projRShiftInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22799,15 +22450,13 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22828,7 +22477,7 @@ func (p projRShiftInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -22907,15 +22556,13 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -22936,7 +22583,7 @@ func (p projRShiftInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23015,15 +22662,13 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23044,7 +22689,7 @@ func (p projRShiftInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23123,15 +22768,13 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23152,7 +22795,7 @@ func (p projRShiftInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23231,15 +22874,13 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23260,7 +22901,7 @@ func (p projRShiftInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23339,15 +22980,13 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23368,7 +23007,7 @@ func (p projRShiftInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23447,15 +23086,13 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23476,7 +23113,7 @@ func (p projRShiftInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23555,15 +23192,13 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23584,7 +23219,7 @@ func (p projRShiftInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -23665,15 +23300,13 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23699,7 +23332,7 @@ func (p projRShiftDatumInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23793,15 +23426,13 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23827,7 +23458,7 @@ func (p projRShiftDatumInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23921,15 +23552,13 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -23955,7 +23584,7 @@ func (p projRShiftDatumInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24047,15 +23676,13 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24080,7 +23707,7 @@ func (p projJSONFetchValJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24167,15 +23794,13 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24197,7 +23822,7 @@ func (p projJSONFetchValJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24277,15 +23902,13 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24307,7 +23930,7 @@ func (p projJSONFetchValJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24387,15 +24010,13 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24417,7 +24038,7 @@ func (p projJSONFetchValJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24497,15 +24118,13 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24539,7 +24158,7 @@ func (p projJSONFetchTextJSONBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24653,15 +24272,13 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24692,7 +24309,7 @@ func (p projJSONFetchTextJSONInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24799,15 +24416,13 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24838,7 +24453,7 @@ func (p projJSONFetchTextJSONInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24945,15 +24560,13 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -24984,7 +24597,7 @@ func (p projJSONFetchTextJSONInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25091,15 +24704,13 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25121,7 +24732,7 @@ func (p projJSONFetchValPathJSONDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25199,15 +24810,13 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25239,7 +24848,7 @@ func (p projJSONFetchTextPathJSONDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25347,15 +24956,13 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25382,7 +24989,7 @@ func (p projEQBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -25479,15 +25086,13 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25506,7 +25111,7 @@ func (p projEQBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25575,15 +25180,13 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25608,7 +25211,7 @@ func (p projEQDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -25699,15 +25302,13 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25732,7 +25333,7 @@ func (p projEQDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -25823,15 +25424,13 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25856,7 +25455,7 @@ func (p projEQDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -25947,15 +25546,13 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -25982,7 +25579,7 @@ func (p projEQDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26079,15 +25676,13 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26106,7 +25701,7 @@ func (p projEQDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26179,15 +25774,13 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26217,7 +25810,7 @@ func (p projEQInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26323,15 +25916,13 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26361,7 +25952,7 @@ func (p projEQInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26467,15 +26058,13 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26505,7 +26094,7 @@ func (p projEQInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26611,15 +26200,13 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26657,7 +26244,7 @@ func (p projEQInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26787,15 +26374,13 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26820,7 +26405,7 @@ func (p projEQInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -26911,15 +26496,13 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -26949,7 +26532,7 @@ func (p projEQInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27055,15 +26638,13 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27093,7 +26674,7 @@ func (p projEQInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27199,15 +26780,13 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27237,7 +26816,7 @@ func (p projEQInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27343,15 +26922,13 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27389,7 +26966,7 @@ func (p projEQInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27519,15 +27096,13 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27552,7 +27127,7 @@ func (p projEQInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27643,15 +27218,13 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27681,7 +27254,7 @@ func (p projEQInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27787,15 +27360,13 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27825,7 +27396,7 @@ func (p projEQInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -27931,15 +27502,13 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -27969,7 +27538,7 @@ func (p projEQInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28075,15 +27644,13 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28121,7 +27688,7 @@ func (p projEQInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28251,15 +27818,13 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28284,7 +27849,7 @@ func (p projEQInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28375,15 +27940,13 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28421,7 +27984,7 @@ func (p projEQFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28551,15 +28114,13 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28597,7 +28158,7 @@ func (p projEQFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28727,15 +28288,13 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28773,7 +28332,7 @@ func (p projEQFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -28903,15 +28462,13 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -28949,7 +28506,7 @@ func (p projEQFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29079,15 +28636,13 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29114,7 +28669,7 @@ func (p projEQFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29211,15 +28766,13 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29245,7 +28798,7 @@ func (p projEQTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29339,15 +28892,13 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29366,7 +28917,7 @@ func (p projEQIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29439,15 +28990,13 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29472,7 +29021,7 @@ func (p projEQJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29559,20 +29108,23 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -29589,11 +29141,17 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -29606,7 +29164,9 @@ func (p projEQDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -29664,15 +29224,13 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29699,7 +29257,7 @@ func (p projNEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -29796,15 +29354,13 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29823,7 +29379,7 @@ func (p projNEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29892,15 +29448,13 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -29925,7 +29479,7 @@ func (p projNEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30016,15 +29570,13 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30049,7 +29601,7 @@ func (p projNEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30140,15 +29692,13 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30173,7 +29723,7 @@ func (p projNEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30264,15 +29814,13 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30299,7 +29847,7 @@ func (p projNEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30396,15 +29944,13 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30423,7 +29969,7 @@ func (p projNEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30496,15 +30042,13 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30534,7 +30078,7 @@ func (p projNEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30640,15 +30184,13 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30678,7 +30220,7 @@ func (p projNEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30784,15 +30326,13 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30822,7 +30362,7 @@ func (p projNEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -30928,15 +30468,13 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -30974,7 +30512,7 @@ func (p projNEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31104,15 +30642,13 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31137,7 +30673,7 @@ func (p projNEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31228,15 +30764,13 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31266,7 +30800,7 @@ func (p projNEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31372,15 +30906,13 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31410,7 +30942,7 @@ func (p projNEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31516,15 +31048,13 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31554,7 +31084,7 @@ func (p projNEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31660,15 +31190,13 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31706,7 +31234,7 @@ func (p projNEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31836,15 +31364,13 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31869,7 +31395,7 @@ func (p projNEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -31960,15 +31486,13 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -31998,7 +31522,7 @@ func (p projNEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32104,15 +31628,13 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32142,7 +31664,7 @@ func (p projNEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32248,15 +31770,13 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32286,7 +31806,7 @@ func (p projNEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32392,15 +31912,13 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32438,7 +31956,7 @@ func (p projNEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32568,15 +32086,13 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32601,7 +32117,7 @@ func (p projNEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32692,15 +32208,13 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32738,7 +32252,7 @@ func (p projNEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -32868,15 +32382,13 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -32914,7 +32426,7 @@ func (p projNEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33044,15 +32556,13 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33090,7 +32600,7 @@ func (p projNEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33220,15 +32730,13 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33266,7 +32774,7 @@ func (p projNEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33396,15 +32904,13 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33431,7 +32937,7 @@ func (p projNEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33528,15 +33034,13 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33562,7 +33066,7 @@ func (p projNETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33656,15 +33160,13 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33683,7 +33185,7 @@ func (p projNEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -33756,15 +33258,13 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33789,7 +33289,7 @@ func (p projNEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -33876,20 +33376,23 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -33906,11 +33409,17 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -33923,7 +33432,9 @@ func (p projNEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -33981,15 +33492,13 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34016,7 +33525,7 @@ func (p projLTBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34113,15 +33622,13 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34140,7 +33647,7 @@ func (p projLTBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34209,15 +33716,13 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34242,7 +33747,7 @@ func (p projLTDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34333,15 +33838,13 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34366,7 +33869,7 @@ func (p projLTDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34457,15 +33960,13 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34490,7 +33991,7 @@ func (p projLTDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34581,15 +34082,13 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34616,7 +34115,7 @@ func (p projLTDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34713,15 +34212,13 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34740,7 +34237,7 @@ func (p projLTDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34813,15 +34310,13 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34851,7 +34346,7 @@ func (p projLTInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -34957,15 +34452,13 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -34995,7 +34488,7 @@ func (p projLTInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35101,15 +34594,13 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35139,7 +34630,7 @@ func (p projLTInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35245,15 +34736,13 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35291,7 +34780,7 @@ func (p projLTInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35421,15 +34910,13 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35454,7 +34941,7 @@ func (p projLTInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35545,15 +35032,13 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35583,7 +35068,7 @@ func (p projLTInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35689,15 +35174,13 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35727,7 +35210,7 @@ func (p projLTInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35833,15 +35316,13 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -35871,7 +35352,7 @@ func (p projLTInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -35977,15 +35458,13 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36023,7 +35502,7 @@ func (p projLTInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36153,15 +35632,13 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36186,7 +35663,7 @@ func (p projLTInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36277,15 +35754,13 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36315,7 +35790,7 @@ func (p projLTInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36421,15 +35896,13 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36459,7 +35932,7 @@ func (p projLTInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36565,15 +36038,13 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36603,7 +36074,7 @@ func (p projLTInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36709,15 +36180,13 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36755,7 +36224,7 @@ func (p projLTInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -36885,15 +36354,13 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -36918,7 +36385,7 @@ func (p projLTInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37009,15 +36476,13 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37055,7 +36520,7 @@ func (p projLTFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37185,15 +36650,13 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37231,7 +36694,7 @@ func (p projLTFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37361,15 +36824,13 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37407,7 +36868,7 @@ func (p projLTFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37537,15 +36998,13 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37583,7 +37042,7 @@ func (p projLTFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37713,15 +37172,13 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37748,7 +37205,7 @@ func (p projLTFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37845,15 +37302,13 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -37879,7 +37334,7 @@ func (p projLTTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -37973,15 +37428,13 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38000,7 +37453,7 @@ func (p projLTIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38073,15 +37526,13 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38106,7 +37557,7 @@ func (p projLTJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38193,20 +37644,23 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -38223,11 +37677,17 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -38240,7 +37700,9 @@ func (p projLTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -38298,15 +37760,13 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38333,7 +37793,7 @@ func (p projLEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38430,15 +37890,13 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38457,7 +37915,7 @@ func (p projLEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38526,15 +37984,13 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38559,7 +38015,7 @@ func (p projLEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38650,15 +38106,13 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38683,7 +38137,7 @@ func (p projLEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38774,15 +38228,13 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38807,7 +38259,7 @@ func (p projLEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -38898,15 +38350,13 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -38933,7 +38383,7 @@ func (p projLEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39030,15 +38480,13 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39057,7 +38505,7 @@ func (p projLEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39130,15 +38578,13 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39168,7 +38614,7 @@ func (p projLEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39274,15 +38720,13 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39312,7 +38756,7 @@ func (p projLEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39418,15 +38862,13 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39456,7 +38898,7 @@ func (p projLEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39562,15 +39004,13 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39608,7 +39048,7 @@ func (p projLEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39738,15 +39178,13 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39771,7 +39209,7 @@ func (p projLEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -39862,15 +39300,13 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -39900,7 +39336,7 @@ func (p projLEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40006,15 +39442,13 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40044,7 +39478,7 @@ func (p projLEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40150,15 +39584,13 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40188,7 +39620,7 @@ func (p projLEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40294,15 +39726,13 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40340,7 +39770,7 @@ func (p projLEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40470,15 +39900,13 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40503,7 +39931,7 @@ func (p projLEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40594,15 +40022,13 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40632,7 +40058,7 @@ func (p projLEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40738,15 +40164,13 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40776,7 +40200,7 @@ func (p projLEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -40882,15 +40306,13 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -40920,7 +40342,7 @@ func (p projLEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41026,15 +40448,13 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41072,7 +40492,7 @@ func (p projLEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41202,15 +40622,13 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41235,7 +40653,7 @@ func (p projLEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41326,15 +40744,13 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41372,7 +40788,7 @@ func (p projLEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41502,15 +40918,13 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41548,7 +40962,7 @@ func (p projLEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41678,15 +41092,13 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41724,7 +41136,7 @@ func (p projLEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -41854,15 +41266,13 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -41900,7 +41310,7 @@ func (p projLEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42030,15 +41440,13 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42065,7 +41473,7 @@ func (p projLEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42162,15 +41570,13 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42196,7 +41602,7 @@ func (p projLETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42290,15 +41696,13 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42317,7 +41721,7 @@ func (p projLEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42390,15 +41794,13 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42423,7 +41825,7 @@ func (p projLEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42510,20 +41912,23 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -42540,11 +41945,17 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -42557,7 +41968,9 @@ func (p projLEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -42615,15 +42028,13 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42650,7 +42061,7 @@ func (p projGTBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42747,15 +42158,13 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42774,7 +42183,7 @@ func (p projGTBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42843,15 +42252,13 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -42876,7 +42283,7 @@ func (p projGTDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -42967,15 +42374,13 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43000,7 +42405,7 @@ func (p projGTDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43091,15 +42496,13 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43124,7 +42527,7 @@ func (p projGTDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43215,15 +42618,13 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43250,7 +42651,7 @@ func (p projGTDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43347,15 +42748,13 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43374,7 +42773,7 @@ func (p projGTDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43447,15 +42846,13 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43485,7 +42882,7 @@ func (p projGTInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43591,15 +42988,13 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43629,7 +43024,7 @@ func (p projGTInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43735,15 +43130,13 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43773,7 +43166,7 @@ func (p projGTInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -43879,15 +43272,13 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -43925,7 +43316,7 @@ func (p projGTInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44055,15 +43446,13 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44088,7 +43477,7 @@ func (p projGTInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44179,15 +43568,13 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44217,7 +43604,7 @@ func (p projGTInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44323,15 +43710,13 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44361,7 +43746,7 @@ func (p projGTInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44467,15 +43852,13 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44505,7 +43888,7 @@ func (p projGTInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44611,15 +43994,13 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44657,7 +44038,7 @@ func (p projGTInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44787,15 +44168,13 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44820,7 +44199,7 @@ func (p projGTInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -44911,15 +44290,13 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -44949,7 +44326,7 @@ func (p projGTInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45055,15 +44432,13 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45093,7 +44468,7 @@ func (p projGTInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45199,15 +44574,13 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45237,7 +44610,7 @@ func (p projGTInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45343,15 +44716,13 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45389,7 +44760,7 @@ func (p projGTInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45519,15 +44890,13 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45552,7 +44921,7 @@ func (p projGTInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45643,15 +45012,13 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45689,7 +45056,7 @@ func (p projGTFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45819,15 +45186,13 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -45865,7 +45230,7 @@ func (p projGTFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -45995,15 +45360,13 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46041,7 +45404,7 @@ func (p projGTFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46171,15 +45534,13 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46217,7 +45578,7 @@ func (p projGTFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46347,15 +45708,13 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46382,7 +45741,7 @@ func (p projGTFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46479,15 +45838,13 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46513,7 +45870,7 @@ func (p projGTTimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46607,15 +45964,13 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46634,7 +45989,7 @@ func (p projGTIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -46707,15 +46062,13 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46740,7 +46093,7 @@ func (p projGTJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46827,20 +46180,23 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -46857,11 +46213,17 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -46874,7 +46236,9 @@ func (p projGTDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -46932,15 +46296,13 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 		col1 := vec1.Bool()
 		col2 := vec2.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -46967,7 +46329,7 @@ func (p projGEBoolBoolOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47064,15 +46426,13 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 		col1 := vec1.Bytes()
 		col2 := vec2.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47091,7 +46451,7 @@ func (p projGEBytesBytesOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47160,15 +46520,13 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47193,7 +46551,7 @@ func (p projGEDecimalInt16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47284,15 +46642,13 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47317,7 +46673,7 @@ func (p projGEDecimalInt32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47408,15 +46764,13 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47441,7 +46795,7 @@ func (p projGEDecimalInt64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47532,15 +46886,13 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47567,7 +46919,7 @@ func (p projGEDecimalFloat64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47664,15 +47016,13 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 		col1 := vec1.Decimal()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47691,7 +47041,7 @@ func (p projGEDecimalDecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47764,15 +47114,13 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47802,7 +47150,7 @@ func (p projGEInt16Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -47908,15 +47256,13 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -47946,7 +47292,7 @@ func (p projGEInt16Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48052,15 +47398,13 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48090,7 +47434,7 @@ func (p projGEInt16Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48196,15 +47540,13 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48242,7 +47584,7 @@ func (p projGEInt16Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48372,15 +47714,13 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int16()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48405,7 +47745,7 @@ func (p projGEInt16DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48496,15 +47836,13 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48534,7 +47872,7 @@ func (p projGEInt32Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48640,15 +47978,13 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48678,7 +48014,7 @@ func (p projGEInt32Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48784,15 +48120,13 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48822,7 +48156,7 @@ func (p projGEInt32Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -48928,15 +48262,13 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -48974,7 +48306,7 @@ func (p projGEInt32Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49104,15 +48436,13 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int32()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49137,7 +48467,7 @@ func (p projGEInt32DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49228,15 +48558,13 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49266,7 +48594,7 @@ func (p projGEInt64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49372,15 +48700,13 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49410,7 +48736,7 @@ func (p projGEInt64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49516,15 +48842,13 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49554,7 +48878,7 @@ func (p projGEInt64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49660,15 +48984,13 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49706,7 +49028,7 @@ func (p projGEInt64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49836,15 +49158,13 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Int64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -49869,7 +49189,7 @@ func (p projGEInt64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -49960,15 +49280,13 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int16()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50006,7 +49324,7 @@ func (p projGEFloat64Int16Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50136,15 +49454,13 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int32()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50182,7 +49498,7 @@ func (p projGEFloat64Int32Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50312,15 +49628,13 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50358,7 +49672,7 @@ func (p projGEFloat64Int64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50488,15 +49802,13 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50534,7 +49846,7 @@ func (p projGEFloat64Float64Op) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50664,15 +49976,13 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 		col1 := vec1.Float64()
 		col2 := vec2.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50699,7 +50009,7 @@ func (p projGEFloat64DecimalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50796,15 +50106,13 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 		col1 := vec1.Timestamp()
 		col2 := vec2.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50830,7 +50138,7 @@ func (p projGETimestampTimestampOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -50924,15 +50232,13 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 		col1 := vec1.Interval()
 		col2 := vec2.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -50951,7 +50257,7 @@ func (p projGEIntervalIntervalOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						//gcassert:bce
@@ -51024,15 +50330,13 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 		col1 := vec1.JSON()
 		col2 := vec2.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51057,7 +50361,7 @@ func (p projGEJSONJSONOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
@@ -51144,20 +50448,23 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 		col1 := vec1.Datum()
 		col2 := vec2.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			col1Nulls := vec1.Nulls()
 			col2Nulls := vec2.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -51174,11 +50481,17 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 				_ = col1.Get(n - 1)
 				_ = col2.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+					if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 						// We only want to perform the projection operation if both values are not
 						// null.
 						arg1 := col1.Get(i)
+						if col1Nulls.NullAt(i) {
+							arg1 = tree.DNull
+						}
 						arg2 := col2.Get(i)
+						if col2Nulls.NullAt(i) {
+							arg2 = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -51191,7 +50504,9 @@ func (p projGEDatumDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops_tmpl.go
@@ -123,25 +123,7 @@ func (p _OP_NAME) Next() coldata.Batch {
 		// of a projection is Null.
 		// */}}
 		_outNulls := projVec.Nulls()
-
-		// {{/*
-		// If calledOnNullInput is true, the function’s definition can handle
-		// null arguments. We would still want to perform the projection, and
-		// there is no need to call projVec.SetNulls(). The behaviour will just
-		// be the same as _HAS_NULLS is false. Since currently only
-		// ConcatDatumDatum needs this calledOnNullInput == true behaviour,
-		// logic for calledOnNullInput is only added to the if statement for
-		// function with Datum, Datum. If we later introduce another projection
-		// operation that has calledOnNullInput == true, we should update this
-		// code accordingly.
-		// */}}
-		// {{if and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum")}}
-		hasNullsAndNotCalledOnNullInput :=
-			(vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls()) && !p.calledOnNullInput
-		// {{else}}
-		hasNullsAndNotCalledOnNullInput := (vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls())
-		// {{end}}
-		if hasNullsAndNotCalledOnNullInput {
+		if vec1.Nulls().MaybeHasNulls() || vec2.Nulls().MaybeHasNulls() {
 			_SET_PROJECTION(true)
 		} else {
 			_SET_PROJECTION(false)
@@ -158,6 +140,7 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	// {{define "setProjection" -}}
 	// {{$hasNulls := $.HasNulls}}
 	// {{with $.Overload}}
+	// {{$isDatum := (and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum"))}}
 	// {{if _HAS_NULLS}}
 	col1Nulls := vec1.Nulls()
 	col2Nulls := vec2.Nulls()
@@ -183,7 +166,13 @@ func _SET_PROJECTION(_HAS_NULLS bool) {
 	// projVec.Nulls() so there is no need to call projVec.SetNulls().
 	// */}}
 	// {{if _HAS_NULLS}}
-	projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+	// {{if $isDatum}}
+	if !p.calledOnNullInput {
+		// {{end}}
+		projVec.SetNulls(_outNulls.Or(*col1Nulls).Or(*col2Nulls))
+		// {{if $isDatum}}
+	}
+	// {{end}}
 	// {{end}}
 	// {{end}}
 	// {{end}}
@@ -198,8 +187,9 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool, _HAS_SEL bool) { // */}}
 	// {{$hasNulls := $.HasNulls}}
 	// {{$hasSel := $.HasSel}}
 	// {{with $.Overload}}
+	// {{$isDatum := (and (eq .Left.VecMethod "Datum") (eq .Right.VecMethod "Datum"))}}
 	// {{if _HAS_NULLS}}
-	if !col1Nulls.NullAt(i) && !col2Nulls.NullAt(i) {
+	if p.calledOnNullInput || (!col1Nulls.NullAt(i) && !col2Nulls.NullAt(i)) {
 		// We only want to perform the projection operation if both values are not
 		// null.
 		// {{end}}
@@ -207,10 +197,28 @@ func _SET_SINGLE_TUPLE_PROJECTION(_HAS_NULLS bool, _HAS_SEL bool) { // */}}
 		//gcassert:bce
 		// {{end}}
 		arg1 := col1.Get(i)
+		// {{if (and _HAS_NULLS $isDatum)}}
+		if col1Nulls.NullAt(i) {
+			// {{/*
+			// If we entered this branch for a null value, calledOnNullInput must be
+			// true. This means the projection should be calculated on null arguments.
+			// When a value is null, the underlying data in the slice is invalid and
+			// can be anything, so we need to overwrite it here. calledOnNullInput is
+			// currently only true for ConcatDatumDatum, so only the datum case needs
+			// to be handled.
+			// */}}
+			arg1 = tree.DNull
+		}
+		// {{end}}
 		// {{if and (.Right.Sliceable) (not _HAS_SEL)}}
 		//gcassert:bce
 		// {{end}}
 		arg2 := col2.Get(i)
+		// {{if (and _HAS_NULLS $isDatum)}}
+		if col2Nulls.NullAt(i) {
+			arg2 = tree.DNull
+		}
+		// {{end}}
 		_ASSIGN(projCol[i], arg1, arg2, projCol, col1, col2)
 		// {{if _HAS_NULLS}}
 	}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -68,14 +68,12 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -87,7 +85,7 @@ func (p projBitandInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -144,14 +142,12 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -163,7 +159,7 @@ func (p projBitandInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -220,14 +216,12 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -239,7 +233,7 @@ func (p projBitandInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -296,14 +290,12 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -315,7 +307,7 @@ func (p projBitandInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -372,14 +364,12 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -391,7 +381,7 @@ func (p projBitandInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -448,14 +438,12 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -467,7 +455,7 @@ func (p projBitandInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -524,14 +512,12 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -543,7 +529,7 @@ func (p projBitandInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -600,14 +586,12 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -619,7 +603,7 @@ func (p projBitandInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -676,14 +660,12 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -695,7 +677,7 @@ func (p projBitandInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -754,16 +736,17 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -780,9 +763,12 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -796,7 +782,9 @@ func (p projBitandDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -856,14 +844,12 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -875,7 +861,7 @@ func (p projBitorInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -932,14 +918,12 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -951,7 +935,7 @@ func (p projBitorInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1008,14 +992,12 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1027,7 +1009,7 @@ func (p projBitorInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1084,14 +1066,12 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1103,7 +1083,7 @@ func (p projBitorInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1160,14 +1140,12 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1179,7 +1157,7 @@ func (p projBitorInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1236,14 +1214,12 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1255,7 +1231,7 @@ func (p projBitorInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1312,14 +1288,12 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1331,7 +1305,7 @@ func (p projBitorInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1388,14 +1362,12 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1407,7 +1379,7 @@ func (p projBitorInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1464,14 +1436,12 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1483,7 +1453,7 @@ func (p projBitorInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1542,16 +1512,17 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -1568,9 +1539,12 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -1584,7 +1558,9 @@ func (p projBitorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1644,14 +1620,12 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1663,7 +1637,7 @@ func (p projBitxorInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1720,14 +1694,12 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1739,7 +1711,7 @@ func (p projBitxorInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1796,14 +1768,12 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1815,7 +1785,7 @@ func (p projBitxorInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1872,14 +1842,12 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1891,7 +1859,7 @@ func (p projBitxorInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1948,14 +1916,12 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1967,7 +1933,7 @@ func (p projBitxorInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2024,14 +1990,12 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2043,7 +2007,7 @@ func (p projBitxorInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2100,14 +2064,12 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2119,7 +2081,7 @@ func (p projBitxorInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2176,14 +2138,12 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2195,7 +2155,7 @@ func (p projBitxorInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2252,14 +2212,12 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2271,7 +2229,7 @@ func (p projBitxorInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2330,16 +2288,17 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -2356,9 +2315,12 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -2372,7 +2334,9 @@ func (p projBitxorDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2432,14 +2396,12 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2458,7 +2420,7 @@ func (p projPlusDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2536,14 +2498,12 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2562,7 +2522,7 @@ func (p projPlusDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2640,14 +2600,12 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2666,7 +2624,7 @@ func (p projPlusDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2744,14 +2702,12 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2769,7 +2725,7 @@ func (p projPlusDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2844,14 +2800,12 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2869,7 +2823,7 @@ func (p projPlusInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2944,14 +2898,12 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2969,7 +2921,7 @@ func (p projPlusInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3044,14 +2996,12 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3069,7 +3019,7 @@ func (p projPlusInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3144,14 +3094,12 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3171,7 +3119,7 @@ func (p projPlusInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3254,14 +3202,12 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3284,7 +3230,7 @@ func (p projPlusInt16ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3374,14 +3320,12 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3399,7 +3343,7 @@ func (p projPlusInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3474,14 +3418,12 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3499,7 +3441,7 @@ func (p projPlusInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3574,14 +3516,12 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3599,7 +3539,7 @@ func (p projPlusInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3674,14 +3614,12 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3701,7 +3639,7 @@ func (p projPlusInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3784,14 +3722,12 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3814,7 +3750,7 @@ func (p projPlusInt32ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3904,14 +3840,12 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3929,7 +3863,7 @@ func (p projPlusInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4004,14 +3938,12 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4029,7 +3961,7 @@ func (p projPlusInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4104,14 +4036,12 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4129,7 +4059,7 @@ func (p projPlusInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4204,14 +4134,12 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4231,7 +4159,7 @@ func (p projPlusInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4314,14 +4242,12 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4344,7 +4270,7 @@ func (p projPlusInt64ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4434,14 +4360,12 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4456,7 +4380,7 @@ func (p projPlusFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4522,14 +4446,12 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg)
@@ -4544,7 +4466,7 @@ func (p projPlusTimestampConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4610,14 +4532,12 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg)
@@ -4632,7 +4552,7 @@ func (p projPlusIntervalConstTimestampOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4698,14 +4618,12 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Add(arg)
@@ -4715,7 +4633,7 @@ func (p projPlusIntervalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4768,14 +4686,12 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4798,7 +4714,7 @@ func (p projPlusIntervalConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4890,14 +4806,12 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4920,7 +4834,7 @@ func (p projPlusDatumConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5010,14 +4924,12 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5040,7 +4952,7 @@ func (p projPlusDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5130,14 +5042,12 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5160,7 +5070,7 @@ func (p projPlusDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5250,14 +5160,12 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5280,7 +5188,7 @@ func (p projPlusDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5368,14 +5276,12 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5394,7 +5300,7 @@ func (p projMinusDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5472,14 +5378,12 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5498,7 +5402,7 @@ func (p projMinusDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5576,14 +5480,12 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5602,7 +5504,7 @@ func (p projMinusDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5680,14 +5582,12 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5705,7 +5605,7 @@ func (p projMinusDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5780,14 +5680,12 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5805,7 +5703,7 @@ func (p projMinusInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5880,14 +5778,12 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5905,7 +5801,7 @@ func (p projMinusInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5980,14 +5876,12 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6005,7 +5899,7 @@ func (p projMinusInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6080,14 +5974,12 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6107,7 +5999,7 @@ func (p projMinusInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6190,14 +6082,12 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6220,7 +6110,7 @@ func (p projMinusInt16ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6310,14 +6200,12 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6335,7 +6223,7 @@ func (p projMinusInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6410,14 +6298,12 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6435,7 +6321,7 @@ func (p projMinusInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6510,14 +6396,12 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6535,7 +6419,7 @@ func (p projMinusInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6610,14 +6494,12 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6637,7 +6519,7 @@ func (p projMinusInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6720,14 +6602,12 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6750,7 +6630,7 @@ func (p projMinusInt32ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6840,14 +6720,12 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6865,7 +6743,7 @@ func (p projMinusInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6940,14 +6818,12 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6965,7 +6841,7 @@ func (p projMinusInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7040,14 +6916,12 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7065,7 +6939,7 @@ func (p projMinusInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7140,14 +7014,12 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7167,7 +7039,7 @@ func (p projMinusInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7250,14 +7122,12 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7280,7 +7150,7 @@ func (p projMinusInt64ConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7370,14 +7240,12 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7392,7 +7260,7 @@ func (p projMinusFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7458,14 +7326,12 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7478,7 +7344,7 @@ func (p projMinusTimestampConstTimestampOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7538,14 +7404,12 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg.Mul(-1))
@@ -7560,7 +7424,7 @@ func (p projMinusTimestampConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7626,14 +7490,12 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Sub(arg)
@@ -7643,7 +7505,7 @@ func (p projMinusIntervalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7696,14 +7558,12 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7726,7 +7586,7 @@ func (p projMinusIntervalConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7816,14 +7676,12 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7842,7 +7700,7 @@ func (p projMinusJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7918,14 +7776,12 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7940,7 +7796,7 @@ func (p projMinusJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8004,14 +7860,12 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8026,7 +7880,7 @@ func (p projMinusJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8090,14 +7944,12 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8112,7 +7964,7 @@ func (p projMinusJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8178,16 +8030,17 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -8204,9 +8057,12 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -8220,7 +8076,9 @@ func (p projMinusDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8282,14 +8140,12 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8312,7 +8168,7 @@ func (p projMinusDatumConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8402,14 +8258,12 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8432,7 +8286,7 @@ func (p projMinusDatumConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8522,14 +8376,12 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8552,7 +8404,7 @@ func (p projMinusDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8642,14 +8494,12 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8672,7 +8522,7 @@ func (p projMinusDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8762,14 +8612,12 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8792,7 +8640,7 @@ func (p projMinusDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8880,14 +8728,12 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8906,7 +8752,7 @@ func (p projMultDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8984,14 +8830,12 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9010,7 +8854,7 @@ func (p projMultDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9088,14 +8932,12 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9114,7 +8956,7 @@ func (p projMultDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9192,14 +9034,12 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9217,7 +9057,7 @@ func (p projMultDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9292,14 +9132,12 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9314,7 +9152,7 @@ func (p projMultDecimalConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9380,14 +9218,12 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9413,7 +9249,7 @@ func (p projMultInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9512,14 +9348,12 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9545,7 +9379,7 @@ func (p projMultInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9644,14 +9478,12 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9677,7 +9509,7 @@ func (p projMultInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9776,14 +9608,12 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9803,7 +9633,7 @@ func (p projMultInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9884,14 +9714,12 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -9901,7 +9729,7 @@ func (p projMultInt16ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9952,14 +9780,12 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9985,7 +9811,7 @@ func (p projMultInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10084,14 +9910,12 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10117,7 +9941,7 @@ func (p projMultInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10216,14 +10040,12 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10249,7 +10071,7 @@ func (p projMultInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10348,14 +10170,12 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10375,7 +10195,7 @@ func (p projMultInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10456,14 +10276,12 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -10473,7 +10291,7 @@ func (p projMultInt32ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10524,14 +10342,12 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10557,7 +10373,7 @@ func (p projMultInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10656,14 +10472,12 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10689,7 +10503,7 @@ func (p projMultInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10788,14 +10602,12 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10821,7 +10633,7 @@ func (p projMultInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10920,14 +10732,12 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10947,7 +10757,7 @@ func (p projMultInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11028,14 +10838,12 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11045,7 +10853,7 @@ func (p projMultInt64ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11096,14 +10904,12 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11118,7 +10924,7 @@ func (p projMultFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11184,14 +10990,12 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -11201,7 +11005,7 @@ func (p projMultFloat64ConstIntervalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11252,14 +11056,12 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11269,7 +11071,7 @@ func (p projMultIntervalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11320,14 +11122,12 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11337,7 +11137,7 @@ func (p projMultIntervalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11388,14 +11188,12 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11405,7 +11203,7 @@ func (p projMultIntervalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11456,14 +11254,12 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -11473,7 +11269,7 @@ func (p projMultIntervalConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11524,14 +11320,12 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11546,7 +11340,7 @@ func (p projMultIntervalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11612,14 +11406,12 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11642,7 +11434,7 @@ func (p projDivDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11732,14 +11524,12 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11762,7 +11552,7 @@ func (p projDivDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11852,14 +11642,12 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11882,7 +11670,7 @@ func (p projDivDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11972,14 +11760,12 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12001,7 +11787,7 @@ func (p projDivDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12088,14 +11874,12 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12117,7 +11901,7 @@ func (p projDivInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12204,14 +11988,12 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12233,7 +12015,7 @@ func (p projDivInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12320,14 +12102,12 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12349,7 +12129,7 @@ func (p projDivInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12436,14 +12216,12 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12467,7 +12245,7 @@ func (p projDivInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12560,14 +12338,12 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12589,7 +12365,7 @@ func (p projDivInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12676,14 +12452,12 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12705,7 +12479,7 @@ func (p projDivInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12792,14 +12566,12 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12821,7 +12593,7 @@ func (p projDivInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12908,14 +12680,12 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12939,7 +12709,7 @@ func (p projDivInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13032,14 +12802,12 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13061,7 +12829,7 @@ func (p projDivInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13148,14 +12916,12 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13177,7 +12943,7 @@ func (p projDivInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13264,14 +13030,12 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13293,7 +13057,7 @@ func (p projDivInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13380,14 +13144,12 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13411,7 +13173,7 @@ func (p projDivInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13504,14 +13266,12 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13530,7 +13290,7 @@ func (p projDivFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13608,14 +13368,12 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13629,7 +13387,7 @@ func (p projDivIntervalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13692,14 +13450,12 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13713,7 +13469,7 @@ func (p projDivIntervalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13776,14 +13532,12 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13797,7 +13551,7 @@ func (p projDivIntervalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13860,14 +13614,12 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13881,7 +13633,7 @@ func (p projDivIntervalConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13944,14 +13696,12 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13974,7 +13724,7 @@ func (p projFloorDivDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14064,14 +13814,12 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14094,7 +13842,7 @@ func (p projFloorDivDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14184,14 +13932,12 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14214,7 +13960,7 @@ func (p projFloorDivDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14304,14 +14050,12 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14333,7 +14077,7 @@ func (p projFloorDivDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14420,14 +14164,12 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14444,7 +14186,7 @@ func (p projFloorDivInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14516,14 +14258,12 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14540,7 +14280,7 @@ func (p projFloorDivInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14612,14 +14352,12 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14636,7 +14374,7 @@ func (p projFloorDivInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14708,14 +14446,12 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14739,7 +14475,7 @@ func (p projFloorDivInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14832,14 +14568,12 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14856,7 +14590,7 @@ func (p projFloorDivInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14928,14 +14662,12 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14952,7 +14684,7 @@ func (p projFloorDivInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15024,14 +14756,12 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15048,7 +14778,7 @@ func (p projFloorDivInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15120,14 +14850,12 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15151,7 +14879,7 @@ func (p projFloorDivInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15244,14 +14972,12 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15268,7 +14994,7 @@ func (p projFloorDivInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15340,14 +15066,12 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15364,7 +15088,7 @@ func (p projFloorDivInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15436,14 +15160,12 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15460,7 +15182,7 @@ func (p projFloorDivInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15532,14 +15254,12 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15563,7 +15283,7 @@ func (p projFloorDivInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15656,14 +15376,12 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15682,7 +15400,7 @@ func (p projFloorDivFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15760,14 +15478,12 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15790,7 +15506,7 @@ func (p projModDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15880,14 +15596,12 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15910,7 +15624,7 @@ func (p projModDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16000,14 +15714,12 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16030,7 +15742,7 @@ func (p projModDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16120,14 +15832,12 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16149,7 +15859,7 @@ func (p projModDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16236,14 +15946,12 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16260,7 +15968,7 @@ func (p projModInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16332,14 +16040,12 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16356,7 +16062,7 @@ func (p projModInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16428,14 +16134,12 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16452,7 +16156,7 @@ func (p projModInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16524,14 +16228,12 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16555,7 +16257,7 @@ func (p projModInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16648,14 +16350,12 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16672,7 +16372,7 @@ func (p projModInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16744,14 +16444,12 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16768,7 +16466,7 @@ func (p projModInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16840,14 +16538,12 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16864,7 +16560,7 @@ func (p projModInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16936,14 +16632,12 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16967,7 +16661,7 @@ func (p projModInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17060,14 +16754,12 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17084,7 +16776,7 @@ func (p projModInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17156,14 +16848,12 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17180,7 +16870,7 @@ func (p projModInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17252,14 +16942,12 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17276,7 +16964,7 @@ func (p projModInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17348,14 +17036,12 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17379,7 +17065,7 @@ func (p projModInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17472,14 +17158,12 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17498,7 +17182,7 @@ func (p projModFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17576,14 +17260,12 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17602,7 +17284,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17680,14 +17362,12 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17706,7 +17386,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17784,14 +17464,12 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17810,7 +17488,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17888,14 +17566,12 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17913,7 +17589,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17988,14 +17664,12 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18019,7 +17693,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18112,14 +17786,12 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18143,7 +17815,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18236,14 +17908,12 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18267,7 +17937,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18360,14 +18030,12 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18387,7 +18055,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18468,14 +18136,12 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18499,7 +18165,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18592,14 +18258,12 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18623,7 +18287,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18716,14 +18380,12 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18747,7 +18409,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18840,14 +18502,12 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18867,7 +18527,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18948,14 +18608,12 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18979,7 +18637,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19072,14 +18730,12 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19103,7 +18759,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19196,14 +18852,12 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19227,7 +18881,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19320,14 +18974,12 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19347,7 +18999,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19428,14 +19080,12 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19450,7 +19100,7 @@ func (p projPowFloat64ConstFloat64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19516,14 +19166,12 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19540,7 +19188,7 @@ func (p projConcatBytesConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19610,14 +19258,12 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19633,7 +19279,7 @@ func (p projConcatJSONConstJSONOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19702,16 +19348,17 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -19728,9 +19375,12 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, p.constArg.(tree.Datum), arg.(tree.Datum))
 						if err != nil {
@@ -19744,7 +19394,9 @@ func (p projConcatDatumConstDatumOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19804,14 +19456,12 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19829,7 +19479,7 @@ func (p projLShiftInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19904,14 +19554,12 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19929,7 +19577,7 @@ func (p projLShiftInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20004,14 +19652,12 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20029,7 +19675,7 @@ func (p projLShiftInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20104,14 +19750,12 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20129,7 +19773,7 @@ func (p projLShiftInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20204,14 +19848,12 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20229,7 +19871,7 @@ func (p projLShiftInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20304,14 +19946,12 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20329,7 +19969,7 @@ func (p projLShiftInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20404,14 +20044,12 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20429,7 +20067,7 @@ func (p projLShiftInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20504,14 +20142,12 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20529,7 +20165,7 @@ func (p projLShiftInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20604,14 +20240,12 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20629,7 +20263,7 @@ func (p projLShiftInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20706,14 +20340,12 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20736,7 +20368,7 @@ func (p projLShiftDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20826,14 +20458,12 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20856,7 +20486,7 @@ func (p projLShiftDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20946,14 +20576,12 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20976,7 +20604,7 @@ func (p projLShiftDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21064,14 +20692,12 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21089,7 +20715,7 @@ func (p projRShiftInt16ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21164,14 +20790,12 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21189,7 +20813,7 @@ func (p projRShiftInt16ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21264,14 +20888,12 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21289,7 +20911,7 @@ func (p projRShiftInt16ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21364,14 +20986,12 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21389,7 +21009,7 @@ func (p projRShiftInt32ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21464,14 +21084,12 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21489,7 +21107,7 @@ func (p projRShiftInt32ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21564,14 +21182,12 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21589,7 +21205,7 @@ func (p projRShiftInt32ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21664,14 +21280,12 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21689,7 +21303,7 @@ func (p projRShiftInt64ConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21764,14 +21378,12 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21789,7 +21401,7 @@ func (p projRShiftInt64ConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21864,14 +21476,12 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21889,7 +21499,7 @@ func (p projRShiftInt64ConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21966,14 +21576,12 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21996,7 +21604,7 @@ func (p projRShiftDatumConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22086,14 +21694,12 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22116,7 +21722,7 @@ func (p projRShiftDatumConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22206,14 +21812,12 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22236,7 +21840,7 @@ func (p projRShiftDatumConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22324,14 +21928,12 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22353,7 +21955,7 @@ func (p projJSONFetchValJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22438,14 +22040,12 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22464,7 +22064,7 @@ func (p projJSONFetchValJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22540,14 +22140,12 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22566,7 +22164,7 @@ func (p projJSONFetchValJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22642,14 +22240,12 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22668,7 +22264,7 @@ func (p projJSONFetchValJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22744,14 +22340,12 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22782,7 +22376,7 @@ func (p projJSONFetchTextJSONConstBytesOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22894,14 +22488,12 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22929,7 +22521,7 @@ func (p projJSONFetchTextJSONConstInt16Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23032,14 +22624,12 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23067,7 +22657,7 @@ func (p projJSONFetchTextJSONConstInt32Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23170,14 +22760,12 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23205,7 +22793,7 @@ func (p projJSONFetchTextJSONConstInt64Op) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23308,14 +22896,12 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23334,7 +22920,7 @@ func (p projJSONFetchValPathJSONConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23410,14 +22996,12 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23446,7 +23030,7 @@ func (p projJSONFetchTextPathJSONConstDatumOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -71,14 +71,12 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -90,7 +88,7 @@ func (p projBitandInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -147,14 +145,12 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -166,7 +162,7 @@ func (p projBitandInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -223,14 +219,12 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -242,7 +236,7 @@ func (p projBitandInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -299,14 +293,12 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -318,7 +310,7 @@ func (p projBitandInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -375,14 +367,12 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -394,7 +384,7 @@ func (p projBitandInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -451,14 +441,12 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -470,7 +458,7 @@ func (p projBitandInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -527,14 +515,12 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -546,7 +532,7 @@ func (p projBitandInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -603,14 +589,12 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -622,7 +606,7 @@ func (p projBitandInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -679,14 +663,12 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -698,7 +680,7 @@ func (p projBitandInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -757,16 +739,17 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -783,9 +766,12 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -799,7 +785,9 @@ func (p projBitandDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -859,14 +847,12 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -878,7 +864,7 @@ func (p projBitorInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -935,14 +921,12 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -954,7 +938,7 @@ func (p projBitorInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1011,14 +995,12 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1030,7 +1012,7 @@ func (p projBitorInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1087,14 +1069,12 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1106,7 +1086,7 @@ func (p projBitorInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1163,14 +1143,12 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1182,7 +1160,7 @@ func (p projBitorInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1239,14 +1217,12 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1258,7 +1234,7 @@ func (p projBitorInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1315,14 +1291,12 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1334,7 +1308,7 @@ func (p projBitorInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1391,14 +1365,12 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1410,7 +1382,7 @@ func (p projBitorInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1467,14 +1439,12 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1486,7 +1456,7 @@ func (p projBitorInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1545,16 +1515,17 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -1571,9 +1542,12 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -1587,7 +1561,9 @@ func (p projBitorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -1647,14 +1623,12 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1666,7 +1640,7 @@ func (p projBitxorInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1723,14 +1697,12 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1742,7 +1714,7 @@ func (p projBitxorInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1799,14 +1771,12 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1818,7 +1788,7 @@ func (p projBitxorInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1875,14 +1845,12 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1894,7 +1862,7 @@ func (p projBitxorInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -1951,14 +1919,12 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -1970,7 +1936,7 @@ func (p projBitxorInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2027,14 +1993,12 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2046,7 +2010,7 @@ func (p projBitxorInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2103,14 +2067,12 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2122,7 +2084,7 @@ func (p projBitxorInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2179,14 +2141,12 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2198,7 +2158,7 @@ func (p projBitxorInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2255,14 +2215,12 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2274,7 +2232,7 @@ func (p projBitxorInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2333,16 +2291,17 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -2359,9 +2318,12 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -2375,7 +2337,9 @@ func (p projBitxorDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -2435,14 +2399,12 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2461,7 +2423,7 @@ func (p projPlusDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2539,14 +2501,12 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2565,7 +2525,7 @@ func (p projPlusDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2643,14 +2603,12 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2669,7 +2627,7 @@ func (p projPlusDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2747,14 +2705,12 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2772,7 +2728,7 @@ func (p projPlusDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2847,14 +2803,12 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2872,7 +2826,7 @@ func (p projPlusInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -2947,14 +2901,12 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -2972,7 +2924,7 @@ func (p projPlusInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3047,14 +2999,12 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3072,7 +3022,7 @@ func (p projPlusInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3147,14 +3097,12 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3174,7 +3122,7 @@ func (p projPlusInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3257,14 +3205,12 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3287,7 +3233,7 @@ func (p projPlusInt16DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3375,14 +3321,12 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3400,7 +3344,7 @@ func (p projPlusInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3475,14 +3419,12 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3500,7 +3442,7 @@ func (p projPlusInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3575,14 +3517,12 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3600,7 +3540,7 @@ func (p projPlusInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3675,14 +3615,12 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3702,7 +3640,7 @@ func (p projPlusInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -3785,14 +3723,12 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3815,7 +3751,7 @@ func (p projPlusInt32DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3903,14 +3839,12 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -3928,7 +3862,7 @@ func (p projPlusInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4003,14 +3937,12 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4028,7 +3960,7 @@ func (p projPlusInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4103,14 +4035,12 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4128,7 +4058,7 @@ func (p projPlusInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4203,14 +4133,12 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4230,7 +4158,7 @@ func (p projPlusInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4313,14 +4241,12 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4343,7 +4269,7 @@ func (p projPlusInt64DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4431,14 +4357,12 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4453,7 +4377,7 @@ func (p projPlusFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4519,14 +4443,12 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg)
@@ -4541,7 +4463,7 @@ func (p projPlusTimestampIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4607,14 +4529,12 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(p.constArg, arg)
@@ -4629,7 +4549,7 @@ func (p projPlusIntervalTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4695,14 +4615,12 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Add(p.constArg)
@@ -4712,7 +4630,7 @@ func (p projPlusIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -4765,14 +4683,12 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4795,7 +4711,7 @@ func (p projPlusIntervalDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4885,14 +4801,12 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -4915,7 +4829,7 @@ func (p projPlusDatumIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5007,14 +4921,12 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5037,7 +4949,7 @@ func (p projPlusDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5129,14 +5041,12 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5159,7 +5069,7 @@ func (p projPlusDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5251,14 +5161,12 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5281,7 +5189,7 @@ func (p projPlusDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5371,14 +5279,12 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5397,7 +5303,7 @@ func (p projMinusDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5475,14 +5381,12 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5501,7 +5405,7 @@ func (p projMinusDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5579,14 +5483,12 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5605,7 +5507,7 @@ func (p projMinusDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5683,14 +5585,12 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5708,7 +5608,7 @@ func (p projMinusDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5783,14 +5683,12 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5808,7 +5706,7 @@ func (p projMinusInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5883,14 +5781,12 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -5908,7 +5804,7 @@ func (p projMinusInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -5983,14 +5879,12 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6008,7 +5902,7 @@ func (p projMinusInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6083,14 +5977,12 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6110,7 +6002,7 @@ func (p projMinusInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6193,14 +6085,12 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6223,7 +6113,7 @@ func (p projMinusInt16DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6311,14 +6201,12 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6336,7 +6224,7 @@ func (p projMinusInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6411,14 +6299,12 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6436,7 +6322,7 @@ func (p projMinusInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6511,14 +6397,12 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6536,7 +6420,7 @@ func (p projMinusInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6611,14 +6495,12 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6638,7 +6520,7 @@ func (p projMinusInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6721,14 +6603,12 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6751,7 +6631,7 @@ func (p projMinusInt32DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6839,14 +6719,12 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6864,7 +6742,7 @@ func (p projMinusInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -6939,14 +6817,12 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -6964,7 +6840,7 @@ func (p projMinusInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7039,14 +6915,12 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7064,7 +6938,7 @@ func (p projMinusInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7139,14 +7013,12 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7166,7 +7038,7 @@ func (p projMinusInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7249,14 +7121,12 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7279,7 +7149,7 @@ func (p projMinusInt64DatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7367,14 +7237,12 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7389,7 +7257,7 @@ func (p projMinusFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7455,14 +7323,12 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7475,7 +7341,7 @@ func (p projMinusTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7535,14 +7401,12 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Timestamp()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						t_res := duration.Add(arg, p.constArg.Mul(-1))
@@ -7557,7 +7421,7 @@ func (p projMinusTimestampIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7623,14 +7487,12 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Sub(p.constArg)
@@ -7640,7 +7502,7 @@ func (p projMinusIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -7693,14 +7555,12 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7723,7 +7583,7 @@ func (p projMinusIntervalDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7811,14 +7671,12 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7837,7 +7695,7 @@ func (p projMinusJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7913,14 +7771,12 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -7935,7 +7791,7 @@ func (p projMinusJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8001,14 +7857,12 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8023,7 +7877,7 @@ func (p projMinusJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8089,14 +7943,12 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8111,7 +7963,7 @@ func (p projMinusJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8179,16 +8031,17 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -8205,9 +8058,12 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -8221,7 +8077,9 @@ func (p projMinusDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -8283,14 +8141,12 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8313,7 +8169,7 @@ func (p projMinusDatumIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8405,14 +8261,12 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8435,7 +8289,7 @@ func (p projMinusDatumBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8525,14 +8379,12 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8555,7 +8407,7 @@ func (p projMinusDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8647,14 +8499,12 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8677,7 +8527,7 @@ func (p projMinusDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8769,14 +8619,12 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8799,7 +8647,7 @@ func (p projMinusDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8889,14 +8737,12 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -8915,7 +8761,7 @@ func (p projMultDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -8993,14 +8839,12 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9019,7 +8863,7 @@ func (p projMultDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9097,14 +8941,12 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9123,7 +8965,7 @@ func (p projMultDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9201,14 +9043,12 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9226,7 +9066,7 @@ func (p projMultDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9301,14 +9141,12 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9323,7 +9161,7 @@ func (p projMultDecimalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9389,14 +9227,12 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9422,7 +9258,7 @@ func (p projMultInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9521,14 +9357,12 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9554,7 +9388,7 @@ func (p projMultInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9653,14 +9487,12 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9686,7 +9518,7 @@ func (p projMultInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9785,14 +9617,12 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9812,7 +9642,7 @@ func (p projMultInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9893,14 +9723,12 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -9910,7 +9738,7 @@ func (p projMultInt16IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -9961,14 +9789,12 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -9994,7 +9820,7 @@ func (p projMultInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10093,14 +9919,12 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10126,7 +9950,7 @@ func (p projMultInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10225,14 +10049,12 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10258,7 +10080,7 @@ func (p projMultInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10357,14 +10179,12 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10384,7 +10204,7 @@ func (p projMultInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10465,14 +10285,12 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -10482,7 +10300,7 @@ func (p projMultInt32IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10533,14 +10351,12 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10566,7 +10382,7 @@ func (p projMultInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10665,14 +10481,12 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10698,7 +10512,7 @@ func (p projMultInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10797,14 +10611,12 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10830,7 +10642,7 @@ func (p projMultInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -10929,14 +10741,12 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -10956,7 +10766,7 @@ func (p projMultInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11037,14 +10847,12 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Mul(int64(arg))
@@ -11054,7 +10862,7 @@ func (p projMultInt64IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11105,14 +10913,12 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11127,7 +10933,7 @@ func (p projMultFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11193,14 +10999,12 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.MulFloat(float64(arg))
@@ -11210,7 +11014,7 @@ func (p projMultFloat64IntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11261,14 +11065,12 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11278,7 +11080,7 @@ func (p projMultIntervalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11329,14 +11131,12 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11346,7 +11146,7 @@ func (p projMultIntervalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11397,14 +11197,12 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.Mul(int64(p.constArg))
@@ -11414,7 +11212,7 @@ func (p projMultIntervalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11465,14 +11263,12 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = arg.MulFloat(float64(p.constArg))
@@ -11482,7 +11278,7 @@ func (p projMultIntervalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11533,14 +11329,12 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11555,7 +11349,7 @@ func (p projMultIntervalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11621,14 +11415,12 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11651,7 +11443,7 @@ func (p projDivDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11741,14 +11533,12 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11771,7 +11561,7 @@ func (p projDivDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11861,14 +11651,12 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -11891,7 +11679,7 @@ func (p projDivDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -11981,14 +11769,12 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12010,7 +11796,7 @@ func (p projDivDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12097,14 +11883,12 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12126,7 +11910,7 @@ func (p projDivInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12213,14 +11997,12 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12242,7 +12024,7 @@ func (p projDivInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12329,14 +12111,12 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12358,7 +12138,7 @@ func (p projDivInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12445,14 +12225,12 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12476,7 +12254,7 @@ func (p projDivInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12569,14 +12347,12 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12598,7 +12374,7 @@ func (p projDivInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12685,14 +12461,12 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12714,7 +12488,7 @@ func (p projDivInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12801,14 +12575,12 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12830,7 +12602,7 @@ func (p projDivInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -12917,14 +12689,12 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -12948,7 +12718,7 @@ func (p projDivInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13041,14 +12811,12 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13070,7 +12838,7 @@ func (p projDivInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13157,14 +12925,12 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13186,7 +12952,7 @@ func (p projDivInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13273,14 +13039,12 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13302,7 +13066,7 @@ func (p projDivInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13389,14 +13153,12 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13420,7 +13182,7 @@ func (p projDivInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13513,14 +13275,12 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13539,7 +13299,7 @@ func (p projDivFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13617,14 +13377,12 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13638,7 +13396,7 @@ func (p projDivIntervalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13701,14 +13459,12 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13722,7 +13478,7 @@ func (p projDivIntervalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13785,14 +13541,12 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13806,7 +13560,7 @@ func (p projDivIntervalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13869,14 +13623,12 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Interval()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13890,7 +13642,7 @@ func (p projDivIntervalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -13953,14 +13705,12 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -13983,7 +13733,7 @@ func (p projFloorDivDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14073,14 +13823,12 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14103,7 +13851,7 @@ func (p projFloorDivDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14193,14 +13941,12 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14223,7 +13969,7 @@ func (p projFloorDivDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14313,14 +14059,12 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14342,7 +14086,7 @@ func (p projFloorDivDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14429,14 +14173,12 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14453,7 +14195,7 @@ func (p projFloorDivInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14525,14 +14267,12 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14549,7 +14289,7 @@ func (p projFloorDivInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14621,14 +14361,12 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14645,7 +14383,7 @@ func (p projFloorDivInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14717,14 +14455,12 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14748,7 +14484,7 @@ func (p projFloorDivInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14841,14 +14577,12 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14865,7 +14599,7 @@ func (p projFloorDivInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -14937,14 +14671,12 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -14961,7 +14693,7 @@ func (p projFloorDivInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15033,14 +14765,12 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15057,7 +14787,7 @@ func (p projFloorDivInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15129,14 +14859,12 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15160,7 +14888,7 @@ func (p projFloorDivInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15253,14 +14981,12 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15277,7 +15003,7 @@ func (p projFloorDivInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15349,14 +15075,12 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15373,7 +15097,7 @@ func (p projFloorDivInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15445,14 +15169,12 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15469,7 +15191,7 @@ func (p projFloorDivInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15541,14 +15263,12 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15572,7 +15292,7 @@ func (p projFloorDivInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15665,14 +15385,12 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15691,7 +15409,7 @@ func (p projFloorDivFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15769,14 +15487,12 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15799,7 +15515,7 @@ func (p projModDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -15889,14 +15605,12 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -15919,7 +15633,7 @@ func (p projModDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16009,14 +15723,12 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16039,7 +15751,7 @@ func (p projModDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16129,14 +15841,12 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16158,7 +15868,7 @@ func (p projModDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16245,14 +15955,12 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16269,7 +15977,7 @@ func (p projModInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16341,14 +16049,12 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16365,7 +16071,7 @@ func (p projModInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16437,14 +16143,12 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16461,7 +16165,7 @@ func (p projModInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16533,14 +16237,12 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16564,7 +16266,7 @@ func (p projModInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16657,14 +16359,12 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16681,7 +16381,7 @@ func (p projModInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16753,14 +16453,12 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16777,7 +16475,7 @@ func (p projModInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16849,14 +16547,12 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16873,7 +16569,7 @@ func (p projModInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -16945,14 +16641,12 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -16976,7 +16670,7 @@ func (p projModInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17069,14 +16763,12 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17093,7 +16785,7 @@ func (p projModInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17165,14 +16857,12 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17189,7 +16879,7 @@ func (p projModInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17261,14 +16951,12 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17285,7 +16973,7 @@ func (p projModInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17357,14 +17045,12 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17388,7 +17074,7 @@ func (p projModInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17481,14 +17167,12 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17507,7 +17191,7 @@ func (p projModFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17585,14 +17269,12 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17611,7 +17293,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17689,14 +17371,12 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17715,7 +17395,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17793,14 +17473,12 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17819,7 +17497,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17897,14 +17575,12 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -17922,7 +17598,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -17997,14 +17673,12 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18028,7 +17702,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18121,14 +17795,12 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18152,7 +17824,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18245,14 +17917,12 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18276,7 +17946,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18369,14 +18039,12 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18396,7 +18064,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18477,14 +18145,12 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18508,7 +18174,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18601,14 +18267,12 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18632,7 +18296,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18725,14 +18389,12 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18756,7 +18418,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18849,14 +18511,12 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18876,7 +18536,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -18957,14 +18617,12 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -18988,7 +18646,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19081,14 +18739,12 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19112,7 +18768,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19205,14 +18861,12 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19236,7 +18890,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19329,14 +18983,12 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Decimal()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19356,7 +19008,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19437,14 +19089,12 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Float64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19459,7 +19109,7 @@ func (p projPowFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19525,14 +19175,12 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19549,7 +19197,7 @@ func (p projConcatBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19619,14 +19267,12 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19642,7 +19288,7 @@ func (p projConcatJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19711,16 +19357,17 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -19737,9 +19384,12 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						_res, err := eval.BinaryOp(_overloadHelper.EvalCtx, _overloadHelper.BinOp, arg.(tree.Datum), p.constArg.(tree.Datum))
 						if err != nil {
@@ -19753,7 +19403,9 @@ func (p projConcatDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -19813,14 +19465,12 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19838,7 +19488,7 @@ func (p projLShiftInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -19913,14 +19563,12 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -19938,7 +19586,7 @@ func (p projLShiftInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20013,14 +19661,12 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20038,7 +19684,7 @@ func (p projLShiftInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20113,14 +19759,12 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20138,7 +19782,7 @@ func (p projLShiftInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20213,14 +19857,12 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20238,7 +19880,7 @@ func (p projLShiftInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20313,14 +19955,12 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20338,7 +19978,7 @@ func (p projLShiftInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20413,14 +20053,12 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20438,7 +20076,7 @@ func (p projLShiftInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20513,14 +20151,12 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20538,7 +20174,7 @@ func (p projLShiftInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20613,14 +20249,12 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20638,7 +20272,7 @@ func (p projLShiftInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20715,14 +20349,12 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20745,7 +20377,7 @@ func (p projLShiftDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20837,14 +20469,12 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20867,7 +20497,7 @@ func (p projLShiftDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -20959,14 +20589,12 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -20989,7 +20617,7 @@ func (p projLShiftDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21079,14 +20707,12 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21104,7 +20730,7 @@ func (p projRShiftInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21179,14 +20805,12 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21204,7 +20828,7 @@ func (p projRShiftInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21279,14 +20903,12 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21304,7 +20926,7 @@ func (p projRShiftInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21379,14 +21001,12 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21404,7 +21024,7 @@ func (p projRShiftInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21479,14 +21099,12 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21504,7 +21122,7 @@ func (p projRShiftInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21579,14 +21197,12 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21604,7 +21220,7 @@ func (p projRShiftInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21679,14 +21295,12 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21704,7 +21318,7 @@ func (p projRShiftInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21779,14 +21393,12 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21804,7 +21416,7 @@ func (p projRShiftInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21879,14 +21491,12 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Int64()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -21904,7 +21514,7 @@ func (p projRShiftInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -21981,14 +21591,12 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22011,7 +21619,7 @@ func (p projRShiftDatumInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22103,14 +21711,12 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22133,7 +21739,7 @@ func (p projRShiftDatumInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22225,14 +21831,12 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Datum()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22255,7 +21859,7 @@ func (p projRShiftDatumInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22345,14 +21949,12 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22374,7 +21976,7 @@ func (p projJSONFetchValJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22459,14 +22061,12 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22485,7 +22085,7 @@ func (p projJSONFetchValJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22563,14 +22163,12 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22589,7 +22187,7 @@ func (p projJSONFetchValJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22667,14 +22265,12 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22693,7 +22289,7 @@ func (p projJSONFetchValJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -22771,14 +22367,12 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22809,7 +22403,7 @@ func (p projJSONFetchTextJSONBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22921,14 +22515,12 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -22956,7 +22548,7 @@ func (p projJSONFetchTextJSONInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23061,14 +22653,12 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23096,7 +22686,7 @@ func (p projJSONFetchTextJSONInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23201,14 +22791,12 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23236,7 +22824,7 @@ func (p projJSONFetchTextJSONInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23341,14 +22929,12 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.JSON()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23367,7 +22953,7 @@ func (p projJSONFetchValPathJSONDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23443,14 +23029,12 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bytes()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23479,7 +23063,7 @@ func (p projJSONFetchTextPathJSONDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23585,14 +23169,12 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23616,7 +23198,7 @@ func (p projEQBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23709,14 +23291,12 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23732,7 +23312,7 @@ func (p projEQBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23799,14 +23379,12 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23828,7 +23406,7 @@ func (p projEQDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -23915,14 +23493,12 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -23944,7 +23520,7 @@ func (p projEQDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24031,14 +23607,12 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24060,7 +23634,7 @@ func (p projEQDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24147,14 +23721,12 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24178,7 +23750,7 @@ func (p projEQDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24271,14 +23843,12 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24294,7 +23864,7 @@ func (p projEQDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24363,14 +23933,12 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24397,7 +23965,7 @@ func (p projEQInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24499,14 +24067,12 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24533,7 +24099,7 @@ func (p projEQInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24635,14 +24201,12 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24669,7 +24233,7 @@ func (p projEQInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24771,14 +24335,12 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24813,7 +24375,7 @@ func (p projEQInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -24939,14 +24501,12 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -24968,7 +24528,7 @@ func (p projEQInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25055,14 +24615,12 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25089,7 +24647,7 @@ func (p projEQInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25191,14 +24749,12 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25225,7 +24781,7 @@ func (p projEQInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25327,14 +24883,12 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25361,7 +24915,7 @@ func (p projEQInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25463,14 +25017,12 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25505,7 +25057,7 @@ func (p projEQInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25631,14 +25183,12 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25660,7 +25210,7 @@ func (p projEQInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25747,14 +25297,12 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25781,7 +25329,7 @@ func (p projEQInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -25883,14 +25431,12 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -25917,7 +25463,7 @@ func (p projEQInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26019,14 +25565,12 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26053,7 +25597,7 @@ func (p projEQInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26155,14 +25699,12 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26197,7 +25739,7 @@ func (p projEQInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26323,14 +25865,12 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26352,7 +25892,7 @@ func (p projEQInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26439,14 +25979,12 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26481,7 +26019,7 @@ func (p projEQFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26607,14 +26145,12 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26649,7 +26185,7 @@ func (p projEQFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26775,14 +26311,12 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26817,7 +26351,7 @@ func (p projEQFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -26943,14 +26477,12 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -26985,7 +26517,7 @@ func (p projEQFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27111,14 +26643,12 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27142,7 +26672,7 @@ func (p projEQFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27235,14 +26765,12 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27265,7 +26793,7 @@ func (p projEQTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27355,14 +26883,12 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27378,7 +26904,7 @@ func (p projEQIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27447,14 +26973,12 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27476,7 +27000,7 @@ func (p projEQJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27561,16 +27085,17 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -27586,9 +27111,12 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -27601,7 +27129,9 @@ func (p projEQDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -27659,14 +27189,12 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27690,7 +27218,7 @@ func (p projNEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27783,14 +27311,12 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27806,7 +27332,7 @@ func (p projNEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27873,14 +27399,12 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -27902,7 +27426,7 @@ func (p projNEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -27989,14 +27513,12 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28018,7 +27540,7 @@ func (p projNEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28105,14 +27627,12 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28134,7 +27654,7 @@ func (p projNEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28221,14 +27741,12 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28252,7 +27770,7 @@ func (p projNEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28345,14 +27863,12 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28368,7 +27884,7 @@ func (p projNEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28437,14 +27953,12 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28471,7 +27985,7 @@ func (p projNEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28573,14 +28087,12 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28607,7 +28119,7 @@ func (p projNEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28709,14 +28221,12 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28743,7 +28253,7 @@ func (p projNEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -28845,14 +28355,12 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -28887,7 +28395,7 @@ func (p projNEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29013,14 +28521,12 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29042,7 +28548,7 @@ func (p projNEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29129,14 +28635,12 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29163,7 +28667,7 @@ func (p projNEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29265,14 +28769,12 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29299,7 +28801,7 @@ func (p projNEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29401,14 +28903,12 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29435,7 +28935,7 @@ func (p projNEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29537,14 +29037,12 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29579,7 +29077,7 @@ func (p projNEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29705,14 +29203,12 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29734,7 +29230,7 @@ func (p projNEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29821,14 +29317,12 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29855,7 +29349,7 @@ func (p projNEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -29957,14 +29451,12 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -29991,7 +29483,7 @@ func (p projNEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30093,14 +29585,12 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30127,7 +29617,7 @@ func (p projNEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30229,14 +29719,12 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30271,7 +29759,7 @@ func (p projNEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30397,14 +29885,12 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30426,7 +29912,7 @@ func (p projNEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30513,14 +29999,12 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30555,7 +30039,7 @@ func (p projNEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30681,14 +30165,12 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30723,7 +30205,7 @@ func (p projNEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -30849,14 +30331,12 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -30891,7 +30371,7 @@ func (p projNEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31017,14 +30497,12 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31059,7 +30537,7 @@ func (p projNEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31185,14 +30663,12 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31216,7 +30692,7 @@ func (p projNEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31309,14 +30785,12 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31339,7 +30813,7 @@ func (p projNETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31429,14 +30903,12 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31452,7 +30924,7 @@ func (p projNEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31521,14 +30993,12 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31550,7 +31020,7 @@ func (p projNEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31635,16 +31105,17 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -31660,9 +31131,12 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -31675,7 +31149,9 @@ func (p projNEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -31733,14 +31209,12 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31764,7 +31238,7 @@ func (p projLTBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -31857,14 +31331,12 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31880,7 +31352,7 @@ func (p projLTBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31947,14 +31419,12 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -31976,7 +31446,7 @@ func (p projLTDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32063,14 +31533,12 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32092,7 +31560,7 @@ func (p projLTDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32179,14 +31647,12 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32208,7 +31674,7 @@ func (p projLTDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32295,14 +31761,12 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32326,7 +31790,7 @@ func (p projLTDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32419,14 +31883,12 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32442,7 +31904,7 @@ func (p projLTDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32511,14 +31973,12 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32545,7 +32005,7 @@ func (p projLTInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32647,14 +32107,12 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32681,7 +32139,7 @@ func (p projLTInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32783,14 +32241,12 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32817,7 +32273,7 @@ func (p projLTInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -32919,14 +32375,12 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -32961,7 +32415,7 @@ func (p projLTInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33087,14 +32541,12 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33116,7 +32568,7 @@ func (p projLTInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33203,14 +32655,12 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33237,7 +32687,7 @@ func (p projLTInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33339,14 +32789,12 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33373,7 +32821,7 @@ func (p projLTInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33475,14 +32923,12 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33509,7 +32955,7 @@ func (p projLTInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33611,14 +33057,12 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33653,7 +33097,7 @@ func (p projLTInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33779,14 +33223,12 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33808,7 +33250,7 @@ func (p projLTInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -33895,14 +33337,12 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -33929,7 +33369,7 @@ func (p projLTInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34031,14 +33471,12 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34065,7 +33503,7 @@ func (p projLTInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34167,14 +33605,12 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34201,7 +33637,7 @@ func (p projLTInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34303,14 +33739,12 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34345,7 +33779,7 @@ func (p projLTInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34471,14 +33905,12 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34500,7 +33932,7 @@ func (p projLTInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34587,14 +34019,12 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34629,7 +34059,7 @@ func (p projLTFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34755,14 +34185,12 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34797,7 +34225,7 @@ func (p projLTFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -34923,14 +34351,12 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -34965,7 +34391,7 @@ func (p projLTFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35091,14 +34517,12 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35133,7 +34557,7 @@ func (p projLTFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35259,14 +34683,12 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35290,7 +34712,7 @@ func (p projLTFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35383,14 +34805,12 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35413,7 +34833,7 @@ func (p projLTTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35503,14 +34923,12 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35526,7 +34944,7 @@ func (p projLTIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35595,14 +35013,12 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35624,7 +35040,7 @@ func (p projLTJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35709,16 +35125,17 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -35734,9 +35151,12 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -35749,7 +35169,9 @@ func (p projLTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -35807,14 +35229,12 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35838,7 +35258,7 @@ func (p projLEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -35931,14 +35351,12 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -35954,7 +35372,7 @@ func (p projLEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36021,14 +35439,12 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36050,7 +35466,7 @@ func (p projLEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36137,14 +35553,12 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36166,7 +35580,7 @@ func (p projLEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36253,14 +35667,12 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36282,7 +35694,7 @@ func (p projLEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36369,14 +35781,12 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36400,7 +35810,7 @@ func (p projLEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36493,14 +35903,12 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36516,7 +35924,7 @@ func (p projLEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36585,14 +35993,12 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36619,7 +36025,7 @@ func (p projLEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36721,14 +36127,12 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36755,7 +36159,7 @@ func (p projLEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36857,14 +36261,12 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -36891,7 +36293,7 @@ func (p projLEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -36993,14 +36395,12 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37035,7 +36435,7 @@ func (p projLEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37161,14 +36561,12 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37190,7 +36588,7 @@ func (p projLEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37277,14 +36675,12 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37311,7 +36707,7 @@ func (p projLEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37413,14 +36809,12 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37447,7 +36841,7 @@ func (p projLEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37549,14 +36943,12 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37583,7 +36975,7 @@ func (p projLEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37685,14 +37077,12 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37727,7 +37117,7 @@ func (p projLEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37853,14 +37243,12 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -37882,7 +37270,7 @@ func (p projLEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -37969,14 +37357,12 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38003,7 +37389,7 @@ func (p projLEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38105,14 +37491,12 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38139,7 +37523,7 @@ func (p projLEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38241,14 +37625,12 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38275,7 +37657,7 @@ func (p projLEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38377,14 +37759,12 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38419,7 +37799,7 @@ func (p projLEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38545,14 +37925,12 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38574,7 +37952,7 @@ func (p projLEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38661,14 +38039,12 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38703,7 +38079,7 @@ func (p projLEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38829,14 +38205,12 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -38871,7 +38245,7 @@ func (p projLEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -38997,14 +38371,12 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39039,7 +38411,7 @@ func (p projLEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39165,14 +38537,12 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39207,7 +38577,7 @@ func (p projLEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39333,14 +38703,12 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39364,7 +38732,7 @@ func (p projLEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39457,14 +38825,12 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39487,7 +38853,7 @@ func (p projLETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39577,14 +38943,12 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39600,7 +38964,7 @@ func (p projLEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -39669,14 +39033,12 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39698,7 +39060,7 @@ func (p projLEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39783,16 +39145,17 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -39808,9 +39171,12 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -39823,7 +39189,9 @@ func (p projLEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -39881,14 +39249,12 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -39912,7 +39278,7 @@ func (p projGTBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40005,14 +39371,12 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40028,7 +39392,7 @@ func (p projGTBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40095,14 +39459,12 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40124,7 +39486,7 @@ func (p projGTDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40211,14 +39573,12 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40240,7 +39600,7 @@ func (p projGTDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40327,14 +39687,12 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40356,7 +39714,7 @@ func (p projGTDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40443,14 +39801,12 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40474,7 +39830,7 @@ func (p projGTDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40567,14 +39923,12 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40590,7 +39944,7 @@ func (p projGTDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40659,14 +40013,12 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40693,7 +40045,7 @@ func (p projGTInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40795,14 +40147,12 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40829,7 +40179,7 @@ func (p projGTInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -40931,14 +40281,12 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -40965,7 +40313,7 @@ func (p projGTInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41067,14 +40415,12 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41109,7 +40455,7 @@ func (p projGTInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41235,14 +40581,12 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41264,7 +40608,7 @@ func (p projGTInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41351,14 +40695,12 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41385,7 +40727,7 @@ func (p projGTInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41487,14 +40829,12 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41521,7 +40861,7 @@ func (p projGTInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41623,14 +40963,12 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41657,7 +40995,7 @@ func (p projGTInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41759,14 +41097,12 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41801,7 +41137,7 @@ func (p projGTInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -41927,14 +41263,12 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -41956,7 +41290,7 @@ func (p projGTInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42043,14 +41377,12 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42077,7 +41409,7 @@ func (p projGTInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42179,14 +41511,12 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42213,7 +41543,7 @@ func (p projGTInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42315,14 +41645,12 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42349,7 +41677,7 @@ func (p projGTInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42451,14 +41779,12 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42493,7 +41819,7 @@ func (p projGTInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42619,14 +41945,12 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42648,7 +41972,7 @@ func (p projGTInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42735,14 +42059,12 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42777,7 +42099,7 @@ func (p projGTFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -42903,14 +42225,12 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -42945,7 +42265,7 @@ func (p projGTFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43071,14 +42391,12 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43113,7 +42431,7 @@ func (p projGTFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43239,14 +42557,12 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43281,7 +42597,7 @@ func (p projGTFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43407,14 +42723,12 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43438,7 +42752,7 @@ func (p projGTFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43531,14 +42845,12 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43561,7 +42873,7 @@ func (p projGTTimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43651,14 +42963,12 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43674,7 +42984,7 @@ func (p projGTIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -43743,14 +43053,12 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43772,7 +43080,7 @@ func (p projGTJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43857,16 +43165,17 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -43882,9 +43191,12 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -43897,7 +43209,9 @@ func (p projGTDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
@@ -43955,14 +43269,12 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -43986,7 +43298,7 @@ func (p projGEBoolBoolConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44079,14 +43391,12 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44102,7 +43412,7 @@ func (p projGEBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44169,14 +43479,12 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44198,7 +43506,7 @@ func (p projGEDecimalInt16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44285,14 +43593,12 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44314,7 +43620,7 @@ func (p projGEDecimalInt32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44401,14 +43707,12 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44430,7 +43734,7 @@ func (p projGEDecimalInt64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44517,14 +43821,12 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44548,7 +43850,7 @@ func (p projGEDecimalFloat64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44641,14 +43943,12 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44664,7 +43964,7 @@ func (p projGEDecimalDecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44733,14 +44033,12 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44767,7 +44065,7 @@ func (p projGEInt16Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -44869,14 +44167,12 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -44903,7 +44199,7 @@ func (p projGEInt16Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45005,14 +44301,12 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45039,7 +44333,7 @@ func (p projGEInt16Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45141,14 +44435,12 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45183,7 +44475,7 @@ func (p projGEInt16Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45309,14 +44601,12 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45338,7 +44628,7 @@ func (p projGEInt16DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45425,14 +44715,12 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45459,7 +44747,7 @@ func (p projGEInt32Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45561,14 +44849,12 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45595,7 +44881,7 @@ func (p projGEInt32Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45697,14 +44983,12 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45731,7 +45015,7 @@ func (p projGEInt32Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -45833,14 +45117,12 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -45875,7 +45157,7 @@ func (p projGEInt32Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46001,14 +45283,12 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46030,7 +45310,7 @@ func (p projGEInt32DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46117,14 +45397,12 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46151,7 +45429,7 @@ func (p projGEInt64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46253,14 +45531,12 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46287,7 +45563,7 @@ func (p projGEInt64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46389,14 +45665,12 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46423,7 +45697,7 @@ func (p projGEInt64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46525,14 +45799,12 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46567,7 +45839,7 @@ func (p projGEInt64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46693,14 +45965,12 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46722,7 +45992,7 @@ func (p projGEInt64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46809,14 +46079,12 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -46851,7 +46119,7 @@ func (p projGEFloat64Int16ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -46977,14 +46245,12 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47019,7 +46285,7 @@ func (p projGEFloat64Int32ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47145,14 +46411,12 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47187,7 +46451,7 @@ func (p projGEFloat64Int64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47313,14 +46577,12 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47355,7 +46617,7 @@ func (p projGEFloat64Float64ConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47481,14 +46743,12 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47512,7 +46772,7 @@ func (p projGEFloat64DecimalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47605,14 +46865,12 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47635,7 +46893,7 @@ func (p projGETimestampTimestampConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47725,14 +46983,12 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47748,7 +47004,7 @@ func (p projGEIntervalIntervalConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						//gcassert:bce
 						arg := col.Get(i)
@@ -47817,14 +47073,12 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47846,7 +47100,7 @@ func (p projGEJSONJSONConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -47931,16 +47185,17 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls() && !p.calledOnNullInput
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -47956,9 +47211,12 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
+						if colNulls.NullAt(i) {
+							arg = tree.DNull
+						}
 
 						{
 							var cmpResult int
@@ -47971,7 +47229,9 @@ func (p projGEDatumDatumConstOp) Next() coldata.Batch {
 					}
 				}
 			}
-			projVec.SetNulls(_outNulls.Or(*colNulls))
+			if !p.calledOnNullInput {
+				projVec.SetNulls(_outNulls.Or(*colNulls))
+			}
 		} else {
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]

--- a/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_like_ops.eg.go
@@ -44,14 +44,12 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -64,7 +62,7 @@ func (p projPrefixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -126,14 +124,12 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -146,7 +142,7 @@ func (p projSuffixBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -208,14 +204,12 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -228,7 +222,7 @@ func (p projContainsBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						if _caseInsensitive {
@@ -290,14 +284,12 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -322,7 +314,7 @@ func (p projSkeletonBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 
@@ -418,14 +410,12 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 		col := col
 		projCol := projVec.Bool()
 		_outNulls := projVec.Nulls()
-
-		hasNullsAndNotCalledOnNullInput := vec.Nulls().MaybeHasNulls()
-		if hasNullsAndNotCalledOnNullInput {
+		if vec.Nulls().MaybeHasNulls() {
 			colNulls := vec.Nulls()
 			if sel := batch.Selection(); sel != nil {
 				sel = sel[:n]
 				for _, i := range sel {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Match(arg) != _negate
@@ -435,7 +425,7 @@ func (p projRegexpBytesBytesConstOp) Next() coldata.Batch {
 				_ = projCol.Get(n - 1)
 				_ = col.Get(n - 1)
 				for i := 0; i < n; i++ {
-					if !colNulls.NullAt(i) {
+					if p.calledOnNullInput || !colNulls.NullAt(i) {
 						// We only want to perform the projection operation if the value is not null.
 						arg := col.Get(i)
 						projCol[i] = p.constArg.Match(arg) != _negate

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -2272,3 +2272,25 @@ SELECT ('foo'::STRING || col::STRING[])::STRING[] FROM (VALUES (ARRAY['bar':::ST
 ----
 {foo,bar}
 {foo,baz}
+
+# Regression test for #87919 - datum concatenation should be performed for
+# null arguments.
+statement ok
+CREATE TABLE t1_87919 (
+  a  INT
+);
+CREATE TABLE t2_87919 (
+  b INT,
+  c TIME[]
+);
+INSERT INTO t1_87919 (a) VALUES (NULL);
+INSERT INTO t2_87919 (c) VALUES (ARRAY['03:23:06.042923']);
+
+query T rowsort
+SELECT ('09:20:35.19023'::TIME || c)::TIME[] AS col_25551
+FROM t1_87919
+FULL JOIN t2_87919 ON a = b
+ORDER BY a;
+----
+{09:20:35.19023}
+{09:20:35.19023,03:23:06.042923}


### PR DESCRIPTION
Most projections skip rows for which one or more arguments are null, and just output a null for those rows. However, some projections can actually accept null arguments. Previously, we were using the values from the vec even when the `Nulls` bitmap was set for that row, which invalidates the data in the vec for that row. This could cause a non-null value to be unexpectedly concatenated to an array when an argument was null (nothing should be added to the array in this case).

This commit modifies the projection operators that operate on datum-backed vectors to explicitly set the argument to `tree.DNull` in the case when the `Nulls` bitmap is set. This ensures that the projection is not performed with the invalid (and arbitrary) value in the datum vec at that index.

Fixes #87919

Release note (bug fix): Fixed a bug in `Concat` projection operators for arrays that could cause non-null values to be added to the array when one of the arguments was null.