### PR TITLE
kvcoord: fix extremely rare OOM hazard in the DistSender

### DIFF
--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -22,10 +22,11 @@ import (
 
 // Options provides reusable configuration of Retry objects.
 type Options struct {
-	InitialBackoff      time.Duration   // Default retry backoff interval
-	MaxBackoff          time.Duration   // Maximum retry backoff interval
-	Multiplier          float64         // Default backoff constant
-	MaxRetries          int             // Maximum number of attempts (0 for infinite)
+	InitialBackoff time.Duration // Default retry backoff interval
+	MaxBackoff     time.Duration // Maximum retry backoff interval
+	Multiplier     float64       // Default backoff constant
+	// Maximum number of retries; attempts = MaxRetries + 1. (0 for infinite)
+	MaxRetries          int
 	RandomizationFactor float64         // Randomize the backoff interval by constant
 	Closer              <-chan struct{} // Optionally end retry loop channel close
 }


### PR DESCRIPTION
The outer loop in the DistSender subdivides a BathRequest into partial batches corresponding to a single range and sends them out. Previously, the resolved span passed into the function responsible for sending out this partial batch (`sendPartialBatch`) corresponded to the span of the entire batch request (as opposed to the partial batch). This resolved span is used to check if the request needs to be subdivided further between retries in the outer loop of the DistSender. Given the wrong parameter value, we'd always end up determining that the batch needed to be subdivided.

This wasn't really an issue in practice as we don't expect too many retries here. However, if we did (eg. timeouts causing the transport to be exhausted on every try), the infinite recursion here could lead to an OOM.

References #87167

Release note: None