### PR TITLE
ttl: refactor storage param Setter to not modify TableDescriptor TTL settings directly

### DIFF
--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -78,7 +78,7 @@ func AlterColumnType(
 			)
 		}
 	}
-	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, col); err != nil {
+	if err := schemaexpr.ValidateTTLExpressionDoesNotDependOnColumn(tableDesc, tableDesc.GetRowLevelTTL(), col); err != nil {
 		return err
 	}
 

--- a/pkg/sql/catalog/schemaexpr/BUILD.bazel
+++ b/pkg/sql/catalog/schemaexpr/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/catalog",
+        "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -2605,7 +2605,8 @@ func (desc *wrapper) GetStorageParams(spaceBetweenEqual bool) []string {
 	appendStorageParam := func(key, value string) {
 		storageParams = append(storageParams, key+spacing+`=`+spacing+value)
 	}
-	if ttl := desc.GetRowLevelTTL(); ttl != nil {
+	if desc.HasRowLevelTTL() {
+		ttl := desc.GetRowLevelTTL()
 		appendStorageParam(`ttl`, `'on'`)
 		if ttl.HasDurationExpr() {
 			appendStorageParam(`ttl_expire_after`, string(ttl.DurationExpr))

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -396,7 +396,7 @@ func (sc *SchemaChanger) maybeUpdateScheduledJobsForRowLevelTTL(
 	ctx context.Context, tableDesc catalog.TableDescriptor,
 ) error {
 	// Drop the scheduled job if one exists and the table descriptor is being dropped.
-	if tableDesc.Dropped() && tableDesc.GetRowLevelTTL() != nil {
+	if tableDesc.Dropped() && tableDesc.HasRowLevelTTL() {
 		if err := sc.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			scheduleID := tableDesc.GetRowLevelTTL().ScheduleID
 			if scheduleID > 0 {
@@ -1554,8 +1554,8 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 						scTable.RowLevelTTL.ScheduleID = j.ScheduleID()
 					}
 				} else if m.Dropped() {
-					if ttl := scTable.RowLevelTTL; ttl != nil {
-						if err := DeleteSchedule(ctx, sc.execCfg, txn, ttl.ScheduleID); err != nil {
+					if scTable.HasRowLevelTTL() {
+						if err := DeleteSchedule(ctx, sc.execCfg, txn, scTable.GetRowLevelTTL().ScheduleID); err != nil {
 							return err
 						}
 					}

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/storageparam",
         "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )


### PR DESCRIPTION
refs https://github.com/cockroachdb/cockroach/issues/88254

Changes the storage param Setter to modify UpdatedRowLevelTTL instead of the TableDescriptor directly so that the update can more easily be moved into a schema changer mutation if necessary.

Release note: None