### PR TITLE
nightlies: disable random backup/restore during logictests

### DIFF
--- a/build/teamcity/cockroach/nightlies/sqllogic_backup_restore_impl.sh
+++ b/build/teamcity/cockroach/nightlies/sqllogic_backup_restore_impl.sh
@@ -33,7 +33,7 @@ for config in "${configs[@]}"; do
 $BAZEL_BIN/pkg/cmd/bazci/bazci_/bazci test -- --config=ci \
     //pkg/ccl/logictestccl/tests/$config/... \
     --test_arg=-show-sql \
-    --test_env=COCKROACH_LOGIC_TEST_BACKUP_RESTORE_PROBABILITY=0.5 \
+    --test_env=COCKROACH_LOGIC_TEST_BACKUP_RESTORE_PROBABILITY=0.0 \
     --test_env=GO_TEST_WRAP_TESTV=1 \
     --test_env=GO_TEST_WRAP=1 \
     --test_env=GO_TEST_JSON_OUTPUT_FILE=$GO_TEST_JSON_OUTPUT_FILE.$config \


### PR DESCRIPTION
We have a long tail of failures to investigate:
https://teamcity.cockroachdb.com/viewLog.html?buildId=6559490&buildTypeId=Cockroach_Nightlies_SqlLogicBackupRestore

We should do this before we allow the github poster to open numerous issues on every nightly run.

Release note: None