### PR TITLE
kvserver: fix flaky test for consistency checks

### DIFF
--- a/pkg/kv/kvserver/replica_consistency_test.go
+++ b/pkg/kv/kvserver/replica_consistency_test.go
@@ -124,8 +124,10 @@ func TestGetChecksumNotSuccessfulExitConditions(t *testing.T) {
 
 	// Context is canceled during the initial waiting.
 	id = uuid.FastMakeV4()
+	ctx, cancel = context.WithCancel(context.Background())
+	cancel()
 	rc, err = tc.repl.getChecksum(ctx, id)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.ErrorIs(t, err, context.Canceled)
 	require.Nil(t, rc.Checksum)
 	requireChecksumTaskNotStarted(id)
 }


### PR DESCRIPTION
There was a race in selecting between a canceled context.Done and 0-time timer.

Fixes #88133

Release justification: flaky test fix
Release note: None