### PR TITLE
Roachtest redirect SSH flakes to test-eng

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/internal/team",
         "//pkg/roachprod",
         "//pkg/roachprod/config",
+        "//pkg/roachprod/errors",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -204,17 +204,21 @@ func TestCreatePostRequest(t *testing.T) {
 
 			expectedTeam := "@cockroachdb/unowned"
 			expectedName := "github_test"
+			expectedMessagePrefix := ""
 
 			if c.category == clusterCreationErr {
 				expectedTeam = "@cockroachdb/dev-inf"
 				expectedName = "cluster_creation"
+				expectedMessagePrefix = "test github_test was skipped due to "
 			} else if c.category == sshErr {
 				expectedTeam = "@cockroachdb/test-eng"
 				expectedName = "ssh_problem"
+				expectedMessagePrefix = "test github_test failed due to "
 			}
 
 			require.Contains(t, req.MentionOnCreate, expectedTeam)
 			require.Equal(t, expectedName, req.TestName)
+			require.True(t, strings.HasPrefix(req.Message, expectedMessagePrefix), req.Message)
 		}
 	}
 }

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -382,8 +382,15 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 
 	filter := registry.NewTestFilter(cfg.args)
 	clusterType := roachprodCluster
+	bindTo := ""
 	if local {
 		clusterType = localCluster
+
+		// This will suppress the annoying "Allow incoming network connections" popup from
+		// OSX when running a roachtest
+		bindTo = "localhost"
+
+		fmt.Printf("--local specified. Binding http listener to localhost only")
 		if cfg.parallelism != 1 {
 			fmt.Printf("--local specified. Overriding --parallelism to 1.\n")
 			cfg.parallelism = 1
@@ -398,7 +405,7 @@ func runTests(register func(registry.Registry), cfg cliCfg) error {
 		keepClustersOnTestFailure: cfg.debugEnabled,
 		clusterID:                 cfg.clusterID,
 	}
-	if err := runner.runHTTPServer(cfg.httpPort, os.Stdout); err != nil {
+	if err := runner.runHTTPServer(cfg.httpPort, os.Stdout, bindTo); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -343,7 +343,7 @@ runner itself.
 		if errors.Is(err, errTestsFailed) {
 			code = ExitCodeTestsFailed
 		}
-		if errors.Is(err, errClusterProvisioningFailed) {
+		if errors.Is(err, errSomeClusterProvisioningFailed) {
 			code = ExitCodeClusterProvisioningFailed
 		}
 		// Cobra has already printed the error message.

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -39,6 +39,18 @@ type testStatus struct {
 	progress float64
 }
 
+// Holds all error information from a single invocation of t.{Fatal,Error}{,f} to
+// preserve any structured errors
+// e.g. t.Fatalf("foo %s %s %s", "hello", err1, err2) would mean that
+// failure.errors == [err1, err2], with all args (including the non error "hello")
+// being captured in the squashedErr
+type failure struct {
+	// This is the single error created from variadic args passed to t.{Fatal,Error}{,f}
+	squashedErr error
+	// errors are all the `errors` present in the variadic args
+	errors []error
+}
+
 type testImpl struct {
 	spec *registry.TestSpec
 
@@ -75,18 +87,12 @@ type testImpl struct {
 		// test is being marked as failed (i.e. when the failed field above is also
 		// set). This is used to cancel the context passed to t.spec.Run(), so async
 		// test goroutines can be notified.
-		cancel  func()
-		failLoc struct {
-			file string
-			line int
-		}
+		cancel func()
 
-		// Errors are all the errors passed to `addFailure`, in order of
-		// these calls.
-		//
-		// NB: the first failure is not always the relevant one due to:
-		// https://github.com/cockroachdb/cockroach/issues/44436
-		errors []error
+		// failures added via addFailures, in order
+		// A test can have multiple calls to t.Fail()/Error(), with each call
+		// referencing 0+ errors. failure captures all the errors
+		failures []failure
 
 		// status is a map from goroutine id to status set by that goroutine. A
 		// special goroutine is indicated by runnerID; that one provides the test's
@@ -105,6 +111,10 @@ type testImpl struct {
 	// Version strings look like "20.1.4".
 	versionsBinaryOverride map[string]string
 	skipInit               bool
+}
+
+func newFailure(squashedErr error, errs []error) failure {
+	return failure{squashedErr: squashedErr, errors: errs}
 }
 
 // BuildVersion exposes the build version of the cluster
@@ -258,21 +268,15 @@ func (t *testImpl) Skipf(format string, args ...interface{}) {
 	panic(errTestFatal)
 }
 
-// This creates an error from the first arg, and adds each subsequent arg
-// as error detail
-func argsToErr(depth int, args ...interface{}) error {
-	// NB: we'd probably not allow multiple arguments here and we'd want
-	// the one remaining arg to be an `error`, but we are trying to be
-	// compatible with `(*testing.T).Fatal`.
-	var err error
-	for _, arg := range args {
-		if err == nil {
-			err = errors.NewWithDepthf(depth+1, "%v", arg)
-			continue
+// collectErrors extracts any arg that is an error
+func collectErrors(args []interface{}) []error {
+	var errs []error
+	for _, a := range args {
+		if err, ok := a.(error); ok {
+			errs = append(errs, err)
 		}
-		err = errors.WithDetailf(err, "%v", arg)
 	}
-	return err
+	return errs
 }
 
 // Fatal marks the test as failed, prints the args to t.L(), and calls
@@ -284,61 +288,69 @@ func argsToErr(depth int, args ...interface{}) error {
 // ATTENTION: Since this calls panic(errTestFatal), it should only be called
 // from a test's closure. The test runner itself should never call this.
 func (t *testImpl) Fatal(args ...interface{}) {
-	t.addFailure(argsToErr(1, args...))
+	t.addFailure("", args...)
 	panic(errTestFatal)
 }
 
 // Fatalf is like Fatal, but takes a format string.
 func (t *testImpl) Fatalf(format string, args ...interface{}) {
-	t.addFailure(errors.NewWithDepthf(1, format, args...))
+	t.addFailure(format, args...)
 	panic(errTestFatal)
 }
 
 // FailNow implements the TestingT interface.
 func (t *testImpl) FailNow() {
-	t.addFailure(errors.NewWithDepthf(1, "FailNow called"))
+	t.addFailure("FailNow called")
 	panic(errTestFatal)
 }
 
+// Error implements the TestingT interface
 func (t *testImpl) Error(args ...interface{}) {
-	t.addFailure(argsToErr(1, args...))
+	t.addFailure("", args...)
 }
 
 // Errorf implements the TestingT interface.
 func (t *testImpl) Errorf(format string, args ...interface{}) {
-	t.addFailure(errors.NewWithDepthf(1, format, args...))
+	t.addFailure(format, args...)
 }
 
-func formatFailure(b *strings.Builder, errs ...error) {
-	for i, err := range errs {
+// We take the first error from each failure which is the
+// "squashed" error that contains all information of a failure
+func formatFailure(b *strings.Builder, reportFailures ...failure) {
+	for i, failure := range reportFailures {
 		if i > 0 {
 			fmt.Fprintln(b)
 		}
-		file, line, fn, ok := errors.GetOneLineSource(err)
+		file, line, fn, ok := errors.GetOneLineSource(failure.squashedErr)
 		if !ok {
 			file, line, fn = "<unknown>", 0, "unknown"
 		}
-		fmt.Fprintf(b, "(%s:%d).%s: %v", file, line, fn, err)
+		fmt.Fprintf(b, "(%s:%d).%s: %v", file, line, fn, failure.squashedErr)
 	}
 }
 
-func (t *testImpl) addFailure(reportErr error) {
+func (t *testImpl) addFailure(format string, args ...interface{}) {
+	if format == "" {
+		format = strings.Repeat(" %v", len(args))[1:]
+	}
+	reportFailure := newFailure(errors.NewWithDepthf(1, format, args...), collectErrors(args))
+
 	t.mu.Lock()
 	defer t.mu.Unlock()
 
-	t.mu.errors = append(t.mu.errors, reportErr)
+	t.mu.failures = append(t.mu.failures, reportFailure)
 
 	var b strings.Builder
-	formatFailure(&b, reportErr)
+	formatFailure(&b, reportFailure)
 	msg := b.String()
 
-	t.L().Printf("test failure #%d: %s", len(t.mu.errors), msg)
+	t.L().Printf("test failure #%d: %s", len(t.mu.failures), msg)
 	// Also dump the verbose error (incl. all stack traces) to a log file, in case
 	// we need it. The stacks are sometimes helpful, but we don't want them in the
 	// main log as they are highly verbose.
 	{
 		cl, err := t.L().ChildLogger(
-			fmt.Sprintf("failure_%d", len(t.mu.errors)),
+			fmt.Sprintf("failure_%d", len(t.mu.failures)),
 			logger.QuietStderr, logger.QuietStdout,
 		)
 		if err == nil {
@@ -347,7 +359,7 @@ func (t *testImpl) addFailure(reportErr error) {
 			// so it's better to write only it to the file to avoid confusion.
 			path := cl.File.Name()
 			cl.Close() // we just wanted the filename
-			_ = os.WriteFile(path, []byte(fmt.Sprintf("%+v", reportErr)), 0644)
+			_ = os.WriteFile(path, []byte(fmt.Sprintf("%+v", reportFailure.squashedErr)), 0644)
 		}
 	}
 
@@ -369,15 +381,35 @@ func (t *testImpl) Failed() bool {
 }
 
 func (t *testImpl) failedRLocked() bool {
-	return len(t.mu.errors) > 0
+	return len(t.mu.failures) > 0
 }
 
-func (t *testImpl) FailureMsg() string {
+func (t *testImpl) firstFailure() failure {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	if len(t.mu.failures) <= 0 {
+		return failure{}
+	}
+	return t.mu.failures[0]
+}
+
+func (t *testImpl) failureMsg() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	var b strings.Builder
-	formatFailure(&b, t.mu.errors...)
+	formatFailure(&b, t.mu.failures...)
 	return b.String()
+}
+
+// failureContainsError returns true if any of the errors in a given failure
+// matches the reference error
+func failureContainsError(f failure, refError error) bool {
+	for _, err := range f.errors {
+		if errors.Is(err, refError) {
+			return true
+		}
+	}
+	return errors.Is(f.squashedErr, refError)
 }
 
 func (t *testImpl) ArtifactsDir() string {

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -71,6 +71,10 @@ type testImpl struct {
 		syncutil.RWMutex
 		done bool
 
+		// cancel, if set, is called from the t.Fatal() family of functions when the
+		// test is being marked as failed (i.e. when the failed field above is also
+		// set). This is used to cancel the context passed to t.spec.Run(), so async
+		// test goroutines can be notified.
 		cancel  func()
 		failLoc struct {
 			file string
@@ -83,11 +87,6 @@ type testImpl struct {
 		// NB: the first failure is not always the relevant one due to:
 		// https://github.com/cockroachdb/cockroach/issues/44436
 		errors []error
-		// If len(errors)>0, this indicates whether the test timed out
-		// cancel, if set, is called from the t.Fatal() family of functions when the
-		// test is being marked as failed (i.e. when the failed field above is also
-		// set). This is used to cancel the context passed to t.spec.Run(), so async
-		// test goroutines can be notified.
 
 		// status is a map from goroutine id to status set by that goroutine. A
 		// special goroutine is indicated by runnerID; that one provides the test's

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -50,8 +50,13 @@ import (
 )
 
 var (
-	errTestsFailed               = fmt.Errorf("some tests failed")
-	errClusterProvisioningFailed = fmt.Errorf("some clusters could not be created")
+	errTestsFailed = fmt.Errorf("some tests failed")
+
+	// reference error used by main.go at the end of a run of tests
+	errSomeClusterProvisioningFailed = fmt.Errorf("some clusters could not be created")
+
+	// reference error used when cluster creation fails for a test
+	errClusterProvisioningFailed = fmt.Errorf("cluster could not be created")
 )
 
 // testRunner runs tests.
@@ -310,7 +315,7 @@ func (r *testRunner) Run(
 
 	if r.numClusterErrs > 0 {
 		shout(ctx, l, lopt.stdout, "%d clusters could not be created", r.numClusterErrs)
-		return errClusterProvisioningFailed
+		return errSomeClusterProvisioningFailed
 	}
 
 	if len(r.status.fail) > 0 {
@@ -572,6 +577,7 @@ func (r *testRunner) runWorker(
 			wStatus.SetStatus("creating cluster")
 			c, vmCreateOpts, clusterCreateErr = allocateCluster(ctx, testToRun.spec, testToRun.alloc, artifactsRootDir, wStatus)
 			if clusterCreateErr != nil {
+				clusterCreateErr = errors.Mark(clusterCreateErr, errClusterProvisioningFailed)
 				atomic.AddInt32(&r.numClusterErrs, 1)
 				shout(ctx, l, stdout, "Unable to create (or reuse) cluster for test %s due to: %s.",
 					testToRun.spec.Name, clusterCreateErr)
@@ -622,12 +628,9 @@ func (r *testRunner) runWorker(
 			// Instead, let's report an infrastructure issue, mark the test as failed and continue with the next test.
 
 			// Generate failure reason and mark the test failed to preclude fetching (cluster) artifacts.
-			t.addFailure(clusterCreateErr)
-			issueOutput := "test %s was skipped due to %s"
-			issueOutput = fmt.Sprintf(issueOutput, t.spec.Name, t.FailureMsg())
-
+			t.Error(clusterCreateErr)
 			// N.B. issue title is of the form "roachtest: ${t.spec.Name} failed" (see UnitTestFormatter).
-			if err := github.MaybePost(t, clusterCreationErr, issueOutput); err != nil {
+			if err := github.MaybePost(t, t.failureMsg()); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
 		} else {
@@ -663,7 +666,7 @@ func (r *testRunner) runWorker(
 			shout(ctx, l, stdout, "test returned error: %s: %s", t.Name(), err)
 			// Mark the test as failed if it isn't already.
 			if !t.Failed() {
-				t.addFailure(err)
+				t.Error(err)
 			}
 		} else {
 			msg := "test passed: %s (run %d)"
@@ -679,7 +682,7 @@ func (r *testRunner) runWorker(
 			if err != nil {
 				failureMsg += fmt.Sprintf("%+v", err)
 			} else {
-				failureMsg += t.FailureMsg()
+				failureMsg += t.failureMsg()
 			}
 			if c != nil {
 				if debug {
@@ -800,10 +803,7 @@ func (r *testRunner) runTest(
 		// during the post-flight checks; the test itself runs on a different
 		// goroutine and has similar code to terminate errTestFatal.
 		if err := recover(); err != nil && err != errTestFatal {
-			if _, ok := err.(error); !ok {
-				err = errors.Newf("%v", err)
-			}
-			t.addFailure(err.(error))
+			t.Error(err)
 		}
 
 		t.mu.Lock()
@@ -812,7 +812,7 @@ func (r *testRunner) runTest(
 
 		durationStr := fmt.Sprintf("%.2fs", t.duration().Seconds())
 		if t.Failed() {
-			output := fmt.Sprintf("test artifacts and logs in: %s\n%s", t.ArtifactsDir(), t.FailureMsg())
+			output := fmt.Sprintf("test artifacts and logs in: %s\n%s", t.ArtifactsDir(), t.failureMsg())
 
 			if teamCity {
 				shout(ctx, l, stdout, "##teamcity[testFailed name='%s' details='%s' flowId='%s']",
@@ -821,14 +821,7 @@ func (r *testRunner) runTest(
 
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", runID, durationStr, output)
 
-			cat := otherErr
-
-			// This will override the created issue's owner as it is likely due to an SSH flake
-			if strings.Contains(output, "SSH_PROBLEM") {
-				cat = sshErr
-			}
-
-			if err := github.MaybePost(t, cat, output); err != nil {
+			if err := github.MaybePost(t, output); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
 		} else {
@@ -865,7 +858,7 @@ func (r *testRunner) runTest(
 			start:   t.start,
 			end:     t.end,
 			pass:    !t.Failed(),
-			failure: t.FailureMsg(),
+			failure: t.failureMsg(),
 		})
 		r.status.Lock()
 		delete(r.status.running, t)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1186,14 +1186,15 @@ func (r *testRunner) removeWorker(ctx context.Context, name string) {
 // runHTTPServer starts a server running in the background.
 //
 // httpPort: The port on which to serve the web interface. Pass 0 for allocating
+// bindTo: The host/ip on which to bind. Leave empty to bind on all local ips
 //
 //	a port automatically (which will be printed to stdout).
-func (r *testRunner) runHTTPServer(httpPort int, stdout io.Writer) error {
+func (r *testRunner) runHTTPServer(httpPort int, stdout io.Writer, bindTo string) error {
 	http.HandleFunc("/", r.serveHTTP)
 	// Run an http server in the background.
 	// We handle the case where httpPort is 0, which means we automatically
 	// allocate a port.
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", httpPort))
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%d", bindTo, httpPort))
 	if err != nil {
 		return err
 	}
@@ -1203,7 +1204,11 @@ func (r *testRunner) runHTTPServer(httpPort int, stdout io.Writer) error {
 			panic(err)
 		}
 	}()
-	fmt.Fprintf(stdout, "HTTP server listening on all network interfaces, port %d.\n", httpPort)
+	bindToDesc := "all network interfaces"
+	if bindTo != "" {
+		bindToDesc = bindTo
+	}
+	fmt.Fprintf(stdout, "HTTP server listening on %s, port %d.\n", bindToDesc, httpPort)
 	return nil
 }
 

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -620,24 +620,16 @@ func (r *testRunner) runWorker(
 			// N.B. cluster creation must have failed...
 			// We don't want to prematurely abort the test suite since it's likely a transient issue.
 			// Instead, let's report an infrastructure issue, mark the test as failed and continue with the next test.
-			// Note, we fake the test name so that all cluster creation errors are posted to the same github issue.
-			oldName := t.spec.Name
-			oldOwner := t.spec.Owner
+
 			// Generate failure reason and mark the test failed to preclude fetching (cluster) artifacts.
 			t.addFailure(clusterCreateErr)
 			issueOutput := "test %s was skipped due to %s"
-			issueOutput = fmt.Sprintf(issueOutput, oldName, t.FailureMsg())
-			// N.B. issue title is of the form "roachtest: ${t.spec.Name} failed" (see UnitTestFormatter).
-			t.spec.Name = "cluster_creation"
-			t.spec.Owner = registry.OwnerDevInf
+			issueOutput = fmt.Sprintf(issueOutput, t.spec.Name, t.FailureMsg())
 
-			if err := github.MaybePost(t, issueOutput); err != nil {
+			// N.B. issue title is of the form "roachtest: ${t.spec.Name} failed" (see UnitTestFormatter).
+			if err := github.MaybePost(t, clusterCreationErr, issueOutput); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
-
-			// Restore test name and owner.
-			t.spec.Name = oldName
-			t.spec.Owner = oldOwner
 		} else {
 			c.setTest(t)
 			err = c.PutLibraries(ctx, "./lib", t.spec.NativeLibs)
@@ -829,7 +821,14 @@ func (r *testRunner) runTest(
 
 			shout(ctx, l, stdout, "--- FAIL: %s (%s)\n%s", runID, durationStr, output)
 
-			if err := github.MaybePost(t, output); err != nil {
+			cat := otherErr
+
+			// This will override the created issue's owner as it is likely due to an SSH flake
+			if strings.Contains(output, "SSH_PROBLEM") {
+				cat = sshErr
+			}
+
+			if err := github.MaybePost(t, cat, output); err != nil {
 				shout(ctx, l, stdout, "failed to post issue: %s", err)
 			}
 		} else {

--- a/pkg/roachprod/errors/errors.go
+++ b/pkg/roachprod/errors/errors.go
@@ -33,6 +33,10 @@ const (
 	unclassifiedExitCode = 1
 )
 
+// ErrSSH255 is a reference error used to mark an SSH error with an exit
+// code of 255. This could be indicative of an SSH flake.
+var ErrSSH255 = errors.New("SSH error occurred with exit code 255")
+
 // Cmd wraps errors that result from a command run against the cluster.
 type Cmd struct {
 	Err error
@@ -116,7 +120,7 @@ func ClassifyCmdError(err error) Error {
 
 	if exitErr, ok := asExitError(err); ok {
 		if exitErr.ExitCode() == 255 {
-			return SSH{err}
+			return SSH{errors.Mark(err, ErrSSH255)}
 		}
 		return Cmd{err}
 	}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -642,7 +641,7 @@ func runCmdOnSingleNode(
 		detailMsg := fmt.Sprintf("Node %d. Command with error:\n```\n%s\n```\n", node, cmd)
 		err = errors.WithDetail(err, detailMsg)
 		err = rperrors.ClassifyCmdError(err)
-		if reflect.TypeOf(err) == reflect.TypeOf(rperrors.SSH{}) {
+		if errors.Is(err, rperrors.ErrSSH255) {
 			result.RemoteExitStatus = "255"
 		}
 		result.Err = err

--- a/pkg/testutils/lint/passes/fmtsafe/fmtsafe.go
+++ b/pkg/testutils/lint/passes/fmtsafe/fmtsafe.go
@@ -245,8 +245,8 @@ func checkCallExpr(pass *analysis.Pass, enclosingFnName string, call *ast.CallEx
 		return
 	}
 
-	pass.Reportf(call.Lparen, escNl("%s(): %s argument is not a constant expression"+Tip),
-		enclosingFnName, argType)
+	pass.Reportf(call.Lparen, escNl("%s() [calling %s]: %s argument is not a constant expression"+Tip),
+		enclosingFnName, fnName, argType)
 }
 
 // Tip is exported for use in tests.

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -92,12 +92,15 @@ var requireConstFmt = map[string]bool{
 	"(*github.com/cockroachdb/cockroach/pkg/util/grpcutil.grpcLogger).Fatalf":   true,
 
 	// Both of these signatures need to be included for the linter to not flag
-	// roachtest testImpl.Errorf since it is in the main package
-	"(*main.testImpl).Errorf": true,
-	"(*github.com/cockroachdb/cockroach/pkg/cmd/roachtest.testImpl).Errorf": true,
+	// roachtest testImpl.addFailure since it is in the main package
+	"(*github.com/cockroachdb/cockroach/pkg/cmd/roachtest.testImpl).addFailure": true,
+	"(*main.testImpl).addFailure": true,
 
 	"(*main.testImpl).Fatalf": true,
 	"(*github.com/cockroachdb/cockroach/pkg/cmd/roachtest.testImpl).Fatalf": true,
+
+	"(*main.testImpl).Errorf": true,
+	"(*github.com/cockroachdb/cockroach/pkg/cmd/roachtest.testImpl).Errorf": true,
 
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Debugf":   true,
 	"(*github.com/cockroachdb/cockroach/pkg/kv/kvserver.raftLogger).Infof":    true,


### PR DESCRIPTION
*See second commit note at the bottom* 

This PR inspects the failure output of a roachtest, and if it sees an SSH_PROBLEM, overrides the owning team to test-eng when reporting the github issue. 

Currently errors are classified as an `SSH` error by roachprod if the exit code is `255` with an accompanying message prefixed with `SSH_PROBLEM` [[1]](https://github.com/cockroachdb/cockroach/blob/ad3bd1355463cefdc07e995765fa82adfe391d05/pkg/roachprod/errors/errors.go#L112). The errors are stringified and saved into `t.mu.output|failureMsg`. Thus in the test_runner at the call site of issue posting, we can check `t.mu.output` for `SSH_PROBLEM` and override the team and issue name accordingly.


Resolves: https://github.com/cockroachdb/cockroach/issues/82398

Release justification: test-only change
Release note: none