### PR TITLE
 cluster-ui: enable active execs blocking info for CC dedicated

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsSection.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useContext, useMemo } from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames/bind";
 import {
   ActiveStatement,
@@ -31,7 +31,6 @@ import {
 } from "./activeStatementsTable";
 import { StatementViewType } from "src/statementsPage/statementPageTypes";
 import { calculateActiveFilters } from "src/queryFilter/filter";
-import { CockroachCloudContext } from "src/contexts";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 
 const sortableTableCx = classNames.bind(sortableTableStyles);
@@ -43,6 +42,7 @@ type ActiveStatementsSectionProps = {
   statements: ActiveStatement[];
   selectedColumns?: string[];
   sortSetting: SortSetting;
+  isTenant?: boolean;
   onChangeSortSetting: (sortSetting: SortSetting) => void;
   onClearFilters: () => void;
   onColumnsSelect: (columns: string[]) => void;
@@ -52,6 +52,7 @@ export const ActiveStatementsSection: React.FC<
   ActiveStatementsSectionProps
 > = ({
   filters,
+  isTenant,
   pagination,
   search,
   statements,
@@ -61,12 +62,11 @@ export const ActiveStatementsSection: React.FC<
   onChangeSortSetting,
   onColumnsSelect,
 }) => {
-  const isCockroachCloud = useContext(CockroachCloudContext);
-
   const columns = useMemo(
-    () => makeActiveStatementsColumns(isCockroachCloud),
-    [isCockroachCloud],
+    () => makeActiveStatementsColumns(isTenant),
+    [isTenant],
   );
+
   const shownColumns = columns.filter(col =>
     isSelectedColumn(selectedColumns, col),
   );

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeStatementsTable/activeStatementsTable.tsx
@@ -23,7 +23,7 @@ import { Tooltip } from "@cockroachlabs/ui-components";
 import { limitText } from "../../util";
 
 export function makeActiveStatementsColumns(
-  isCockroachCloud: boolean,
+  isTenant: boolean,
 ): ColumnDescriptor<ActiveStatement>[] {
   return [
     activeStatementColumnsFromCommon.executionID,
@@ -42,9 +42,7 @@ export function makeActiveStatementsColumns(
     activeStatementColumnsFromCommon.status,
     activeStatementColumnsFromCommon.startTime,
     activeStatementColumnsFromCommon.elapsedTime,
-    !isCockroachCloud
-      ? activeStatementColumnsFromCommon.timeSpentWaiting
-      : null,
+    !isTenant ? activeStatementColumnsFromCommon.timeSpentWaiting : null,
     activeStatementColumnsFromCommon.applicationName,
   ].filter(col => col != null);
 }

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsSection.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsSection.tsx
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import React, { useMemo, useContext } from "react";
+import React, { useMemo } from "react";
 import classNames from "classnames/bind";
 import {
   ActiveStatementFilters,
@@ -30,7 +30,6 @@ import {
 } from "./activeTransactionsTable";
 import { TransactionViewType } from "src/transactionsPage/transactionsPageTypes";
 import { calculateActiveFilters } from "src/queryFilter/filter";
-import { CockroachCloudContext } from "src/contexts";
 import { isSelectedColumn } from "src/columnsSelector/utils";
 import { SortedTable } from "src/sortedtable";
 
@@ -38,6 +37,7 @@ const sortableTableCx = classNames.bind(sortableTableStyles);
 
 type ActiveTransactionsSectionProps = {
   filters: ActiveStatementFilters;
+  isTenant?: boolean;
   pagination: ISortedTablePagination;
   search: string;
   transactions: ActiveTransaction[];
@@ -52,6 +52,7 @@ export const ActiveTransactionsSection: React.FC<
   ActiveTransactionsSectionProps
 > = ({
   filters,
+  isTenant,
   pagination,
   search,
   transactions,
@@ -61,11 +62,9 @@ export const ActiveTransactionsSection: React.FC<
   onClearFilters,
   onColumnsSelect,
 }) => {
-  const isCockroachCloud = useContext(CockroachCloudContext);
-
   const columns = useMemo(
-    () => makeActiveTransactionsColumns(isCockroachCloud),
-    [isCockroachCloud],
+    () => makeActiveTransactionsColumns(isTenant),
+    [isTenant],
   );
   const shownColumns = columns.filter(col =>
     isSelectedColumn(selectedColumns, col),

--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/activeTransactionsTable/activeTransactionsTable.tsx
@@ -23,7 +23,7 @@ import { Tooltip } from "@cockroachlabs/ui-components";
 import { limitText } from "../../util";
 
 export function makeActiveTransactionsColumns(
-  isCockroachCloud: boolean,
+  isTenant: boolean,
 ): ColumnDescriptor<ActiveTransaction>[] {
   const execType: ExecutionType = "transaction";
   return [
@@ -50,9 +50,7 @@ export function makeActiveTransactionsColumns(
     activeTransactionColumnsFromCommon.status,
     activeTransactionColumnsFromCommon.startTime,
     activeTransactionColumnsFromCommon.elapsedTime,
-    !isCockroachCloud
-      ? activeTransactionColumnsFromCommon.timeSpentWaiting
-      : null,
+    !isTenant ? activeTransactionColumnsFromCommon.timeSpentWaiting : null,
     {
       name: "statementCount",
       title: executionsTableTitles.statementCount(execType),

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsPage.selectors.ts
@@ -23,6 +23,7 @@ import {
 } from "src/selectors/activeExecutions.selectors";
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as sessionsActions } from "src/store/sessions";
+import { selectIsTenant } from "src/store/uiConfig";
 import { localStorageSelector } from "../store/utils/selectors";
 
 export const selectSortSetting = (state: AppState): SortSetting =>
@@ -54,6 +55,7 @@ export const mapStateToActiveStatementsPageProps = (
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
   internalAppNamePrefix: selectAppName(state),
+  isTenant: selectIsTenant(state),
 });
 
 export const mapDispatchToActiveStatementsPageProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -54,6 +54,7 @@ export type ActiveStatementsViewStateProps = {
   sessionsError: Error | null;
   filters: ActiveStatementFilters;
   internalAppNamePrefix: string;
+  isTenant?: boolean;
 };
 
 export type ActiveStatementsViewProps = ActiveStatementsViewStateProps &
@@ -70,6 +71,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   sessionsError,
   filters,
   internalAppNamePrefix,
+  isTenant,
 }: ActiveStatementsViewProps) => {
   const [pagination, setPagination] = useState<ISortedTablePagination>({
     current: 1,
@@ -204,6 +206,7 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
             onClearFilters={clearFilters}
             onChangeSortSetting={onSortClick}
             onColumnsSelect={onColumnsSelect}
+            isTenant={isTenant}
           />
         </Loading>
       </div>

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.reducer.ts
@@ -29,7 +29,7 @@ const initialState: SessionsState = {
   valid: true,
 };
 
-const ssessionsSlice = createSlice({
+const sessionsSlice = createSlice({
   name: `${DOMAIN_NAME}/sessions`,
   initialState,
   reducers: {
@@ -52,4 +52,4 @@ const ssessionsSlice = createSlice({
   },
 });
 
-export const { reducer, actions } = ssessionsSlice;
+export const { reducer, actions } = sessionsSlice;

--- a/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/store/sessions/sessions.sagas.ts
@@ -8,15 +8,31 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { all, call, put, takeLatest, PutEffect } from "redux-saga/effects";
+import {
+  all,
+  call,
+  put,
+  takeLatest,
+  AllEffect,
+  PutEffect,
+  SelectEffect,
+  select,
+} from "redux-saga/effects";
 
 import { actions } from "./sessions.reducer";
+import { actions as clusterLockActions } from "../clusterLocks/clusterLocks.reducer";
 import { getSessions } from "src/api/sessionsApi";
+import { selectIsTenant } from "../uiConfig";
 
-export function* refreshSessionsAndClusterLocksSaga(): Generator<PutEffect> {
-  yield put(actions.request());
-
-  // TODO (xzhang) request clusterLocks info here. This is currently not available on CC.
+export function* refreshSessionsAndClusterLocksSaga(): Generator<
+  AllEffect<PutEffect> | SelectEffect | PutEffect
+> {
+  const isTenant = yield select(selectIsTenant);
+  if (isTenant) {
+    yield put(actions.request());
+    return;
+  }
+  yield all([put(actions.request()), put(clusterLockActions.request())]);
 }
 
 export function* requestSessionsSaga(): any {

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsPage.selectors.tsx
@@ -24,6 +24,7 @@ import {
 import { actions as localStorageActions } from "src/store/localStorage";
 import { actions as sessionsActions } from "src/store/sessions";
 import { localStorageSelector } from "../store/utils/selectors";
+import { selectIsTenant } from "src/store/uiConfig";
 
 export const selectSortSetting = (state: AppState): SortSetting =>
   localStorageSelector(state)["sortSetting/ActiveTransactionsPage"];
@@ -54,6 +55,7 @@ export const mapStateToActiveTransactionsPageProps = (
   sortSetting: selectSortSetting(state),
   filters: selectFilters(state),
   internalAppNamePrefix: selectAppName(state),
+  isTenant: selectIsTenant(state),
 });
 
 export const mapDispatchToActiveTransactionsPageProps = (

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -54,6 +54,7 @@ export type ActiveTransactionsViewStateProps = {
   filters: ActiveTransactionFilters;
   sortSetting: SortSetting;
   internalAppNamePrefix: string;
+  isTenant?: boolean;
 };
 
 export type ActiveTransactionsViewProps = ActiveTransactionsViewStateProps &
@@ -66,6 +67,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   refreshLiveWorkload,
   onFiltersChange,
   onSortChange,
+  isTenant,
   selectedColumns,
   sortSetting,
   transactions,
@@ -205,6 +207,7 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
             onClearFilters={clearFilters}
             onChangeSortSetting={onChangeSortSetting}
             onColumnsSelect={onColumnsSelect}
+            isTenant={isTenant}
           />
         </Loading>
       </div>


### PR DESCRIPTION
This commit enables wait time insights for active executions pages on CC Dedicated. This includes the `Time Spent Waiting` column in the overview pages and the wait time insights panel in the details pages. The feature is still gated for serverless.

Release note (ui change): Dedicated CC now contains information for which transactions are blocked / waiting on the active execution pages. This includes the `Time Spent Waiting` column in the overview pages and the wait time insights panel on the details pages. Feature currently unavailable for serverless.