### PR TITLE
release-22.1: backupccl: elide spans from backups that were subsequently reintroduced

### DIFF
--- a/pkg/ccl/backupccl/BUILD.bazel
+++ b/pkg/ccl/backupccl/BUILD.bazel
@@ -272,6 +272,7 @@ go_test(
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/span",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/ccl/backupccl/backup.proto
+++ b/pkg/ccl/backupccl/backup.proto
@@ -80,6 +80,12 @@ message BackupManifest {
   // here are covered in the interval (0, startTime], which, in conjunction with
   // the coverage from (startTime, endTime] implied for all spans in Spans,
   // results in coverage from [0, endTime] for these spans.
+  //
+  // The first set of spans in this field are new spans that did not
+  // exist in the previous backup (a new index, for example), while the remaining
+  // spans are re-introduced spans, which need to be backed up again from (0,
+  // startTime] because a non-mvcc operation may have occurred on this span. See
+  // the getReintroducedSpans() for more information.
   repeated roachpb.Span introduced_spans = 15 [(gogoproto.nullable) = false];
 
   repeated DescriptorRevision descriptor_changes = 16  [(gogoproto.nullable) = false];

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1455,7 +1455,7 @@ func getReintroducedSpans(
 	// backup was offline at the endTime of the last backup.
 	latestTableDescChangeInLastBackup := make(map[descpb.ID]*descpb.TableDescriptor)
 	for _, rev := range lastBackup.DescriptorChanges {
-		if table, _, _, _, _ := descpb.FromDescriptor(rev.Desc); table != nil {
+		if table, _, _, _ := descpb.FromDescriptor(rev.Desc); table != nil {
 			if trackedRev, ok := latestTableDescChangeInLastBackup[table.GetID()]; !ok {
 				latestTableDescChangeInLastBackup[table.GetID()] = table
 			} else if trackedRev.Version < table.Version {
@@ -1486,6 +1486,7 @@ func getReintroducedSpans(
 	// table may have been OFFLINE at the time of the last backup, and OFFLINE at
 	// the time of the current backup, but may have been PUBLIC at some time in
 	// between.
+
 	for _, rev := range revs {
 		rawTable, _, _, _ := descpb.FromDescriptor(rev.Desc)
 		if rawTable == nil {
@@ -1510,7 +1511,6 @@ func getReintroducedSpans(
 			allRevs = append(allRevs, rev)
 		}
 	}
-
 	tableSpans, err := spansForAllTableIndexes(execCfg, tablesToReinclude, allRevs)
 	if err != nil {
 		return nil, err
@@ -1872,8 +1872,7 @@ func getBackupDetailAndManifest(
 		}
 	}
 
-	var newSpans roachpb.Spans
-
+	var newSpans, reIntroducedSpans roachpb.Spans
 	var priorIDs map[descpb.ID]descpb.ID
 
 	var revs []BackupManifest_DescriptorRevision
@@ -1954,11 +1953,11 @@ func getBackupDetailAndManifest(
 
 		newSpans = filterSpans(spans, prevBackups[len(prevBackups)-1].Spans)
 
-		tableSpans, err := getReintroducedSpans(ctx, execCfg, prevBackups, tables, revs, endTime)
+		reIntroducedSpans, err = getReintroducedSpans(ctx, execCfg, prevBackups, tables, revs, endTime)
 		if err != nil {
 			return jobspb.BackupDetails{}, BackupManifest{}, err
 		}
-		newSpans = append(newSpans, tableSpans...)
+		newSpans = append(newSpans, reIntroducedSpans...)
 	}
 
 	// if CompleteDbs is lost by a 1.x node, FormatDescriptorTrackingVersion

--- a/pkg/ccl/backupccl/backup_planning.go
+++ b/pkg/ccl/backupccl/backup_planning.go
@@ -1420,13 +1420,55 @@ func getReintroducedSpans(
 ) ([]roachpb.Span, error) {
 	reintroducedTables := make(map[descpb.ID]struct{})
 
+	// First, create a map that indicates which tables from the previous backup
+	// were offline when the last backup was taken. To create this map, we must
+	// iterate two fields in the _last_ backup's manifest:
+	//
+	// 1. manifest.Descriptors contains a list of descriptors _explicitly_
+	// included in the backup, gathered at backup startTime. This includes all
+	// public descriptors, and in the case of cluster backups, offline
+	// descriptors.
+	//
+	// 2. manifest.DescriptorChanges contains a list of descriptor changes tracked
+	// in the backup. While investigating #88042, it was discovered that during
+	// revision history database and table.* backups, a table can get included in
+	// manifest.DescriptorChanges when it transitions from an online to offline
+	// state, causing its spans to get backed up. However, if this table was
+	// offline when the backup began, it's excluded from manifest.Descriptors.
+	// Therefore, to find all descriptors covered in the backup that were offline
+	// at backup time, we must find all tables in manifest.DescriptorChanges whose
+	// last change brought the table offline.
 	offlineInLastBackup := make(map[descpb.ID]struct{})
 	lastBackup := prevBackups[len(prevBackups)-1]
+
 	for _, desc := range lastBackup.Descriptors {
 		// TODO(pbardea): Also check that lastWriteTime is set once those are
 		// populated on the table descriptor.
 		if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil && table.Offline() {
 			offlineInLastBackup[table.GetID()] = struct{}{}
+		}
+	}
+
+	// Gather all the descriptors that were offline at the endTime of the last
+	// backup, according the backup's descriptor changes. If the last descriptor
+	// change in the previous backup interval put the table offline, then that
+	// backup was offline at the endTime of the last backup.
+	latestTableDescChangeInLastBackup := make(map[descpb.ID]*descpb.TableDescriptor)
+	for _, rev := range lastBackup.DescriptorChanges {
+		if table, _, _, _, _ := descpb.FromDescriptor(rev.Desc); table != nil {
+			if trackedRev, ok := latestTableDescChangeInLastBackup[table.GetID()]; !ok {
+				latestTableDescChangeInLastBackup[table.GetID()] = table
+			} else if trackedRev.Version < table.Version {
+				latestTableDescChangeInLastBackup[table.GetID()] = table
+			}
+		}
+	}
+
+	if knobs := execCfg.BackupRestoreTestingKnobs; knobs == nil || !knobs.SkipDescriptorChangeIntroduction {
+		for _, table := range latestTableDescChangeInLastBackup {
+			if table.Offline() {
+				offlineInLastBackup[table.GetID()] = struct{}{}
+			}
 		}
 	}
 

--- a/pkg/ccl/backupccl/bench_covering_test.go
+++ b/pkg/ccl/backupccl/bench_covering_test.go
@@ -10,10 +10,12 @@ package backupccl
 
 import (
 	"context"
-	fmt "fmt"
+	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/stretchr/testify/require"
 )
 
 func BenchmarkCoverageChecks(b *testing.B) {
@@ -44,7 +46,6 @@ func BenchmarkCoverageChecks(b *testing.B) {
 
 func BenchmarkRestoreEntryCover(b *testing.B) {
 	r, _ := randutil.NewTestRand()
-
 	for _, numBackups := range []int{1, 2, 24, 24 * 4} {
 		b.Run(fmt.Sprintf("numBackups=%d", numBackups), func(b *testing.B) {
 			for _, baseFiles := range []int{0, 100, 10000} {
@@ -58,7 +59,10 @@ func BenchmarkRestoreEntryCover(b *testing.B) {
 								if err := checkCoverage(ctx, backups[numBackups-1].Spans, backups); err != nil {
 									b.Fatal(err)
 								}
-								cov := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, nil)
+								introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+								require.NoError(b, err)
+
+								cov := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, introducedSpanFrontier, nil)
 								b.ReportMetric(float64(len(cov)), "coverSize")
 							}
 						})

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -533,6 +533,30 @@ func TestDataDriven(t *testing.T) {
 				require.NoError(t, err)
 				return ""
 
+			case "import":
+				server := lastCreatedServer
+				user := "root"
+				jobType := "IMPORT"
+
+				// First, run the backup.
+				_, err := ds.getSQLDB(t, server, user).Exec(d.Input)
+
+				// Tag the job.
+				if d.HasArg("tag") {
+					tagJob(t, server, user, jobType, ds, d)
+				}
+
+				// Check if we expect a pausepoint error.
+				if d.HasArg("expect-pausepoint") {
+					expectPausepoint(t, err, jobType, server, user, ds)
+					ret := append(ds.noticeBuffer, "job paused at pausepoint")
+					return strings.Join(ret, "\n")
+				}
+
+				// All other errors are bad.
+				require.NoError(t, err)
+				return ""
+
 			case "restore":
 				server := lastCreatedServer
 				user := "root"

--- a/pkg/ccl/backupccl/datadriven_test.go
+++ b/pkg/ccl/backupccl/datadriven_test.go
@@ -71,6 +71,10 @@ var localityCfgs = map[string]roachpb.Locality{
 	},
 }
 
+var customKnobs = map[string]sql.BackupRestoreTestingKnobs{
+	"skip-descriptor-change-intro": {SkipDescriptorChangeIntroduction: true},
+}
+
 type sqlDBKey struct {
 	server string
 	user   string
@@ -126,6 +130,7 @@ type serverCfg struct {
 	splits                int
 	ioConf                base.ExternalIODirConfig
 	localities            string
+	customTestingKnobs    string
 }
 
 func (d *datadrivenTestState) addServer(t *testing.T, cfg serverCfg) error {
@@ -135,6 +140,10 @@ func (d *datadrivenTestState) addServer(t *testing.T, cfg serverCfg) error {
 	params.ServerArgs.ExternalIODirConfig = cfg.ioConf
 	params.ServerArgs.Knobs = base.TestingKnobs{
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+	}
+	if cfg.customTestingKnobs != "" {
+		knobs := customKnobs[cfg.customTestingKnobs]
+		params.ServerArgs.Knobs.BackupRestore = &knobs
 	}
 
 	// If the server needs to control temporary object cleanup, let us set that up
@@ -236,105 +245,107 @@ func (d *datadrivenTestState) getSQLDB(t *testing.T, server string, user string)
 // commands. The test files are in testdata/backup-restore. The following
 // syntax is provided:
 //
-// - "new-server name=<name> [args]"
-//   Create a new server with the input name.
+//   - "new-server name=<name> [args]"
+//     Create a new server with the input name.
 //
-//   Supported arguments:
+//     Supported arguments:
 //
-//   + share-io-dir: can be specified to share an IO directory with an existing
-//   server. This is useful when restoring from a backup taken in another
-//   server.
+//   - share-io-dir: can be specified to share an IO directory with an existing
+//     server. This is useful when restoring from a backup taken in another
+//     server.
 //
-//   + allow-implicit-access: can be specified to set
-//   `EnableNonAdminImplicitAndArbitraryOutbound` to true
+//   - allow-implicit-access: can be specified to set
+//     `EnableNonAdminImplicitAndArbitraryOutbound` to true
 //
-//   + disable-http: disables use of external HTTP endpoints.
+//   - disable-http: disables use of external HTTP endpoints.
 //
-//   + localities: specifies the localities that will be used when starting up
-//   the test cluster. The cluster will have len(localities) nodes, with each
-//   node assigned a locality config corresponding to the locality. Please
-//   update the `localityCfgs` map when adding new localities.
+//   - localities: specifies the localities that will be used when starting up
+//     the test cluster. The cluster will have len(localities) nodes, with each
+//     node assigned a locality config corresponding to the locality. Please
+//     update the `localityCfgs` map when adding new localities.
 //
-//   + nodes: specifies the number of nodes in the test cluster.
+//   - nodes: specifies the number of nodes in the test cluster.
 //
-//   + splits: specifies the number of ranges the bank table is split into.
+//   - splits: specifies the number of ranges the bank table is split into.
 //
-//   + control-temp-object-cleanup: sets up the server in a way that the test
-//   can control when to run the temporary object reconciliation loop using
-//   nudge-and-wait-for-temp-cleanup
+//   - control-temp-object-cleanup: sets up the server in a way that the test
+//     can control when to run the temporary object reconciliation loop using
+//     nudge-and-wait-for-temp-cleanup
 //
-// - "exec-sql [server=<name>] [user=<name>] [args]"
-//   Executes the input SQL query on the target server. By default, server is
-//   the last created server.
+//   - knobs: specificies a custom debug testing knob setup
 //
-//   Supported arguments:
+//   - "exec-sql [server=<name>] [user=<name>] [args]"
+//     Executes the input SQL query on the target server. By default, server is
+//     the last created server.
 //
-//   + expect-error-regex=<regex>: expects the query to return an error with a string
-//   matching the provided regex
+//     Supported arguments:
 //
-//   + expect-error-ignore: expects the query to return an error, but we will
-//   ignore it.
+//   - expect-error-regex=<regex>: expects the query to return an error with a string
+//     matching the provided regex
 //
-// - "query-sql [server=<name>] [user=<name>]"
-//   Executes the input SQL query and print the results.
+//   - expect-error-ignore: expects the query to return an error, but we will
+//     ignore it.
 //
-// - "reset"
-//    Clear all state associated with the test.
+//   - "query-sql [server=<name>] [user=<name>]"
+//     Executes the input SQL query and print the results.
 //
-// - "job" [server=<name>] [user=<name>] [args]
-//   Executes job specific operations.
+//   - "reset"
+//     Clear all state associated with the test.
 //
-//   Supported arguments:
+//   - "job" [server=<name>] [user=<name>] [args]
+//     Executes job specific operations.
 //
-//   + resume=<tag>: resumes the job referenced by the tag, use in conjunction
-//   with wait-for-state.
+//     Supported arguments:
 //
-//   + cancel=<tag>: cancels the job referenced by the tag and waits for it to
-//   reach a CANCELED state.
+//   - resume=<tag>: resumes the job referenced by the tag, use in conjunction
+//     with wait-for-state.
 //
-//   + wait-for-state=<succeeded|paused|failed|cancelled> tag=<tag>: wait for
-//   the job referenced by the tag to reach the specified state.
+//   - cancel=<tag>: cancels the job referenced by the tag and waits for it to
+//     reach a CANCELED state.
 //
-// - "save-cluster-ts" tag=<tag>
-//   Saves the `SELECT cluster_logical_timestamp()` with the tag. Can be used
-//   in the future with intstructions such as `aost`.
+//   - wait-for-state=<succeeded|paused|failed|cancelled> tag=<tag>: wait for
+//     the job referenced by the tag to reach the specified state.
 //
-// - "backup" [args]
-//   Executes backup specific operations.
+//   - "save-cluster-ts" tag=<tag>
+//     Saves the `SELECT cluster_logical_timestamp()` with the tag. Can be used
+//     in the future with intstructions such as `aost`.
 //
-//   Supported arguments:
+//   - "backup" [args]
+//     Executes backup specific operations.
 //
-//   + tag=<tag>: tag the backup job to reference it in the future.
+//     Supported arguments:
 //
-//   + expect-pausepoint: expects the backup job to end up in a paused state because
-//   of a pausepoint error.
+//   - tag=<tag>: tag the backup job to reference it in the future.
 //
-// - "restore" [args]
-//   Executes restore specific operations.
+//   - expect-pausepoint: expects the backup job to end up in a paused state because
+//     of a pausepoint error.
 //
-//   Supported arguments:
+//   - "restore" [args]
+//     Executes restore specific operations.
 //
-//   + tag=<tag>: tag the restore job to reference it in the future.
+//     Supported arguments:
 //
-//   + expect-pausepoint: expects the restore job to end up in a paused state because
-//   of a pausepoint error.
+//   - tag=<tag>: tag the restore job to reference it in the future.
 //
-//   + aost: expects a tag referencing a previously saved cluster timestamp
-//   using `save-cluster-ts`. It then runs the restore as of the saved cluster
-//   timestamp.
+//   - expect-pausepoint: expects the restore job to end up in a paused state because
+//     of a pausepoint error.
 //
-// - "schema" [args]
-//   Executes schema change specific operations.
+//   - aost: expects a tag referencing a previously saved cluster timestamp
+//     using `save-cluster-ts`. It then runs the restore as of the saved cluster
+//     timestamp.
 //
-//   Supported arguments:
+//   - "schema" [args]
+//     Executes schema change specific operations.
 //
-//   + tag=<tag>: tag the schema change job to reference it in the future.
+//     Supported arguments:
 //
-//   + expect-pausepoint: expects the schema change job to end up in a paused state because
-//   of a pausepoint error.
+//   - tag=<tag>: tag the schema change job to reference it in the future.
 //
-// - "nudge-and-wait-for-temp-cleanup"
-//    Nudges the temporary object reconciliation loop to run, and waits for completion.
+//   - expect-pausepoint: expects the schema change job to end up in a paused state because
+//     of a pausepoint error.
+//
+//   - "nudge-and-wait-for-temp-cleanup"
+//     Nudges the temporary object reconciliation loop to run, and waits for completion.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -359,7 +370,7 @@ func TestDataDriven(t *testing.T) {
 				return ""
 
 			case "new-server":
-				var name, shareDirWith, iodir, localities string
+				var name, shareDirWith, iodir, localities, knobs string
 				var splits int
 				var nudgeTempObjectCleanup chan time.Time
 				var tempObjectCleanupDone chan struct{}
@@ -392,6 +403,10 @@ func TestDataDriven(t *testing.T) {
 					tempObjectCleanupDone = make(chan struct{})
 				}
 
+				if d.HasArg("knobs") {
+					d.ScanArgs(t, "knobs", &knobs)
+				}
+
 				lastCreatedServer = name
 				cfg := serverCfg{
 					name:                    name,
@@ -402,6 +417,7 @@ func TestDataDriven(t *testing.T) {
 					splits:                  splits,
 					ioConf:                  io,
 					localities:              localities,
+					customTestingKnobs:      knobs,
 				}
 				err := ds.addServer(t, cfg)
 				if err != nil {

--- a/pkg/ccl/backupccl/restoration_data.go
+++ b/pkg/ccl/backupccl/restoration_data.go
@@ -63,10 +63,13 @@ func (*mainRestorationData) isMainBundle() bool { return true }
 type restorationDataBase struct {
 	// spans is the spans included in this bundle.
 	spans []roachpb.Span
+
 	// rekeys maps old table IDs to their new table descriptor.
 	tableRekeys []execinfrapb.TableRekey
+
 	// tenantRekeys maps tenants being restored to their new ID.
 	tenantRekeys []execinfrapb.TenantRekey
+
 	// pkIDs stores the ID of the primary keys for all of the tables that we're
 	// restoring for RowCount calculation.
 	pkIDs map[uint64]bool

--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -251,6 +251,11 @@ func restore(
 		return emptyRowCount, errors.Wrap(err, "resolving locality locations")
 	}
 
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backupManifests, endTime)
+	if err != nil {
+		return emptyRowCount, err
+	}
+
 	if err := checkCoverage(restoreCtx, dataToRestore.getSpans(), backupManifests); err != nil {
 		return emptyRowCount, err
 	}
@@ -260,7 +265,7 @@ func restore(
 	highWaterMark := job.Progress().Details.(*jobspb.Progress_Restore).Restore.HighWater
 
 	importSpans := makeSimpleImportSpans(dataToRestore.getSpans(), backupManifests, backupLocalityMap,
-		highWaterMark)
+		introducedSpanFrontier, highWaterMark)
 
 	if len(importSpans) == 0 {
 		// There are no files to restore.

--- a/pkg/ccl/backupccl/restore_planning.go
+++ b/pkg/ccl/backupccl/restore_planning.go
@@ -1785,6 +1785,11 @@ func doRestorePlan(
 				"use SHOW BACKUP to find correct targets")
 	}
 
+	if err := checkMissingIntroducedSpans(sqlDescs, mainBackupManifests, endTime,
+		p.ExecCfg().Codec); err != nil {
+		return err
+	}
+
 	var revalidateIndexes []jobspb.RestoreDetails_RevalidateIndex
 	for _, desc := range sqlDescs {
 		tbl, ok := desc.(catalog.TableDescriptor)

--- a/pkg/ccl/backupccl/restore_span_covering.go
+++ b/pkg/ccl/backupccl/restore_span_covering.go
@@ -13,7 +13,9 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/interval"
+	spanUtils "github.com/cockroachdb/cockroach/pkg/util/span"
 )
 
 type intervalSpan roachpb.Span
@@ -34,25 +36,29 @@ func (ie intervalSpan) Range() interval.Range {
 // based on the lowWaterMark before the covering for them is generated. Consider
 // a chain of backups with files f1, f2… which cover spans as follows:
 //
-//  backup
-//  0|     a___1___c c__2__e          h__3__i
-//  1|         b___4___d           g____5___i
-//  2|     a___________6______________h         j_7_k
-//  3|                                  h_8_i              l_9_m
-//   keys--a---b---c---d---e---f---g---h----i---j---k---l----m------p---->
+//	backup
+//	0|     a___1___c c__2__e          h__3__i
+//	1|         b___4___d           g____5___i
+//	2|     a___________6______________h         j_7_k
+//	3|                                  h_8_i              l_9_m
+//	 keys--a---b---c---d---e---f---g---h----i---j---k---l----m------p---->
+//
 // spans: |-------span1-------||---span2---|           |---span3---|
 //
 // The cover for those spans would look like:
-//  [a, c): 1, 4, 6
-//  [c, e): 2, 4, 6
-//  [e, f): 6
-//  [f, i): 3, 5, 6, 8
-//  [l, m): 9
+//
+//	[a, c): 1, 4, 6
+//	[c, e): 2, 4, 6
+//	[e, f): 6
+//	[f, i): 3, 5, 6, 8
+//	[l, m): 9
+//
 // This example is tested in TestRestoreEntryCoverExample.
 func makeSimpleImportSpans(
 	requiredSpans []roachpb.Span,
 	backups []BackupManifest,
 	backupLocalityMap map[int]storeByLocalityKV,
+	introducedSpanFrontier *spanUtils.Frontier,
 	lowWaterMark roachpb.Key,
 ) []execinfrapb.RestoreSpanEntry {
 	if len(backups) < 1 {
@@ -62,8 +68,8 @@ func makeSimpleImportSpans(
 	for i := range backups {
 		sort.Sort(BackupFileDescriptors(backups[i].Files))
 	}
-
 	var cover []execinfrapb.RestoreSpanEntry
+
 	for _, span := range requiredSpans {
 		if span.EndKey.Compare(lowWaterMark) < 0 {
 			continue
@@ -73,8 +79,32 @@ func makeSimpleImportSpans(
 		}
 
 		spanCoverStart := len(cover)
-
 		for layer := range backups {
+
+			var coveredLater bool
+			introducedSpanFrontier.SpanEntries(span, func(s roachpb.Span,
+				ts hlc.Timestamp) (done spanUtils.OpResult) {
+				if backups[layer].EndTime.Less(ts) {
+					coveredLater = true
+				}
+				return spanUtils.StopMatch
+			})
+			if coveredLater {
+				// Don't use this backup to cover this span if the span was reintroduced
+				// after the backup's endTime. In this case, this backup may have
+				// invalid data, and further, a subsequent backup will contain all of
+				// this span's data. Consider the following example:
+				//
+				// T0: Begin IMPORT INTO on existing table foo, ingest some data
+				// T1: Backup foo
+				// T2: Rollback IMPORT via clearRange
+				// T3: Incremental backup of foo, with a full reintroduction of foo’s span
+				// T4: RESTORE foo: should only restore foo from the incremental backup.
+				//    If data from the full backup were also restored,
+				//    the imported-but-then-clearRanged data will leak in the restored cluster.
+				//    This logic seeks to avoid this form of data corruption.
+				continue
+			}
 			covPos := spanCoverStart
 			// TODO(dt): binary search to the first file in required span?
 			for _, f := range backups[layer].Files {
@@ -115,6 +145,31 @@ func makeSimpleImportSpans(
 	}
 
 	return cover
+}
+
+// createIntroducedSpanFrontier creates a span frontier that tracks the end time
+// of the latest incremental backup of each introduced span in the backup chain.
+// See ReintroducedSpans( ) for more information. Note: this function assumes
+// that manifests are sorted in increasing EndTime.
+func createIntroducedSpanFrontier(
+	manifests []BackupManifest, asOf hlc.Timestamp,
+) (*spanUtils.Frontier, error) {
+	introducedSpanFrontier, err := spanUtils.MakeFrontier(roachpb.Span{})
+	if err != nil {
+		return nil, err
+	}
+	for i, m := range manifests {
+		if i == 0 {
+			continue
+		}
+		if !asOf.IsEmpty() && asOf.Less(m.StartTime) {
+			break
+		}
+		if err := introducedSpanFrontier.AddSpansAt(m.EndTime, m.IntroducedSpans...); err != nil {
+			return nil, err
+		}
+	}
+	return introducedSpanFrontier, nil
 }
 
 func makeEntry(start, end roachpb.Key, f execinfrapb.RestoreFileSpec) execinfrapb.RestoreSpanEntry {

--- a/pkg/ccl/backupccl/restore_span_covering_test.go
+++ b/pkg/ccl/backupccl/restore_span_covering_test.go
@@ -14,33 +14,64 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	spanUtils "github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 // MockBackupChain returns a chain of mock backup manifests that have spans and
 // file spans suitable for checking coverage computations. Every 3rd inc backup
-// introduces a span and drops a span. Incremental backups have half as many
-// files as the base. Files spans are ordered by start key but may overlap.
+// reintroduces a span. On a random backup, one random span is dropped and
+// another is added. Incremental backups have half as many files as the base.
+// Files spans are ordered by start key but may overlap.
 func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []BackupManifest {
 	backups := make([]BackupManifest, length)
 	ts := hlc.Timestamp{WallTime: time.Second.Nanoseconds()}
+
+	// spanIdxToDrop represents that span that will get dropped during this mock backup chain.
+	spanIdxToDrop := r.Intn(spans)
+
+	// backupWithDroppedSpan represents the first backup that will observe the dropped span.
+	backupWithDroppedSpan := r.Intn(len(backups))
+
+	genTableID := func(j int) uint32 {
+		return uint32(10 + j*2)
+	}
+
 	for i := range backups {
 		backups[i].Spans = make(roachpb.Spans, spans)
+		backups[i].IntroducedSpans = make(roachpb.Spans, 0)
 		for j := range backups[i].Spans {
-			backups[i].Spans[j] = makeTableSpan(uint32(100 + j + (i / 3)))
+			tableID := genTableID(j)
+			backups[i].Spans[j] = makeTableSpan(tableID)
 		}
 		backups[i].EndTime = ts.Add(time.Minute.Nanoseconds()*int64(i), 0)
 		if i > 0 {
 			backups[i].StartTime = backups[i-1].EndTime
+
+			if i >= backupWithDroppedSpan {
+				// At and after the backupWithDroppedSpan, drop the span at
+				// span[spanIdxToDrop], present in the first i backups, and add a new
+				// one.
+				newTableID := genTableID(spanIdxToDrop) + 1
+				backups[i].Spans[spanIdxToDrop] = makeTableSpan(newTableID)
+				backups[i].IntroducedSpans = append(backups[i].IntroducedSpans, backups[i].Spans[spanIdxToDrop])
+			}
+
 			if i%3 == 0 {
-				backups[i].IntroducedSpans = roachpb.Spans{backups[i].Spans[spans-1]}
+				// Reintroduce an existing span
+				spanIdx := r.Intn(spans)
+				backups[i].IntroducedSpans = append(backups[i].IntroducedSpans, backups[i].Spans[spanIdx])
 			}
 		}
 
@@ -79,16 +110,40 @@ func MockBackupChain(length, spans, baseFiles int, r *rand.Rand) []BackupManifes
 // length to the number of files a file's end key was greater than any prior end
 // key when walking files in order by start key in the backups. This check is
 // thus sensitive to ordering; the coverage correctness check however is not.
+//
+// The function also verifies that a cover does not cross a span boundary.
 func checkRestoreCovering(
 	backups []BackupManifest, spans roachpb.Spans, cov []execinfrapb.RestoreSpanEntry,
 ) error {
 	var expectedPartitions int
 	required := make(map[string]*roachpb.SpanGroup)
-	for _, s := range spans {
+
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	if err != nil {
+		return err
+	}
+
+	for _, span := range spans {
 		var last roachpb.Key
 		for _, b := range backups {
+			var coveredLater bool
+			introducedSpanFrontier.Entries(func(s roachpb.Span,
+				ts hlc.Timestamp) (done spanUtils.OpResult) {
+				if span.Overlaps(s) {
+					if b.EndTime.Less(ts) {
+						coveredLater = true
+					}
+					return spanUtils.StopMatch
+				}
+				return spanUtils.ContinueMatch
+			})
+			if coveredLater {
+				// Skip spans that were later re-introduced. See makeSimpleImportSpans
+				// for explanation.
+				continue
+			}
 			for _, f := range b.Files {
-				if sp := s.Intersect(f.Span); sp.Valid() {
+				if sp := span.Intersect(f.Span); sp.Valid() {
 					if required[f.Path] == nil {
 						required[f.Path] = &roachpb.SpanGroup{}
 					}
@@ -101,10 +156,21 @@ func checkRestoreCovering(
 			}
 		}
 	}
+	var spanIdx int
 	for _, c := range cov {
 		for _, f := range c.Files {
 			required[f.Path].Sub(c.Span)
 		}
+		for spans[spanIdx].EndKey.Compare(c.Span.Key) < 0 {
+			spanIdx++
+		}
+		// Assert that every cover is contained by a required span.
+		requiredSpan := spans[spanIdx]
+		if requiredSpan.Overlaps(c.Span) && !requiredSpan.Contains(c.Span) {
+			return errors.Errorf("cover with requiredSpan %v is not contained by required requiredSpan"+
+				" %v", c.Span, requiredSpan)
+		}
+
 	}
 	for name, uncovered := range required {
 		for _, missing := range uncovered.Slice() {
@@ -134,7 +200,7 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		return r
 	}
 
-	// Setup and test the example in the comnent on makeSimpleImportSpans.
+	// Setup and test the example in the comment of makeSimpleImportSpans.
 	spans := []roachpb.Span{sp("a", "f"), sp("f", "i"), sp("l", "m")}
 	backups := []BackupManifest{
 		{Files: []BackupManifest_File{f("a", "c", "1"), f("c", "e", "2"), f("h", "i", "3")}},
@@ -142,7 +208,16 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Files: []BackupManifest_File{f("a", "h", "6"), f("j", "k", "7")}},
 		{Files: []BackupManifest_File{f("h", "i", "8"), f("l", "m", "9")}},
 	}
-	cover := makeSimpleImportSpans(spans, backups, nil, nil)
+
+	for i := range backups {
+		backups[i].StartTime = hlc.Timestamp{WallTime: int64(i)}
+		backups[i].EndTime = hlc.Timestamp{WallTime: int64(i + 1)}
+	}
+
+	emptySpanFrontier, err := spanUtils.MakeFrontier(roachpb.Span{})
+	require.NoError(t, err)
+
+	cover := makeSimpleImportSpans(spans, backups, nil, emptySpanFrontier, nil)
 	require.Equal(t, []execinfrapb.RestoreSpanEntry{
 		{Span: sp("a", "c"), Files: paths("1", "4", "6")},
 		{Span: sp("c", "e"), Files: paths("2", "4", "6")},
@@ -150,11 +225,243 @@ func TestRestoreEntryCoverExample(t *testing.T) {
 		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
 		{Span: sp("l", "m"), Files: paths("9")},
 	}, cover)
+
+	// check that introduced spans are properly elided
+	backups[2].IntroducedSpans = []roachpb.Span{sp("a", "f")}
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+	require.NoError(t, err)
+
+	coverIntroduced := makeSimpleImportSpans(spans, backups, nil, introducedSpanFrontier, nil)
+	require.Equal(t, []execinfrapb.RestoreSpanEntry{
+		{Span: sp("a", "f"), Files: paths("6")},
+		{Span: sp("f", "i"), Files: paths("3", "5", "6", "8")},
+		{Span: sp("l", "m"), Files: paths("9")},
+	}, coverIntroduced)
+}
+
+type mockBackupInfo struct {
+	// tableIDs identifies the tables included in the backup.
+	tableIDs []int
+
+	// indexIDs defines a map from tableID to tableIndexes included in the backup.
+	indexIDs map[int][]int
+
+	// reintroducedTableIDs identifies a set of TableIDs to reintroduce in the backup.
+	reintroducedTableIDs map[int]struct{}
+
+	// expectedBackupSpanCount defines the number of backup spans created by spansForAllTableIndexes.
+	expectedBackupSpanCount int
+}
+
+func createMockTables(
+	info mockBackupInfo,
+) (tables []catalog.TableDescriptor, reIntroducedTables []catalog.TableDescriptor) {
+	tables = make([]catalog.TableDescriptor, 0)
+	reIntroducedTables = make([]catalog.TableDescriptor, 0)
+	for _, tableID := range info.tableIDs {
+		indexes := make([]descpb.IndexDescriptor, 0)
+		for _, indexID := range info.indexIDs[tableID] {
+			indexes = append(indexes, getMockIndexDesc(descpb.IndexID(indexID)))
+		}
+		table := getMockTableDesc(descpb.ID(tableID), indexes[0], indexes, nil, nil)
+		tables = append(tables, table)
+		if _, ok := info.reintroducedTableIDs[tableID]; ok {
+			reIntroducedTables = append(reIntroducedTables, table)
+		}
+	}
+	return tables, reIntroducedTables
+}
+
+func createMockManifest(
+	t *testing.T,
+	execCfg *sql.ExecutorConfig,
+	info mockBackupInfo,
+	endTime hlc.Timestamp,
+	path string,
+) BackupManifest {
+	tables, _ := createMockTables(info)
+
+	spans, err := spansForAllTableIndexes(execCfg, tables,
+		nil /* revs */)
+	require.NoError(t, err)
+	require.Equal(t, info.expectedBackupSpanCount, len(spans))
+
+	files := make([]BackupManifest_File, len(spans))
+	for _, sp := range spans {
+		files = append(files, BackupManifest_File{Span: sp, Path: path})
+	}
+
+	return BackupManifest{Spans: spans,
+		EndTime: endTime, Files: files}
+}
+
+// TestRestoreEntryCoverReIntroducedSpans checks that all reintroduced spans are
+// covered in RESTORE by files in the incremental backup that reintroduced the
+// spans. The test also checks the invariants required during RESTORE to elide
+// files from the full backup that are later reintroduced. These include:
+//
+//   - During BackupManifest creation, spansForAllTableIndexes will merge
+//     adjacent indexes within a table, but not indexes across tables.
+//
+//   - During spansForAllRestoreTableIndexes, each restored index will have its
+//     own span.
+func TestRestoreEntryCoverReIntroducedSpans(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	codec := keys.SystemSQLCodec
+	execCfg := &sql.ExecutorConfig{
+		Codec: codec,
+	}
+
+	testCases := []struct {
+		name string
+		full mockBackupInfo
+		inc  mockBackupInfo
+
+		// expectedRestoreSpanCount defines the number of required spans passed to
+		// makeSimpleImportSpans.
+		expectedRestoreSpanCount int
+	}{
+		{
+			name: "adjacent indexes",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "non-adjacent indexes",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 3,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "dropped non-adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 2,
+		},
+		{
+			name: "new non-adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 3,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "new adjacent index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1}, 2: {1}},
+				expectedBackupSpanCount: 2,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 3,
+		},
+		{
+			name: "new in-between index",
+			full: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 3}, 2: {1}},
+				expectedBackupSpanCount: 3,
+			},
+			inc: mockBackupInfo{
+				tableIDs:                []int{1, 2},
+				indexIDs:                map[int][]int{1: {1, 2, 3}, 2: {1}},
+				reintroducedTableIDs:    map[int]struct{}{1: {}},
+				expectedBackupSpanCount: 2,
+			},
+			expectedRestoreSpanCount: 4,
+		},
+	}
+
+	fullBackupPath := "full"
+	incBackupPath := "inc"
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			backups := []BackupManifest{
+				createMockManifest(t, execCfg, test.full, hlc.Timestamp{WallTime: int64(1)}, fullBackupPath),
+				createMockManifest(t, execCfg, test.inc, hlc.Timestamp{WallTime: int64(2)}, incBackupPath),
+			}
+
+			// Create the IntroducedSpans field for incremental backup.
+			incTables, reIntroducedTables := createMockTables(test.inc)
+
+			newSpans := filterSpans(backups[1].Spans, backups[0].Spans)
+			reIntroducedSpans, err := spansForAllTableIndexes(execCfg, reIntroducedTables, nil)
+			require.NoError(t, err)
+			backups[1].IntroducedSpans = append(newSpans, reIntroducedSpans...)
+
+			restoreSpans := spansForAllRestoreTableIndexes(codec, incTables, nil)
+			require.Equal(t, test.expectedRestoreSpanCount, len(restoreSpans))
+
+			introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+			require.NoError(t, err)
+
+			cover := makeSimpleImportSpans(restoreSpans, backups, nil, introducedSpanFrontier, nil)
+
+			for _, reIntroTable := range reIntroducedTables {
+				var coveredReIntroducedGroup roachpb.SpanGroup
+				for _, entry := range cover {
+					// If a restoreSpanEntry overlaps with re-introduced span,
+					// assert the entry only contains files from the incremental backup.
+					if reIntroTable.TableSpan(codec).Overlaps(entry.Span) {
+						coveredReIntroducedGroup.Add(entry.Span)
+						for _, files := range entry.Files {
+							require.Equal(t, incBackupPath, files.Path)
+						}
+					}
+				}
+				// Assert that all re-introduced indexes are included in the restore
+				for _, reIntroIndexSpan := range reIntroTable.AllIndexSpans(codec) {
+					require.Equal(t, true, coveredReIntroducedGroup.Encloses(reIntroIndexSpan))
+				}
+			}
+		})
+	}
 }
 
 func TestRestoreEntryCover(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-
 	r, _ := randutil.NewTestRand()
 	for _, numBackups := range []int{1, 2, 3, 5, 9, 10, 11, 12} {
 		for _, spans := range []int{1, 2, 3, 5, 9, 11, 12} {
@@ -162,7 +469,10 @@ func TestRestoreEntryCover(t *testing.T) {
 				backups := MockBackupChain(numBackups, spans, files, r)
 
 				t.Run(fmt.Sprintf("numBackups=%d, numSpans=%d, numFiles=%d", numBackups, spans, files), func(t *testing.T) {
-					cover := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil, nil)
+					introducedSpanFrontier, err := createIntroducedSpanFrontier(backups, hlc.Timestamp{})
+					require.NoError(t, err)
+					cover := makeSimpleImportSpans(backups[numBackups-1].Spans, backups, nil,
+						introducedSpanFrontier, nil)
 					if err := checkRestoreCovering(backups, backups[numBackups-1].Spans, cover); err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -327,17 +327,104 @@ func fullClusterTargetsBackup(
 	return fullClusterDescs, fullClusterDBIDs, nil
 }
 
+// checkMissingIntroducedSpans asserts that each backup's IntroducedSpans
+// contain all tables that require an introduction (i.e. a backup from ts=0), if
+// they are also restore targets. This specifically entails checking the
+// following invariant on each table we seek to restore: if the nth backup
+// contains a table in its backupManifest.Descriptors field but the n-1th does
+// not, then that table must be covered by the nth backup's
+// manifest.IntroducedSpans field. Note: this check assumes that
+// mainBackupManifests are sorted by Endtime and this check only applies to
+// backups with a start time that is less than the restore AOST.
+func checkMissingIntroducedSpans(
+	restoringDescs []catalog.Descriptor,
+	mainBackupManifests []BackupManifest,
+	endTime hlc.Timestamp,
+	codec keys.SQLCodec,
+) error {
+	// Gather the tables we'd like to restore.
+	requiredTables := make(map[descpb.ID]struct{})
+	for _, restoringDesc := range restoringDescs {
+		if _, ok := restoringDesc.(catalog.TableDescriptor); ok {
+			requiredTables[restoringDesc.GetID()] = struct{}{}
+		}
+	}
+
+	for i, b := range mainBackupManifests {
+		if !endTime.IsEmpty() && endTime.Less(b.StartTime) {
+			// No need to check a backup that began after the restore AOST.
+			return nil
+		}
+
+		if i == 0 {
+			// The full backup does not contain reintroduced spans.
+			continue
+		}
+
+		// Gather the tables included in the previous backup.
+		prevTables := make(map[descpb.ID]struct{})
+		for _, desc := range mainBackupManifests[i-1].Descriptors {
+			if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil {
+				prevTables[table.GetID()] = struct{}{}
+			}
+		}
+
+		// Gather the tables that were reintroduced in the current backup (i.e.
+		// backed up from ts=0).
+		tablesIntroduced := make(map[descpb.ID]struct{})
+		for _, span := range mainBackupManifests[i].IntroducedSpans {
+			_, tableID, err := codec.DecodeTablePrefix(span.Key)
+			if err != nil {
+				return err
+			}
+			tablesIntroduced[descpb.ID(tableID)] = struct{}{}
+		}
+
+		// If the table in the current backup was not in prevBackup.Descriptors,
+		// then it needs to be introduced.
+		for _, desc := range mainBackupManifests[i].Descriptors {
+			if table, _, _, _ := descpb.FromDescriptor(&desc); table != nil {
+
+				if _, required := requiredTables[table.GetID()]; !required {
+					continue
+				}
+
+				_, inPrevBackup := prevTables[table.GetID()]
+
+				_, introduced := tablesIntroduced[table.GetID()]
+
+				if !inPrevBackup && !introduced {
+					tableError := errors.Newf("table %q cannot be safely restored from this backup."+
+						" This backup is affected by issue #88042, which produced incorrect backups after an IMPORT."+
+						" To continue the restore, you can either:"+
+						" 1) restore to a system time before the import completed, %v;"+
+						" 2) restore with a newer backup chain (a full backup [+ incrementals])"+
+						" taken after the current backup target;"+
+						" 3) or remove table %v from the restore targets.",
+						table.Name, mainBackupManifests[i].StartTime.GoTime().String(), table.Name)
+					return errors.WithIssueLink(tableError, errors.IssueLink{
+						IssueURL: "https://www.cockroachlabs.com/docs/advisories/a88042",
+						Detail: `An incremental database backup with revision history can incorrectly backup data for a table 
+that was running an IMPORT at the time of the previous incremental in this chain of backups.`,
+					})
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // selectTargets loads all descriptors from the selected backup manifest(s),
 // filters the descriptors based on the targets specified in the restore, and
 // calculates the max descriptor ID in the backup.
 // Post filtering, the method returns:
-//  - A list of all descriptors (table, type, database, schema) along with their
-//    parent databases.
-//  - A list of database descriptors IFF the user is restoring on the cluster or
-//    database level.
-//  - A map of table patterns to the resolved descriptor IFF the user is
-//    restoring on the table leve.
-//  - A list of tenants to restore, if applicable.
+//   - A list of all descriptors (table, type, database, schema) along with their
+//     parent databases.
+//   - A list of database descriptors IFF the user is restoring on the cluster or
+//     database level.
+//   - A map of table patterns to the resolved descriptor IFF the user is
+//     restoring on the table leve.
+//   - A list of tenants to restore, if applicable.
 func selectTargets(
 	ctx context.Context,
 	p sql.PlanHookState,

--- a/pkg/ccl/backupccl/targets.go
+++ b/pkg/ccl/backupccl/targets.go
@@ -576,13 +576,18 @@ func MakeBackupTableEntry(
 		return BackupTableEntry{}, errors.Wrapf(err, "making spans for table %s", fullyQualifiedTableName)
 	}
 
+	introducedSpanFrontier, err := createIntroducedSpanFrontier(backupManifests, hlc.Timestamp{})
+	if err != nil {
+		return BackupTableEntry{}, err
+	}
+
 	entry := makeSimpleImportSpans(
 		[]roachpb.Span{tablePrimaryIndexSpan},
 		backupManifests,
-		nil,           /*backupLocalityInfo*/
+		nil, /*backupLocalityInfo*/
+		introducedSpanFrontier,
 		roachpb.Key{}, /*lowWaterMark*/
 	)
-
 	lastSchemaChangeTime := findLastSchemaChangeTime(backupManifests, tbDesc, endTime)
 
 	backupTableEntry := BackupTableEntry{

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-missing-data
@@ -1,0 +1,404 @@
+# This test induces the skipped span introduction bug described in
+# https://github.com/cockroachdb/cockroach/issues/88042
+# and ensures that RESTORE now fails with an expected error message.
+# The exact timeline that induces the bug is the following:
+#
+# - t0: begin import jobs and pause it
+# - t1: wildcard table or database backup with revision history
+# - t2: cancel an import job, and continue a different one
+# - t3: run an incremental backup with revision history
+#       - the testing knob will induce this incremental backup to skip the
+#         introduction of the imported tables
+# - t4: restore the tables.
+#       - If we restore AOST after the imports completed/failed, the restore should fail as it now
+#         detects that the incremental backup at t3 forgot to re-introduce the span.
+#       - If we restore AOST before the import completed/failed, the restore should succeed, as the
+#         skipped span introduction is irrelevant.
+#
+# The test also ensures that similar backup/restore/import scenarios are safe from corruption:
+#  - the timeline above with table/database backups w/o revision history
+#  - revision history cluster backups
+#  - revision history table/database backups which includes an incremental backup between t1 and t2
+
+new-server name=s1 knobs=skip-descriptor-change-intro
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE goodfoo (i INT PRIMARY KEY, s STRING);
+CREATE INDEX goodfoo_idx on goodfoo (s);
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz;
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+import expect-pausepoint tag=aaa
+IMPORT INTO goodfoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Create 5 backup chains:
+#
+# 1. A corrupt database backup chain with revision history
+#
+# 2. A corrupt wildcard table backup chain with revision history
+#
+# 3. A clean database backup chain with revision history which includes two
+#    backups that observe the offline descriptors.
+#
+# 4. A clean data database backup chain without revision history
+#
+# 5. A clean cluster backup chain with revision history
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database_double_inc/' with revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database_no_hist/';
+----
+
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+# Conduct another incremental backup on the database_double_inc chain
+# and ensure the processors spin up
+exec-sql
+INSERT INTO baz VALUES (4, 'a');
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database_double_inc/' with revision_history;
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+save-cluster-ts tag=t0
+----
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job cancel=a
+----
+
+job cancel=aa
+----
+
+job tag=a wait-for-state=cancelled
+----
+
+
+job tag=aa wait-for-state=cancelled
+----
+
+job resume=aaa
+----
+
+job tag=aaa wait-for-state=succeeded
+----
+
+
+# Verify proper rollback
+query-sql
+SELECT count(*) FROM d.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d.foofoo;
+----
+1
+
+# Verify completed import
+query-sql
+SELECT count(*) FROM d.goodfoo;
+----
+3
+
+
+# Because BackupRestoreTestingKnobs.SkipDescriptorChangeIntroduction is turned on,
+# this backup will be unable to introduce foo, foofoo, and goodfoo.
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' with revision_history;
+----
+
+# However, the following backup chains avoid the bug
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database_double_inc/' with revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database_no_hist/';
+----
+
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+# Note that we're purposely skipping the reintroduction of foo, foofoo, goodfoo in the
+# incremental to simulate the bug.
+# - note that goodfoo did get backed up in the incremental backup, but only because when
+#   the import resumed, it re-ingested goodfoo using an addsstable request at a timestamp greater than
+#   the incremental backup start time. If it had been introduced, 6 rows should have appeared in
+#   SHOW BACKUP, as seen in different backup chains.
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo' or object_name = 'goodfoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 0 incremental
+d goodfoo table 3 incremental
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo' or object_name = 'goodfoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 0 incremental
+d goodfoo table 3 incremental
+
+# In all show backups below, the foo,foofoo, and goodfoo should get introduced
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database_double_inc/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo' or object_name = 'goodfoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 1 incremental
+d goodfoo table 6 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database_no_hist/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo' or object_name = 'goodfoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 1 incremental
+d goodfoo table 6 incremental
+
+# Note that the cluster level SHOW BACKUP includes foo and foofoo in the full
+# backup while the database ones do not. This is because CLUSTER
+# backup manifests includes these in the Descriptors field (i.e. cluster backups
+# explicitly backup offline tables, see #88043), while database
+# backups only include these descriptors in manifest.DescriptorChanges (see
+# #88042).
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo' or object_name = 'goodfoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 3 full
+d foofoo table 4 full
+d goodfoo table 3 full
+d foo table 0 incremental
+d foofoo table 1 incremental
+d goodfoo table 6 incremental
+
+
+############
+# Restore validation
+############
+
+# check that RESTORE will fail if any corrupt table restore is attempted
+exec-sql expect-error-regex='table "foo" cannot be safely restored from this backup .*'
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name = d_fail;
+----
+regex matches error
+
+exec-sql expect-error-regex='table "goodfoo" cannot be safely restored from this backup .*'
+RESTORE TABLE d.goodfoo FROM LATEST IN 'nodelocal://0/database/' with into_db = defaultdb;
+----
+regex matches error
+
+exec-sql expect-error-regex='table "foofoo" cannot be safely restored from this backup .*'
+RESTORE TABLE d.foofoo FROM LATEST IN 'nodelocal://0/database/' with into_db = defaultdb;
+----
+regex matches error
+
+
+# Ensure the restore succeeds if there are no corrupt tables in the target
+exec-sql
+RESTORE TABLE d.baz FROM LATEST IN 'nodelocal://0/database/' with into_db = defaultdb;
+----
+
+
+# Check that the wildcard restore encounters the same errors
+
+exec-sql
+CREATE DATABASE defaultdb2;
+----
+
+exec-sql expect-error-regex='table "foo" cannot be safely restored from this backup .*'
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/table/' with into_db = defaultdb2;
+----
+regex matches error
+
+exec-sql expect-error-regex='table "foofoo" cannot be safely restored from this backup .*'
+RESTORE TABLE d.foofoo FROM LATEST IN 'nodelocal://0/table/' with into_db = defaultdb2;
+----
+regex matches error
+
+# Ensure the restore succeeds if there are no corrupt tables in the target
+exec-sql
+RESTORE TABLE d.baz FROM LATEST IN 'nodelocal://0/table/' with into_db = defaultdb2;
+----
+
+######################
+# Check that you can restore AOST while the tables are offline
+restore aost=t0
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' AS OF SYSTEM TIME t0 with new_db_name=d_t0;
+----
+
+
+query-sql
+SELECT table_name FROM [SHOW TABLES FROM d_t0];
+----
+baz
+
+
+###########################
+# Check the alternative scenarios
+###########################
+
+# Check that a backup chain with the intermediate incremental backup restores properly
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_double_inc/' with new_db_name = d_double_inc;
+----
+
+query-sql
+SELECT count(*) FROM d_double_inc.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d_double_inc.foofoo;
+----
+1
+
+query-sql
+SELECT count(*) FROM d_double_inc.goodfoo;
+----
+3
+
+
+# Check that that backup chain with the intermediate incremental backup restores properly
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database_no_hist/' with new_db_name = d_no_hist;
+----
+
+query-sql
+SELECT count(*) FROM d_no_hist.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d_no_hist.foofoo;
+----
+1
+
+query-sql
+SELECT count(*) FROM d_no_hist.goodfoo;
+----
+3
+
+
+# Check the cluster level restore
+new-server name=s2 share-io-dir=s1
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+query-sql
+SELECT count(*) FROM d.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d.foofoo;
+----
+1
+
+
+query-sql
+SELECT count(*) FROM d.goodfoo;
+----
+3

--- a/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
+++ b/pkg/ccl/backupccl/testdata/backup-restore/in-progress-import-rollback
@@ -1,0 +1,251 @@
+
+# Ensure clear range induces full reintroduction of spans and that restore properly elides
+# clear ranged data from initial backup
+# - begin import jobs and pause it
+# - run inc backup - verify inc has captured the data
+# - roll it back it back non-mvcc
+# - run an inc backup and ensure we reintroduce the table spans
+
+new-server name=s1
+----
+
+exec-sql
+CREATE DATABASE d;
+USE d;
+CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
+CREATE INDEX foo_idx ON foo (s);
+CREATE INDEX foo_to_drop_idx ON foo (s);
+CREATE TABLE foofoo (i INT PRIMARY KEY, s STRING);
+INSERT INTO foofoo VALUES (10, 'x0');
+CREATE TABLE baz (i INT PRIMARY KEY, s STRING);
+INSERT INTO baz VALUES (1, 'x'),(2,'y'),(3,'z');
+----
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';
+----
+
+
+exec-sql
+EXPORT INTO CSV 'nodelocal://0/export1/' FROM SELECT * FROM baz;
+----
+
+
+# Pause the import job, in order to back up the importing data.
+import expect-pausepoint tag=a
+IMPORT INTO foo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+import expect-pausepoint tag=aa
+IMPORT INTO foofoo (i,s) CSV DATA ('nodelocal://0/export1/export*-n*.0.csv')
+----
+job paused at pausepoint
+
+
+# Ensure table, database, and cluster full backups capture importing rows.
+exec-sql
+BACKUP INTO 'nodelocal://0/cluster/' with revision_history;
+----
+
+
+exec-sql
+BACKUP DATABASE d INTO 'nodelocal://0/database/' with revision_history;
+----
+
+exec-sql
+BACKUP TABLE d.* INTO 'nodelocal://0/table/' with revision_history;
+----
+
+
+exec-sql
+SET CLUSTER SETTING jobs.debug.pausepoints = '';
+----
+
+
+# Resume the job so the next set of incremental backups observes that tables are back online
+job cancel=a
+----
+
+job cancel=aa
+----
+
+job tag=a wait-for-state=cancelled
+----
+
+
+job tag=aa wait-for-state=cancelled
+----
+
+# Verify proper rollback
+query-sql
+SELECT count(*) FROM d.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d.foofoo;
+----
+1
+
+
+# Even though the full table will get backed up from ts=0 during the next round of incremental
+# backups, only active indexes (foo_idx and foo_new_idx) should appear in the restored cluster.
+exec-sql
+DROP INDEX foo_to_drop_idx;
+----
+NOTICE: the data for dropped indexes is reclaimed asynchronously
+HINT: The reclamation delay can be customized in the zone configuration for the table.
+
+exec-sql
+CREATE INDEX foo_new_idx ON foo (s);
+----
+
+
+# Ensure incremental backups backup the newly online spans from ts=0, as the
+# import was rolled back via non-mvcc clear range. So, backup 0 rows from foo
+# (it was empty pre-import), and 1 row from foo (had 1 row pre-import);
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://0/cluster/' with revision_history;
+----
+
+exec-sql
+BACKUP DATABASE d INTO LATEST IN 'nodelocal://0/database/' with revision_history;
+----
+
+
+exec-sql
+BACKUP TABLE d.* INTO LATEST IN 'nodelocal://0/table/' with revision_history;
+----
+
+
+# Note that the cluster level SHOW BACKUP includes foo and foofoo in the full
+# backup while the the table and database ones do not. This is because CLUSTER
+# backup manifests includes these in the Descriptors field (i.e. cluster backups
+# explicitly backup offline tables, see #88043), while table and database
+# backups only include these descriptors in manifest.DescriptorChanges (see
+# #88042).
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/cluster/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 3 full
+d foofoo table 4 full
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/database/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+
+query-sql
+SELECT
+  database_name, object_name, object_type, rows, backup_type
+FROM
+  [SHOW BACKUP FROM LATEST IN 'nodelocal://0/table/']
+WHERE
+  object_name = 'foo' or object_name = 'foofoo'
+ORDER BY
+  start_time, database_name;
+----
+d foo table 0 incremental
+d foofoo table 1 incremental
+
+
+# To verify the incremental backed up the pre-import state table, restore d and ensure all tables
+# are in their pre-import state.
+
+new-server name=s2 share-io-dir=s1
+----
+
+exec-sql
+RESTORE FROM LATEST IN 'nodelocal://0/cluster/';
+----
+
+
+query-sql
+SELECT count(*) FROM d.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d.foofoo;
+----
+1
+
+
+query-sql
+select DISTINCT index_name FROM [SHOW INDEXES FROM d.foo];
+----
+foo_pkey
+foo_idx
+foo_new_idx
+
+
+exec-sql
+RESTORE DATABASE d FROM LATEST IN 'nodelocal://0/database/' with new_db_name=d2;
+----
+
+query-sql
+SELECT count(*) FROM d2.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d2.foofoo;
+----
+1
+
+query-sql
+select DISTINCT index_name FROM [SHOW INDEXES FROM d2.foo];
+----
+foo_pkey
+foo_idx
+foo_new_idx
+
+exec-sql
+CREATE DATABASE d3;
+----
+
+exec-sql
+RESTORE TABLE d.* FROM LATEST IN 'nodelocal://0/database/' with into_db=d3;
+----
+
+query-sql
+SELECT count(*) FROM d3.foo;
+----
+0
+
+
+query-sql
+SELECT count(*) FROM d3.foofoo;
+----
+1
+
+query-sql
+select DISTINCT index_name FROM [SHOW INDEXES FROM d3.foo];
+----
+foo_pkey
+foo_idx
+foo_new_idx

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1567,6 +1567,11 @@ type BackupRestoreTestingKnobs struct {
 	// testing. This is typically the bulk mem monitor if not
 	// specified here.
 	BackupMemMonitor *mon.BytesMonitor
+
+	// SkipDescriptorChangeIntroduction skips checking the
+	// backupManifest.DescriptorChanges when deciding which spans to reintroduce.
+	// This helps simulate the bug described in 88042.
+	SkipDescriptorChangeIntroduction bool
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}
@@ -2229,8 +2234,10 @@ func (st *SessionTracing) getSessionTrace() ([]traceRow, error) {
 //
 // Args:
 // kvTracingEnabled: If set, the traces will also include "KV trace" messages -
-//   verbose messages around the interaction of SQL with KV. Some of the messages
-//   are per-row.
+//
+//	verbose messages around the interaction of SQL with KV. Some of the messages
+//	are per-row.
+//
 // showResults: If set, result rows are reported in the trace.
 func (st *SessionTracing) StartTracing(
 	recType tracing.RecordingType, kvTracingEnabled, showResults bool,
@@ -2450,11 +2457,11 @@ type traceRow [traceNumCols]tree.Datum
 
 // A regular expression to split log messages.
 // It has three parts:
-// - the (optional) code location, with at least one forward slash and a period
-//   in the file name:
-//   ((?:[^][ :]+/[^][ :]+\.[^][ :]+:[0-9]+)?)
-// - the (optional) tag: ((?:\[(?:[^][]|\[[^]]*\])*\])?)
-// - the message itself: the rest.
+//   - the (optional) code location, with at least one forward slash and a period
+//     in the file name:
+//     ((?:[^][ :]+/[^][ :]+\.[^][ :]+:[0-9]+)?)
+//   - the (optional) tag: ((?:\[(?:[^][]|\[[^]]*\])*\])?)
+//   - the message itself: the rest.
 var logMessageRE = regexp.MustCompile(
 	`(?s:^((?:[^][ :]+/[^][ :]+\.[^][ :]+:[0-9]+)?) *((?:\[(?:[^][]|\[[^]]*\])*\])?) *(.*))`)
 


### PR DESCRIPTION
Backport 1/1 commits from #87312.

/cc @cockroachdb/release

---

Currently RESTORE may restore invalid backup data from a backed up table that
underwent an IMPORT rollback. See https://github.com/cockroachdb/cockroach/issues/87305 for a detailed explanation.

This patch ensures that RESTORE elides older backup data that were deleted via
a non-MVCC operation. Because incremental backups always reintroduce spans
(i.e. backs them up from timestamp 0) that may have undergone a non-mvcc
operation, restore can identify restoring spans with potentially corrupt data
in the backup chain and only ingest the spans' reintroduced data to any system
time, without the corrupt data.

Here's the basic impliemenation in Restore:
- For each span we want to restore
   - identify the last time, l, the span was introduced, using the manifests
   - dont restore the span using a backup if backup.EndTime < l

This implementation rests on the following assumption: the input spans for each
restoration flow (created in createImportingDescriptors) and the
restoreSpanEntries (created by makeSimpleImportSpans) do not span across
multiple tables. Given this assumption, makeSimpleImportSpans skips adding
files from a backups for a given input span that was reintroduced in a
subsequent backup.

It's worth noting that all significant refactoring occurs on code run by
the restore coordinator; therefore, no special care needs to be taken for
mixed / cross version backups. In other words, if the coordinator has updated,
the cluster restores properly; else, the bug will exist on the restored cluster.
It's also worth noting that other forms of this bug are apparent on older
cluster versions (https://github.com/cockroachdb/cockroach/issues/88042, https://github.com/cockroachdb/cockroach/issues/88043) and has not been noticed by customers; thus,
there is no need to fail a mixed version restore to protect the customer from
this already existing bug.

Informs https://github.com/cockroachdb/cockroach/issues/87305

Release justification: bug fix

Release note: fix for TA advisory
https://cockroachlabs.atlassian.net/browse/TSE-198; https://www.cockroachlabs.com/docs/advisories/a88042
