### PR TITLE
tests: new roachtest for job backward compatibility in new schema changer

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -75,6 +75,7 @@ go_library(
         "many_splits.go",
         "mixed_version_cdc.go",
         "mixed_version_decommission.go",
+        "mixed_version_job_compatibility_in_declarative_schema_changer.go",
         "mixed_version_jobs.go",
         "mixed_version_schemachange.go",
         "multitenant.go",

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -1,0 +1,143 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/stretchr/testify/require"
+)
+
+// testSetupResetStep setups the testing state (e.g. create a few databases and tables)
+// and always use declarative schema changer on all nodes.
+func testSetupResetStep(c cluster.Cluster) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		db := c.Conn(ctx, t.L(), 1)
+		setUpQuery := `
+CREATE DATABASE testdb; 
+CREATE SCHEMA testdb.testsc; 
+CREATE TABLE testdb.testsc.t (i INT PRIMARY KEY);
+CREATE TYPE testdb.testsc.typ AS ENUM ('a', 'b');
+CREATE SEQUENCE testdb.testsc.s;
+CREATE VIEW testdb.testsc.v AS (SELECT i*2 FROM testdb.testsc.t);
+`
+		_, err := db.ExecContext(ctx, setUpQuery)
+		require.NoError(t, err)
+
+		// Set all nodes to always use declarative schema changer
+		// so that we don't fall back to legacy schema changer implicitly.
+		// Being explicit can help catch bugs that will otherwise be
+		// buried by the fallback.
+		for _, node := range c.All() {
+			db = c.Conn(ctx, t.L(), node)
+			_, err = db.ExecContext(ctx, "SET use_declarative_schema_changer = unsafe_always")
+			require.NoError(t, err)
+		}
+	}
+}
+
+// setShortGCTTLInSystemZoneConfig sets gc.ttlseconds in the default zone config
+// to be 1 second.
+func setShortGCTTLInSystemZoneConfig(c cluster.Cluster) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		db := c.Conn(ctx, t.L(), 1)
+		_, err := db.ExecContext(ctx, "ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 1;")
+		require.NoError(t, err)
+	}
+}
+
+func planAndRunSchemaChange(
+	c cluster.Cluster, nodeToPlanSchemaChange option.NodeListOption, schemaChangeStmt string,
+) versionStep {
+	return func(ctx context.Context, t test.Test, u *versionUpgradeTest) {
+		gatewayDB := c.Conn(ctx, t.L(), nodeToPlanSchemaChange[0])
+		defer gatewayDB.Close()
+		t.Status("Running: ", schemaChangeStmt)
+		_, err := gatewayDB.ExecContext(ctx, schemaChangeStmt)
+		require.NoError(t, err)
+	}
+}
+
+func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.Registry) {
+	// declarative_schema_changer/job-compatibility-mixed-version tests that,
+	// in a mixed version cluster, jobs created by the declarative schema changer
+	// are both backward and forward compatible. That is, declarative schema
+	// changer job created by nodes running newer (resp. older) binary versions
+	// be adopted and finished by nodes running older (resp. newer) binary versions.
+	// This test requires us to come back and change the to-be-tests stmts to be those
+	// supported in the "previous" major release.
+	r.Add(registry.TestSpec{
+		Name:    "declarative_schema_changer/job-compatibility-mixed-version",
+		Owner:   registry.OwnerSQLSchema,
+		Cluster: r.MakeClusterSpec(4),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// An empty string means that the cockroach binary specified by flag
+			// `cockroach` will be used.
+			const mainVersion = ""
+			allNodes := c.All()
+			upgradedNodes := c.Nodes(1, 2)
+			oldNodes := c.Nodes(3, 4)
+			predV, err := PredecessorVersion(*t.BuildVersion())
+			require.NoError(t, err)
+
+			u := newVersionUpgradeTest(c,
+				// System setup.
+				uploadAndStartFromCheckpointFixture(allNodes, predV),
+				waitForUpgradeStep(allNodes),
+				preventAutoUpgradeStep(1),
+				setShortJobIntervalsStep(1),
+				setShortGCTTLInSystemZoneConfig(c),
+
+				// Upgrade some nodes.
+				binaryUpgradeStep(upgradedNodes, mainVersion),
+
+				// Job backward compatibility test:
+				//   - upgraded nodes: plan schema change and create schema changer jobs
+				//   - older nodes: adopt and execute schema changer jobs
+				testSetupResetStep(c),
+
+				// Halt job execution on upgraded nodes.
+				disableJobAdoptionStep(c, upgradedNodes),
+
+				// Run schema change stmts, chosen from those supported in `predV` version.
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP SEQUENCE testdb.testsc.s`),
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP TYPE testdb.testsc.typ`),
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP VIEW testdb.testsc.v`),
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP TABLE testdb.testsc.t`),
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP SCHEMA testdb.testsc`),
+				planAndRunSchemaChange(c, upgradedNodes.RandNode(), `DROP DATABASE testdb CASCADE`),
+				enableJobAdoptionStep(c, upgradedNodes),
+
+				// Job forward compatibility test:
+				//   - older nodes: plan schema change and create schema changer jobs
+				//   - upgraded nodes: adopt and execute schema changer jobs
+				testSetupResetStep(c),
+
+				// Halt job execution on old nodes.
+				disableJobAdoptionStep(c, oldNodes),
+
+				// Run schema change stmts, chosen from those supported in `predV` version.
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP SEQUENCE testdb.testsc.s`),
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP TYPE testdb.testsc.typ`),
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP VIEW testdb.testsc.v`),
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP TABLE testdb.testsc.t`),
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP SCHEMA testdb.testsc`),
+				planAndRunSchemaChange(c, oldNodes.RandNode(), `DROP DATABASE testdb CASCADE`),
+				enableJobAdoptionStep(c, oldNodes),
+			)
+			u.run(ctx, t)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -131,6 +131,7 @@ func RegisterTests(r registry.Registry) {
 	registerValidateSystemSchemaAfterVersionUpgrade(r)
 	registerVersion(r)
 	registerYCSB(r)
+	registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r)
 }
 
 // RegisterBenchmarks registers all benchmarks to the registry. This powers `roachtest bench`.


### PR DESCRIPTION
Backport 2/2 commits from #86950.

/cc @cockroachdb/release

---

Commit 1: Moved a few functions so that we can reuse them in the next commit.
Commit 2: We added a roachtest that tests job backward compatibility in the
declarartive schema changer in a mixed-version cluster. Namely, we test that
DDL stmts supported in v22.1 can be planed in nodes running in v22.2 and the
jobs created can be adopted and finished by nodes running in v22.1.

Fixes: #79840

Release justification: test only changes.

Release note: None
