### PR TITLE
opt: fix error due to estimated row count must be non-zero

### DIFF
--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -865,6 +865,27 @@ func TestSpan_KeyCount(t *testing.T) {
 			span:     ParseSpan(&evalCtx, "(/US_WEST - /US_WEST/fix]"),
 			expected: "FAIL",
 		},
+		{ // 23
+			// Fails since the key count overflows.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/0 - /9223372036854775807]"),
+			expected: "FAIL",
+		},
+		{ // 24
+			// Succeeds since the key count is int64 max.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/1 - /9223372036854775807]"),
+			expected: "9223372036854775807",
+		},
+		{ // 25
+			// Fails since the key count overflows.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/-9223372036854775808 - /9223372036854775807]"),
+			expected: "FAIL",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3300,3 +3300,37 @@ project
  └── projections
       ├── NULL [as="?column?":33, type=unknown]
       └── 1 [as="?column?":34, type=int]
+
+# Regression test for #85499. Avoid overflow when calculating distinct count.
+exec-ddl
+CREATE TABLE t85499 (c0 INT);
+----
+
+norm
+SELECT t85499.rowid FROM t85499
+WHERE (t85499.rowid) BETWEEN (0) AND (
+  CASE  WHEN NULL THEN t85499.rowid
+  ELSE IF(NULL, 1, 9223372036854775807) END
+)
+UNION SELECT t85499.rowid FROM t85499;
+----
+union
+ ├── columns: rowid:9(int!null)
+ ├── left columns: t85499.rowid:2(int)
+ ├── right columns: t85499.rowid:6(int)
+ ├── stats: [rows=1111.111, distinct(9)=1111.11, null(9)=0]
+ ├── key: (9)
+ ├── select
+ │    ├── columns: t85499.rowid:2(int!null)
+ │    ├── stats: [rows=111.1111, distinct(2)=111.111, null(2)=0]
+ │    ├── key: (2)
+ │    ├── scan t85499
+ │    │    ├── columns: t85499.rowid:2(int!null)
+ │    │    ├── stats: [rows=1000, distinct(2)=1000, null(2)=0]
+ │    │    └── key: (2)
+ │    └── filters
+ │         └── (t85499.rowid:2 >= 0) AND (t85499.rowid:2 <= 9223372036854775807) [type=bool, outer=(2), constraints=(/2: [/0 - /9223372036854775807]; tight)]
+ └── scan t85499
+      ├── columns: t85499.rowid:6(int!null)
+      ├── stats: [rows=1000, distinct(6)=1000, null(6)=0]
+      └── key: (6)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5608,12 +5608,12 @@ func MaxDistinctCount(evalCtx CompareContext, first, last Datum) (_ int64, ok bo
 		return 0, false
 	}
 
-	delta := end - start
-	if delta < 0 {
+	delta := (end - start) + 1
+	if delta <= 0 {
 		// Overflow or underflow.
 		return 0, false
 	}
-	return delta + 1, true
+	return delta, true
 }
 
 // ParsePath splits a string of the form "/foo/bar" into strings ["foo", "bar"].


### PR DESCRIPTION
This commit fixes an error in the statistics code that was caused by integer overflow when calculating the distinct count.

Fixes #85499

Release note (bug fix): Fixed a rare internal error that could occur during planning when a predicate included values close to the maximum or minimum int64 value. The error, "estimated row count must be non-zero", has now been fixed.