### PR TITLE
cli/sql: increase maxHistEntries

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2164,7 +2164,7 @@ func (c *cliState) configurePreShellDefaults(
 		// anyone. We do prefer a limit however (as opposed to no limit at
 		// all), to prevent abnormal situation where a history runs into
 		// megabytes and starts slowing down the shell.
-		const maxHistEntries = 1000
+		const maxHistEntries = 10000
 
 		c.ins.SetCompleter(c)
 		if err := c.ins.UseHistory(maxHistEntries, true /*dedup*/); err != nil {


### PR DESCRIPTION
As discussed this morning.

In light of PR #88272, we don't need the limit to be as low as 1000. This commit increases it back to 10000, which is the common default in unix shells and the screen/tmux utilities.
