### PR TITLE
ui: insights transaction details support multiple blocking transactions

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -38,15 +38,8 @@ export type TransactionInsightEvent = {
   execType: InsightExecEnum;
 };
 
-export type TransactionInsightEventDetails = {
-  executionID: string;
-  queries: string[];
-  insights: Insight[];
-  startTime: Moment;
-  elapsedTime: number;
-  contentionThreshold: number;
-  application: string;
-  fingerprintID: string;
+export type BlockedContentionDetails = {
+  collectionTimeStamp: Moment;
   blockingExecutionID: string;
   blockingFingerprintID: string;
   blockingQueries: string[];
@@ -55,6 +48,19 @@ export type TransactionInsightEventDetails = {
   databaseName: string;
   tableName: string;
   indexName: string;
+  contentionTimeMs: number;
+};
+
+export type TransactionInsightEventDetails = {
+  executionID: string;
+  queries: string[];
+  insights: Insight[];
+  startTime: Moment;
+  totalContentionTime: number;
+  contentionThreshold: number;
+  application: string;
+  fingerprintID: string;
+  blockingContentionDetails: BlockedContentionDetails[];
   execType: InsightExecEnum;
 };
 
@@ -97,7 +103,11 @@ export type EventExecution = {
   fingerprintID: string;
   queries: string[];
   startTime: Moment;
-  elapsedTime: number;
+  contentionTimeMs: number;
+  schemaName: string;
+  databaseName: string;
+  tableName: string;
+  indexName: string;
   execType: InsightExecEnum;
 };
 

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/insightDetailsTables.tsx
@@ -42,16 +42,40 @@ export function makeInsightDetailsColumns(
       sort: (item: EventExecution) => item.queries.length,
     },
     {
-      name: "startTime",
-      title: insightsTableTitles.startTime(execType),
+      name: "contentionStartTime",
+      title: insightsTableTitles.contentionStartTime(execType),
       cell: (item: EventExecution) => item.startTime.format(DATE_FORMAT),
       sort: (item: EventExecution) => item.startTime.unix(),
     },
     {
-      name: "elapsedTime",
-      title: insightsTableTitles.elapsedTime(execType),
-      cell: (item: EventExecution) => Duration(item.elapsedTime * 1e6),
-      sort: (item: EventExecution) => item.elapsedTime,
+      name: "contention",
+      title: insightsTableTitles.contention(execType),
+      cell: (item: EventExecution) => Duration(item.contentionTimeMs * 1e6),
+      sort: (item: EventExecution) => item.contentionTimeMs,
+    },
+    {
+      name: "schemaName",
+      title: insightsTableTitles.schemaName(execType),
+      cell: (item: EventExecution) => item.schemaName,
+      sort: (item: EventExecution) => item.schemaName,
+    },
+    {
+      name: "databaseName",
+      title: insightsTableTitles.databaseName(execType),
+      cell: (item: EventExecution) => item.databaseName,
+      sort: (item: EventExecution) => item.databaseName,
+    },
+    {
+      name: "tableName",
+      title: insightsTableTitles.tableName(execType),
+      cell: (item: EventExecution) => item.tableName,
+      sort: (item: EventExecution) => item.tableName,
+    },
+    {
+      name: "indexName",
+      title: insightsTableTitles.indexName(execType),
+      cell: (item: EventExecution) => item.indexName,
+      sort: (item: EventExecution) => item.indexName,
     },
   ];
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -27,7 +27,12 @@ export const insightsColumnLabels = {
   numRetries: "Retries",
   isFullScan: "Full Scan",
   contention: "Contention Time",
+  contentionStartTime: "Contention Start Time (UTC)",
   rowsProcessed: "Rows Processed",
+  schemaName: "Schema Name",
+  databaseName: "Database Name",
+  tableName: "Table Name",
+  indexName: "Index Name",
 };
 
 export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
@@ -99,6 +104,12 @@ export const insightsTableTitles: InsightsTableTitleType = {
       "startTime",
     );
   },
+  contentionStartTime: (execType: InsightExecEnum) => {
+    return makeToolTip(
+      <p>The timestamp at which contention was detected for the {execType}.</p>,
+      "contentionStartTime",
+    );
+  },
   elapsedTime: (execType: InsightExecEnum) => {
     return makeToolTip(
       <p>The time elapsed since the {execType} started execution.</p>,
@@ -110,6 +121,21 @@ export const insightsTableTitles: InsightsTableTitleType = {
       <p>The user that started the {execType}.</p>,
       "username",
     );
+  },
+  schemaName: (execType: InsightExecEnum) => {
+    return makeToolTip(<p>The name of the contended schema.</p>, "schemaName");
+  },
+  databaseName: (execType: InsightExecEnum) => {
+    return makeToolTip(
+      <p>The name of the contended database.</p>,
+      "databaseName",
+    );
+  },
+  tableName: (execType: InsightExecEnum) => {
+    return makeToolTip(<p>The name of the contended table.</p>, "tableName");
+  },
+  indexName: (execType: InsightExecEnum) => {
+    return makeToolTip(<p>The name of the contended index.</p>, "indexName");
   },
   applicationName: (execType: InsightExecEnum) => {
     return makeToolTip(


### PR DESCRIPTION
This adds support for multiple blocking transactions for a single waiting transaction. The cards were merged into the table, and the data was piped through to show multiple rows. The total contention time was also fixed to aggregate the contention time instead of just picking the latest.

before:
https://loom.com/share/0384ed937a344e2fb0105fefbc313acb

after:
https://www.loom.com/share/78e906f50a694cd59ac893ddb9c2239a

closes #88264

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: (ui change): Add support for multiple
 blocking transaction on insights transaction
 details page. Merged the cards into the table,
 and fixed the total contention time.