### PR TITLE
bazel: upgrade `rules_go`

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -18,12 +18,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Load go bazel tools. This gives us access to the go bazel SDK/toolchains.
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "0f95eeba78dc5eeea37673039ac9db00eb25d1a2c65a7c44779678ad460ced95",
-    strip_prefix = "cockroachdb-rules_go-4e5db62",
+    sha256 = "8a11a59c977f90b09b05cc91901c36fd566683824993c76fa79bc0927e67726f",
+    strip_prefix = "cockroachdb-rules_go-c7e85b7",
     urls = [
-        # cockroachdb/rules_go as of 4e5db6270b33b19f1ebcafee5dd97f54f990afdb
+        # cockroachdb/rules_go as of c7e85b7266f5eb686354c8e6f362ca3baaf47199
         # (upstream release-0.34 plus a few patches).
-        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-165-g4e5db62.tar.gz",
+        "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-167-gc7e85b7.tar.gz",
     ],
 )
 

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -973,7 +973,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/bmatcuk-doublestar-v4.0.1-0-gf7a8118.tar.gz": "d11c3b3a45574f89d6a6b2f50e53feea50df60407b35f36193bf5815d32c79d1",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-protobuf-3f5d91f.tar.gz": "6d4e7fe1cbd958dee69ce9becbf8892d567f082b6782d3973a118d0aa00807a8",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_foreign_cc-6f7f1b1.tar.gz": "272ac2cde4efd316c8d7c0140dee411c89da104466701ac179286ef5a89c7b58",
-    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-165-g4e5db62.tar.gz": "0f95eeba78dc5eeea37673039ac9db00eb25d1a2c65a7c44779678ad460ced95",
+    "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_go-v0.27.0-167-gc7e85b7.tar.gz": "8a11a59c977f90b09b05cc91901c36fd566683824993c76fa79bc0927e67726f",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/cockroachdb-rules_nodejs-5.5.0-1-g59a92cc.tar.gz": "7f3f747db3f924547b9ffdf86da6c604335ad95e09d4e5a69fdcfdb505099421",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/google-starlark-go-e043a3d.tar.gz": "a35c6468e0e0921833a63290161ff903295eaaf5915200bbce272cbc8dfd1c1c",
     "https://storage.googleapis.com/public-bazel-artifacts/bazel/platforms-0.0.4.tar.gz": "079945598e4b6cc075846f7fd6a9d0857c33a7afc0de868c2ccb96405225135d",


### PR DESCRIPTION
Pull in cockroachdb/rules_go#8.

Closes #88048

Release note: None