### PR TITLE
kv: remove ConditionalPutRequest.DeprecatedExpValue

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -54,24 +54,14 @@ func ConditionalPut(
 		ts = h.Timestamp
 	}
 
-	var expVal []byte
-	if len(args.ExpBytes) != 0 {
-		expVal = args.ExpBytes
-	} else {
-		// Compatibility with 20.1 requests.
-		if args.DeprecatedExpValue != nil {
-			expVal = args.DeprecatedExpValue.TagAndDataBytes()
-		}
-	}
-
 	handleMissing := storage.CPutMissingBehavior(args.AllowIfDoesNotExist)
 	var err error
 	if args.Blind {
 		err = storage.MVCCBlindConditionalPut(
-			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, expVal, handleMissing, h.Txn)
+			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, args.ExpBytes, handleMissing, h.Txn)
 	} else {
 		err = storage.MVCCConditionalPut(
-			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, expVal, handleMissing, h.Txn)
+			ctx, readWriter, cArgs.Stats, args.Key, ts, cArgs.Now, args.Value, args.ExpBytes, handleMissing, h.Txn)
 	}
 	// NB: even if MVCC returns an error, it may still have written an intent
 	// into the batch. This allows callers to consume errors like WriteTooOld

--- a/pkg/roachpb/api.go
+++ b/pkg/roachpb/api.go
@@ -1159,20 +1159,11 @@ func NewPutInline(key Key, value Value) Request {
 // into the request.
 func NewConditionalPut(key Key, value Value, expValue []byte, allowNotExist bool) Request {
 	value.InitChecksum(key)
-	// Compatibility with 20.1 servers.
-	var expValueVal *Value
-	if expValue != nil {
-		expValueVal = &Value{}
-		expValueVal.SetTagAndData(expValue)
-		// The expected value does not need a checksum, so we don't initialize it.
-	}
-
 	return &ConditionalPutRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
 		Value:               value,
-		DeprecatedExpValue:  expValueVal,
 		ExpBytes:            expValue,
 		AllowIfDoesNotExist: allowNotExist,
 	}
@@ -1186,20 +1177,11 @@ func NewConditionalPut(key Key, value Value, expValue []byte, allowNotExist bool
 // into the request.
 func NewConditionalPutInline(key Key, value Value, expValue []byte, allowNotExist bool) Request {
 	value.InitChecksum(key)
-	// Compatibility with 20.1 servers.
-	var expValueVal *Value
-	if expValue != nil {
-		expValueVal = &Value{}
-		expValueVal.SetTagAndData(expValue)
-		// The expected value does not need a checksum, so we don't initialize it.
-	}
-
 	return &ConditionalPutRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
 		Value:               value,
-		DeprecatedExpValue:  expValueVal,
 		ExpBytes:            expValue,
 		AllowIfDoesNotExist: allowNotExist,
 		Inline:              true,

--- a/pkg/roachpb/api.proto
+++ b/pkg/roachpb/api.proto
@@ -248,15 +248,7 @@ message ConditionalPutRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   // The value to put.
   Value value = 2 [(gogoproto.nullable) = false];
-  // deprecated_exp_val represents the expected existing value for the key. If
-  // the existing value is different, the request will return a
-  // ConditionFailedError. A missing (Go nil) deprecated_exp_value.raw_bytes
-  // means that the key is expected to not exist.
-  //
-  // This is deprecated in 20.2 in favor of exp_bytes, which clarifies that the
-  // checksum and timestamp of the expected value are irrelevant. Remove in
-  // 21.1.
-  Value deprecated_exp_value = 3;
+  reserved 3;
   // exp_bytes represents the expected existing value for the key. If empty, the
   // key is expected to not exist. If not empty, these bytes are expected to
   // contain the tag and data of the existing value (without the existing


### PR DESCRIPTION
This commit removes the ConditionalPutRequest.DeprecatedExpValue field, which was replaced by the ExpBytes introduced in 9e14f24. This has been possible since v21.1.

Release justification: None, wait.

Release note: None.