### PR TITLE
kvnemesis: store and assert on presence of execution  timestamp

### DIFF
--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -149,6 +149,7 @@ message Result {
   bytes value = 4;
   // Only set if Type is ResultType_Values. The RawBytes of a roachpb.Value.
   repeated KeyValue values = 5 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp optional_timestamp = 6 [(gogoproto.nullable) = false];
 }
 
 message Step {


### PR DESCRIPTION
Only review the last commit here, the others are https://github.com/cockroachdb/cockroach/pull/87877.

----

We currently don't support non-transactional `DeleteRange` because
we want to be able to match up its deletion tombstones with it, but
weren't able to retrieve its execution timestamp.

This is possible though, and in fact it's possible for all MVCC-aware
operations. Rather than plumbing something one-off for DeleteRange,
add a `OptionalTimestamp` field to `Result` and populate it for all
MVCC-aware operations.

This will enable further simplifications in the future, including
addressing the following TODO:

https://github.com/cockroachdb/cockroach/blob/7cde315da539fe3d790f546a1ddde6cc882fca6b/pkg/kv/kvnemesis/validator.go#L43-L46

Release note: None