### PR TITLE
sql/stats: remove statistics forecasting time horizon

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
+++ b/pkg/sql/opt/exec/execbuilder/testdata/forecast1401
@@ -1,0 +1,18621 @@
+# LogicTest: local
+
+# Test whether statistics forecasts help the query from case 1401.
+
+statement ok
+CREATE TABLE t1401 (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  c TIMESTAMPTZ NULL,
+  d TIMESTAMPTZ NULL,
+  e TIMESTAMPTZ NULL,
+  f INT8 NULL,
+  CONSTRAINT "primary" PRIMARY KEY (a ASC),
+  INDEX (b ASC),
+  INDEX (f ASC, c DESC) WHERE (e IS NOT NULL) AND (f IS NOT NULL),
+  INDEX (c ASC),
+  INDEX (f ASC, c DESC) STORING (b) WHERE f IS NOT NULL
+)
+
+statement ok
+ALTER TABLE t1401 INJECT STATISTICS '[
+      {
+          "avg_size": 0,
+          "columns": [
+              "a"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 5426151229,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 547085,
+                  "num_range": 0,
+                  "upper_bound": "1515160"
+              },
+              {
+                  "distinct_range": 22890145.583130755,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "27011782"
+              },
+              {
+                  "distinct_range": 22628152.541867904,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "51849707"
+              },
+              {
+                  "distinct_range": 24898728.349881213,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "83312473"
+              },
+              {
+                  "distinct_range": 25140262.559962925,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "115625210"
+              },
+              {
+                  "distinct_range": 24713520.262727853,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "146458376"
+              },
+              {
+                  "distinct_range": 24309621.191461302,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "175980828"
+              },
+              {
+                  "distinct_range": 24162031.64350044,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "205044412"
+              },
+              {
+                  "distinct_range": 22173930.058920052,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "228793559"
+              },
+              {
+                  "distinct_range": 21619342.31872933,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "251297205"
+              },
+              {
+                  "distinct_range": 23381827.43257939,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "278096071"
+              },
+              {
+                  "distinct_range": 24486710.93784027,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "308183037"
+              },
+              {
+                  "distinct_range": 23434727.587627325,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "335127457"
+              },
+              {
+                  "distinct_range": 23273279.156472206,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "361631060"
+              },
+              {
+                  "distinct_range": 24985924.50076375,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "393396815"
+              },
+              {
+                  "distinct_range": 22911107.216342054,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "418947160"
+              },
+              {
+                  "distinct_range": 24262653.79475886,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "448322462"
+              },
+              {
+                  "distinct_range": 23303174.11398081,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "474906930"
+              },
+              {
+                  "distinct_range": 21757041.36974102,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "497711718"
+              },
+              {
+                  "distinct_range": 23132134.20404237,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "523838090"
+              },
+              {
+                  "distinct_range": 24823020.153152063,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "555041229"
+              },
+              {
+                  "distinct_range": 24448511.246721543,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "585005110"
+              },
+              {
+                  "distinct_range": 21700262.121315803,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "607685096"
+              },
+              {
+                  "distinct_range": 20509321.314351544,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "627936617"
+              },
+              {
+                  "distinct_range": 23554155.698760435,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "655213726"
+              },
+              {
+                  "distinct_range": 24871608.721221495,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "686583126"
+              },
+              {
+                  "distinct_range": 23481573.458622273,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "713657364"
+              },
+              {
+                  "distinct_range": 21267843.70832717,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "735415151"
+              },
+              {
+                  "distinct_range": 23159789.483369034,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "761614849"
+              },
+              {
+                  "distinct_range": 24478888.115998674,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "791676549"
+              },
+              {
+                  "distinct_range": 23999734.054625228,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "820247259"
+              },
+              {
+                  "distinct_range": 21888520.98335093,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "843344488"
+              },
+              {
+                  "distinct_range": 21578350.434853453,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "865759480"
+              },
+              {
+                  "distinct_range": 22749247.55520597,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "890898954"
+              },
+              {
+                  "distinct_range": 23818138.995835368,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "918932195"
+              },
+              {
+                  "distinct_range": 23258056.422602247,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "945394752"
+              },
+              {
+                  "distinct_range": 24223145.01818146,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "974647089"
+              },
+              {
+                  "distinct_range": 24426231.04951371,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1004539517"
+              },
+              {
+                  "distinct_range": 24571641.808721013,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1034902789"
+              },
+              {
+                  "distinct_range": 23614238.26449519,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1062349447"
+              },
+              {
+                  "distinct_range": 25203639.922322545,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1094890856"
+              },
+              {
+                  "distinct_range": 24180286.922851864,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1124010639"
+              },
+              {
+                  "distinct_range": 23017559.888642363,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1149836216"
+              },
+              {
+                  "distinct_range": 21861695.10021512,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1172873383"
+              },
+              {
+                  "distinct_range": 25052451.376704037,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1204873216"
+              },
+              {
+                  "distinct_range": 25580264.78797957,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1238824830"
+              },
+              {
+                  "distinct_range": 25293768.255639408,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1271695609"
+              },
+              {
+                  "distinct_range": 24105024.184147697,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1300584693"
+              },
+              {
+                  "distinct_range": 21807029.055669308,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1323500094"
+              },
+              {
+                  "distinct_range": 24235532.435368307,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1352790905"
+              },
+              {
+                  "distinct_range": 23662909.700632654,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1380375998"
+              },
+              {
+                  "distinct_range": 24875116.101027995,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1411757450"
+              },
+              {
+                  "distinct_range": 21431101.522671454,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1433857663"
+              },
+              {
+                  "distinct_range": 22569503.243840482,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1458551295"
+              },
+              {
+                  "distinct_range": 26754449.796028376,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1497552494"
+              },
+              {
+                  "distinct_range": 24078420.036740474,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1526360656"
+              },
+              {
+                  "distinct_range": 22364459.37229146,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1550558585"
+              },
+              {
+                  "distinct_range": 23365632.917453814,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1577313111"
+              },
+              {
+                  "distinct_range": 21654882.524382923,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1599893987"
+              },
+              {
+                  "distinct_range": 23533332.844936874,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1627112678"
+              },
+              {
+                  "distinct_range": 22652685.10585769,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1652011297"
+              },
+              {
+                  "distinct_range": 23148258.11058322,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1678180386"
+              },
+              {
+                  "distinct_range": 21218700.085228775,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1699836419"
+              },
+              {
+                  "distinct_range": 25307679.94023673,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1732758481"
+              },
+              {
+                  "distinct_range": 24744624.114791445,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1763696082"
+              },
+              {
+                  "distinct_range": 18764155.458598584,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1780932151"
+              },
+              {
+                  "distinct_range": 23619028.00099452,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1808392389"
+              },
+              {
+                  "distinct_range": 23929471.181574516,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1836753418"
+              },
+              {
+                  "distinct_range": 22328071.31037333,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1860864771"
+              },
+              {
+                  "distinct_range": 23110237.165221944,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1886933285"
+              },
+              {
+                  "distinct_range": 25645845.356480327,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1921139834"
+              },
+              {
+                  "distinct_range": 23971469.08726264,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1949625930"
+              },
+              {
+                  "distinct_range": 23424977.475671288,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1976543440"
+              },
+              {
+                  "distinct_range": 24377008.81545063,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2006278884"
+              },
+              {
+                  "distinct_range": 23410504.46042945,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2033156518"
+              },
+              {
+                  "distinct_range": 23584394.28829363,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2060518774"
+              },
+              {
+                  "distinct_range": 21747221.421154644,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2083301914"
+              },
+              {
+                  "distinct_range": 24312121.720618546,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2112832230"
+              },
+              {
+                  "distinct_range": 25378590.547941696,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2146017562"
+              },
+              {
+                  "distinct_range": 24234651.95789947,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2175305636"
+              },
+              {
+                  "distinct_range": 24017101.16078749,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2203928514"
+              },
+              {
+                  "distinct_range": 23796325.861767262,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2231898162"
+              },
+              {
+                  "distinct_range": 22843629.49684929,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2257276116"
+              },
+              {
+                  "distinct_range": 23462297.35829707,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2284296831"
+              },
+              {
+                  "distinct_range": 26091257.813249163,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2320314498"
+              },
+              {
+                  "distinct_range": 25008935.344469573,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2352160930"
+              },
+              {
+                  "distinct_range": 19113408.870334048,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2369956479"
+              },
+              {
+                  "distinct_range": 22769656.26493432,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2395147262"
+              },
+              {
+                  "distinct_range": 24618333.191125453,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2425664012"
+              },
+              {
+                  "distinct_range": 23642478.96013228,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2453190875"
+              },
+              {
+                  "distinct_range": 23509881.34687439,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2480343983"
+              },
+              {
+                  "distinct_range": 23132945.083621692,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2506472501"
+              },
+              {
+                  "distinct_range": 26509327.10962372,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2544327662"
+              },
+              {
+                  "distinct_range": 22091508.98803602,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2567886087"
+              },
+              {
+                  "distinct_range": 22420265.46316584,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2592217600"
+              },
+              {
+                  "distinct_range": 23319480.66176366,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2618846321"
+              },
+              {
+                  "distinct_range": 23784930.98227259,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2646782830"
+              },
+              {
+                  "distinct_range": 23726814.835269842,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2674551184"
+              },
+              {
+                  "distinct_range": 24694174.911481004,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2705319656"
+              },
+              {
+                  "distinct_range": 23729966.0013766,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2733097091"
+              },
+              {
+                  "distinct_range": 23473262.07474525,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2760148233"
+              },
+              {
+                  "distinct_range": 24762546.708408665,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2791146247"
+              },
+              {
+                  "distinct_range": 23098135.56418559,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2817182861"
+              },
+              {
+                  "distinct_range": 22485134.614111267,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2841670895"
+              },
+              {
+                  "distinct_range": 24221866.450647607,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2870919265"
+              },
+              {
+                  "distinct_range": 23521060.764413226,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2898103609"
+              },
+              {
+                  "distinct_range": 22931835.890934166,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2923707232"
+              },
+              {
+                  "distinct_range": 24009078.03845322,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2952305993"
+              },
+              {
+                  "distinct_range": 21266336.83642429,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2974060651"
+              },
+              {
+                  "distinct_range": 21216804.873757634,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2995712772"
+              },
+              {
+                  "distinct_range": 22959354.923368737,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3021387361"
+              },
+              {
+                  "distinct_range": 25303420.370571993,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3054293708"
+              },
+              {
+                  "distinct_range": 26517694.34125032,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3092187118"
+              },
+              {
+                  "distinct_range": 25821934.17382197,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3127092717"
+              },
+              {
+                  "distinct_range": 21823567.075786345,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3150044867"
+              },
+              {
+                  "distinct_range": 22799064.177183814,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3175309834"
+              },
+              {
+                  "distinct_range": 22469491.89541264,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3199760001"
+              },
+              {
+                  "distinct_range": 25230775.934707146,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3232400057"
+              },
+              {
+                  "distinct_range": 25415213.07991435,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3265722595"
+              },
+              {
+                  "distinct_range": 23492632.522898212,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3292827607"
+              },
+              {
+                  "distinct_range": 24498145.63338429,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3322951560"
+              },
+              {
+                  "distinct_range": 23449179.901607625,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3349935937"
+              },
+              {
+                  "distinct_range": 25620902.909454886,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3384045186"
+              },
+              {
+                  "distinct_range": 22512315.82624819,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3408599206"
+              },
+              {
+                  "distinct_range": 23855205.568724535,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3436740980"
+              },
+              {
+                  "distinct_range": 21311657.78542569,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3458589998"
+              },
+              {
+                  "distinct_range": 22450441.18124615,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3482994154"
+              },
+              {
+                  "distinct_range": 23387058.73452094,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3509807365"
+              },
+              {
+                  "distinct_range": 21920191.71105844,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3532975767"
+              },
+              {
+                  "distinct_range": 22600382.47662709,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3557745229"
+              },
+              {
+                  "distinct_range": 20533267.54067447,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3578042290"
+              },
+              {
+                  "distinct_range": 23408529.120039515,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3604914488"
+              },
+              {
+                  "distinct_range": 23578093.747521352,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3632258972"
+              },
+              {
+                  "distinct_range": 23742584.589172155,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3660072813"
+              },
+              {
+                  "distinct_range": 21847017.628964074,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3683077204"
+              },
+              {
+                  "distinct_range": 23204319.064537823,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3709395567"
+              },
+              {
+                  "distinct_range": 25051711.349195648,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3741392782"
+              },
+              {
+                  "distinct_range": 24467634.691272505,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3771418190"
+              },
+              {
+                  "distinct_range": 24000846.961483944,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3799992239"
+              },
+              {
+                  "distinct_range": 22363288.580203995,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3824187376"
+              },
+              {
+                  "distinct_range": 22955894.32780113,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3849853026"
+              },
+              {
+                  "distinct_range": 20973911.546386883,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3871011065"
+              },
+              {
+                  "distinct_range": 23074926.675372154,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3896986650"
+              },
+              {
+                  "distinct_range": 24058875.571018394,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3925735570"
+              },
+              {
+                  "distinct_range": 22818938.148180474,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3951050839"
+              },
+              {
+                  "distinct_range": 22782115.340066183,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3976273015"
+              },
+              {
+                  "distinct_range": 36894581.92730094,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "8939085269"
+              },
+              {
+                  "distinct_range": 36828770.0742172,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "11925511929"
+              },
+              {
+                  "distinct_range": 36806815.235008046,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "14561311935"
+              },
+              {
+                  "distinct_range": 36792138.050899245,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "17005018629"
+              },
+              {
+                  "distinct_range": 36786403.60624026,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "19381088778"
+              },
+              {
+                  "distinct_range": 37532304.900883764,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "21751342687"
+              },
+              {
+                  "distinct_range": 37566866.19801692,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "24572320100"
+              },
+              {
+                  "distinct_range": 37515749.30488634,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "26773921157"
+              },
+              {
+                  "distinct_range": 37533250.96060445,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "29154566474"
+              },
+              {
+                  "distinct_range": 37502274.24149237,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "31235573792"
+              },
+              {
+                  "distinct_range": 37534079.621633485,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "33625460668"
+              },
+              {
+                  "distinct_range": 37471268.49949331,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "35473372860"
+              },
+              {
+                  "distinct_range": 37498315.57895084,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "37521437136"
+              },
+              {
+                  "distinct_range": 37552891.110808566,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "40141091473"
+              },
+              {
+                  "distinct_range": 37510696.84760305,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "42295840001"
+              },
+              {
+                  "distinct_range": 37553677.89840093,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "44926081580"
+              },
+              {
+                  "distinct_range": 37513259.520347886,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "47104394130"
+              },
+              {
+                  "distinct_range": 37551776.719141416,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "49709253905"
+              },
+              {
+                  "distinct_range": 37588402.66230607,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "52909150153"
+              },
+              {
+                  "distinct_range": 37552938.02175833,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "55529496901"
+              },
+              {
+                  "distinct_range": 37558778.11584604,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "58230321207"
+              },
+              {
+                  "distinct_range": 37500721.822100356,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "60298250196"
+              },
+              {
+                  "distinct_range": 37528794.93627203,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "62630661519"
+              },
+              {
+                  "distinct_range": 37531151.64851037,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "64988360864"
+              },
+              {
+                  "distinct_range": 37539713.06345723,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "67442685662"
+              },
+              {
+                  "distinct_range": 37571539.52190958,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "70338170452"
+              },
+              {
+                  "distinct_range": 37556402.90097951,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "73005770801"
+              },
+              {
+                  "distinct_range": 37543428.33653623,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "75504661910"
+              },
+              {
+                  "distinct_range": 37523114.11356827,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "77778192985"
+              },
+              {
+                  "distinct_range": 37544916.57287067,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "80295233769"
+              },
+              {
+                  "distinct_range": 37536354.35350102,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "82710798325"
+              },
+              {
+                  "distinct_range": 37469625.25286097,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "84547795794"
+              },
+              {
+                  "distinct_range": 37483674.40424886,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "86482417422"
+              },
+              {
+                  "distinct_range": 37537423.190161854,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "88910158705"
+              },
+              {
+                  "distinct_range": 37492983.55845513,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "90915414647"
+              },
+              {
+                  "distinct_range": 37536989.69836736,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "93338192908"
+              },
+              {
+                  "distinct_range": 37552125.04144441,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "95947669664"
+              },
+              {
+                  "distinct_range": 37486397.36999784,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "97902464580"
+              },
+              {
+                  "distinct_range": 37566340.32520581,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "100715370168"
+              },
+              {
+                  "distinct_range": 37536958.232761964,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "103137808183"
+              },
+              {
+                  "distinct_range": 37555001.87597586,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "105786086844"
+              },
+              {
+                  "distinct_range": 37492129.06124425,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "107784628026"
+              },
+              {
+                  "distinct_range": 37531086.20779749,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "110141582914"
+              },
+              {
+                  "distinct_range": 37547841.12392788,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "112695297111"
+              },
+              {
+                  "distinct_range": 37497447.14424832,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "114736215588"
+              },
+              {
+                  "distinct_range": 37456925.97830271,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "116493033889"
+              },
+              {
+                  "distinct_range": 37515621.75441131,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "118693424305"
+              },
+              {
+                  "distinct_range": 37585371.587420195,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "121834075083"
+              },
+              {
+                  "distinct_range": 37522679.476398565,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "124103288762"
+              },
+              {
+                  "distinct_range": 37554507.778110676,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "126744712735"
+              },
+              {
+                  "distinct_range": 37579979.47819078,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "129784871631"
+              },
+              {
+                  "distinct_range": 37567148.035225086,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "132610223006"
+              },
+              {
+                  "distinct_range": 37540867.522358604,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "135078274553"
+              },
+              {
+                  "distinct_range": 37527812.88295977,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "137400274858"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "b"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 5081612065,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 547085,
+                  "num_range": 0,
+                  "upper_bound": "629315097"
+              },
+              {
+                  "distinct_range": 21804529.4588784,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "654811719"
+              },
+              {
+                  "distinct_range": 21554900.312778868,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "679649484"
+              },
+              {
+                  "distinct_range": 23717798.548730288,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "711112061"
+              },
+              {
+                  "distinct_range": 23947781.492393397,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "743424240"
+              },
+              {
+                  "distinct_range": 23549939.949553274,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "774287361"
+              },
+              {
+                  "distinct_range": 23145674.92519768,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "803773508"
+              },
+              {
+                  "distinct_range": 23006817.29217205,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "832807177"
+              },
+              {
+                  "distinct_range": 21115233.725149453,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "856539119"
+              },
+              {
+                  "distinct_range": 20592592.17708978,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "879039568"
+              },
+              {
+                  "distinct_range": 22266402.735045385,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "905819769"
+              },
+              {
+                  "distinct_range": 23308662.282735676,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "935850115"
+              },
+              {
+                  "distinct_range": 22305635.418867294,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "962743434"
+              },
+              {
+                  "distinct_range": 22156100.29689912,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "989209127"
+              },
+              {
+                  "distinct_range": 23695244.699676815,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1020590169"
+              },
+              {
+                  "distinct_range": 21769195.849826965,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1045992102"
+              },
+              {
+                  "distinct_range": 22904379.97819489,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1074698332"
+              },
+              {
+                  "distinct_range": 21981129.958556835,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1100675524"
+              },
+              {
+                  "distinct_range": 20501043.924331408,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1122968867"
+              },
+              {
+                  "distinct_range": 21807860.660895813,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1148474441"
+              },
+              {
+                  "distinct_range": 23410440.994830243,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1178852034"
+              },
+              {
+                  "distinct_range": 23061654.194814973,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1208063192"
+              },
+              {
+                  "distinct_range": 20530365.93718921,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1230422601"
+              },
+              {
+                  "distinct_range": 19496806.00246398,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1250594932"
+              },
+              {
+                  "distinct_range": 22211710.19849621,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1277218542"
+              },
+              {
+                  "distinct_range": 23472968.041740235,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1307812371"
+              },
+              {
+                  "distinct_range": 22189630.976161662,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1334373126"
+              },
+              {
+                  "distinct_range": 19964914.114492618,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1355501173"
+              },
+              {
+                  "distinct_range": 21810146.792878106,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1381012893"
+              },
+              {
+                  "distinct_range": 23038688.64137993,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1410149530"
+              },
+              {
+                  "distinct_range": 22581345.49690022,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1437856966"
+              },
+              {
+                  "distinct_range": 20534213.638697106,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1460225063"
+              },
+              {
+                  "distinct_range": 20185181.464156363,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1481822305"
+              },
+              {
+                  "distinct_range": 21375159.665644705,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1506199843"
+              },
+              {
+                  "distinct_range": 22401803.841003627,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1533373275"
+              },
+              {
+                  "distinct_range": 21879294.874467876,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1559071852"
+              },
+              {
+                  "distinct_range": 22608800.08219813,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1586862244"
+              },
+              {
+                  "distinct_range": 22946535.4853498,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1615702580"
+              },
+              {
+                  "distinct_range": 23111286.688320566,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1645075730"
+              },
+              {
+                  "distinct_range": 22161820.19981747,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1671557606"
+              },
+              {
+                  "distinct_range": 23685745.428282052,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1702904400"
+              },
+              {
+                  "distinct_range": 22711554.9941199,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1731008408"
+              },
+              {
+                  "distinct_range": 21570248.758814406,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1755886013"
+              },
+              {
+                  "distinct_range": 20382818.224699363,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1777915505"
+              },
+              {
+                  "distinct_range": 23487512.232197363,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1808559954"
+              },
+              {
+                  "distinct_range": 23984946.596371546,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1841012617"
+              },
+              {
+                  "distinct_range": 23637931.27270556,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1872187858"
+              },
+              {
+                  "distinct_range": 22514264.47575097,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1899694066"
+              },
+              {
+                  "distinct_range": 20242151.24149217,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1921414793"
+              },
+              {
+                  "distinct_range": 22714994.132833228,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1949529384"
+              },
+              {
+                  "distinct_range": 22111648.244452365,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "1975869777"
+              },
+              {
+                  "distinct_range": 23252455.85930006,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2005710825"
+              },
+              {
+                  "distinct_range": 19767980.04242167,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2026430127"
+              },
+              {
+                  "distinct_range": 21080504.121593036,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2050077534"
+              },
+              {
+                  "distinct_range": 25100544.521348383,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2087216843"
+              },
+              {
+                  "distinct_range": 22416619.034167353,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2114433790"
+              },
+              {
+                  "distinct_range": 20688088.776691165,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2137152930"
+              },
+              {
+                  "distinct_range": 21651301.219899844,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2162242362"
+              },
+              {
+                  "distinct_range": 19927201.050289102,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2183291362"
+              },
+              {
+                  "distinct_range": 21782878.27565721,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2208729905"
+              },
+              {
+                  "distinct_range": 20868409.72205084,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2231869566"
+              },
+              {
+                  "distinct_range": 21418515.57493383,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2256357062"
+              },
+              {
+                  "distinct_range": 19628560.323008224,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2276792903"
+              },
+              {
+                  "distinct_range": 23607894.84877154,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2307861081"
+              },
+              {
+                  "distinct_range": 22859281.22850849,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2336424826"
+              },
+              {
+                  "distinct_range": 16902818.525844805,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2352134490"
+              },
+              {
+                  "distinct_range": 21833318.936973665,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2377708620"
+              },
+              {
+                  "distinct_range": 22148491.456223395,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2404152807"
+              },
+              {
+                  "distinct_range": 20469973.537344564,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2426376418"
+              },
+              {
+                  "distinct_range": 21427455.539703455,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2450886670"
+              },
+              {
+                  "distinct_range": 23796112.393816758,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2482634802"
+              },
+              {
+                  "distinct_range": 22222372.375296894,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2509288839"
+              },
+              {
+                  "distinct_range": 21721327.12404792,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2534563253"
+              },
+              {
+                  "distinct_range": 22604886.346910127,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2562341798"
+              },
+              {
+                  "distinct_range": 21646244.020646244,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2587417942"
+              },
+              {
+                  "distinct_range": 21747481.023641862,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2612761920"
+              },
+              {
+                  "distinct_range": 19893012.963995438,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2633739580"
+              },
+              {
+                  "distinct_range": 22473360.8093273,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2661124094"
+              },
+              {
+                  "distinct_range": 23473194.39903376,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2691718710"
+              },
+              {
+                  "distinct_range": 22383276.21256846,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2718837860"
+              },
+              {
+                  "distinct_range": 21931840.44594416,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2744679684"
+              },
+              {
+                  "distinct_range": 21664886.79398126,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2769804860"
+              },
+              {
+                  "distinct_range": 20745130.421199434,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2792655942"
+              },
+              {
+                  "distinct_range": 21316763.102999408,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2816886418"
+              },
+              {
+                  "distinct_range": 24124210.24250176,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2849873679"
+              },
+              {
+                  "distinct_range": 23107385.990348976,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2879234051"
+              },
+              {
+                  "distinct_range": 17297666.76848973,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2895545914"
+              },
+              {
+                  "distinct_range": 20916985.311197735,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2918800590"
+              },
+              {
+                  "distinct_range": 22772758.4577469,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2947093783"
+              },
+              {
+                  "distinct_range": 21827985.901285212,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2972653531"
+              },
+              {
+                  "distinct_range": 21750908.271683406,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2998006644"
+              },
+              {
+                  "distinct_range": 21303374.06726007,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3022203569"
+              },
+              {
+                  "distinct_range": 24442232.6942826,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3056462294"
+              },
+              {
+                  "distinct_range": 19812267.982590433,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3077272655"
+              },
+              {
+                  "distinct_range": 20033722.844535105,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3098545885"
+              },
+              {
+                  "distinct_range": 21097986.575254615,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3122235796"
+              },
+              {
+                  "distinct_range": 21524432.80933553,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3146994731"
+              },
+              {
+                  "distinct_range": 21502968.62811175,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3171698333"
+              },
+              {
+                  "distinct_range": 22473979.849499207,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3199084683"
+              },
+              {
+                  "distinct_range": 21679798.239057563,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3224249171"
+              },
+              {
+                  "distinct_range": 21198371.178071614,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3248185108"
+              },
+              {
+                  "distinct_range": 22645571.20614817,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3276087157"
+              },
+              {
+                  "distinct_range": 21008691.51676071,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3299561022"
+              },
+              {
+                  "distinct_range": 20410186.815781582,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3321651237"
+              },
+              {
+                  "distinct_range": 22010378.565266624,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3347709218"
+              },
+              {
+                  "distinct_range": 21459421.428990602,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3372301069"
+              },
+              {
+                  "distinct_range": 20882573.381921187,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3395474189"
+              },
+              {
+                  "distinct_range": 21951957.54217064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3421371145"
+              },
+              {
+                  "distinct_range": 19246889.784910217,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3441054908"
+              },
+              {
+                  "distinct_range": 19299935.465493567,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3460841164"
+              },
+              {
+                  "distinct_range": 20996054.826563597,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3484284665"
+              },
+              {
+                  "distinct_range": 23350112.545544494,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3514455730"
+              },
+              {
+                  "distinct_range": 24410486.993028726,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3548584244"
+              },
+              {
+                  "distinct_range": 23715812.87291982,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3580039630"
+              },
+              {
+                  "distinct_range": 19860382.492581643,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3600949481"
+              },
+              {
+                  "distinct_range": 20756604.654847752,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3623827224"
+              },
+              {
+                  "distinct_range": 20363086.852465715,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3645813070"
+              },
+              {
+                  "distinct_range": 23238475.76797328,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3675607303"
+              },
+              {
+                  "distinct_range": 23428047.42571172,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3706045558"
+              },
+              {
+                  "distinct_range": 21545057.41488382,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3730857819"
+              },
+              {
+                  "distinct_range": 22608496.55345195,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3758647292"
+              },
+              {
+                  "distinct_range": 21568114.522001583,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3783519352"
+              },
+              {
+                  "distinct_range": 23684499.177858837,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3814861657"
+              },
+              {
+                  "distinct_range": 20630189.861290235,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3837447880"
+              },
+              {
+                  "distinct_range": 21879266.12351862,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3863146379"
+              },
+              {
+                  "distinct_range": 19478829.72829261,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3883283080"
+              },
+              {
+                  "distinct_range": 20509186.049857058,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3905594743"
+              },
+              {
+                  "distinct_range": 21509309.540877663,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3930314674"
+              },
+              {
+                  "distinct_range": 20011750.9778723,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3951541409"
+              },
+              {
+                  "distinct_range": 20617839.148801647,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3974099409"
+              },
+              {
+                  "distinct_range": 18660077.060173646,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "3992690514"
+              },
+              {
+                  "distinct_range": 21400106.73686653,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4017131241"
+              },
+              {
+                  "distinct_range": 21695071.747913763,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4042336082"
+              },
+              {
+                  "distinct_range": 21814405.32105898,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4067859256"
+              },
+              {
+                  "distinct_range": 20020420.27095503,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4089104321"
+              },
+              {
+                  "distinct_range": 21327585.613874834,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4113361962"
+              },
+              {
+                  "distinct_range": 23175406.897611488,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4142946312"
+              },
+              {
+                  "distinct_range": 22520362.62482373,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4170470728"
+              },
+              {
+                  "distinct_range": 22083043.403185464,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4196730924"
+              },
+              {
+                  "distinct_range": 20523070.484355643,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4219073872"
+              },
+              {
+                  "distinct_range": 21115611.224192206,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4242806735"
+              },
+              {
+                  "distinct_range": 19212301.072495475,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4262424011"
+              },
+              {
+                  "distinct_range": 21203156.31381858,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4286371760"
+              },
+              {
+                  "distinct_range": 22183259.845158745,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4312914416"
+              },
+              {
+                  "distinct_range": 20939881.022027913,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4336223563"
+              },
+              {
+                  "distinct_range": 20915563.97920681,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "4359474863"
+              },
+              {
+                  "distinct_range": 35130995.74808966,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "8692929997"
+              },
+              {
+                  "distinct_range": 35045396.55325351,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "11114024352"
+              },
+              {
+                  "distinct_range": 35049340.39115703,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "13585497189"
+              },
+              {
+                  "distinct_range": 35065781.414406,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "16291293180"
+              },
+              {
+                  "distinct_range": 35083266.9421324,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "19300440422"
+              },
+              {
+                  "distinct_range": 35706766.42375961,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "21241561265"
+              },
+              {
+                  "distinct_range": 35744754.19679677,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "23528542837"
+              },
+              {
+                  "distinct_range": 35758998.93852224,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "25979115235"
+              },
+              {
+                  "distinct_range": 35768581.77596177,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "28553442414"
+              },
+              {
+                  "distinct_range": 35793268.095920265,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "31512848456"
+              },
+              {
+                  "distinct_range": 35750227.33493094,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "33859997300"
+              },
+              {
+                  "distinct_range": 35751231.13079658,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "36218529172"
+              },
+              {
+                  "distinct_range": 35720975.38543154,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "38276086735"
+              },
+              {
+                  "distinct_range": 35751546.06096704,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "40638233781"
+              },
+              {
+                  "distinct_range": 35723937.57197211,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "42721855456"
+              },
+              {
+                  "distinct_range": 35750031.397323385,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "45066812920"
+              },
+              {
+                  "distinct_range": 35743058.57984113,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "47335717108"
+              },
+              {
+                  "distinct_range": 35780671.5722436,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "50085218138"
+              },
+              {
+                  "distinct_range": 35763867.94889645,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "52597176382"
+              },
+              {
+                  "distinct_range": 35752453.92989406,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "54969733636"
+              },
+              {
+                  "distinct_range": 35732646.676171824,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "57133884669"
+              },
+              {
+                  "distinct_range": 35733371.427384235,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "59304990507"
+              },
+              {
+                  "distinct_range": 35758664.999753945,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "61751436328"
+              },
+              {
+                  "distinct_range": 35764369.14118272,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "64269926360"
+              },
+              {
+                  "distinct_range": 35735405.171253584,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "66460879551"
+              },
+              {
+                  "distinct_range": 35772723.54578763,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "69092759446"
+              },
+              {
+                  "distinct_range": 35732709.66265656,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "71257525205"
+              },
+              {
+                  "distinct_range": 35756302.23959233,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "73675376881"
+              },
+              {
+                  "distinct_range": 35719042.90958356,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "75716245503"
+              },
+              {
+                  "distinct_range": 35763669.118365034,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "78225598538"
+              },
+              {
+                  "distinct_range": 35782288.83879476,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "81000469713"
+              },
+              {
+                  "distinct_range": 35748725.61603879,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "83330783269"
+              },
+              {
+                  "distinct_range": 35768585.12904687,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "85905254874"
+              },
+              {
+                  "distinct_range": 35761122.31861337,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "88382167238"
+              },
+              {
+                  "distinct_range": 35709813.67249378,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "90347098149"
+              },
+              {
+                  "distinct_range": 35782791.259976715,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "93129813893"
+              },
+              {
+                  "distinct_range": 35773281.04109219,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "95769514705"
+              },
+              {
+                  "distinct_range": 35694534.53474467,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "97620396058"
+              },
+              {
+                  "distinct_range": 35754086.63035867,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "100011919099"
+              },
+              {
+                  "distinct_range": 35760136.294719346,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "102476583804"
+              },
+              {
+                  "distinct_range": 35737245.4058155,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "104685825158"
+              },
+              {
+                  "distinct_range": 35778836.01292197,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "107407300513"
+              },
+              {
+                  "distinct_range": 35765664.14178164,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "109942736035"
+              },
+              {
+                  "distinct_range": 35772360.8653807,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "112569500987"
+              },
+              {
+                  "distinct_range": 35753125.25902129,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "114949842330"
+              },
+              {
+                  "distinct_range": 35790532.42234391,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "117860842935"
+              },
+              {
+                  "distinct_range": 35801302.6097832,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "120971436412"
+              },
+              {
+                  "distinct_range": 35783809.18486874,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "123770346507"
+              },
+              {
+                  "distinct_range": 35736822.37878387,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "125975345151"
+              },
+              {
+                  "distinct_range": 35752651.46351407,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "128350208056"
+              },
+              {
+                  "distinct_range": 35742736.32569799,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "130615755785"
+              },
+              {
+                  "distinct_range": 35750491.66849026,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "132965913316"
+              },
+              {
+                  "distinct_range": 35719556.88433113,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "135011224108"
+              },
+              {
+                  "distinct_range": 35754052.44276579,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "137402427965"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "c"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 5365341093,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 547085,
+                  "num_range": 0,
+                  "upper_bound": "2020-01-24 20:59:20.188674+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-02-06 16:24:37.316041+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-02-17 07:01:43.57992+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-03-02 00:18:01.835346+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-03-15 23:13:11.552177+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-03-28 22:29:16.221812+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-04-07 15:53:46.113499+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-04-15 21:12:14.120714+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-04-21 04:04:25.303986+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-04-26 17:16:10.401437+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-05-02 20:18:07.650908+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-05-09 19:00:47.522012+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-05-15 21:40:46.847922+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-05-21 22:22:20.924308+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-05-29 15:01:01.406105+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-06-04 00:33:36.578104+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-06-10 16:46:41.020843+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-06-16 03:13:53.404016+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-06-21 01:40:54.446458+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-06-26 22:38:15.621407+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-03 01:28:06.960376+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-09 20:15:46.37031+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-14 00:35:01.234428+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-18 00:01:30.09699+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-23 06:06:23.211179+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-07-29 03:25:32.341762+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-03 00:07:51.644238+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-07 01:17:54.372987+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-11 23:36:22.267172+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-17 14:05:26.076991+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-22 18:39:41.500461+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-26 22:33:31.815907+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-08-30 21:12:24.17285+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-04 15:54:27.912627+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-09 16:13:39.645637+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-13 20:44:48.487439+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-18 02:29:01.498993+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-22 22:04:58.626927+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-09-27 18:30:45.791743+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-01 23:53:49.880883+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-06 22:57:28.611825+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-11 16:42:49.327708+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-15 21:20:35.349138+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-19 01:23:47.772712+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-24 00:41:22.852791+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-10-29 01:23:37.02457+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-02 20:03:25.876977+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-06 23:15:14.048606+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-10 01:00:14.600288+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-14 01:53:20.329498+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-17 23:07:32.187396+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-21 21:04:21.330862+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-24 03:33:58.061+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-11-28 16:52:58.164846+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-03 20:33:27.432662+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-06 23:37:55.257714+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-10 00:00:10.913006+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-12 22:08:58.140171+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-15 04:44:52.901011+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-18 15:02:05.056069+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-20 22:34:51.736375+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-23 20:49:47.277091+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-26 21:55:51.383329+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2020-12-30 18:16:50.499302+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-02 18:52:18.681481+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-04 01:24:50.844795+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-06 23:09:26.099471+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-09 17:51:09.425114+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-11 20:32:38.743748+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-14 17:41:30.488059+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-17 22:15:02.457439+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-20 23:35:20.097871+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-23 16:43:11.262319+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-26 15:41:58.320409+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-29 01:04:11.629233+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-01-31 07:31:37.565143+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-02 19:25:41.367069+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-05 16:01:15.949587+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-08 17:20:50.861519+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-11 08:34:07.228979+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-13 19:16:54.39684+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-16 01:36:05.590328+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-18 20:13:53.446552+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-20 23:58:28.492016+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-24 06:54:47.931757+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-27 01:00:58.882608+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-02-28 18:54:16.699591+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-03 00:26:36.248841+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-05 19:48:41.663466+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-08 01:50:01.579611+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-10 21:32:43.52514+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-13 00:38:55.409833+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-16 06:58:33.652627+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-18 03:11:35.492168+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-20 00:41:58.305405+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-22 16:37:36.73439+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-24 21:22:51.439668+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-27 00:09:50.668842+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-03-29 20:50:21.439061+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-01 15:07:25.311788+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-03 15:59:19.503753+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-06 15:50:21.139616+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-08 19:11:02.756737+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-10 20:37:08.657193+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-13 15:41:38.867099+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-15 20:57:01.821743+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-17 20:58:22.20269+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-20 03:48:04.730819+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-21 23:47:52.475437+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-23 20:03:45.039655+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-25 21:25:37.214458+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-04-28 20:02:21.259251+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-01 19:32:40.792951+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-04 19:49:58.643461+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-06 19:17:08.3362+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-08 18:43:53.532834+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-10 18:41:30.808075+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-13 16:38:11.589001+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-16 01:41:13.791437+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-18 17:24:27.769496+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-21 00:44:52.85736+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-23 01:44:41.059448+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-26 00:45:46.216685+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-28 00:29:50.109338+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-05-30 01:42:00.980161+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-01 01:10:12.073044+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-03 00:22:42.267972+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-05 02:09:17.209107+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-07 02:51:51.002295+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-09 19:48:50.731778+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-12 01:43:15.720963+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-14 02:17:24.22018+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-16 16:37:24.686603+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-18 17:40:05.420928+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-20 20:47:25.080109+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-23 17:33:17.324342+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-25 18:07:03.307108+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-27 18:48:19.119105+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-06-29 17:34:07.107625+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-01 15:37:24.448456+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-03 17:50:14.594918+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-05 23:57:38.919869+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-08 03:47:22.281296+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-10 01:19:26.302944+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-12 15:50:34.028309+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-15 16:00:32.138527+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-17 18:03:12.737524+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-20 00:00:29.951428+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-21 23:30:49.024137+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-23 23:17:16.894796+00:00"
+              },
+              {
+                  "distinct_range": 26826704.324898064,
+                  "num_eq": 547085,
+                  "num_range": 26807186,
+                  "upper_bound": "2021-07-25 22:59:15.014873+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-07-28 14:37:56.437212+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-07-30 19:07:16.804683+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-01 22:07:55.684634+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-04 01:57:18.100155+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-05 22:24:38.581494+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-07 23:00:12.946935+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-10 01:11:22.759969+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-12 19:17:54.670582+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-14 21:21:17.605248+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-17 00:56:08.576627+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-19 19:17:02.820196+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-21 23:52:49.258512+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-24 04:42:58.881845+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-26 16:20:37.780255+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-28 17:35:42.152344+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-08-30 23:30:39.578172+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-02 21:18:17.154251+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-04 22:50:28.634025+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-06 21:00:44.101777+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-09 14:55:23.954377+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-11 21:01:20.107752+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-13 21:58:35.851022+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-16 01:52:06.990972+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-17 22:55:13.258609+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-20 01:45:22.344603+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-22 21:04:28.108124+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-25 16:28:55.213957+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-27 15:37:17.781076+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-09-29 22:58:14.1832+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-02 16:01:50.700351+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-04 22:07:15.678014+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-06 23:07:15.48318+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-08 22:44:10.945473+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-10 19:36:09.70679+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-13 14:02:36.961637+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-15 17:13:15.434227+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-17 20:08:36.695424+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-20 18:27:06.494321+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-22 23:16:40.561146+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-25 00:40:08.227192+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-27 16:38:08.897406+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-10-30 05:43:30.249539+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-01 22:07:23.069399+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-04 00:41:09.228982+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-06 05:24:07.544422+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-08 01:24:37.767137+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-10 02:27:40.950558+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-12 02:11:58.407965+00:00"
+              },
+              {
+                  "distinct_range": 27374188.658475306,
+                  "num_eq": 547085,
+                  "num_range": 27354272,
+                  "upper_bound": "2021-11-14 18:38:52.817597+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "d"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 1889961545,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 550934,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-26 16:46:36+00:00"
+              },
+              {
+                  "distinct_range": 1889961542.9999998,
+                  "num_eq": 550934,
+                  "num_range": 3513860583,
+                  "upper_bound": "2021-11-14 18:39:11.810889+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 1955891971,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "e"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 120198242,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 542207,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-22 19:07:11+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-03-08 21:41:51+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-03-19 17:46:41+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-03-27 21:54:15+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-02 21:25:27+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-05 23:19:37+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-12 19:14:47+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-18 02:31:41+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-21 17:42:44+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-25 02:21:02+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-04-28 21:30:19+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-03 01:14:42+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-06 04:48:59+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-12 02:14:26+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-15 21:41:16+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-18 19:45:55+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-24 01:23:09+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-05-28 22:34:40+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-01 21:19:47+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-05 22:02:18+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-10 23:25:50+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-14 00:25:01+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-17 01:24:34+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-21 23:59:05+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-26 01:08:30+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-06-30 19:42:07+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-04 16:11:37+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-09 00:53:14+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-11 17:15:17+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-16 00:01:28+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-18 02:36:04+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-21 16:06:56+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-24 00:34:35+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-28 03:26:50+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-07-31 18:49:09+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-04 14:23:53+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-07 01:18:05+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-10 04:44:15+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-13 16:05:03+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-20 23:24:27+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-24 01:38:30+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-08-27 19:10:21+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-01 03:50:11+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-04 19:09:58+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-08 23:04:18+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-12 05:12:40+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-15 23:05:26+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-19 19:56:39+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-22 17:58:48+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-25 22:10:05+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-09-28 20:51:36+00:00"
+              },
+              {
+                  "distinct_range": 578693.5033867438,
+                  "num_eq": 542207,
+                  "num_range": 9217524,
+                  "upper_bound": "2020-10-03 23:23:25+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-09 09:28:53+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-13 01:01:06+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-16 00:56:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-19 01:24:11+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-23 18:25:16+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-26 01:41:56+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-10-29 20:55:55+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-02 18:40:38+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-07 00:31:43+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-09 20:34:13+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-13 12:42:28+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-15 19:47:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-20 08:27:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-23 02:02:35+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-11-26 21:44:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-02 16:50:45+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-05 22:15:42+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-09 00:32:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-12 17:36:55+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-15 02:22:43+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-17 02:41:27+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-19 18:24:24+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-22 00:59:00+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-26 17:15:28+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2020-12-30 23:39:08+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-02 04:44:07+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-04 18:48:20+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-07 22:52:42+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-10 02:07:33+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-13 16:32:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-16 17:07:01+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-19 21:25:50+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-22 00:48:17+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-25 18:35:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-28 14:51:11+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-01-31 03:20:09+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-02 22:46:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-05 04:01:49+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-08 00:41:54+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-12 18:25:21+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-14 21:10:43+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-17 21:43:42+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-19 23:47:10+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-25 01:29:14+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-02-27 18:08:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-01 16:02:01+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-04 17:49:25+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-06 19:28:52+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-09 17:55:47+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-12 03:02:44+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-14 23:13:35+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-17 03:00:33+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-19 15:21:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-21 20:30:39+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-23 20:08:56+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-26 02:02:29+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-28 02:40:38+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-03-30 18:14:04+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-02 23:44:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-06 01:47:36.303021+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-08 21:40:36+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-10 21:22:48.557995+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-13 22:26:17+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-17 00:10:07+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-20 03:48:15+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-21 22:36:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-23 20:00:00.509711+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-04-26 01:24:40+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-01 02:31:46.351841+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-04 18:37:35.841277+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-06 03:20:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-07 23:05:43+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-11 03:45:40+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-14 18:02:42+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-18 23:24:07+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-21 15:37:59+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-23 23:12:10+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-27 19:51:38+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-05-29 18:30:24+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-01 17:40:09+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-03 22:25:17.515569+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-06 03:40:32+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-08 23:56:11.552781+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-11 22:22:56+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-14 00:19:11+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-17 21:00:33+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-20 23:24:04+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-24 12:21:58+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-26 12:10:06+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-28 15:45:02+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-06-30 03:50:42+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-02 19:52:06+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-06 17:00:07.650399+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-09 00:01:20+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-10 22:13:54+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-13 02:53:53+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-15 16:28:29+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-17 21:41:09+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-20 05:18:15+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-22 23:20:12+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-24 20:01:36+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-26 15:50:45+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-07-30 00:39:57+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-01 00:14:02.117185+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-02 16:32:18+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-05 16:24:40+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-07 17:11:24+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-09 20:30:33+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-12 18:49:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-15 18:34:51.239515+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-18 15:49:26+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-21 00:34:54+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-23 13:54:33+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-25 21:05:07+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-27 22:37:48+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-08-29 20:21:36+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-02 00:29:25+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-05 04:02:17+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-07 00:39:43.018315+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-09 21:46:18+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-11 23:30:41.156915+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-13 23:45:59+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-16 14:52:29+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-18 13:19:13+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-21 23:07:03.20889+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-25 16:29:38+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-26 19:08:00.874691+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-09-29 18:21:46+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-01 22:46:05+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-04 13:25:31+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-06 22:00:45+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-08 15:16:17+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-10 18:12:31.733377+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-12 20:52:36+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-15 15:01:45+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-17 08:36:01+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-21 00:31:23+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-23 00:08:24+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-25 02:20:30.777325+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-27 11:16:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-10-30 00:12:56+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-01 15:52:13+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-04 21:09:46+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-06 19:07:03+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-08 17:51:37+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-09 23:04:21+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-11 20:56:27+00:00"
+              },
+              {
+                  "distinct_range": 612734.2792383517,
+                  "num_eq": 542207,
+                  "num_range": 9759731,
+                  "upper_bound": "2021-11-14 01:25:16+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 3447878972,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 8033503,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 547240,
+                  "num_range": 0,
+                  "upper_bound": "2577"
+              },
+              {
+                  "distinct_range": 115780.07132053739,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "263084"
+              },
+              {
+                  "distinct_range": 81702.84780771664,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "446917"
+              },
+              {
+                  "distinct_range": 67665.1152692754,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "599165"
+              },
+              {
+                  "distinct_range": 51348.27896458034,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "714700"
+              },
+              {
+                  "distinct_range": 49601.617926870225,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "826305"
+              },
+              {
+                  "distinct_range": 31582.12044266691,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "897366"
+              },
+              {
+                  "distinct_range": 36107.43919227618,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "978609"
+              },
+              {
+                  "distinct_range": 40091.42635309895,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1068816"
+              },
+              {
+                  "distinct_range": 45240.29864874061,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1170608"
+              },
+              {
+                  "distinct_range": 51445.16754122685,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1286361"
+              },
+              {
+                  "distinct_range": 48269.62221948671,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1394969"
+              },
+              {
+                  "distinct_range": 59637.58558400309,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1529155"
+              },
+              {
+                  "distinct_range": 43529.63749501383,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1627098"
+              },
+              {
+                  "distinct_range": 42718.973440870504,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1723217"
+              },
+              {
+                  "distinct_range": 50089.61635419992,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "1835920"
+              },
+              {
+                  "distinct_range": 57069.14941684615,
+                  "num_eq": 1641721,
+                  "num_range": 26267547,
+                  "upper_bound": "1964327"
+              },
+              {
+                  "distinct_range": 41558.97717918516,
+                  "num_eq": 547240,
+                  "num_range": 26267547,
+                  "upper_bound": "2057836"
+              },
+              {
+                  "distinct_range": 42925.19499850346,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2154419"
+              },
+              {
+                  "distinct_range": 38335.87645514603,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2240676"
+              },
+              {
+                  "distinct_range": 40902.97929326655,
+                  "num_eq": 1094481,
+                  "num_range": 26267547,
+                  "upper_bound": "2332709"
+              },
+              {
+                  "distinct_range": 46620.294201435245,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2437606"
+              },
+              {
+                  "distinct_range": 42350.085740794326,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2532895"
+              },
+              {
+                  "distinct_range": 35973.2174026099,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2613836"
+              },
+              {
+                  "distinct_range": 42739.862262441085,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2710002"
+              },
+              {
+                  "distinct_range": 38251.432282839436,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2796069"
+              },
+              {
+                  "distinct_range": 55431.37691711033,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "2920791"
+              },
+              {
+                  "distinct_range": 48199.84466658073,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3029242"
+              },
+              {
+                  "distinct_range": 40394.53648737841,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3120131"
+              },
+              {
+                  "distinct_range": 36323.88293918835,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3201861"
+              },
+              {
+                  "distinct_range": 47495.402492338864,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3308727"
+              },
+              {
+                  "distinct_range": 32183.451838092304,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3381141"
+              },
+              {
+                  "distinct_range": 50126.94956721968,
+                  "num_eq": 1094481,
+                  "num_range": 26267547,
+                  "upper_bound": "3493928"
+              },
+              {
+                  "distinct_range": 58149.59037935844,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3624766"
+              },
+              {
+                  "distinct_range": 57560.25894526083,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3754278"
+              },
+              {
+                  "distinct_range": 51968.27696651561,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3871208"
+              },
+              {
+                  "distinct_range": 46806.960266534035,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "3976525"
+              },
+              {
+                  "distinct_range": 44100.302322601565,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4075752"
+              },
+              {
+                  "distinct_range": 33523.0030766822,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4151180"
+              },
+              {
+                  "distinct_range": 45366.964907200505,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4253257"
+              },
+              {
+                  "distinct_range": 60850.470564133095,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4390172"
+              },
+              {
+                  "distinct_range": 41126.534128372965,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4482708"
+              },
+              {
+                  "distinct_range": 37409.65721784632,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4566881"
+              },
+              {
+                  "distinct_range": 48901.62018274976,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4676911"
+              },
+              {
+                  "distinct_range": 51144.27962200809,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4791987"
+              },
+              {
+                  "distinct_range": 57112.704832035866,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "4920492"
+              },
+              {
+                  "distinct_range": 35773.21804714691,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5000983"
+              },
+              {
+                  "distinct_range": 40583.869210550045,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5092298"
+              },
+              {
+                  "distinct_range": 41029.64555172645,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5184616"
+              },
+              {
+                  "distinct_range": 39308.76220872045,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5273062"
+              },
+              {
+                  "distinct_range": 43947.85836943755,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5371946"
+              },
+              {
+                  "distinct_range": 42255.86382222065,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5467023"
+              },
+              {
+                  "distinct_range": 29879.903706170793,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5534254"
+              },
+              {
+                  "distinct_range": 40032.315432484334,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5624328"
+              },
+              {
+                  "distinct_range": 31439.00979275784,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5695067"
+              },
+              {
+                  "distinct_range": 33160.33757877598,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5769679"
+              },
+              {
+                  "distinct_range": 32490.56195948103,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5842784"
+              },
+              {
+                  "distinct_range": 37426.54605230763,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5926995"
+              },
+              {
+                  "distinct_range": 29551.46032019935,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "5993487"
+              },
+              {
+                  "distinct_range": 42188.75292738751,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6088413"
+              },
+              {
+                  "distinct_range": 26345.692873633678,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6147692"
+              },
+              {
+                  "distinct_range": 29849.237138333134,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6214854"
+              },
+              {
+                  "distinct_range": 26643.025248755326,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6274802"
+              },
+              {
+                  "distinct_range": 22166.595230481456,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6324678"
+              },
+              {
+                  "distinct_range": 34331.44491576482,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6401925"
+              },
+              {
+                  "distinct_range": 26109.24919117521,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6460672"
+              },
+              {
+                  "distinct_range": 22209.26175964689,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6510644"
+              },
+              {
+                  "distinct_range": 19808.825051078868,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6555215"
+              },
+              {
+                  "distinct_range": 20435.934141208378,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6601197"
+              },
+              {
+                  "distinct_range": 21163.931795093664,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6648817"
+              },
+              {
+                  "distinct_range": 22953.25936196922,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6700463"
+              },
+              {
+                  "distinct_range": 18186.1636137558,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6741383"
+              },
+              {
+                  "distinct_range": 24448.36565480811,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6796393"
+              },
+              {
+                  "distinct_range": 20843.043940328596,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6843291"
+              },
+              {
+                  "distinct_range": 20426.156394941296,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6889251"
+              },
+              {
+                  "distinct_range": 16527.5022924494,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6926439"
+              },
+              {
+                  "distinct_range": 22615.927115754974,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "6977326"
+              },
+              {
+                  "distinct_range": 17934.164425872434,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7017679"
+              },
+              {
+                  "distinct_range": 23534.146378836173,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7070632"
+              },
+              {
+                  "distinct_range": 18019.49748420331,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7111177"
+              },
+              {
+                  "distinct_range": 28636.796601215272,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7175611"
+              },
+              {
+                  "distinct_range": 22758.148879639768,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7226818"
+              },
+              {
+                  "distinct_range": 21776.818708834693,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7275817"
+              },
+              {
+                  "distinct_range": 24864.80875718327,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7331764"
+              },
+              {
+                  "distinct_range": 25291.029605825508,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7388670"
+              },
+              {
+                  "distinct_range": 26822.580225659876,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7449022"
+              },
+              {
+                  "distinct_range": 32944.78271788809,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7523149"
+              },
+              {
+                  "distinct_range": 22141.261978789476,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7572968"
+              },
+              {
+                  "distinct_range": 26636.358603573226,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7632901"
+              },
+              {
+                  "distinct_range": 29680.348793719942,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7699683"
+              },
+              {
+                  "distinct_range": 26692.802866115002,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7759743"
+              },
+              {
+                  "distinct_range": 32549.228437083508,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7832980"
+              },
+              {
+                  "distinct_range": 29992.347788242205,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7900464"
+              },
+              {
+                  "distinct_range": 36081.66149757206,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "7981649"
+              },
+              {
+                  "distinct_range": 18167.497007245925,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8022527"
+              },
+              {
+                  "distinct_range": 25367.029360901444,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8079604"
+              },
+              {
+                  "distinct_range": 21214.15385546548,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8127337"
+              },
+              {
+                  "distinct_range": 27913.687820463525,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8190144"
+              },
+              {
+                  "distinct_range": 22147.484180959436,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8239977"
+              },
+              {
+                  "distinct_range": 23314.14708782688,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8292435"
+              },
+              {
+                  "distinct_range": 28954.573354895354,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8357584"
+              },
+              {
+                  "distinct_range": 24546.143117478903,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8412814"
+              },
+              {
+                  "distinct_range": 18671.49538301266,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8454826"
+              },
+              {
+                  "distinct_range": 19380.826430388068,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8498434"
+              },
+              {
+                  "distinct_range": 24358.14372334369,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8553241"
+              },
+              {
+                  "distinct_range": 23525.25751859337,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8606174"
+              },
+              {
+                  "distinct_range": 22359.039054738067,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8656483"
+              },
+              {
+                  "distinct_range": 20252.823620206706,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8702053"
+              },
+              {
+                  "distinct_range": 27443.022670607286,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8763801"
+              },
+              {
+                  "distinct_range": 20165.71278982727,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8809175"
+              },
+              {
+                  "distinct_range": 28178.131412686813,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8872577"
+              },
+              {
+                  "distinct_range": 30367.902133500487,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8940906"
+              },
+              {
+                  "distinct_range": 22163.484129396475,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "8990775"
+              },
+              {
+                  "distinct_range": 29697.23762818126,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9057595"
+              },
+              {
+                  "distinct_range": 25543.473236721016,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9115069"
+              },
+              {
+                  "distinct_range": 29998.569990412165,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9182567"
+              },
+              {
+                  "distinct_range": 26110.138077199488,
+                  "num_eq": 1094481,
+                  "num_range": 26814787,
+                  "upper_bound": "9241316"
+              },
+              {
+                  "distinct_range": 29977.681168841587,
+                  "num_eq": 547240,
+                  "num_range": 26267547,
+                  "upper_bound": "9308767"
+              },
+              {
+                  "distinct_range": 24210.144200301078,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9363241"
+              },
+              {
+                  "distinct_range": 22363.483484859466,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9413560"
+              },
+              {
+                  "distinct_range": 27965.687652883902,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9476484"
+              },
+              {
+                  "distinct_range": 24068.811322440564,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9530640"
+              },
+              {
+                  "distinct_range": 24758.586877281814,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9586348"
+              },
+              {
+                  "distinct_range": 27063.023895227605,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9647241"
+              },
+              {
+                  "distinct_range": 22726.593425777828,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9698377"
+              },
+              {
+                  "distinct_range": 31918.119359844735,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9770194"
+              },
+              {
+                  "distinct_range": 26005.249526334454,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9828707"
+              },
+              {
+                  "distinct_range": 31099.899774495036,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "9898683"
+              },
+              {
+                  "distinct_range": 35970.995187549204,
+                  "num_eq": 1094481,
+                  "num_range": 26814787,
+                  "upper_bound": "9979619"
+              },
+              {
+                  "distinct_range": 29164.794899637567,
+                  "num_eq": 547240,
+                  "num_range": 26267547,
+                  "upper_bound": "10045241"
+              },
+              {
+                  "distinct_range": 29730.12641107962,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10112135"
+              },
+              {
+                  "distinct_range": 31862.1195403151,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10183826"
+              },
+              {
+                  "distinct_range": 29477.68278018411,
+                  "num_eq": 1094481,
+                  "num_range": 26814787,
+                  "upper_bound": "10250152"
+              },
+              {
+                  "distinct_range": 32543.450677925688,
+                  "num_eq": 547240,
+                  "num_range": 26267547,
+                  "upper_bound": "10323376"
+              },
+              {
+                  "distinct_range": 30835.900625283888,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10392758"
+              },
+              {
+                  "distinct_range": 32229.22946834272,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10465275"
+              },
+              {
+                  "distinct_range": 25004.808306007362,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10521537"
+              },
+              {
+                  "distinct_range": 27203.023444051698,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10582745"
+              },
+              {
+                  "distinct_range": 27829.243648156928,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10645362"
+              },
+              {
+                  "distinct_range": 34821.66555815522,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10723712"
+              },
+              {
+                  "distinct_range": 30499.457265093923,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10792337"
+              },
+              {
+                  "distinct_range": 33343.89254278979,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10867362"
+              },
+              {
+                  "distinct_range": 31993.67467190853,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "10939349"
+              },
+              {
+                  "distinct_range": 34041.22362883742,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11015943"
+              },
+              {
+                  "distinct_range": 35165.22000653942,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11095066"
+              },
+              {
+                  "distinct_range": 39251.42906015439,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11183383"
+              },
+              {
+                  "distinct_range": 29497.23827271827,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11249753"
+              },
+              {
+                  "distinct_range": 32159.451915436744,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11322113"
+              },
+              {
+                  "distinct_range": 38854.09700730125,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11409536"
+              },
+              {
+                  "distinct_range": 34820.77667213094,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11487884"
+              },
+              {
+                  "distinct_range": 35889.66211632759,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11568637"
+              },
+              {
+                  "distinct_range": 29335.01657328718,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11634642"
+              },
+              {
+                  "distinct_range": 37755.87832430336,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11719594"
+              },
+              {
+                  "distinct_range": 32275.89598461742,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11792216"
+              },
+              {
+                  "distinct_range": 24146.14440655292,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11846546"
+              },
+              {
+                  "distinct_range": 36605.659808885095,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11928910"
+              },
+              {
+                  "distinct_range": 31307.010218152263,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "11999352"
+              },
+              {
+                  "distinct_range": 30342.12443879637,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12067623"
+              },
+              {
+                  "distinct_range": 45272.298545614685,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12169487"
+              },
+              {
+                  "distinct_range": 37853.65578697416,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12254659"
+              },
+              {
+                  "distinct_range": 50459.39294030038,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12368194"
+              },
+              {
+                  "distinct_range": 41500.75514459483,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12461572"
+              },
+              {
+                  "distinct_range": 44211.413075636556,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12561049"
+              },
+              {
+                  "distinct_range": 45330.520580205026,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12663044"
+              },
+              {
+                  "distinct_range": 40179.42606950267,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12753449"
+              },
+              {
+                  "distinct_range": 43220.74960157654,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12850697"
+              },
+              {
+                  "distinct_range": 39320.31772703609,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "12939169"
+              },
+              {
+                  "distinct_range": 35106.10908592481,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13018159"
+              },
+              {
+                  "distinct_range": 61690.023414065516,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13156963"
+              },
+              {
+                  "distinct_range": 41918.08713299427,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13251280"
+              },
+              {
+                  "distinct_range": 42261.197138366326,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13346369"
+              },
+              {
+                  "distinct_range": 54140.26996684369,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13468186"
+              },
+              {
+                  "distinct_range": 31846.119591878058,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13539841"
+              },
+              {
+                  "distinct_range": 37814.100358893695,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13624924"
+              },
+              {
+                  "distinct_range": 38140.76597281658,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13710742"
+              },
+              {
+                  "distinct_range": 61465.57969293482,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13849041"
+              },
+              {
+                  "distinct_range": 47654.95753369712,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "13956266"
+              },
+              {
+                  "distinct_range": 49135.84165014752,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14066823"
+              },
+              {
+                  "distinct_range": 41312.75575045961,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14159778"
+              },
+              {
+                  "distinct_range": 58524.25583859244,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14291459"
+              },
+              {
+                  "distinct_range": 69072.22184571056,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14446873"
+              },
+              {
+                  "distinct_range": 53347.82807619811,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14566907"
+              },
+              {
+                  "distinct_range": 57306.92642834104,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14695849"
+              },
+              {
+                  "distinct_range": 62701.5757096961,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "14836929"
+              },
+              {
+                  "distinct_range": 73523.31861229245,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15002358"
+              },
+              {
+                  "distinct_range": 68298.44656157486,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15156031"
+              },
+              {
+                  "distinct_range": 59935.80684514902,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15290888"
+              },
+              {
+                  "distinct_range": 71357.99225714647,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15451445"
+              },
+              {
+                  "distinct_range": 75715.31154816684,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15621806"
+              },
+              {
+                  "distinct_range": 61278.469184823894,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15759684"
+              },
+              {
+                  "distinct_range": 73785.98443246719,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "15925704"
+              },
+              {
+                  "distinct_range": 69874.44148262322,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "16082923"
+              },
+              {
+                  "distinct_range": 75718.4226492518,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "16253291"
+              },
+              {
+                  "distinct_range": 60018.91768841919,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "16388335"
+              },
+              {
+                  "distinct_range": 77564.63892168128,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "16562857"
+              },
+              {
+                  "distinct_range": 90859.26274382448,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "16767292"
+              },
+              {
+                  "distinct_range": 106081.43590961875,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "17005977"
+              },
+              {
+                  "distinct_range": 97689.46295439168,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "17225780"
+              },
+              {
+                  "distinct_range": 146576.4165177408,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "17555579"
+              },
+              {
+                  "distinct_range": 232081.9187373271,
+                  "num_eq": 547240,
+                  "num_range": 26814787,
+                  "upper_bound": "18077766"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 25263499,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f",
+              "c"
+          ],
+          "created_at": "2021-11-14 21:03:36.731171",
+          "distinct_count": 5389115020,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5470854424
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "a"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 5761422680,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 578248,
+                  "num_range": 0,
+                  "upper_bound": "1297786"
+              },
+              {
+                  "distinct_range": 24856338.69330944,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "31152596"
+              },
+              {
+                  "distinct_range": 26458098.071018368,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "66432428"
+              },
+              {
+                  "distinct_range": 22872077.964382738,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "91071599"
+              },
+              {
+                  "distinct_range": 24243468.997545265,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "119165601"
+              },
+              {
+                  "distinct_range": 25452666.95848486,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "150888006"
+              },
+              {
+                  "distinct_range": 23813433.74947164,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "177831656"
+              },
+              {
+                  "distinct_range": 24889509.863126263,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "207786163"
+              },
+              {
+                  "distinct_range": 25346949.398996882,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "239165440"
+              },
+              {
+                  "distinct_range": 24027422.41088693,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "266673243"
+              },
+              {
+                  "distinct_range": 25635446.01061341,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "299001882"
+              },
+              {
+                  "distinct_range": 25759289.656232536,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "331750938"
+              },
+              {
+                  "distinct_range": 24355950.73586186,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "360157004"
+              },
+              {
+                  "distinct_range": 22759543.806027833,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "384538440"
+              },
+              {
+                  "distinct_range": 24143682.60299568,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "412359568"
+              },
+              {
+                  "distinct_range": 21436511.306213863,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "433954957"
+              },
+              {
+                  "distinct_range": 23354911.163840257,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "459741661"
+              },
+              {
+                  "distinct_range": 24251919.970756665,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "487858943"
+              },
+              {
+                  "distinct_range": 24824926.005115263,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "517619775"
+              },
+              {
+                  "distinct_range": 23111506.7723191,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "542819336"
+              },
+              {
+                  "distinct_range": 23152689.872919925,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "568116980"
+              },
+              {
+                  "distinct_range": 22718395.21124002,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "592405054"
+              },
+              {
+                  "distinct_range": 25801289.47695665,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "625298509"
+              },
+              {
+                  "distinct_range": 22239894.662138846,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "648534144"
+              },
+              {
+                  "distinct_range": 23746649.03664902,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "675304965"
+              },
+              {
+                  "distinct_range": 23256238.85440003,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "700851476"
+              },
+              {
+                  "distinct_range": 24135162.7599014,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "728649476"
+              },
+              {
+                  "distinct_range": 23703378.504617605,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "755309124"
+              },
+              {
+                  "distinct_range": 23312027.384914663,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "780991069"
+              },
+              {
+                  "distinct_range": 24314150.846517622,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "809280607"
+              },
+              {
+                  "distinct_range": 25344328.28970929,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "840651445"
+              },
+              {
+                  "distinct_range": 24321875.39809921,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "868962467"
+              },
+              {
+                  "distinct_range": 25127113.68262668,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "899645174"
+              },
+              {
+                  "distinct_range": 25608902.72642411,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "931884733"
+              },
+              {
+                  "distinct_range": 26330779.58515138,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "966682258"
+              },
+              {
+                  "distinct_range": 24989927.185799733,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "996941477"
+              },
+              {
+                  "distinct_range": 27401862.90548138,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1036135103"
+              },
+              {
+                  "distinct_range": 25785682.55881665,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1068974791"
+              },
+              {
+                  "distinct_range": 22606072.971392587,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1093010375"
+              },
+              {
+                  "distinct_range": 22330163.903848823,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1116439996"
+              },
+              {
+                  "distinct_range": 23456585.714923467,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1142477375"
+              },
+              {
+                  "distinct_range": 25722540.255770758,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1175100845"
+              },
+              {
+                  "distinct_range": 25753663.664591264,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1207830629"
+              },
+              {
+                  "distinct_range": 24502724.414272696,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1236651211"
+              },
+              {
+                  "distinct_range": 26546426.811466377,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1272271571"
+              },
+              {
+                  "distinct_range": 18856457.57854731,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1289457721"
+              },
+              {
+                  "distinct_range": 24417421.757002406,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1318036372"
+              },
+              {
+                  "distinct_range": 24568722.260094162,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1347046107"
+              },
+              {
+                  "distinct_range": 26901130.720015656,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1384085206"
+              },
+              {
+                  "distinct_range": 24197754.095865197,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1412053739"
+              },
+              {
+                  "distinct_range": 23457484.729437962,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1438093349"
+              },
+              {
+                  "distinct_range": 23209967.968013495,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1463528253"
+              },
+              {
+                  "distinct_range": 24814871.400957443,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1493259093"
+              },
+              {
+                  "distinct_range": 24072806.93201508,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1520888627"
+              },
+              {
+                  "distinct_range": 21557320.76605635,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1542721230"
+              },
+              {
+                  "distinct_range": 24526522.0128175,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1571609817"
+              },
+              {
+                  "distinct_range": 24714961.76567075,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1601044949"
+              },
+              {
+                  "distinct_range": 24397116.93946981,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1629566431"
+              },
+              {
+                  "distinct_range": 24207341.492210273,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1657561213"
+              },
+              {
+                  "distinct_range": 26550946.913454708,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1693199132"
+              },
+              {
+                  "distinct_range": 22035662.03606861,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1716003367"
+              },
+              {
+                  "distinct_range": 26053065.41293393,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1749782434"
+              },
+              {
+                  "distinct_range": 25452832.64759509,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1781505381"
+              },
+              {
+                  "distinct_range": 24232055.306410775,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1809567984"
+              },
+              {
+                  "distinct_range": 23608439.6837469,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1835985896"
+              },
+              {
+                  "distinct_range": 25186222.860879797,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1866853691"
+              },
+              {
+                  "distinct_range": 25516318.315597225,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1898785320"
+              },
+              {
+                  "distinct_range": 24143251.84370079,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1926605278"
+              },
+              {
+                  "distinct_range": 23147921.677991934,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1951891540"
+              },
+              {
+                  "distinct_range": 24394132.956958935,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1980404634"
+              },
+              {
+                  "distinct_range": 22266480.356400635,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2003697187"
+              },
+              {
+                  "distinct_range": 24959999.661460817,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2033865132"
+              },
+              {
+                  "distinct_range": 25716871.025449503,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2066469291"
+              },
+              {
+                  "distinct_range": 25591920.789235685,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2098652046"
+              },
+              {
+                  "distinct_range": 24650989.352835678,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2127900014"
+              },
+              {
+                  "distinct_range": 23589863.749427374,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2154270975"
+              },
+              {
+                  "distinct_range": 24408543.381806396,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2182824609"
+              },
+              {
+                  "distinct_range": 24608817.04219979,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2211950110"
+              },
+              {
+                  "distinct_range": 25705535.440658685,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2244515707"
+              },
+              {
+                  "distinct_range": 23640155.074692063,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2271014042"
+              },
+              {
+                  "distinct_range": 26178619.056027643,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2305247978"
+              },
+              {
+                  "distinct_range": 22647879.550205626,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2329377139"
+              },
+              {
+                  "distinct_range": 23727473.68773494,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2356098616"
+              },
+              {
+                  "distinct_range": 26707524.20997025,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2392352938"
+              },
+              {
+                  "distinct_range": 24017702.444217447,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2419834766"
+              },
+              {
+                  "distinct_range": 24249011.12675426,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2447944032"
+              },
+              {
+                  "distinct_range": 23688302.806153554,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2474565094"
+              },
+              {
+                  "distinct_range": 24849551.186436024,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2504399562"
+              },
+              {
+                  "distinct_range": 24200224.748617798,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2532374856"
+              },
+              {
+                  "distinct_range": 23287697.30727863,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2557997619"
+              },
+              {
+                  "distinct_range": 24351473.63935478,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2586391172"
+              },
+              {
+                  "distinct_range": 23527881.917234063,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2612606286"
+              },
+              {
+                  "distinct_range": 24945218.247680716,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2642729295"
+              },
+              {
+                  "distinct_range": 25287341.452311326,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2673917465"
+              },
+              {
+                  "distinct_range": 22691847.886517607,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2698145553"
+              },
+              {
+                  "distinct_range": 25851945.360288806,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2731214415"
+              },
+              {
+                  "distinct_range": 22790585.22566477,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2755666591"
+              },
+              {
+                  "distinct_range": 24874649.724564563,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2785576377"
+              },
+              {
+                  "distinct_range": 25192646.52012764,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2816464383"
+              },
+              {
+                  "distinct_range": 25705761.95732361,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2849030750"
+              },
+              {
+                  "distinct_range": 25071927.66757114,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2879542087"
+              },
+              {
+                  "distinct_range": 22290268.662520796,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2902885720"
+              },
+              {
+                  "distinct_range": 27061259.007059295,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2940593621"
+              },
+              {
+                  "distinct_range": 23198539.040874798,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2966001058"
+              },
+              {
+                  "distinct_range": 25836016.498545736,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2999014615"
+              },
+              {
+                  "distinct_range": 24976206.04028811,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3029231938"
+              },
+              {
+                  "distinct_range": 26012892.894011527,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3062867356"
+              },
+              {
+                  "distinct_range": 24635128.272298332,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3092069179"
+              },
+              {
+                  "distinct_range": 25457326.36524154,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3123806832"
+              },
+              {
+                  "distinct_range": 24619290.79886511,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3152962681"
+              },
+              {
+                  "distinct_range": 24753674.45965646,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3182511897"
+              },
+              {
+                  "distinct_range": 23461235.940404564,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3208560819"
+              },
+              {
+                  "distinct_range": 21759133.991559017,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3230796924"
+              },
+              {
+                  "distinct_range": 24903736.23984038,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3260794334"
+              },
+              {
+                  "distinct_range": 23760375.290182203,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3287600553"
+              },
+              {
+                  "distinct_range": 24904801.806776363,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3317601180"
+              },
+              {
+                  "distinct_range": 25554127.4399373,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3349658040"
+              },
+              {
+                  "distinct_range": 24929168.84403592,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3379732366"
+              },
+              {
+                  "distinct_range": 25195565.410300832,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3410629562"
+              },
+              {
+                  "distinct_range": 26211419.978023186,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3444983833"
+              },
+              {
+                  "distinct_range": 24720486.864362415,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3474435209"
+              },
+              {
+                  "distinct_range": 26819720.328488328,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3511141199"
+              },
+              {
+                  "distinct_range": 23933642.398781355,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3538399790"
+              },
+              {
+                  "distinct_range": 25824492.42063073,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3571373420"
+              },
+              {
+                  "distinct_range": 25140097.087749224,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3602096645"
+              },
+              {
+                  "distinct_range": 23797768.32520774,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3628999619"
+              },
+              {
+                  "distinct_range": 24744768.410000347,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3658522534"
+              },
+              {
+                  "distinct_range": 26076738.12326163,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3692386676"
+              },
+              {
+                  "distinct_range": 24925798.536460806,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3722450793"
+              },
+              {
+                  "distinct_range": 26409096.770735238,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3757543819"
+              },
+              {
+                  "distinct_range": 25023886.627997283,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3787907087"
+              },
+              {
+                  "distinct_range": 24571768.570599243,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3816925595"
+              },
+              {
+                  "distinct_range": 23075376.23988194,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3842039521"
+              },
+              {
+                  "distinct_range": 24133269.439868134,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3869832385"
+              },
+              {
+                  "distinct_range": 26230879.47796947,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3904258344"
+              },
+              {
+                  "distinct_range": 21983918.76201077,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3926954896"
+              },
+              {
+                  "distinct_range": 24618490.683144685,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3956108425"
+              },
+              {
+                  "distinct_range": 24783775.928156767,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3985746781"
+              },
+              {
+                  "distinct_range": 38396141.97736822,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "9798701137"
+              },
+              {
+                  "distinct_range": 38216035.92022619,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "11781181455"
+              },
+              {
+                  "distinct_range": 38284326.29473615,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "14425766860"
+              },
+              {
+                  "distinct_range": 38278205.79897192,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "16993517646"
+              },
+              {
+                  "distinct_range": 38225634.25115119,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "19048371083"
+              },
+              {
+                  "distinct_range": 38236777.83512208,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "21194131313"
+              },
+              {
+                  "distinct_range": 38247387.68752953,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "23434214562"
+              },
+              {
+                  "distinct_range": 38219657.56770578,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "25443373907"
+              },
+              {
+                  "distinct_range": 38187971.501133785,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "27240604456"
+              },
+              {
+                  "distinct_range": 38268255.81442043,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "29692662449"
+              },
+              {
+                  "distinct_range": 38186517.10203313,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "31481263613"
+              },
+              {
+                  "distinct_range": 38217618.57295073,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "33475303511"
+              },
+              {
+                  "distinct_range": 38135564.61065146,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "35005263708"
+              },
+              {
+                  "distinct_range": 39046459.63673626,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "37476845648"
+              },
+              {
+                  "distinct_range": 38956607.0524103,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "39248812739"
+              },
+              {
+                  "distinct_range": 38956323.230749816,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "41019184780"
+              },
+              {
+                  "distinct_range": 38970154.24229521,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "42870267225"
+              },
+              {
+                  "distinct_range": 38902254.12362875,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "44382646581"
+              },
+              {
+                  "distinct_range": 39058373.419990115,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "46990530448"
+              },
+              {
+                  "distinct_range": 39029132.39666178,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "49287403623"
+              },
+              {
+                  "distinct_range": 38978710.00051753,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "51192166461"
+              },
+              {
+                  "distinct_range": 38972152.67491723,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "53055488840"
+              },
+              {
+                  "distinct_range": 39028572.852042004,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "55347130083"
+              },
+              {
+                  "distinct_range": 39007867.81723224,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "57460581963"
+              },
+              {
+                  "distinct_range": 39016537.58722475,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "59645220384"
+              },
+              {
+                  "distinct_range": 38906487.4230706,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "61175060206"
+              },
+              {
+                  "distinct_range": 39038413.54843294,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "63562314674"
+              },
+              {
+                  "distinct_range": 38980327.162238784,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "65477569212"
+              },
+              {
+                  "distinct_range": 38994886.77816127,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "67492774716"
+              },
+              {
+                  "distinct_range": 38984287.4390987,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "69434224055"
+              },
+              {
+                  "distinct_range": 38979308.41785862,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "71342865244"
+              },
+              {
+                  "distinct_range": 38997753.63891889,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "73378991313"
+              },
+              {
+                  "distinct_range": 39055268.08802547,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "75949905677"
+              },
+              {
+                  "distinct_range": 38997895.61951594,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "77987076667"
+              },
+              {
+                  "distinct_range": 39046061.87615024,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "80454286230"
+              },
+              {
+                  "distinct_range": 38952431.928798296,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "82203204411"
+              },
+              {
+                  "distinct_range": 39017141.89690324,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "84392936948"
+              },
+              {
+                  "distinct_range": 38983057.94823747,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "86326169497"
+              },
+              {
+                  "distinct_range": 38963239.21709073,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "88135988212"
+              },
+              {
+                  "distinct_range": 38998324.00733013,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "90176326694"
+              },
+              {
+                  "distinct_range": 38955764.020197,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "91943585367"
+              },
+              {
+                  "distinct_range": 38987350.34403215,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "93905771054"
+              },
+              {
+                  "distinct_range": 39040582.75177705,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "96315202401"
+              },
+              {
+                  "distinct_range": 38974703.499665864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "98194445838"
+              },
+              {
+                  "distinct_range": 38998548.366915636,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "100236434348"
+              },
+              {
+                  "distinct_range": 38982168.61229233,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "102163754525"
+              },
+              {
+                  "distinct_range": 39011287.2917798,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "104304731004"
+              },
+              {
+                  "distinct_range": 39047528.061418846,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "106787872941"
+              },
+              {
+                  "distinct_range": 38993582.36447417,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "108793663720"
+              },
+              {
+                  "distinct_range": 38989722.16711626,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "110772222233"
+              },
+              {
+                  "distinct_range": 38988158.82719843,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "112739981321"
+              },
+              {
+                  "distinct_range": 39040401.93819794,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "115147539271"
+              },
+              {
+                  "distinct_range": 39009044.908538185,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "117270400270"
+              },
+              {
+                  "distinct_range": 39060990.46447372,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "119910189698"
+              },
+              {
+                  "distinct_range": 39017109.86846557,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "122099649707"
+              },
+              {
+                  "distinct_range": 38998781.476120554,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "124143370567"
+              },
+              {
+                  "distinct_range": 39013608.907237895,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "126303435102"
+              },
+              {
+                  "distinct_range": 38986112.41862237,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "128257212779"
+              },
+              {
+                  "distinct_range": 39075823.67395421,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "131094040050"
+              },
+              {
+                  "distinct_range": 38952594.95397732,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "132843846024"
+              },
+              {
+                  "distinct_range": 39059128.46829855,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "135460866451"
+              },
+              {
+                  "distinct_range": 38979867.19574013,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "137373117788"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "b"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 5339885775,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 578248,
+                  "num_range": 0,
+                  "upper_bound": "629097723"
+              },
+              {
+                  "distinct_range": 23399792.48407356,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "658952533"
+              },
+              {
+                  "distinct_range": 24907645.283087615,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "694232179"
+              },
+              {
+                  "distinct_range": 21531726.608426604,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "718871154"
+              },
+              {
+                  "distinct_range": 22822428.13293954,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "746963963"
+              },
+              {
+                  "distinct_range": 23969932.657044664,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "778716816"
+              },
+              {
+                  "distinct_range": 22403796.503021836,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "805621288"
+              },
+              {
+                  "distinct_range": 23420635.704758454,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "835542590"
+              },
+              {
+                  "distinct_range": 23857576.422552675,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "866907923"
+              },
+              {
+                  "distinct_range": 22617691.893323246,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "894410734"
+              },
+              {
+                  "distinct_range": 24117316.25393378,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "926682546"
+              },
+              {
+                  "distinct_range": 24235351.981170826,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "959378953"
+              },
+              {
+                  "distinct_range": 22911886.13976789,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "987735068"
+              },
+              {
+                  "distinct_range": 21315495.928351484,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1011851719"
+              },
+              {
+                  "distinct_range": 22687203.599040024,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1039552910"
+              },
+              {
+                  "distinct_range": 19923584.97208223,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1060624231"
+              },
+              {
+                  "distinct_range": 21774527.197543647,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1085867552"
+              },
+              {
+                  "distinct_range": 22609033.898264404,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1113345791"
+              },
+              {
+                  "distinct_range": 23144483.774797045,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1142402845"
+              },
+              {
+                  "distinct_range": 21498109.469787836,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1166959651"
+              },
+              {
+                  "distinct_range": 21545586.023696374,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1191632607"
+              },
+              {
+                  "distinct_range": 21102574.012744896,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1215248893"
+              },
+              {
+                  "distinct_range": 24255430.70079986,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1248018340"
+              },
+              {
+                  "distinct_range": 20688925.113528192,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1270699983"
+              },
+              {
+                  "distinct_range": 22112461.5021936,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1296817658"
+              },
+              {
+                  "distinct_range": 21658433.680807777,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1321769604"
+              },
+              {
+                  "distinct_range": 22516322.100383103,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1348986601"
+              },
+              {
+                  "distinct_range": 22026028.968935896,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1374876836"
+              },
+              {
+                  "distinct_range": 21663441.963745628,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1399841260"
+              },
+              {
+                  "distinct_range": 22575024.64620157,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1427223270"
+              },
+              {
+                  "distinct_range": 23565489.597296547,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1457612548"
+              },
+              {
+                  "distinct_range": 22540167.675033506,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1484896410"
+              },
+              {
+                  "distinct_range": 23380000.313426197,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1514688275"
+              },
+              {
+                  "distinct_range": 23825627.47126751,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1545944665"
+              },
+              {
+                  "distinct_range": 24406226.546726506,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1579270404"
+              },
+              {
+                  "distinct_range": 23153811.94671144,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1608356073"
+              },
+              {
+                  "distinct_range": 25520370.053726528,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1646266584"
+              },
+              {
+                  "distinct_range": 23946394.240199763,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1677937680"
+              },
+              {
+                  "distinct_range": 20897341.933581017,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1701084237"
+              },
+              {
+                  "distinct_range": 20663595.608095527,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1723710185"
+              },
+              {
+                  "distinct_range": 21707668.535571873,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1748785156"
+              },
+              {
+                  "distinct_range": 23828405.780306157,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1780050998"
+              },
+              {
+                  "distinct_range": 23849627.553078555,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1811389175"
+              },
+              {
+                  "distinct_range": 22630331.35172261,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1838927912"
+              },
+              {
+                  "distinct_range": 24534464.137054272,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1872737755"
+              },
+              {
+                  "distinct_range": 17221616.698731847,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1889100858"
+              },
+              {
+                  "distinct_range": 22480914.032161627,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1916218981"
+              },
+              {
+                  "distinct_range": 22757155.5408896,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1944121807"
+              },
+              {
+                  "distinct_range": 24918194.748741698,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "1979444383"
+              },
+              {
+                  "distinct_range": 22275672.083507296,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2005998932"
+              },
+              {
+                  "distinct_range": 21459074.892031495,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2030460777"
+              },
+              {
+                  "distinct_range": 21446889.717414696,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2054893077"
+              },
+              {
+                  "distinct_range": 22871676.661578108,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2083130419"
+              },
+              {
+                  "distinct_range": 22120139.191592976,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2109268427"
+              },
+              {
+                  "distinct_range": 19630395.75679683,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2129760069"
+              },
+              {
+                  "distinct_range": 22486374.553390156,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2156893408"
+              },
+              {
+                  "distinct_range": 22600785.28246695,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2184348265"
+              },
+              {
+                  "distinct_range": 22286015.543574076,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2210930833"
+              },
+              {
+                  "distinct_range": 22112418.072456732,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2237048393"
+              },
+              {
+                  "distinct_range": 24439030.873471424,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2270496990"
+              },
+              {
+                  "distinct_range": 20142369.77647989,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2292013843"
+              },
+              {
+                  "distinct_range": 23923471.378899094,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2323605613"
+              },
+              {
+                  "distinct_range": 23138862.042563055,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2352645441"
+              },
+              {
+                  "distinct_range": 22127182.264179714,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2378802120"
+              },
+              {
+                  "distinct_range": 21535574.41325484,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2403450523"
+              },
+              {
+                  "distinct_range": 22989006.064238068,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2432036395"
+              },
+              {
+                  "distinct_range": 23422109.98875994,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2461962408"
+              },
+              {
+                  "distinct_range": 21947281.218182184,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2487647732"
+              },
+              {
+                  "distinct_range": 21165616.958285376,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2511410760"
+              },
+              {
+                  "distinct_range": 22372218.514231764,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2538228409"
+              },
+              {
+                  "distinct_range": 20221111.56537086,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2559908425"
+              },
+              {
+                  "distinct_range": 22849892.02789933,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2588081707"
+              },
+              {
+                  "distinct_range": 23496155.198446885,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2618245696"
+              },
+              {
+                  "distinct_range": 23364515.828468584,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2647988447"
+              },
+              {
+                  "distinct_range": 22419302.621967383,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2674935693"
+              },
+              {
+                  "distinct_range": 21448806.727790017,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2699372638"
+              },
+              {
+                  "distinct_range": 22168105.871268,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2725638161"
+              },
+              {
+                  "distinct_range": 22156565.326065764,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2751872928"
+              },
+              {
+                  "distinct_range": 23190266.61220945,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2781070806"
+              },
+              {
+                  "distinct_range": 21236557.456563853,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2805000368"
+              },
+              {
+                  "distinct_range": 23735207.650987536,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2835951377"
+              },
+              {
+                  "distinct_range": 20513286.612591296,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2858250333"
+              },
+              {
+                  "distinct_range": 21495027.991130706,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2882799625"
+              },
+              {
+                  "distinct_range": 24419736.926792275,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2916175882"
+              },
+              {
+                  "distinct_range": 21886751.926985107,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2941705173"
+              },
+              {
+                  "distinct_range": 22100002.15354067,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2967789897"
+              },
+              {
+                  "distinct_range": 21606724.380350858,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2992613491"
+              },
+              {
+                  "distinct_range": 22689204.31593351,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3020320421"
+              },
+              {
+                  "distinct_range": 21852341.62905825,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3045761572"
+              },
+              {
+                  "distinct_range": 20809777.684830524,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3068711343"
+              },
+              {
+                  "distinct_range": 21495016.491285596,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3093260607"
+              },
+              {
+                  "distinct_range": 21086920.093081065,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3116840637"
+              },
+              {
+                  "distinct_range": 22255991.316225994,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3143341984"
+              },
+              {
+                  "distinct_range": 22725057.101165574,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3171152036"
+              },
+              {
+                  "distinct_range": 20144246.380282823,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3192672760"
+              },
+              {
+                  "distinct_range": 23401085.905639023,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3222531690"
+              },
+              {
+                  "distinct_range": 20230956.124141403,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3244232212"
+              },
+              {
+                  "distinct_range": 22401285.48608485,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3271129766"
+              },
+              {
+                  "distinct_range": 22714982.390369594,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3298910787"
+              },
+              {
+                  "distinct_range": 23204178.457857817,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3328151647"
+              },
+              {
+                  "distinct_range": 22584576.444398694,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3355560637"
+              },
+              {
+                  "distinct_range": 19909738.80428616,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3376604141"
+              },
+              {
+                  "distinct_range": 24616923.7364721,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3410730797"
+              },
+              {
+                  "distinct_range": 20853396.412432965,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3433778327"
+              },
+              {
+                  "distinct_range": 23477662.81053618,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3463882631"
+              },
+              {
+                  "distinct_range": 22602025.91511219,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3491341003"
+              },
+              {
+                  "distinct_range": 23734269.739581123,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3522288867"
+              },
+              {
+                  "distinct_range": 22138357.8152788,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3548475209"
+              },
+              {
+                  "distinct_range": 22983694.000378184,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3577045172"
+              },
+              {
+                  "distinct_range": 22274713.020043187,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3603597125"
+              },
+              {
+                  "distinct_range": 22351372.001939807,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3630357666"
+              },
+              {
+                  "distinct_range": 21045348.78412484,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3653841759"
+              },
+              {
+                  "distinct_range": 19576386.082371477,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3674228710"
+              },
+              {
+                  "distinct_range": 22542442.280908197,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3701518962"
+              },
+              {
+                  "distinct_range": 21459286.705499683,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3725981321"
+              },
+              {
+                  "distinct_range": 22685760.334347714,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3753678373"
+              },
+              {
+                  "distinct_range": 23315449.396584585,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3783266250"
+              },
+              {
+                  "distinct_range": 22640083.747522335,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3810832751"
+              },
+              {
+                  "distinct_range": 22951045.169837687,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3839305206"
+              },
+              {
+                  "distinct_range": 23885416.126275722,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3870765918"
+              },
+              {
+                  "distinct_range": 22418803.242245506,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3897711785"
+              },
+              {
+                  "distinct_range": 24546073.480498727,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3931565967"
+              },
+              {
+                  "distinct_range": 21645190.136654392,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3956484957"
+              },
+              {
+                  "distinct_range": 23496924.62261723,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "3986651433"
+              },
+              {
+                  "distinct_range": 22756672.983327657,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4014552861"
+              },
+              {
+                  "distinct_range": 21607422.472212937,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4039378182"
+              },
+              {
+                  "distinct_range": 22457388.658190932,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4066430884"
+              },
+              {
+                  "distinct_range": 23831451.636891674,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4097707093"
+              },
+              {
+                  "distinct_range": 22683815.852759957,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4125398570"
+              },
+              {
+                  "distinct_range": 24150504.17514128,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4157788946"
+              },
+              {
+                  "distinct_range": 22739225.432791743,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4185639896"
+              },
+              {
+                  "distinct_range": 22343849.126671772,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4212379869"
+              },
+              {
+                  "distinct_range": 20930013.754102323,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4235600400"
+              },
+              {
+                  "distinct_range": 21971929.65895417,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4261349628"
+              },
+              {
+                  "distinct_range": 23972332.611735176,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4293110834"
+              },
+              {
+                  "distinct_range": 19862645.73094882,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4314060060"
+              },
+              {
+                  "distinct_range": 22371386.29351032,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4340875426"
+              },
+              {
+                  "distinct_range": 22560841.979224864,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "4368217443"
+              },
+              {
+                  "distinct_range": 36141229.39010217,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "9871708654"
+              },
+              {
+                  "distinct_range": 36010533.20603779,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "12155913443"
+              },
+              {
+                  "distinct_range": 35961138.5876597,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "14025414506"
+              },
+              {
+                  "distinct_range": 35903727.252611235,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "15568643453"
+              },
+              {
+                  "distinct_range": 35944841.31064969,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "17332399493"
+              },
+              {
+                  "distinct_range": 36003398.7211207,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "19545764211"
+              },
+              {
+                  "distinct_range": 35953087.173531145,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "21361516024"
+              },
+              {
+                  "distinct_range": 35958911.98308193,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "23215828023"
+              },
+              {
+                  "distinct_range": 35929361.02047064,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "24889571555"
+              },
+              {
+                  "distinct_range": 35976557.32783393,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "26871478312"
+              },
+              {
+                  "distinct_range": 36012844.65783399,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "29179601154"
+              },
+              {
+                  "distinct_range": 36014674.81539973,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "31507040592"
+              },
+              {
+                  "distinct_range": 35980587.31750806,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "33520598132"
+              },
+              {
+                  "distinct_range": 36708548.198666714,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "35525890561"
+              },
+              {
+                  "distinct_range": 36729060.13112752,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "37700054909"
+              },
+              {
+                  "distinct_range": 36691179.66907472,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "39581548154"
+              },
+              {
+                  "distinct_range": 36692319.50965493,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "41470702547"
+              },
+              {
+                  "distinct_range": 36669998.50907348,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "43220359121"
+              },
+              {
+                  "distinct_range": 36714509.117588684,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "45272003073"
+              },
+              {
+                  "distinct_range": 36731342.097654074,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "47466715832"
+              },
+              {
+                  "distinct_range": 36713021.20722333,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "49506620813"
+              },
+              {
+                  "distinct_range": 36693927.33287015,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "51406687757"
+              },
+              {
+                  "distinct_range": 36692698.624299966,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "53298417461"
+              },
+              {
+                  "distinct_range": 36750311.57240262,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "55680216668"
+              },
+              {
+                  "distinct_range": 36739383.32520373,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "57950611871"
+              },
+              {
+                  "distinct_range": 36729341.539611794,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "60127328963"
+              },
+              {
+                  "distinct_range": 36699906.433147095,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "62069093808"
+              },
+              {
+                  "distinct_range": 36702560.7277104,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "64029912269"
+              },
+              {
+                  "distinct_range": 36711148.62396146,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "66055175753"
+              },
+              {
+                  "distinct_range": 36695774.47362662,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "67967912057"
+              },
+              {
+                  "distinct_range": 36696545.36503013,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "69886002091"
+              },
+              {
+                  "distinct_range": 36658275.475183815,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "71570281479"
+              },
+              {
+                  "distinct_range": 36750569.50868593,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "73954826211"
+              },
+              {
+                  "distinct_range": 36706093.97011926,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "75941688266"
+              },
+              {
+                  "distinct_range": 36721969.46670568,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "78054358407"
+              },
+              {
+                  "distinct_range": 36705206.758220516,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "80034635743"
+              },
+              {
+                  "distinct_range": 36728741.921308786,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "82205955778"
+              },
+              {
+                  "distinct_range": 36763149.77462603,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "84733572014"
+              },
+              {
+                  "distinct_range": 36702173.29957454,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "86691626276"
+              },
+              {
+                  "distinct_range": 36686736.207772434,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "88543860209"
+              },
+              {
+                  "distinct_range": 36707212.47387852,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "90539098221"
+              },
+              {
+                  "distinct_range": 36709842.64988532,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "92554276024"
+              },
+              {
+                  "distinct_range": 36765783.77427545,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "95114019834"
+              },
+              {
+                  "distinct_range": 36650631.02517786,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "96758247698"
+              },
+              {
+                  "distinct_range": 36629145.04329573,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "98299358531"
+              },
+              {
+                  "distinct_range": 36720979.286997624,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "100403729405"
+              },
+              {
+                  "distinct_range": 36734774.536687374,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "102630135835"
+              },
+              {
+                  "distinct_range": 36797233.81834601,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "105647475339"
+              },
+              {
+                  "distinct_range": 36737867.04816638,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "107903185350"
+              },
+              {
+                  "distinct_range": 36697458.894325055,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "109827639035"
+              },
+              {
+                  "distinct_range": 36696571.51714853,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "111745900309"
+              },
+              {
+                  "distinct_range": 36768764.12988942,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "114342979706"
+              },
+              {
+                  "distinct_range": 36731459.33689571,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "116538781642"
+              },
+              {
+                  "distinct_range": 36718344.69689674,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "118621396870"
+              },
+              {
+                  "distinct_range": 36772583.71688492,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "121267870866"
+              },
+              {
+                  "distinct_range": 36723808.916050896,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "123396155882"
+              },
+              {
+                  "distinct_range": 36715304.24648927,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "125454107652"
+              },
+              {
+                  "distinct_range": 36742297.15741543,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "127753190758"
+              },
+              {
+                  "distinct_range": 36754363.835711636,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "130179169236"
+              },
+              {
+                  "distinct_range": 36792513.83577365,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "133117593094"
+              },
+              {
+                  "distinct_range": 36672101.13810948,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "134879503400"
+              },
+              {
+                  "distinct_range": 36765650.25825433,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "137437517512"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "c"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 5701907084,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 578248,
+                  "num_range": 0,
+                  "upper_bound": "2020-01-24 19:28:16.269623+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-02-08 02:18:43.479646+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-02-24 00:35:32.940966+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-03-05 05:32:21.193687+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-03-17 21:29:59.304002+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-03-30 16:06:06.978064+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-04-07 23:46:47.89612+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-04-16 14:22:33.002335+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-04-23 22:17:29.707608+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-04-30 03:34:34.803017+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-05-07 18:10:39.313788+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-05-15 00:39:39.984752+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-05-21 17:47:19.972381+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-05-27 13:27:46.026521+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-02 17:42:21.006795+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-07 01:44:10.418279+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-12 23:21:26.937171+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-19 01:59:46.938261+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-25 18:24:17.070157+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-06-30 21:00:50.777878+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-06 02:30:21.848245+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-11 00:37:14.887266+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-17 17:44:58.46163+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-21 23:44:37.736991+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-27 00:04:05.496033+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-07-31 22:03:55.466305+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-05 22:36:19.260863+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-10 20:47:11.490133+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-15 16:51:34.793489+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-20 20:24:58.037853+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-26 14:52:52.416758+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-08-31 14:10:24.084691+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-09-05 22:05:48.319737+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-09-11 19:15:27.220489+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-09-17 00:08:39.689026+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-09-21 17:41:26.415235+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-09-27 21:10:36.981379+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-02 23:10:21.222641+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-06 18:29:05.500304+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-10 05:44:06.83041+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-14 18:35:16.7065+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-19 17:31:29.028613+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-24 16:49:28.879454+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-10-28 21:43:28.947112+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-02 21:23:11.680553+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-05 12:15:23.697743+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-09 02:45:28.369729+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-13 17:21:10.765915+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-18 16:33:28.421508+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-21 21:35:27.945244+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-24 22:04:38.583079+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-11-29 02:38:16.80254+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-03 02:23:55.802785+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-06 04:32:48.345845+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-09 00:15:53.146966+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-12 02:54:58.600921+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-15 16:34:00.930817+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-18 19:08:05.26746+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-21 17:26:59.196875+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-25 20:00:56.861517+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2020-12-28 20:04:33.046944+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-01 02:19:36.320699+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-04 02:00:51.05522+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-07 00:29:39.036413+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-09 16:40:00.030641+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-12 14:33:42.574219+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-15 20:24:12.129569+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-18 15:38:27.149272+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-21 02:00:23.472858+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-23 22:17:20.861668+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-26 01:36:14.998091+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-29 01:46:26.156545+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-01-31 23:21:11.197784+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-04 01:40:50.751006+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-06 19:32:31.326865+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-09 07:10:49.447017+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-11 23:52:03.7392+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-14 03:35:54.594113+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-17 16:25:37.567398+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-19 23:25:09.98743+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-22 22:49:15.889803+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-25 01:57:31.021086+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-02-27 09:15:29.997668+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-02 20:55:19.474473+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-05 02:23:23.033264+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-07 19:14:22.972298+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-10 03:30:18.611511+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-12 22:41:51.745306+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-15 03:55:40.881455+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-17 16:35:32.803488+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-19 18:23:32.881927+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-21 23:00:36.219304+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-24 16:26:08.720607+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-26 23:37:56.199332+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-03-29 00:56:47.327046+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-01 02:50:59.394575+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-03 00:54:29.612453+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-05 22:51:02.434678+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-08 18:22:30.22434+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-11 14:20:15.370541+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-14 02:26:39.978878+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-16 01:32:16.999534+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-19 03:05:57.945025+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-21 14:34:51.560561+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-23 23:30:15.868692+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-26 17:00:29.164369+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-04-29 15:51:37.923107+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-01 19:23:36.919398+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-04 15:49:59.258866+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-06 22:40:14.858913+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-09 02:01:04.592657+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-11 15:31:07.131148+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-13 13:59:53.603008+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-15 20:40:14.561298+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-18 00:20:12.538395+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-20 19:13:35.929004+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-23 01:28:29.898472+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-25 20:00:06.605514+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-28 02:30:45.127885+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-05-30 22:25:09.45357+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-02 20:23:37.592111+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-05 18:04:33.813322+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-07 19:33:40.130276+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-10 17:12:19.937436+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-12 17:28:14.291878+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-15 07:37:12.629414+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-17 15:26:24.516646+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-19 13:10:31.356093+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-22 01:23:35.638754+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-25 04:08:11.769903+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-27 16:44:46.733989+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-06-30 05:45:46.018371+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-02 20:10:38.993596+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-05 01:10:49.255799+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-07 19:03:42.500852+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-10 17:35:12.427552+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-13 01:07:23.724873+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-16 01:13:07.748183+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-18 16:34:30.237357+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-20 23:45:55.803205+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-23 00:09:49.794903+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-25 14:42:06.28106+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-28 14:01:00.880906+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-07-30 08:43:54.302471+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-01 16:54:52.973182+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-04 00:57:43.545778+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-06 18:47:53.746592+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-09 15:59:03.366416+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-11 16:48:22.838571+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-13 16:51:20.838905+00:00"
+              },
+              {
+                  "distinct_range": 28509534.435092848,
+                  "num_eq": 578248,
+                  "num_range": 28334155,
+                  "upper_bound": "2021-08-15 23:08:34.640257+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-18 16:57:45.56775+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-20 19:48:05.245006+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-22 20:57:33.326377+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-25 03:52:56.802615+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-27 00:15:34.615859+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-28 21:45:18.452292+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-08-31 01:19:34.008168+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-02 01:57:08.220675+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-04 14:59:53.157928+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-07 00:57:28.852725+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-09 21:45:06.54973+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-11 23:36:57.424185+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-14 02:05:21.174843+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-16 19:39:29.30895+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-18 23:03:11.61381+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-21 00:50:41.959858+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-23 12:27:51.859505+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-25 20:57:02.947102+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-09-28 20:44:03.105013+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-01 03:41:35.145344+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-03 04:51:12.670589+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-05 03:31:57.136002+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-07 18:36:32.327327+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-10 05:52:52.67323+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-13 15:58:23.583879+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-15 21:31:33.87508+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-18 02:22:47.751948+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-21 01:01:05.704407+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-24 00:16:09.559189+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-26 09:39:52.366318+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-28 15:59:12.843173+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-10-30 09:05:49.048381+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-01 23:05:45.820703+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-03 21:25:16.223413+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-06 04:06:59.006641+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-09 01:32:00.29981+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-12 00:36:22.268027+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-14 04:18:27.711837+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-16 21:13:05.674223+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-18 23:26:01.667398+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-20 19:42:34.870393+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-22 23:55:27.184235+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-26 18:03:48.315411+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-11-28 23:38:52.804442+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-12-02 04:25:06.84841+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-12-04 01:42:18.860451+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-12-06 02:12:05.742239+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-12-08 00:36:06.226884+00:00"
+              },
+              {
+                  "distinct_range": 29091361.60685864,
+                  "num_eq": 578248,
+                  "num_range": 28912403,
+                  "upper_bound": "2021-12-09 23:53:05.380424+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "d"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 2107756184,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 573334,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-26 21:33:24+00:00"
+              },
+              {
+                  "distinct_range": 2107756182,
+                  "num_eq": 573334,
+                  "num_range": 3728965030,
+                  "upper_bound": "2021-12-09 23:54:22.530768+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 2052369078,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "e"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 131613916,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 585271,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-19 23:43:12+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-03-01 17:56:52+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-03-09 04:26:08+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-03-18 22:28:41+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-03-27 00:55:13+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-02 18:11:10+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-07 19:08:39+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-11 01:43:50+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-17 14:52:11+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-21 19:12:51+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-24 19:02:17+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-04-29 22:09:56+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-04 16:39:41+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-08 16:52:57+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-12 18:11:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-17 01:38:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-21 13:23:27+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-25 17:04:53+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-05-29 19:40:56+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-02 22:36:27+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-06 23:34:46+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-10 20:47:54+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-15 00:04:14+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-19 22:58:22+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-23 23:15:56+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-27 23:01:00+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-06-30 04:01:16+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-04 04:09:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-10 22:31:59+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-13 22:55:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-18 20:31:22+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-24 17:07:52+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-29 16:15:54+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-07-31 22:04:09+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-03 18:45:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-06 19:41:03+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-10 02:24:01+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-12 23:01:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-15 22:04:31+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-20 16:41:42+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-24 01:07:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-08-28 02:15:45+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-01 19:59:46+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-06 00:24:50+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-11 19:15:35+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-14 23:50:44+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-19 21:40:31+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-23 19:02:20+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-09-28 03:42:47+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-02 00:00:03+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-04 18:41:53+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-08 18:02:17+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-11 21:29:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-14 21:28:07+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-19 23:04:38+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-24 05:40:09+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-27 21:55:41+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-10-30 17:36:30+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-03 20:57:26+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-05 23:54:19+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-08 12:37:54+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-12 01:23:52+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-15 02:54:58+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-19 16:23:22+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-21 21:35:42+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-24 22:04:46+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-11-28 16:35:17+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-01 14:32:49+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-05 08:38:31+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-07 02:33:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-09 19:04:07+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-12 01:24:45+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-14 23:35:13+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-17 02:42:48+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-20 02:09:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-24 04:15:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-28 18:29:43+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2020-12-31 22:32:32+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-02 23:45:12+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-07 02:05:04+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-08 20:43:00+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-11 18:40:35+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-14 02:34:03+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-16 10:32:23+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-21 01:22:35+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-24 19:12:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-26 19:19:17+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-01-28 19:53:40+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-01 14:36:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-04 21:25:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-07 06:13:08+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-10 17:41:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-13 21:40:06+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-18 21:30:05+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-21 02:31:34+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-24 18:17:52+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-02-27 03:26:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-02 20:42:14+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-05 02:23:43+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-08 02:51:00+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-11 02:40:38+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-13 22:21:31+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-15 22:59:58+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-18 18:59:44+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-20 01:16:45+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-21 23:01:00+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-24 21:48:17+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-27 19:43:37+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-03-30 01:04:49+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-02 01:24:40+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-03 15:42:25+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-06 15:11:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-09 15:07:58+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-13 23:07:11+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-15 19:23:51+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-18 18:22:44+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-21 00:16:53+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-24 16:11:10+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-27 19:33:56.640946+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-04-30 16:12:50+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-04 15:50:07+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-07 00:17:49+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-08 22:18:37+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-11 20:08:51.514311+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-13 18:12:56+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-16 01:03:16+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-18 02:03:36+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-20 19:44:52.96351+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-22 22:16:02+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-24 03:37:10+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-28 04:56:56+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-05-31 23:15:58+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-04 21:21:26+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-07 16:34:20+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-11 00:07:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-12 12:27:08.383883+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-15 15:42:53+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-17 22:08:22+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-20 19:25:20+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-23 23:54:33+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-26 23:00:28+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-06-30 17:46:54+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-07-04 14:05:16+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-07-08 00:28:15+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-07-11 16:02:10+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-07-15 02:31:23+00:00"
+              },
+              {
+                  "distinct_range": 651173.7996125439,
+                  "num_eq": 585271,
+                  "num_range": 9949608,
+                  "upper_bound": "2021-07-17 21:48:52+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-07-21 19:38:52+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-07-24 12:29:22+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-07-27 18:33:28+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-07-29 20:59:03+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-01 19:08:26+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-04 17:04:56+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-07 21:09:19+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-10 17:07:20+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-12 17:06:31+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-14 18:10:29+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-17 03:33:31+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-19 20:46:30+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-21 19:22:59.214868+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-25 14:18:51+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-27 00:58:59+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-28 20:49:31+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-08-30 23:36:10+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-03 18:27:46+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-05 23:36:26+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-09 01:06:24+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-11 01:40:36+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-13 00:23:15+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-15 18:35:07+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-18 20:55:06+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-21 01:41:16+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-23 23:16:19+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-26 22:28:14+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-09-29 01:51:12+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-02 00:22:13+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-04 21:39:01.962546+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-07 02:39:38+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-10 00:05:11+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-14 13:47:05+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-17 19:50:01+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-21 01:01:05.785295+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-24 22:48:32+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-28 17:45:23.725543+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-10-30 07:25:26.206094+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-02 01:02:02+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-04 02:29:03+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-06 22:59:22+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-10 03:19:18+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-13 04:52:15+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-16 18:38:31+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-19 04:12:54.776374+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-20 23:51:19+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-23 23:22:14.701008+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-27 14:45:17+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-11-30 02:55:01.631594+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-12-02 22:58:48+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-12-05 01:09:08+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-12-07 20:53:18+00:00"
+              },
+              {
+                  "distinct_range": 689478.1369163888,
+                  "num_eq": 585271,
+                  "num_range": 10534879,
+                  "upper_bound": "2021-12-09 23:53:27.26833+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 3654435068,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 8286840,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 578033,
+                  "num_range": 0,
+                  "upper_bound": "2197"
+              },
+              {
+                  "distinct_range": 111345.88432740289,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "250231"
+              },
+              {
+                  "distinct_range": 80792.68823122601,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "430205"
+              },
+              {
+                  "distinct_range": 40140.686678399186,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "519623"
+              },
+              {
+                  "distinct_range": 43994.62714983143,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "617626"
+              },
+              {
+                  "distinct_range": 45389.856851079116,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "718737"
+              },
+              {
+                  "distinct_range": 52588.21858193713,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "835883"
+              },
+              {
+                  "distinct_range": 34083.91733179885,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "911809"
+              },
+              {
+                  "distinct_range": 36958.32395248384,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "994138"
+              },
+              {
+                  "distinct_range": 44123.017012944954,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1092427"
+              },
+              {
+                  "distinct_range": 47211.55637735425,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1197596"
+              },
+              {
+                  "distinct_range": 37609.25158015732,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1281375"
+              },
+              {
+                  "distinct_range": 60103.51473013133,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1415262"
+              },
+              {
+                  "distinct_range": 58797.17031873146,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1546239"
+              },
+              {
+                  "distinct_range": 47286.52528343803,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1651575"
+              },
+              {
+                  "distinct_range": 46096.8989294141,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1754261"
+              },
+              {
+                  "distinct_range": 45842.81269681879,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1856381"
+              },
+              {
+                  "distinct_range": 39986.25971017872,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "1945455"
+              },
+              {
+                  "distinct_range": 31884.230865867812,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2016481"
+              },
+              {
+                  "distinct_range": 32765.901114661396,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2089471"
+              },
+              {
+                  "distinct_range": 40212.06425964062,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2179048"
+              },
+              {
+                  "distinct_range": 58562.836372769016,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2309503"
+              },
+              {
+                  "distinct_range": 43498.57540598371,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2406401"
+              },
+              {
+                  "distinct_range": 40792.512137283244,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2497271"
+              },
+              {
+                  "distinct_range": 46893.72412880749,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2601732"
+              },
+              {
+                  "distinct_range": 45446.42021734592,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2702969"
+              },
+              {
+                  "distinct_range": 45921.8218433502,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2805265"
+              },
+              {
+                  "distinct_range": 44802.22632375183,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2905067"
+              },
+              {
+                  "distinct_range": 36934.08250979808,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "2987342"
+              },
+              {
+                  "distinct_range": 45577.95248969649,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3088872"
+              },
+              {
+                  "distinct_range": 57820.329961615964,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3217673"
+              },
+              {
+                  "distinct_range": 48542.59114704518,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3325807"
+              },
+              {
+                  "distinct_range": 53836.65288025432,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3445734"
+              },
+              {
+                  "distinct_range": 44223.574108530374,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3544247"
+              },
+              {
+                  "distinct_range": 48327.56057211029,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3651902"
+              },
+              {
+                  "distinct_range": 55551.06157686466,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3775648"
+              },
+              {
+                  "distinct_range": 54237.085600174825,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3896467"
+              },
+              {
+                  "distinct_range": 44512.67575833845,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "3995624"
+              },
+              {
+                  "distinct_range": 47566.648621140266,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4101584"
+              },
+              {
+                  "distinct_range": 33605.82221216282,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4176445"
+              },
+              {
+                  "distinct_range": 32338.084542818073,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4248482"
+              },
+              {
+                  "distinct_range": 36910.73889832289,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4330705"
+              },
+              {
+                  "distinct_range": 37426.09401319816,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4414076"
+              },
+              {
+                  "distinct_range": 32940.08036951471,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4487454"
+              },
+              {
+                  "distinct_range": 48288.504914449884,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4595022"
+              },
+              {
+                  "distinct_range": 41847.46380971956,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4688242"
+              },
+              {
+                  "distinct_range": 47142.42337413928,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4793257"
+              },
+              {
+                  "distinct_range": 40151.460652926195,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4882699"
+              },
+              {
+                  "distinct_range": 45429.81033995011,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "4983899"
+              },
+              {
+                  "distinct_range": 26602.73876960685,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5043160"
+              },
+              {
+                  "distinct_range": 43524.61251109065,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5140116"
+              },
+              {
+                  "distinct_range": 30967.545199861444,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5209100"
+              },
+              {
+                  "distinct_range": 34387.38428097628,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5285702"
+              },
+              {
+                  "distinct_range": 26020.944145148354,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5343667"
+              },
+              {
+                  "distinct_range": 36256.21994580708,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5424432"
+              },
+              {
+                  "distinct_range": 39051.617419960676,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5511424"
+              },
+              {
+                  "distinct_range": 31003.907363890103,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5580489"
+              },
+              {
+                  "distinct_range": 36302.00933754687,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5661356"
+              },
+              {
+                  "distinct_range": 37698.585785610434,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5745334"
+              },
+              {
+                  "distinct_range": 38608.08880193213,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5831338"
+              },
+              {
+                  "distinct_range": 28913.30739004503,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5895746"
+              },
+              {
+                  "distinct_range": 31038.024949892297,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "5964887"
+              },
+              {
+                  "distinct_range": 42625.88346929597,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6059841"
+              },
+              {
+                  "distinct_range": 25550.929506407578,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6116759"
+              },
+              {
+                  "distinct_range": 17037.693967649153,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6154713"
+              },
+              {
+                  "distinct_range": 28949.669554073684,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6219202"
+              },
+              {
+                  "distinct_range": 34703.42086710188,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6296508"
+              },
+              {
+                  "distinct_range": 25806.811401424045,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6353996"
+              },
+              {
+                  "distinct_range": 29041.24833755326,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6418689"
+              },
+              {
+                  "distinct_range": 22214.588727877068,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6468175"
+              },
+              {
+                  "distinct_range": 27703.479833782956,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6529888"
+              },
+              {
+                  "distinct_range": 25379.892660791305,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6586425"
+              },
+              {
+                  "distinct_range": 24642.32432129647,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6641319"
+              },
+              {
+                  "distinct_range": 33214.816719953444,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6715309"
+              },
+              {
+                  "distinct_range": 22098.319586106427,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6764536"
+              },
+              {
+                  "distinct_range": 26985.214865315676,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6824649"
+              },
+              {
+                  "distinct_range": 22518.504592659785,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6874812"
+              },
+              {
+                  "distinct_range": 17462.817045860724,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6913713"
+              },
+              {
+                  "distinct_range": 14807.03232495296,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6946698"
+              },
+              {
+                  "distinct_range": 19949.80949917868,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "6991139"
+              },
+              {
+                  "distinct_range": 22618.61277263991,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7041525"
+              },
+              {
+                  "distinct_range": 24082.077645891994,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7095171"
+              },
+              {
+                  "distinct_range": 25180.57413204164,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7151264"
+              },
+              {
+                  "distinct_range": 18307.227299415066,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7192046"
+              },
+              {
+                  "distinct_range": 31542.15717463527,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7262310"
+              },
+              {
+                  "distinct_range": 21919.2022595949,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7311138"
+              },
+              {
+                  "distinct_range": 28772.796805588616,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7375233"
+              },
+              {
+                  "distinct_range": 24010.251149045263,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7428719"
+              },
+              {
+                  "distinct_range": 23810.932620295593,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7481761"
+              },
+              {
+                  "distinct_range": 19905.366854254764,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7526103"
+              },
+              {
+                  "distinct_range": 34803.080131476716,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7603631"
+              },
+              {
+                  "distinct_range": 24376.117367358285,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7657932"
+              },
+              {
+                  "distinct_range": 22924.324299843796,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7708999"
+              },
+              {
+                  "distinct_range": 26540.339500471255,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7768121"
+              },
+              {
+                  "distinct_range": 26829.441150279334,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7827887"
+              },
+              {
+                  "distinct_range": 36338.37150157552,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7908835"
+              },
+              {
+                  "distinct_range": 30086.323866673152,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "7975856"
+              },
+              {
+                  "distinct_range": 25957.198129196884,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8033679"
+              },
+              {
+                  "distinct_range": 30393.831056298208,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8101385"
+              },
+              {
+                  "distinct_range": 33217.5102135852,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8175381"
+              },
+              {
+                  "distinct_range": 24418.76434986103,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8229777"
+              },
+              {
+                  "distinct_range": 23175.26812320205,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8281403"
+              },
+              {
+                  "distinct_range": 31060.91964576219,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8350595"
+              },
+              {
+                  "distinct_range": 25843.622481057995,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8408165"
+              },
+              {
+                  "distinct_range": 23608.47168230888,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8460756"
+              },
+              {
+                  "distinct_range": 20016.697924367192,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8505346"
+              },
+              {
+                  "distinct_range": 23563.13120617438,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8557836"
+              },
+              {
+                  "distinct_range": 26029.922457254193,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8615821"
+              },
+              {
+                  "distinct_range": 26262.460740795475,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8674324"
+              },
+              {
+                  "distinct_range": 19969.561785811526,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8718809"
+              },
+              {
+                  "distinct_range": 24400.358810044054,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8773164"
+              },
+              {
+                  "distinct_range": 31302.436241409316,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8842894"
+              },
+              {
+                  "distinct_range": 32690.48329297233,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8915716"
+              },
+              {
+                  "distinct_range": 27671.157910201928,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "8977357"
+              },
+              {
+                  "distinct_range": 31814.648947047543,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9048228"
+              },
+              {
+                  "distinct_range": 29275.582283515712,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9113443"
+              },
+              {
+                  "distinct_range": 35648.38821624165,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9192854"
+              },
+              {
+                  "distinct_range": 37178.74151468224,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9275674"
+              },
+              {
+                  "distinct_range": 33813.22122180775,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9350997"
+              },
+              {
+                  "distinct_range": 21306.43245837125,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9398460"
+              },
+              {
+                  "distinct_range": 27931.97787687661,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9460682"
+              },
+              {
+                  "distinct_range": 25623.2049188596,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9517761"
+              },
+              {
+                  "distinct_range": 21528.645682990817,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9565719"
+              },
+              {
+                  "distinct_range": 32811.24159079589,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9638810"
+              },
+              {
+                  "distinct_range": 24169.16727331865,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9692650"
+              },
+              {
+                  "distinct_range": 33893.57711515502,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9768152"
+              },
+              {
+                  "distinct_range": 26499.48818038968,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9827183"
+              },
+              {
+                  "distinct_range": 26415.989877805358,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9886028"
+              },
+              {
+                  "distinct_range": 28741.372713218174,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "9950053"
+              },
+              {
+                  "distinct_range": 30885.393644093,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10018854"
+              },
+              {
+                  "distinct_range": 33378.67091588504,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10093209"
+              },
+              {
+                  "distinct_range": 30265.44119318468,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10160629"
+              },
+              {
+                  "distinct_range": 32102.85276564504,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10232142"
+              },
+              {
+                  "distinct_range": 28755.289096982226,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10296198"
+              },
+              {
+                  "distinct_range": 25728.251170497937,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10353511"
+              },
+              {
+                  "distinct_range": 36905.351911059384,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10435722"
+              },
+              {
+                  "distinct_range": 29901.81955289812,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10502332"
+              },
+              {
+                  "distinct_range": 32097.016862776243,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10573832"
+              },
+              {
+                  "distinct_range": 34285.48043857498,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10650207"
+              },
+              {
+                  "distinct_range": 26062.693296440513,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10708265"
+              },
+              {
+                  "distinct_range": 27961.15739122059,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10770552"
+              },
+              {
+                  "distinct_range": 31064.51097060453,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10839752"
+              },
+              {
+                  "distinct_range": 29722.2533107813,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10905962"
+              },
+              {
+                  "distinct_range": 35418.99234193741,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "10984862"
+              },
+              {
+                  "distinct_range": 35654.673034715735,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11064287"
+              },
+              {
+                  "distinct_range": 35055.37070165085,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11142377"
+              },
+              {
+                  "distinct_range": 35942.87685331323,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11222444"
+              },
+              {
+                  "distinct_range": 37869.6226312267,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11306803"
+              },
+              {
+                  "distinct_range": 28641.713448843337,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11370606"
+              },
+              {
+                  "distinct_range": 36541.281355167535,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11452006"
+              },
+              {
+                  "distinct_range": 32246.505759338495,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11523839"
+              },
+              {
+                  "distinct_range": 35515.06028146991,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11602953"
+              },
+              {
+                  "distinct_range": 37361.450166036106,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11686180"
+              },
+              {
+                  "distinct_range": 28402.890346827968,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11749451"
+              },
+              {
+                  "distinct_range": 43328.88530718332,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11845971"
+              },
+              {
+                  "distinct_range": 42312.98929240741,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "11940228"
+              },
+              {
+                  "distinct_range": 32637.960167153164,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12012933"
+              },
+              {
+                  "distinct_range": 41332.10869484428,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12105005"
+              },
+              {
+                  "distinct_range": 39784.69660340259,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12193630"
+              },
+              {
+                  "distinct_range": 44743.86729506386,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12293302"
+              },
+              {
+                  "distinct_range": 49140.54673329419,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12402768"
+              },
+              {
+                  "distinct_range": 36790.42951610462,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12484723"
+              },
+              {
+                  "distinct_range": 44091.59292057451,
+                  "num_eq": 1156067,
+                  "num_range": 28323659,
+                  "upper_bound": "12582942"
+              },
+              {
+                  "distinct_range": 47876.40038879178,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12689592"
+              },
+              {
+                  "distinct_range": 48928.209651991056,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12798585"
+              },
+              {
+                  "distinct_range": 40058.086207025444,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12887819"
+              },
+              {
+                  "distinct_range": 43819.10114816224,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "12985431"
+              },
+              {
+                  "distinct_range": 51476.70354323402,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13100101"
+              },
+              {
+                  "distinct_range": 37559.4219479699,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13183769"
+              },
+              {
+                  "distinct_range": 60625.60357908598,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13318819"
+              },
+              {
+                  "distinct_range": 44797.28825209361,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13418610"
+              },
+              {
+                  "distinct_range": 41757.23177305586,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13511629"
+              },
+              {
+                  "distinct_range": 41527.83589875162,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13604137"
+              },
+              {
+                  "distinct_range": 42816.67260154509,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13699516"
+              },
+              {
+                  "distinct_range": 50915.11012101366,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13812935"
+              },
+              {
+                  "distinct_range": 58789.98766904679,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "13943896"
+              },
+              {
+                  "distinct_range": 45192.78290035591,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14044568"
+              },
+              {
+                  "distinct_range": 50485.94680235446,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14157031"
+              },
+              {
+                  "distinct_range": 57426.63097577484,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14284955"
+              },
+              {
+                  "distinct_range": 46810.67474182846,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14389231"
+              },
+              {
+                  "distinct_range": 43183.88556667399,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14485428"
+              },
+              {
+                  "distinct_range": 56030.054527711276,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14610241"
+              },
+              {
+                  "distinct_range": 55720.75167566505,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14734365"
+              },
+              {
+                  "distinct_range": 61571.01984383104,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "14871521"
+              },
+              {
+                  "distinct_range": 68669.72231031422,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15024490"
+              },
+              {
+                  "distinct_range": 78652.70754079882,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15199697"
+              },
+              {
+                  "distinct_range": 55161.85174707645,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15322576"
+              },
+              {
+                  "distinct_range": 77248.49952744528,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15494655"
+              },
+              {
+                  "distinct_range": 63122.921091325654,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15635268"
+              },
+              {
+                  "distinct_range": 84052.26444125158,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "15822503"
+              },
+              {
+                  "distinct_range": 93319.22928129537,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "16030381"
+              },
+              {
+                  "distinct_range": 93470.96275588407,
+                  "num_eq": 578033,
+                  "num_range": 28323659,
+                  "upper_bound": "16238597"
+              },
+              {
+                  "distinct_range": 82420.00730040969,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "16422196"
+              },
+              {
+                  "distinct_range": 85378.3611392843,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "16612385"
+              },
+              {
+                  "distinct_range": 102659.36736500174,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "16841069"
+              },
+              {
+                  "distinct_range": 95420.15431406215,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "17053627"
+              },
+              {
+                  "distinct_range": 111517.81900422975,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "17302044"
+              },
+              {
+                  "distinct_range": 101203.53405703962,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "17527485"
+              },
+              {
+                  "distinct_range": 161230.28421866603,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "17886641"
+              },
+              {
+                  "distinct_range": 258122.88171808608,
+                  "num_eq": 578033,
+                  "num_range": 28901693,
+                  "upper_bound": "18461634"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 25263499,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f",
+              "c"
+          ],
+          "created_at": "2021-12-10 00:33:22.25132",
+          "distinct_count": 5715039114,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 5782480777
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "a"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 6148389296,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 619321,
+                  "num_range": 0,
+                  "upper_bound": "1478246"
+              },
+              {
+                  "distinct_range": 25163448.560769193,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "31516478"
+              },
+              {
+                  "distinct_range": 24762160.148622047,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "60447228"
+              },
+              {
+                  "distinct_range": 22651441.32381618,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "84368086"
+              },
+              {
+                  "distinct_range": 25755488.127439674,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "116150667"
+              },
+              {
+                  "distinct_range": 27628487.44581675,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "154521847"
+              },
+              {
+                  "distinct_range": 24321554.84516026,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "182299816"
+              },
+              {
+                  "distinct_range": 27381599.98171958,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "219692973"
+              },
+              {
+                  "distinct_range": 26052704.272992846,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "252405528"
+              },
+              {
+                  "distinct_range": 24829538.450113192,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "281518266"
+              },
+              {
+                  "distinct_range": 26736637.77110753,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "316525126"
+              },
+              {
+                  "distinct_range": 26200882.10859486,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "349715904"
+              },
+              {
+                  "distinct_range": 26719453.140567176,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "384662289"
+              },
+              {
+                  "distinct_range": 22093284.864942,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "407447494"
+              },
+              {
+                  "distinct_range": 21065785.62191183,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "428307733"
+              },
+              {
+                  "distinct_range": 23604885.921325963,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "454338349"
+              },
+              {
+                  "distinct_range": 25734781.964036014,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "486057548"
+              },
+              {
+                  "distinct_range": 25701986.516146842,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "517676725"
+              },
+              {
+                  "distinct_range": 27190794.673907407,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "554339386"
+              },
+              {
+                  "distinct_range": 23989663.801548537,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "581289451"
+              },
+              {
+                  "distinct_range": 25869721.451617986,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "613424953"
+              },
+              {
+                  "distinct_range": 25970651.535668217,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "645876933"
+              },
+              {
+                  "distinct_range": 21032846.243023,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "666678701"
+              },
+              {
+                  "distinct_range": 28395211.700734787,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "708347870"
+              },
+              {
+                  "distinct_range": 24605957.517602723,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "736862646"
+              },
+              {
+                  "distinct_range": 26768803.61607857,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "771983115"
+              },
+              {
+                  "distinct_range": 26989048.43054712,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "807896254"
+              },
+              {
+                  "distinct_range": 24521870.13184908,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "836190462"
+              },
+              {
+                  "distinct_range": 27361039.74874121,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "873503864"
+              },
+              {
+                  "distinct_range": 24003975.407467384,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "900488947"
+              },
+              {
+                  "distinct_range": 25119735.93244713,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "930403732"
+              },
+              {
+                  "distinct_range": 26512441.576940957,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "964633465"
+              },
+              {
+                  "distinct_range": 26664976.506749414,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "999389148"
+              },
+              {
+                  "distinct_range": 26618106.09655887,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1033981971"
+              },
+              {
+                  "distinct_range": 26274457.887604013,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1067413947"
+              },
+              {
+                  "distinct_range": 26838337.75638862,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1102781866"
+              },
+              {
+                  "distinct_range": 24573609.262838755,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1131211515"
+              },
+              {
+                  "distinct_range": 23632162.02513745,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1157305942"
+              },
+              {
+                  "distinct_range": 28537592.274700772,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1199635370"
+              },
+              {
+                  "distinct_range": 25217224.68942891,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1229826440"
+              },
+              {
+                  "distinct_range": 26083776.77847077,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1262638454"
+              },
+              {
+                  "distinct_range": 26764177.689281594,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1297742551"
+              },
+              {
+                  "distinct_range": 25672076.920283854,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1329270896"
+              },
+              {
+                  "distinct_range": 24214987.973846413,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1356779379"
+              },
+              {
+                  "distinct_range": 26854543.172708884,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1392205336"
+              },
+              {
+                  "distinct_range": 24822781.500549607,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1421299753"
+              },
+              {
+                  "distinct_range": 25471512.48003872,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1452228407"
+              },
+              {
+                  "distinct_range": 27135034.791163612,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1488681606"
+              },
+              {
+                  "distinct_range": 26971374.974262573,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1524530169"
+              },
+              {
+                  "distinct_range": 26070474.46314475,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1557299551"
+              },
+              {
+                  "distinct_range": 25979313.051330674,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1589778897"
+              },
+              {
+                  "distinct_range": 25778952.154232156,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1621633519"
+              },
+              {
+                  "distinct_range": 27228775.221263226,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1658439881"
+              },
+              {
+                  "distinct_range": 25045501.8913704,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1688146628"
+              },
+              {
+                  "distinct_range": 25948843.137925684,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1720529850"
+              },
+              {
+                  "distinct_range": 28236504.640672036,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1761481622"
+              },
+              {
+                  "distinct_range": 24490261.016452678,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1789693514"
+              },
+              {
+                  "distinct_range": 25358802.716834858,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1820292174"
+              },
+              {
+                  "distinct_range": 24693258.34517919,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1849038424"
+              },
+              {
+                  "distinct_range": 24245181.29272171,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1876622903"
+              },
+              {
+                  "distinct_range": 24794151.580160443,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1905639867"
+              },
+              {
+                  "distinct_range": 27133061.78693255,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1942085687"
+              },
+              {
+                  "distinct_range": 26633501.81225121,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1976731882"
+              },
+              {
+                  "distinct_range": 28450755.17099779,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2018656712"
+              },
+              {
+                  "distinct_range": 24372758.207942627,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2046565424"
+              },
+              {
+                  "distinct_range": 24636174.063233662,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2075160030"
+              },
+              {
+                  "distinct_range": 24435229.08902999,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2103229379"
+              },
+              {
+                  "distinct_range": 27274538.263918187,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2140210005"
+              },
+              {
+                  "distinct_range": 25972122.09181026,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2172666629"
+              },
+              {
+                  "distinct_range": 26666322.429506212,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2207427005"
+              },
+              {
+                  "distinct_range": 26092516.908148475,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2240267073"
+              },
+              {
+                  "distinct_range": 23218414.365112204,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2265414924"
+              },
+              {
+                  "distinct_range": 25623478.339341145,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2296796465"
+              },
+              {
+                  "distinct_range": 25658993.114419818,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2328285192"
+              },
+              {
+                  "distinct_range": 24788082.002102032,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2357285772"
+              },
+              {
+                  "distinct_range": 23040036.08168476,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2382039161"
+              },
+              {
+                  "distinct_range": 25079087.56334259,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2411839782"
+              },
+              {
+                  "distinct_range": 25745911.010481756,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2443593025"
+              },
+              {
+                  "distinct_range": 23463578.17513344,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2469296290"
+              },
+              {
+                  "distinct_range": 26777431.70339652,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2504447325"
+              },
+              {
+                  "distinct_range": 23329037.136245996,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2529843855"
+              },
+              {
+                  "distinct_range": 25152454.23212163,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2559850972"
+              },
+              {
+                  "distinct_range": 23016549.221217595,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2584553012"
+              },
+              {
+                  "distinct_range": 23770649.189846277,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2610974596"
+              },
+              {
+                  "distinct_range": 25951148.32534312,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2643365076"
+              },
+              {
+                  "distinct_range": 27030671.705606457,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2679430981"
+              },
+              {
+                  "distinct_range": 26815013.908241786,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2714715613"
+              },
+              {
+                  "distinct_range": 22268291.99834497,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2737849604"
+              },
+              {
+                  "distinct_range": 25249918.435980316,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2768134122"
+              },
+              {
+                  "distinct_range": 24029313.167868003,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2795181350"
+              },
+              {
+                  "distinct_range": 26039461.550810196,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2827851648"
+              },
+              {
+                  "distinct_range": 27285950.49881684,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2864875923"
+              },
+              {
+                  "distinct_range": 25963199.30675045,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2897304384"
+              },
+              {
+                  "distinct_range": 24327438.673434373,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2925097335"
+              },
+              {
+                  "distinct_range": 26197150.875937205,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2958275948"
+              },
+              {
+                  "distinct_range": 24979589.65492916,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2987799649"
+              },
+              {
+                  "distinct_range": 27096694.610282052,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3024109853"
+              },
+              {
+                  "distinct_range": 25047831.09297077,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3053823097"
+              },
+              {
+                  "distinct_range": 25385245.54047926,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3084498733"
+              },
+              {
+                  "distinct_range": 25747984.986572042,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3116258326"
+              },
+              {
+                  "distinct_range": 26978066.642145377,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3152131319"
+              },
+              {
+                  "distinct_range": 26560868.17035029,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3186526765"
+              },
+              {
+                  "distinct_range": 24183910.288651954,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3213957318"
+              },
+              {
+                  "distinct_range": 24404686.529105753,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3241947975"
+              },
+              {
+                  "distinct_range": 23069290.67975966,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3266765513"
+              },
+              {
+                  "distinct_range": 25985402.34835641,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3299264118"
+              },
+              {
+                  "distinct_range": 24154938.947724454,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3326622288"
+              },
+              {
+                  "distinct_range": 23200296.241016887,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3351729708"
+              },
+              {
+                  "distinct_range": 26721622.5370256,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3386683719"
+              },
+              {
+                  "distinct_range": 25562066.448562086,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3417881125"
+              },
+              {
+                  "distinct_range": 24422980.461161595,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3445918880"
+              },
+              {
+                  "distinct_range": 28483680.50392542,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3487996410"
+              },
+              {
+                  "distinct_range": 23486261.44823611,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3513751861"
+              },
+              {
+                  "distinct_range": 24791315.955276452,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3542761169"
+              },
+              {
+                  "distinct_range": 28158294.030539174,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3583366379"
+              },
+              {
+                  "distinct_range": 24749355.951492175,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3612262721"
+              },
+              {
+                  "distinct_range": 23054573.960913688,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3637047962"
+              },
+              {
+                  "distinct_range": 27916508.669151668,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3676609730"
+              },
+              {
+                  "distinct_range": 27786292.84281351,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3715626389"
+              },
+              {
+                  "distinct_range": 25991146.784620177,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3748143177"
+              },
+              {
+                  "distinct_range": 26579678.434132252,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3782603306"
+              },
+              {
+                  "distinct_range": 25273621.935974296,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3812955827"
+              },
+              {
+                  "distinct_range": 24614184.063661523,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3841492307"
+              },
+              {
+                  "distinct_range": 25807361.858806986,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3873434465"
+              },
+              {
+                  "distinct_range": 24491320.142037034,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3901649110"
+              },
+              {
+                  "distinct_range": 26970313.27901205,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3937493799"
+              },
+              {
+                  "distinct_range": 27468310.753842454,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3975226141"
+              },
+              {
+                  "distinct_range": 39851328.90252629,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "8712436029"
+              },
+              {
+                  "distinct_range": 39677112.08700442,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "10710965664"
+              },
+              {
+                  "distinct_range": 39561509.1260428,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "12153449196"
+              },
+              {
+                  "distinct_range": 39623194.12185893,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "13847681454"
+              },
+              {
+                  "distinct_range": 39668919.809116155,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "15793141513"
+              },
+              {
+                  "distinct_range": 39591239.39865898,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "17346971607"
+              },
+              {
+                  "distinct_range": 39689221.247964896,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "19429425576"
+              },
+              {
+                  "distinct_range": 39604523.458225094,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "21038704973"
+              },
+              {
+                  "distinct_range": 39684018.408741,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "23084226827"
+              },
+              {
+                  "distinct_range": 39651751.93955856,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "24927140395"
+              },
+              {
+                  "distinct_range": 39681086.965583704,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "26952455794"
+              },
+              {
+                  "distinct_range": 39673971.44877171,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "28930309517"
+              },
+              {
+                  "distinct_range": 39654769.778018236,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "30790488096"
+              },
+              {
+                  "distinct_range": 39610523.9758095,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "32426151948"
+              },
+              {
+                  "distinct_range": 39642789.20604612,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "34219673183"
+              },
+              {
+                  "distinct_range": 39719502.20457869,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "36546181235"
+              },
+              {
+                  "distinct_range": 39587105.92307412,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "38083514569"
+              },
+              {
+                  "distinct_range": 39524809.5385048,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "39408648130"
+              },
+              {
+                  "distinct_range": 39584646.90369476,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "40936319365"
+              },
+              {
+                  "distinct_range": 39600686.14328669,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "42529181572"
+              },
+              {
+                  "distinct_range": 39573328.650588594,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "44013969858"
+              },
+              {
+                  "distinct_range": 39658091.179320626,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "45893483572"
+              },
+              {
+                  "distinct_range": 39538132.846152954,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "47258960281"
+              },
+              {
+                  "distinct_range": 39592312.715786576,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "48817117600"
+              },
+              {
+                  "distinct_range": 40452021.76064368,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "50648319520"
+              },
+              {
+                  "distinct_range": 40463985.09876281,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "52546052321"
+              },
+              {
+                  "distinct_range": 40496652.09298104,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "54652713664"
+              },
+              {
+                  "distinct_range": 40319934.61208606,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "55971902545"
+              },
+              {
+                  "distinct_range": 40461819.85535016,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "57857255233"
+              },
+              {
+                  "distinct_range": 40419210.34457981,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "59527647900"
+              },
+              {
+                  "distinct_range": 40428363.5557608,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "61240002597"
+              },
+              {
+                  "distinct_range": 40424946.06288933,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "62936471289"
+              },
+              {
+                  "distinct_range": 40505003.64896234,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "65104115903"
+              },
+              {
+                  "distinct_range": 40310096.39363315,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "66396323958"
+              },
+              {
+                  "distinct_range": 40416782.086977474,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "68055929685"
+              },
+              {
+                  "distinct_range": 40398765.007865176,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "69639623827"
+              },
+              {
+                  "distinct_range": 40440450.87574006,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "71410709124"
+              },
+              {
+                  "distinct_range": 40471976.772332616,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "73355678621"
+              },
+              {
+                  "distinct_range": 40503997.99121175,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "75515799456"
+              },
+              {
+                  "distinct_range": 40460139.96044883,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "77391653147"
+              },
+              {
+                  "distinct_range": 40463483.04165452,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "79286508213"
+              },
+              {
+                  "distinct_range": 40397179.254151,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "80863843378"
+              },
+              {
+                  "distinct_range": 40473182.71279021,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "82816111621"
+              },
+              {
+                  "distinct_range": 40425373.04236749,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "84514554044"
+              },
+              {
+                  "distinct_range": 40402805.333038725,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "86114665549"
+              },
+              {
+                  "distinct_range": 40453353.93412883,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "87953023046"
+              },
+              {
+                  "distinct_range": 40398585.12859033,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "89535985003"
+              },
+              {
+                  "distinct_range": 40490614.5454629,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "91600649346"
+              },
+              {
+                  "distinct_range": 40426930.98403254,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "93306295152"
+              },
+              {
+                  "distinct_range": 40467815.83501669,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "95226376056"
+              },
+              {
+                  "distinct_range": 40476481.33563956,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "97198999181"
+              },
+              {
+                  "distinct_range": 40406200.34741685,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "98813155381"
+              },
+              {
+                  "distinct_range": 40457405.56579588,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "100673726688"
+              },
+              {
+                  "distinct_range": 40348576.04170952,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "102078204424"
+              },
+              {
+                  "distinct_range": 40438624.295323916,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "103840151098"
+              },
+              {
+                  "distinct_range": 40461508.76253205,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "105723720663"
+              },
+              {
+                  "distinct_range": 40329492.47823594,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "107070202563"
+              },
+              {
+                  "distinct_range": 40472569.778236926,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "109018723160"
+              },
+              {
+                  "distinct_range": 40468756.65338627,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "110944387100"
+              },
+              {
+                  "distinct_range": 40445489.67329874,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "112741160745"
+              },
+              {
+                  "distinct_range": 40365208.30466431,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "114200397050"
+              },
+              {
+                  "distinct_range": 40450426.1329106,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "116023058167"
+              },
+              {
+                  "distinct_range": 40328413.83449318,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "117366402926"
+              },
+              {
+                  "distinct_range": 40492650.99710145,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "119445074144"
+              },
+              {
+                  "distinct_range": 40409969.385556355,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "121075148455"
+              },
+              {
+                  "distinct_range": 40551781.60397964,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "123661662387"
+              },
+              {
+                  "distinct_range": 40464284.25442685,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "125561143094"
+              },
+              {
+                  "distinct_range": 40431840.627457105,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "127290000342"
+              },
+              {
+                  "distinct_range": 40520252.62671645,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "129578462099"
+              },
+              {
+                  "distinct_range": 40511065.17568853,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "131792556568"
+              },
+              {
+                  "distinct_range": 40495049.25462533,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "133887899254"
+              },
+              {
+                  "distinct_range": 40454198.29155448,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "135730850106"
+              },
+              {
+                  "distinct_range": 40426233.345441,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "137433248965"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "b"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 5705793245,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 619321,
+                  "num_range": 0,
+                  "upper_bound": "629278183"
+              },
+              {
+                  "distinct_range": 23681890.383706182,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "659316415"
+              },
+              {
+                  "distinct_range": 23304171.741573278,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "688247002"
+              },
+              {
+                  "distinct_range": 21317700.093286302,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "712167674"
+              },
+              {
+                  "distinct_range": 24238873.84821908,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "743949609"
+              },
+              {
+                  "distinct_range": 26008664.35656387,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "782350291"
+              },
+              {
+                  "distinct_range": 22872863.53800195,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "810083138"
+              },
+              {
+                  "distinct_range": 25761225.06492573,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "847442392"
+              },
+              {
+                  "distinct_range": 24516708.711585674,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "880147888"
+              },
+              {
+                  "distinct_range": 23358996.033237394,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "909235726"
+              },
+              {
+                  "distinct_range": 25144096.31453737,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "944173952"
+              },
+              {
+                  "distinct_range": 24638365.486336093,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "977295955"
+              },
+              {
+                  "distinct_range": 25074236.78109658,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1011974794"
+              },
+              {
+                  "distinct_range": 20735515.797844257,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1034640843"
+              },
+              {
+                  "distinct_range": 19620333.374251943,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1055117618"
+              },
+              {
+                  "distinct_range": 21986458.45204213,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1080588744"
+              },
+              {
+                  "distinct_range": 23993747.130663365,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1111586246"
+              },
+              {
+                  "distinct_range": 23953656.923162583,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1142458054"
+              },
+              {
+                  "distinct_range": 25349269.694469575,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1178174757"
+              },
+              {
+                  "distinct_range": 22312386.094777066,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1204448311"
+              },
+              {
+                  "distinct_range": 24217952.84337484,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1236162209"
+              },
+              {
+                  "distinct_range": 24286651.23521453,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1268100298"
+              },
+              {
+                  "distinct_range": 19524610.244118795,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1288400921"
+              },
+              {
+                  "distinct_range": 26530016.761502225,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1329145000"
+              },
+              {
+                  "distinct_range": 22883545.63983487,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1356906695"
+              },
+              {
+                  "distinct_range": 24943717.734102696,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1391108399"
+              },
+              {
+                  "distinct_range": 25099304.282844126,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1425879988"
+              },
+              {
+                  "distinct_range": 22751738.82287106,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1453288517"
+              },
+              {
+                  "distinct_range": 25424771.659081176,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1489298135"
+              },
+              {
+                  "distinct_range": 22286962.5783691,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1515507923"
+              },
+              {
+                  "distinct_range": 23329108.873558022,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1544509892"
+              },
+              {
+                  "distinct_range": 24648198.856211524,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1577665893"
+              },
+              {
+                  "distinct_range": 24618864.421082266,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1610720621"
+              },
+              {
+                  "distinct_range": 24737398.056323115,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1644187329"
+              },
+              {
+                  "distinct_range": 24379946.5999824,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1676433499"
+              },
+              {
+                  "distinct_range": 24920849.668711103,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1710552590"
+              },
+              {
+                  "distinct_range": 22728138.669178512,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1737898519"
+              },
+              {
+                  "distinct_range": 21839321.24532327,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1763017781"
+              },
+              {
+                  "distinct_range": 26487013.68798741,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1803560414"
+              },
+              {
+                  "distinct_range": 23262464.13692098,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1832372149"
+              },
+              {
+                  "distinct_range": 24099874.274977546,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1863705880"
+              },
+              {
+                  "distinct_range": 24681528.03400195,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1896977488"
+              },
+              {
+                  "distinct_range": 23655165.63761661,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1926935446"
+              },
+              {
+                  "distinct_range": 22365862.335816015,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1953343791"
+              },
+              {
+                  "distinct_range": 24838789.171100754,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "1987168805"
+              },
+              {
+                  "distinct_range": 22693996.551740203,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2014424508"
+              },
+              {
+                  "distinct_range": 23537759.08683259,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2044033302"
+              },
+              {
+                  "distinct_range": 25099219.568803128,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2078804577"
+              },
+              {
+                  "distinct_range": 24859919.712940603,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2112704963"
+              },
+              {
+                  "distinct_range": 23932694.435664188,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2143511332"
+              },
+              {
+                  "distinct_range": 23783791.157136466,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2173858401"
+              },
+              {
+                  "distinct_range": 23567618.888938364,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2203555462"
+              },
+              {
+                  "distinct_range": 24973199.084274847,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2237864100"
+              },
+              {
+                  "distinct_range": 22902364.066014584,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2265676714"
+              },
+              {
+                  "distinct_range": 23875375.50742638,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2296305138"
+              },
+              {
+                  "distinct_range": 25940687.99410977,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2334415411"
+              },
+              {
+                  "distinct_range": 22109864.75468124,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2360186566"
+              },
+              {
+                  "distinct_range": 23211361.517378572,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2388853582"
+              },
+              {
+                  "distinct_range": 22462740.37416913,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2415508437"
+              },
+              {
+                  "distinct_range": 22083961.717298992,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2441216238"
+              },
+              {
+                  "distinct_range": 22634413.54119701,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2468315430"
+              },
+              {
+                  "distinct_range": 24859067.340273596,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2502212771"
+              },
+              {
+                  "distinct_range": 24462314.70912532,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2534734468"
+              },
+              {
+                  "distinct_range": 26175833.31386786,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2573863719"
+              },
+              {
+                  "distinct_range": 22178026.872947074,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2599802557"
+              },
+              {
+                  "distinct_range": 22370522.010534436,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2626222690"
+              },
+              {
+                  "distinct_range": 22200987.548318088,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2652218332"
+              },
+              {
+                  "distinct_range": 24918004.007899255,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2686327163"
+              },
+              {
+                  "distinct_range": 23676968.991693936,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2716350590"
+              },
+              {
+                  "distinct_range": 24163043.093313385,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2747886894"
+              },
+              {
+                  "distinct_range": 23450635.831934188,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2777240204"
+              },
+              {
+                  "distinct_range": 20779051.84330622,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2799997236"
+              },
+              {
+                  "distinct_range": 23060528.416065194,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2828242820"
+              },
+              {
+                  "distinct_range": 23328165.392094992,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2857242084"
+              },
+              {
+                  "distinct_range": 22455754.846391723,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2883879063"
+              },
+              {
+                  "distinct_range": 20766776.635825306,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2906610397"
+              },
+              {
+                  "distinct_range": 22851434.537828695,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2934285494"
+              },
+              {
+                  "distinct_range": 23489516.856027402,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2963752444"
+              },
+              {
+                  "distinct_range": 21306645.692713313,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2987648504"
+              },
+              {
+                  "distinct_range": 24519563.06362932,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3020363686"
+              },
+              {
+                  "distinct_range": 20956424.838757165,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3043496035"
+              },
+              {
+                  "distinct_range": 22518167.686850853,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3070293291"
+              },
+              {
+                  "distinct_range": 20085553.52389691,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3091651653"
+              },
+              {
+                  "distinct_range": 21239258.955119874,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3115398362"
+              },
+              {
+                  "distinct_range": 23149968.622942135,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3143892822"
+              },
+              {
+                  "distinct_range": 24323601.833557945,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3175952427"
+              },
+              {
+                  "distinct_range": 24183716.711229317,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3207555430"
+              },
+              {
+                  "distinct_range": 19849718.13227679,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3228461505"
+              },
+              {
+                  "distinct_range": 22566045.468492344,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3255382576"
+              },
+              {
+                  "distinct_range": 21523439.119392585,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3279767171"
+              },
+              {
+                  "distinct_range": 23451682.78497285,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3309123533"
+              },
+              {
+                  "distinct_range": 24644962.218817335,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3342268338"
+              },
+              {
+                  "distinct_range": 23428181.686236136,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3371556294"
+              },
+              {
+                  "distinct_range": 21872412.354060236,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3396754143"
+              },
+              {
+                  "distinct_range": 23679021.376294732,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3426783743"
+              },
+              {
+                  "distinct_range": 22534132.802706867,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3453622202"
+              },
+              {
+                  "distinct_range": 24631543.80163411,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3486720649"
+              },
+              {
+                  "distinct_range": 22710066.15507012,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3514018769"
+              },
+              {
+                  "distinct_range": 22833718.874391854,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3541646245"
+              },
+              {
+                  "distinct_range": 23174175.895499438,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3570208575"
+              },
+              {
+                  "distinct_range": 24497581.917601302,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3602849272"
+              },
+              {
+                  "distinct_range": 24020371.491799116,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3633930646"
+              },
+              {
+                  "distinct_range": 21712021.23443763,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3658750495"
+              },
+              {
+                  "distinct_range": 22028192.89588453,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3684322579"
+              },
+              {
+                  "distinct_range": 20745917.247497812,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3707010325"
+              },
+              {
+                  "distinct_range": 23601192.317458205,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3736807065"
+              },
+              {
+                  "distinct_range": 21904077.42439497,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3762080410"
+              },
+              {
+                  "distinct_range": 20934872.27507335,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3785166752"
+              },
+              {
+                  "distinct_range": 24362982.398717515,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3817356589"
+              },
+              {
+                  "distinct_range": 23172243.112714868,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3845913492"
+              },
+              {
+                  "distinct_range": 22085683.552887537,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3871625498"
+              },
+              {
+                  "distinct_range": 26064463.250119686,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3910267068"
+              },
+              {
+                  "distinct_range": 21191731.7300301,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3933909140"
+              },
+              {
+                  "distinct_range": 22432425.725918137,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3960486534"
+              },
+              {
+                  "distinct_range": 25693618.957595862,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "3997568612"
+              },
+              {
+                  "distinct_range": 22336531.73326657,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4023902915"
+              },
+              {
+                  "distinct_range": 20803835.391995676,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4046711939"
+              },
+              {
+                  "distinct_range": 25545283.174377486,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4083196511"
+              },
+              {
+                  "distinct_range": 25386020.839930154,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4119055351"
+              },
+              {
+                  "distinct_range": 23709520.40197418,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4149176890"
+              },
+              {
+                  "distinct_range": 24184728.693981383,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4180783163"
+              },
+              {
+                  "distinct_range": 22938460.325314235,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4208693798"
+              },
+              {
+                  "distinct_range": 22364191.56159138,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4235097918"
+              },
+              {
+                  "distinct_range": 23524167.017939586,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4264666653"
+              },
+              {
+                  "distinct_range": 22219207.483647157,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4290707486"
+              },
+              {
+                  "distinct_range": 24603215.809147336,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4323708371"
+              },
+              {
+                  "distinct_range": 25100034.128567684,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "4358482666"
+              },
+              {
+                  "distinct_range": 37497322.967578396,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "8811288594"
+              },
+              {
+                  "distinct_range": 37291581.51624836,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "10512155483"
+              },
+              {
+                  "distinct_range": 37306367.501720324,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "12292337287"
+              },
+              {
+                  "distinct_range": 37324889.760240614,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "14182946575"
+              },
+              {
+                  "distinct_range": 37331066.45742664,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "16113451162"
+              },
+              {
+                  "distinct_range": 37321257.140045494,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "17981325864"
+              },
+              {
+                  "distinct_range": 37313321.51288212,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "19801428423"
+              },
+              {
+                  "distinct_range": 37238015.675970815,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "21265605867"
+              },
+              {
+                  "distinct_range": 37320446.479796134,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "23128500792"
+              },
+              {
+                  "distinct_range": 37258250.98606918,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "24673969088"
+              },
+              {
+                  "distinct_range": 37183026.0922761,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "25954817565"
+              },
+              {
+                  "distinct_range": 37345718.24038491,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "27987039481"
+              },
+              {
+                  "distinct_range": 37281413.39300458,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "29637308691"
+              },
+              {
+                  "distinct_range": 37359874.69079007,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "31778489791"
+              },
+              {
+                  "distinct_range": 37316860.643573925,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "33619624384"
+              },
+              {
+                  "distinct_range": 37276646.02911146,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "35247167290"
+              },
+              {
+                  "distinct_range": 37328247.791084796,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "37159263208"
+              },
+              {
+                  "distinct_range": 37346463.33357839,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "39196963814"
+              },
+              {
+                  "distinct_range": 37359905.436783254,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "41338387780"
+              },
+              {
+                  "distinct_range": 37290862.344780795,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "43035582761"
+              },
+              {
+                  "distinct_range": 37347089.01868071,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "45077876031"
+              },
+              {
+                  "distinct_range": 37307395.3839172,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "46863857581"
+              },
+              {
+                  "distinct_range": 37308713.68779076,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "48657347099"
+              },
+              {
+                  "distinct_range": 37295258.41397718,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "50377288449"
+              },
+              {
+                  "distinct_range": 38037798.943084426,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "52039966806"
+              },
+              {
+                  "distinct_range": 38089692.58016211,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "53988784419"
+              },
+              {
+                  "distinct_range": 37989850.76049033,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "55452533327"
+              },
+              {
+                  "distinct_range": 38132520.8183265,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "57723307943"
+              },
+              {
+                  "distinct_range": 38075882.14659633,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "59586839876"
+              },
+              {
+                  "distinct_range": 38065629.76566985,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "61391683796"
+              },
+              {
+                  "distinct_range": 38033836.86339727,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "63035920093"
+              },
+              {
+                  "distinct_range": 38095501.17522955,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "65022975118"
+              },
+              {
+                  "distinct_range": 38019817.41807406,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "66605060722"
+              },
+              {
+                  "distinct_range": 38069267.59594793,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "68430323800"
+              },
+              {
+                  "distinct_range": 38004182.03379615,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "69948384864"
+              },
+              {
+                  "distinct_range": 37981637.14699775,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "71382712762"
+              },
+              {
+                  "distinct_range": 38024733.265541896,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "72986047779"
+              },
+              {
+                  "distinct_range": 38123034.91436947,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "75176762046"
+              },
+              {
+                  "distinct_range": 38113909.958632246,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "77295537528"
+              },
+              {
+                  "distinct_range": 38038972.34973875,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "78963767458"
+              },
+              {
+                  "distinct_range": 38011091.9788201,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "80509481333"
+              },
+              {
+                  "distinct_range": 38037778.55507871,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "82172056333"
+              },
+              {
+                  "distinct_range": 38033209.63925927,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "83813396013"
+              },
+              {
+                  "distinct_range": 38076877.28505147,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "85682829689"
+              },
+              {
+                  "distinct_range": 37955490.085659236,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "87030833284"
+              },
+              {
+                  "distinct_range": 38117738.38646266,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "89179166791"
+              },
+              {
+                  "distinct_range": 38122522.58773734,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "91365664794"
+              },
+              {
+                  "distinct_range": 38059171.562127285,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "93135407937"
+              },
+              {
+                  "distinct_range": 38116002.55272141,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "95270257844"
+              },
+              {
+                  "distinct_range": 38046345.04772609,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "96974152911"
+              },
+              {
+                  "distinct_range": 38046840.23518178,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "98680498608"
+              },
+              {
+                  "distinct_range": 38068961.319900334,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "100504001862"
+              },
+              {
+                  "distinct_range": 38027241.03492222,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "102118407859"
+              },
+              {
+                  "distinct_range": 38089950.08707,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "104068912927"
+              },
+              {
+                  "distinct_range": 38069495.132666185,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "105895436941"
+              },
+              {
+                  "distinct_range": 38083295.578544065,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "107803779243"
+              },
+              {
+                  "distinct_range": 37891227.247754484,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "108977857899"
+              },
+              {
+                  "distinct_range": 38104483.073336184,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "111027051070"
+              },
+              {
+                  "distinct_range": 38045084.02245977,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "112724766456"
+              },
+              {
+                  "distinct_range": 38021213.858210355,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "114312822238"
+              },
+              {
+                  "distinct_range": 38060032.71407654,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "116087178323"
+              },
+              {
+                  "distinct_range": 38000773.66119573,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "117591970380"
+              },
+              {
+                  "distinct_range": 38101862.8672668,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "119622666383"
+              },
+              {
+                  "distinct_range": 38041821.52812645,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "121304514899"
+              },
+              {
+                  "distinct_range": 38012058.26507018,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "122854174983"
+              },
+              {
+                  "distinct_range": 37959536.14344109,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "124214859466"
+              },
+              {
+                  "distinct_range": 38068907.87732002,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "126038084207"
+              },
+              {
+                  "distinct_range": 38111948.73168188,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "128141980162"
+              },
+              {
+                  "distinct_range": 38048716.27335495,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "129857695637"
+              },
+              {
+                  "distinct_range": 38032943.12695534,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "131497812345"
+              },
+              {
+                  "distinct_range": 38080888.96079063,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "133391410794"
+              },
+              {
+                  "distinct_range": 38088017.48339347,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "135329473580"
+              },
+              {
+                  "distinct_range": 38104126.674028195,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "137376154453"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "c"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 6080666004,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 619321,
+                  "num_range": 0,
+                  "upper_bound": "2020-01-24 20:42:31.000305+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-02-08 04:28:33.600659+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-02-21 19:38:02.361232+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-03-02 16:11:12.200979+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-03-16 02:26:41.339969+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-03-31 21:37:19.200738+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-04-09 16:20:59.346571+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-04-19 00:34:50.914331+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-04-26 21:05:43.029301+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-05-03 15:56:44.563676+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-05-11 16:26:02.87032+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-05-19 00:08:25.545705+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-05-27 15:07:11.684325+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-06-01 12:40:41.453762+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-06-06 00:24:50.919566+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-06-11 21:41:03.973945+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-06-18 21:44:34.674833+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-06-25 18:33:39.058369+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-07-03 00:03:11.001354+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-07-08 23:28:25.65954+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-07-15 03:51:14.422584+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-07-21 16:31:50.837784+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-07-25 14:56:28.521944+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-08-02 00:50:14.840007+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-08-07 15:11:37.860342+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-08-13 23:18:01.926208+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-08-20 16:42:47.314544+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-08-25 17:49:39.312683+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-01 02:59:13.153844+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-05 23:39:08.429073+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-11 15:49:56.72102+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-16 23:13:32.170068+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-21 23:20:22.383733+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-09-27 16:05:06.857903+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-02 20:29:45.116387+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-08 03:25:17.67942+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-12 19:04:38.052671+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-16 22:17:17.43296+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-23 15:22:08.728392+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-10-27 20:45:10.807834+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-01 16:19:48.429565+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-06 17:55:14.772925+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-10 23:59:44.905663+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-14 19:42:02.447189+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-19 17:54:25.036973+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-22 19:07:59.639735+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-11-27 08:47:22.453941+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-02 19:21:39.557718+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-06 21:02:04.500712+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-10 21:45:02.382785+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-14 01:21:41.562983+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-17 21:20:47.454948+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-21 18:47:15.767257+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-24 21:26:47.395241+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2020-12-29 02:19:33.693283+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-02 13:38:08.206187+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-04 23:21:51.232456+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-08 00:48:30.589005+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-10 18:54:09.705753+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-13 15:52:04.994759+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-16 05:44:37.161423+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-20 01:53:19.796802+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-23 17:02:08.792406+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-27 19:57:56.872826+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-01-30 02:29:43.081855+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-01 21:32:35.832429+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-04 18:12:18.656389+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-07 21:50:24.610236+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-11 01:07:34.633578+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-13 23:12:07.072872+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-17 00:06:23.529024+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-19 17:07:20.586801+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-22 00:49:57.925796+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-25 00:54:08.160772+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-02-27 16:51:00.153+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-01 21:07:58.540497+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-04 17:27:28.313259+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-07 02:54:33.319439+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-09 20:55:56.604937+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-12 22:44:55.751313+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-15 00:04:29.445581+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-17 18:35:33.302608+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-19 16:20:57.357908+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-21 21:01:44.274387+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-24 17:10:53.741158+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-27 14:39:04.920226+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-03-30 18:43:40.495505+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-01 20:33:23.119148+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-04 01:19:39.75734+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-06 21:02:13.229886+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-09 17:45:52.041727+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-12 21:44:48.443717+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-15 19:55:00.19049+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-17 22:28:57.715172+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-20 20:29:33.373873+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-23 00:50:18.363409+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-26 00:10:02.879059+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-04-28 19:24:34.519471+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-01 00:31:00.39797+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-03 20:19:11.682515+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-06 21:51:52.031162+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-09 16:37:40.31571+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-11 22:27:42.229366+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-14 04:06:34.792968+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-16 03:09:52.466474+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-19 00:54:45.503138+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-21 14:59:09.613347+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-23 04:52:42.830456+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-26 11:31:15.366195+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-28 20:23:54.951287+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-05-30 23:20:58.3476+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-03 16:19:20.180141+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-05 21:07:50.727969+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-07 22:43:48.42878+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-10 00:31:06.619472+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-12 20:09:41.212447+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-14 23:24:24.978333+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-17 19:23:43.962206+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-20 19:40:07.661578+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-23 16:13:06.005219+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-25 20:39:11.191258+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-06-27 23:32:00.162094+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-01 15:33:27.622761+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-03 19:16:52.005801+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-06 01:49:40.436718+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-09 16:23:47.884484+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-12 21:00:01.431276+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-15 17:57:59.889953+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-18 00:40:18.034207+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-20 19:51:38.28919+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-23 00:41:27.337688+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-25 20:59:20.987965+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-28 16:22:38.298404+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-07-31 02:15:42.730224+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-03 12:26:59.603023+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-05 17:58:40.193595+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-07 18:40:47.921951+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-10 15:04:33.922602+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-12 15:56:25.405332+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-15 00:05:01.589446+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-17 21:22:37.308214+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-20 01:02:21.624644+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-22 19:14:19.398613+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-25 18:00:11.931827+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-27 18:06:11.134329+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-08-29 20:57:46.848664+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-09-01 04:44:01.302319+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-09-03 12:55:44.76458+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-09-06 01:25:11.708738+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-09-08 23:43:28.730779+00:00"
+              },
+              {
+                  "distinct_range": 30403328.97491613,
+                  "num_eq": 619321,
+                  "num_range": 30346769,
+                  "upper_bound": "2021-09-11 14:27:41.866546+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-13 23:40:20.190432+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-16 02:07:17.096173+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-18 00:31:58.692204+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-20 06:00:21.197631+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-23 04:59:12.416683+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-25 04:50:12.709242+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-27 20:35:19.038648+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-09-30 04:20:09.812214+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-02 16:51:16.001187+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-04 23:54:29.915911+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-07 20:54:56.880256+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-10 01:00:05.000103+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-13 18:14:37.114687+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-16 18:50:39.735412+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-19 03:40:45.661784+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-22 02:56:23.821698+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-24 02:38:28.049743+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-27 01:11:44.61283+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-10-30 00:01:14.689242+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-01 18:24:08.996783+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-04 00:47:31.865805+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-06 19:25:34.061488+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-09 18:09:37.319627+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-12 01:51:25.251668+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-14 07:16:35.953862+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-17 00:32:55.469246+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-19 23:44:56.587547+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-22 02:38:05.915533+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-24 21:26:05.737281+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-27 22:39:34.511274+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-11-30 03:21:39.346854+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-02 22:48:47.200576+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-04 22:25:48.278568+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-07 01:45:01.310291+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-09 19:10:00.300357+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-11 19:27:12.782679+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-13 19:15:59.818279+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-16 00:28:17.758562+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-18 01:32:27.944491+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-20 17:46:40.942234+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-22 21:49:39.311747+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-24 21:50:13.19844+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-27 19:15:26.637183+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-29 17:52:43.026868+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2021-12-31 16:43:25.846044+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2022-01-02 21:05:40.242072+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2022-01-05 03:26:15.306531+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2022-01-07 21:44:02.18615+00:00"
+              },
+              {
+                  "distinct_range": 31023805.260460827,
+                  "num_eq": 619321,
+                  "num_range": 30966091,
+                  "upper_bound": "2022-01-09 18:58:52.542745+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "d"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 2400885553,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 620961,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-26 19:33:14+00:00"
+              },
+              {
+                  "distinct_range": 2400885551,
+                  "num_eq": 620961,
+                  "num_range": 4015754968,
+                  "upper_bound": "2022-01-09 18:58:58.646811+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 2176221321,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "e"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 147208571,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 617521,
+                  "num_range": 0,
+                  "upper_bound": "2020-02-19 16:52:08+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-03-02 22:58:31+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-03-12 20:28:06+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-03-21 22:42:24+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-03-30 23:26:41+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-05 01:20:36+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-11 20:27:19+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-18 00:49:18+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-21 20:14:17+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-25 23:21:00+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-04-30 16:07:40+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-04 03:09:56+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-08 13:35:12+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-15 07:01:18+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-19 16:54:35+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-25 22:08:12+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-05-29 17:21:35+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-01 22:03:01+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-05 20:21:58+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-10 18:25:35+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-13 02:10:46+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-19 18:26:14+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-24 20:51:01+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-06-29 19:29:08+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-04 09:41:12+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-08 23:21:04+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-14 19:44:42+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-18 01:06:36+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-23 21:28:01+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-07-28 20:56:23+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-04 22:28:04+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-07 23:55:32+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-13 23:46:55+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-19 02:09:13+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-22 00:13:18+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-24 19:23:43+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-08-28 23:49:07+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-03 16:24:59+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-06 19:39:20+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-11 15:32:15+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-14 23:42:00+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-18 13:08:25+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-23 01:41:33+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-25 20:58:27+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-09-29 03:29:42+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-05 16:02:59+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-09 15:23:32+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-12 22:25:58+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-16 13:17:30+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-21 16:39:50+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-26 00:13:10+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-10-29 20:52:55+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-03 00:02:03+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-06 20:37:48+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-10 21:42:51+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-13 23:16:09+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-17 18:40:27+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-21 18:31:14+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-24 18:35:58+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-11-29 14:49:11+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-03 00:08:54+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-06 21:02:46+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-10 18:26:21+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-13 21:04:06+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-16 17:46:56+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-19 01:52:26+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-23 19:49:21+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-26 22:33:38+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2020-12-30 18:34:45+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-02 01:41:36+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-04 17:50:45+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-07 21:15:12+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-10 01:11:50+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-12 15:46:45+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-15 01:04:41+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-18 23:29:46+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-22 00:20:16+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-24 22:51:41+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-28 22:32:51+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-01-30 20:31:02+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-02 13:03:25+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-05 20:00:04+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-09 23:27:12+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-13 09:17:03+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-15 21:33:25+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-19 17:01:29+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-22 23:15:35+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-25 15:47:42+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-02-27 16:09:00+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-01 20:38:52+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-03 23:43:42+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-07 00:42:52+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-09 19:03:02+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-12 22:52:36+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-15 19:16:57+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-18 01:57:18+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-20 02:47:02+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-23 22:46:04+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-26 23:39:50+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-03-30 00:42:55+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-01 00:52:18+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-03 22:47:00+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-06 23:03:07.719021+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-09 02:02:44+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-12 19:24:55+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-15 23:17:14+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-18 17:45:57+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-21 23:30:22+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-25 18:30:51+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-27 21:38:08.855835+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-04-30 01:40:02+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-03 00:56:49+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-06 21:03:09+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-10 02:39:28+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-14 00:59:53.866229+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-15 21:49:40.214818+00:00"
+              },
+              {
+                  "distinct_range": 722026.036989422,
+                  "num_eq": 617521,
+                  "num_range": 10497863,
+                  "upper_bound": "2021-05-18 22:42:38+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-05-21 03:07:32+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-05-23 00:32:08+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-05-25 21:10:09+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-05-28 00:24:24+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-01 23:40:54+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-05 14:09:21+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-06 23:54:54+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-10 03:05:34+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-14 01:21:37+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-17 15:17:21.203535+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-21 23:51:41+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-24 21:27:58.478972+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-26 22:02:52+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-06-30 22:17:49+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-03 17:12:47+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-05 22:48:22.42285+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-09 02:13:08+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-13 14:06:26+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-17 05:54:01+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-19 02:36:42.801789+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-22 21:49:08+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-25 20:59:28+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-07-29 19:27:03+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-01 00:32:57+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-05 19:02:36+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-08 22:53:29+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-11 03:42:43+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-13 04:12:57+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-15 05:53:00+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-18 02:57:37.369043+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-20 19:23:55+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-24 12:02:30+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-26 23:59:04+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-08-29 02:36:36+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-01 07:09:26.727885+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-03 17:38:49+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-06 18:40:59+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-10 21:28:12+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-12 23:43:16+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-15 16:26:42+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-17 17:59:05+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-20 00:28:46+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-22 22:17:12+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-25 01:35:41+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-27 14:48:37+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-09-29 23:09:58+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-02 20:17:15+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-04 22:12:39+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-07 22:58:24+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-10 21:46:29+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-13 01:40:07+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-15 23:17:48+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-19 03:40:57+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-20 21:21:40+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-22 22:41:59+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-24 23:33:34+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-28 16:54:20+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-10-31 17:46:28+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-03 11:52:26+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-06 16:16:16+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-08 22:24:04.627658+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-11 20:37:36.64859+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-14 21:23:47.967588+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-18 19:01:00.729849+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-21 00:08:51.103473+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-23 02:56:57+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-26 19:08:12+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-11-29 00:40:08+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-02 00:36:25+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-04 14:36:27+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-07 00:25:34+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-09 18:36:39+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-12 08:58:10.427119+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-14 18:54:37+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-18 02:03:00+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-20 06:21:38+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-23 01:04:40+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-24 21:50:21+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-27 23:24:01+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2021-12-30 21:13:40+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2022-01-02 01:24:58+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2022-01-07 15:12:24+00:00"
+              },
+              {
+                  "distinct_range": 764498.2013159884,
+                  "num_eq": 617521,
+                  "num_range": 11115385,
+                  "upper_bound": "2022-01-09 18:24:02+00:00"
+              }
+          ],
+          "histo_col_type": "TIMESTAMPTZ",
+          "name": "__auto__",
+          "null_count": 3929384749,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 8668532,
+          "histo_buckets": [
+              {
+                  "distinct_range": 0,
+                  "num_eq": 619334,
+                  "num_range": 0,
+                  "upper_bound": "2577"
+              },
+              {
+                  "distinct_range": 124632.93970783826,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "275485"
+              },
+              {
+                  "distinct_range": 80814.78444217023,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "452445"
+              },
+              {
+                  "distinct_range": 61908.87716230901,
+                  "num_eq": 1238669,
+                  "num_range": 30347402,
+                  "upper_bound": "588007"
+              },
+              {
+                  "distinct_range": 54929.79423436951,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "708287"
+              },
+              {
+                  "distinct_range": 41765.349496718416,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "799741"
+              },
+              {
+                  "distinct_range": 51854.467416103274,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "913287"
+              },
+              {
+                  "distinct_range": 52509.812528103874,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1028268"
+              },
+              {
+                  "distinct_range": 36540.85606028157,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1108282"
+              },
+              {
+                  "distinct_range": 46721.31127750623,
+                  "num_eq": 1238669,
+                  "num_range": 30347402,
+                  "upper_bound": "1210588"
+              },
+              {
+                  "distinct_range": 48079.49689638413,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1315868"
+              },
+              {
+                  "distinct_range": 47163.84048554009,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1419143"
+              },
+              {
+                  "distinct_range": 52940.92457390775,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1535068"
+              },
+              {
+                  "distinct_range": 41400.4569918484,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1625723"
+              },
+              {
+                  "distinct_range": 49860.57420426033,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1734903"
+              },
+              {
+                  "distinct_range": 57141.98358804958,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1860027"
+              },
+              {
+                  "distinct_range": 55536.27389202581,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "1981635"
+              },
+              {
+                  "distinct_range": 40145.02583304028,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2069541"
+              },
+              {
+                  "distinct_range": 61710.21853950743,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2204668"
+              },
+              {
+                  "distinct_range": 32859.50627084824,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2276621"
+              },
+              {
+                  "distinct_range": 52871.051541060304,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2392393"
+              },
+              {
+                  "distinct_range": 38015.04004741603,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2475635"
+              },
+              {
+                  "distinct_range": 53087.06425045144,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2591880"
+              },
+              {
+                  "distinct_range": 38193.147778203645,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2675512"
+              },
+              {
+                  "distinct_range": 44174.37072724327,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2772241"
+              },
+              {
+                  "distinct_range": 47303.129864745795,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2875821"
+              },
+              {
+                  "distinct_range": 53439.16953362389,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "2992837"
+              },
+              {
+                  "distinct_range": 42280.94854302412,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3085420"
+              },
+              {
+                  "distinct_range": 48290.942740883285,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3191163"
+              },
+              {
+                  "distinct_range": 48743.975738168716,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3297898"
+              },
+              {
+                  "distinct_range": 46390.67025932614,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3399480"
+              },
+              {
+                  "distinct_range": 45653.578265758915,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3499448"
+              },
+              {
+                  "distinct_range": 58417.96563887166,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3627366"
+              },
+              {
+                  "distinct_range": 58394.21794143331,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3755232"
+              },
+              {
+                  "distinct_range": 51690.973652970024,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3868420"
+              },
+              {
+                  "distinct_range": 53062.8598665239,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "3984612"
+              },
+              {
+                  "distinct_range": 49737.72553866579,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4093523"
+              },
+              {
+                  "distinct_range": 38912.88568518131,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4178731"
+              },
+              {
+                  "distinct_range": 43980.735655822886,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4275036"
+              },
+              {
+                  "distinct_range": 42395.120165323875,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4367869"
+              },
+              {
+                  "distinct_range": 37193.00436685778,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4449311"
+              },
+              {
+                  "distinct_range": 44334.210998462935,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4546390"
+              },
+              {
+                  "distinct_range": 60342.89919084555,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4678523"
+              },
+              {
+                  "distinct_range": 35360.321485702094,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4755952"
+              },
+              {
+                  "distinct_range": 36323.01660493364,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4835489"
+              },
+              {
+                  "distinct_range": 43309.86320318952,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "4930325"
+              },
+              {
+                  "distinct_range": 37496.24419568593,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5012431"
+              },
+              {
+                  "distinct_range": 43098.87404517957,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5106805"
+              },
+              {
+                  "distinct_range": 39036.64772375424,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5192284"
+              },
+              {
+                  "distinct_range": 36012.9264787675,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5271142"
+              },
+              {
+                  "distinct_range": 42495.59119294766,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5364195"
+              },
+              {
+                  "distinct_range": 40814.98491269525,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5453568"
+              },
+              {
+                  "distinct_range": 41877.23768657218,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5545267"
+              },
+              {
+                  "distinct_range": 40109.86097337195,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5633096"
+              },
+              {
+                  "distinct_range": 31170.22294730104,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5701350"
+              },
+              {
+                  "distinct_range": 33866.499979532084,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5775508"
+              },
+              {
+                  "distinct_range": 34604.505346077705,
+                  "num_eq": 1238669,
+                  "num_range": 30347402,
+                  "upper_bound": "5851282"
+              },
+              {
+                  "distinct_range": 24196.62025723193,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5904266"
+              },
+              {
+                  "distinct_range": 38416.467471421965,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "5988387"
+              },
+              {
+                  "distinct_range": 42511.118533580426,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6081474"
+              },
+              {
+                  "distinct_range": 31273.89078034922,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6149955"
+              },
+              {
+                  "distinct_range": 28429.190639128494,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6212207"
+              },
+              {
+                  "distinct_range": 31382.58216477859,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6280926"
+              },
+              {
+                  "distinct_range": 25925.63530533944,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6337696"
+              },
+              {
+                  "distinct_range": 30191.087114458333,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6403806"
+              },
+              {
+                  "distinct_range": 29379.098536662466,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6468138"
+              },
+              {
+                  "distinct_range": 32004.13247657846,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6538218"
+              },
+              {
+                  "distinct_range": 23134.8241698442,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6588877"
+              },
+              {
+                  "distinct_range": 19734.33657126826,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6632090"
+              },
+              {
+                  "distinct_range": 28489.016569213567,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6694473"
+              },
+              {
+                  "distinct_range": 20359.083688492527,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6739054"
+              },
+              {
+                  "distinct_range": 23911.191201482543,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6791413"
+              },
+              {
+                  "distinct_range": 26210.150988110432,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6848806"
+              },
+              {
+                  "distinct_range": 26490.556492478634,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6906813"
+              },
+              {
+                  "distinct_range": 20840.887934597496,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "6952449"
+              },
+              {
+                  "distinct_range": 30845.518853480535,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7019992"
+              },
+              {
+                  "distinct_range": 26703.37239644538,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7078465"
+              },
+              {
+                  "distinct_range": 23095.092445283884,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7129037"
+              },
+              {
+                  "distinct_range": 23145.784645584976,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7179720"
+              },
+              {
+                  "distinct_range": 28695.438862331524,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7242555"
+              },
+              {
+                  "distinct_range": 22994.6214176601,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7292907"
+              },
+              {
+                  "distinct_range": 28841.121852386015,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7356061"
+              },
+              {
+                  "distinct_range": 30738.197528518765,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7423369"
+              },
+              {
+                  "distinct_range": 24108.93645130572,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7476161"
+              },
+              {
+                  "distinct_range": 23024.762725947236,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7526579"
+              },
+              {
+                  "distinct_range": 27067.351528337003,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7585849"
+              },
+              {
+                  "distinct_range": 34705.43306019069,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7661844"
+              },
+              {
+                  "distinct_range": 31427.79412720929,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7730662"
+              },
+              {
+                  "distinct_range": 23930.8287205181,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7783064"
+              },
+              {
+                  "distinct_range": 33463.70249605855,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7856340"
+              },
+              {
+                  "distinct_range": 29789.20300396319,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7921570"
+              },
+              {
+                  "distinct_range": 31206.757866436965,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "7989904"
+              },
+              {
+                  "distinct_range": 33345.420695356,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8062921"
+              },
+              {
+                  "distinct_range": 31081.169081907232,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8130980"
+              },
+              {
+                  "distinct_range": 27784.34931637947,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8191820"
+              },
+              {
+                  "distinct_range": 23470.032052916285,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8243213"
+              },
+              {
+                  "distinct_range": 25178.039522520638,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8298346"
+              },
+              {
+                  "distinct_range": 33773.79262222468,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8372301"
+              },
+              {
+                  "distinct_range": 28043.747242244517,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8433709"
+              },
+              {
+                  "distinct_range": 26482.79282216225,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8491699"
+              },
+              {
+                  "distinct_range": 24835.524655621368,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8546082"
+              },
+              {
+                  "distinct_range": 32636.186577629913,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8617546"
+              },
+              {
+                  "distinct_range": 30667.411122692916,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8684699"
+              },
+              {
+                  "distinct_range": 28055.621090963694,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8746133"
+              },
+              {
+                  "distinct_range": 25914.674829598665,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8802879"
+              },
+              {
+                  "distinct_range": 28565.283212909802,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8865429"
+              },
+              {
+                  "distinct_range": 30526.29499753042,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "8932273"
+              },
+              {
+                  "distinct_range": 35658.08107665986,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9010354"
+              },
+              {
+                  "distinct_range": 26520.24111427657,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9068426"
+              },
+              {
+                  "distinct_range": 29060.331367201547,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9132060"
+              },
+              {
+                  "distinct_range": 29902.46125328455,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9197538"
+              },
+              {
+                  "distinct_range": 22561.682625899422,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9246942"
+              },
+              {
+                  "distinct_range": 28526.008174838687,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9309406"
+              },
+              {
+                  "distinct_range": 26713.419499207757,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9367901"
+              },
+              {
+                  "distinct_range": 28457.048514969636,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9430214"
+              },
+              {
+                  "distinct_range": 29958.633691456027,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9495815"
+              },
+              {
+                  "distinct_range": 33573.30725346631,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9569331"
+              },
+              {
+                  "distinct_range": 31440.581348906864,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9638177"
+              },
+              {
+                  "distinct_range": 41647.98106899427,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9729374"
+              },
+              {
+                  "distinct_range": 33423.05739851983,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9802561"
+              },
+              {
+                  "distinct_range": 30271.00725006816,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9868846"
+              },
+              {
+                  "distinct_range": 29504.6873211922,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9933453"
+              },
+              {
+                  "distinct_range": 28324.60943310192,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "9995476"
+              },
+              {
+                  "distinct_range": 26640.349660935914,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10053811"
+              },
+              {
+                  "distinct_range": 29768.195425460035,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10118995"
+              },
+              {
+                  "distinct_range": 31790.403199633318,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10188607"
+              },
+              {
+                  "distinct_range": 39290.108725259706,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10274641"
+              },
+              {
+                  "distinct_range": 35310.5426583794,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10351961"
+              },
+              {
+                  "distinct_range": 29443.94801812873,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10416435"
+              },
+              {
+                  "distinct_range": 38578.13448859842,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10500910"
+              },
+              {
+                  "distinct_range": 35677.71859569542,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10579034"
+              },
+              {
+                  "distinct_range": 40372.45570466139,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10667438"
+              },
+              {
+                  "distinct_range": 31958.920514147758,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10737419"
+              },
+              {
+                  "distinct_range": 33728.12397330478,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10811274"
+              },
+              {
+                  "distinct_range": 30685.678582260876,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10878467"
+              },
+              {
+                  "distinct_range": 36638.586968970165,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "10958695"
+              },
+              {
+                  "distinct_range": 38644.35402953228,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11043315"
+              },
+              {
+                  "distinct_range": 40898.101853729466,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11132870"
+              },
+              {
+                  "distinct_range": 32809.72744352554,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11204714"
+              },
+              {
+                  "distinct_range": 35177.19020353328,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11281742"
+              },
+              {
+                  "distinct_range": 35158.922743965326,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11358730"
+              },
+              {
+                  "distinct_range": 38104.09391280983,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11442167"
+              },
+              {
+                  "distinct_range": 35095.44332196666,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11519016"
+              },
+              {
+                  "distinct_range": 31125.924357848737,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11587173"
+              },
+              {
+                  "distinct_range": 36022.060208551484,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11666051"
+              },
+              {
+                  "distinct_range": 23796.10620620439,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11718158"
+              },
+              {
+                  "distinct_range": 29796.966674279574,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11783405"
+              },
+              {
+                  "distinct_range": 32947.190076774445,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11855550"
+              },
+              {
+                  "distinct_range": 43021.23734201574,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "11949754"
+              },
+              {
+                  "distinct_range": 36486.51036806689,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12029649"
+              },
+              {
+                  "distinct_range": 36673.75182863849,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12109954"
+              },
+              {
+                  "distinct_range": 36546.33629815196,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12189980"
+              },
+              {
+                  "distinct_range": 45427.5184536054,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12289453"
+              },
+              {
+                  "distinct_range": 32337.513613693747,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12360263"
+              },
+              {
+                  "distinct_range": 34151.92903528147,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12435046"
+              },
+              {
+                  "distinct_range": 38314.626384330586,
+                  "num_eq": 1238669,
+                  "num_range": 30347402,
+                  "upper_bound": "12518944"
+              },
+              {
+                  "distinct_range": 42182.30426135713,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12611311"
+              },
+              {
+                  "distinct_range": 44998.68984024751,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12709845"
+              },
+              {
+                  "distinct_range": 35729.324168974905,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12788082"
+              },
+              {
+                  "distinct_range": 44629.230470485505,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12885807"
+              },
+              {
+                  "distinct_range": 38416.01078493277,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "12969927"
+              },
+              {
+                  "distinct_range": 40846.49628044998,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13059369"
+              },
+              {
+                  "distinct_range": 41829.28560520628,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13150963"
+              },
+              {
+                  "distinct_range": 41590.89525784439,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13242035"
+              },
+              {
+                  "distinct_range": 51282.6959316261,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13354329"
+              },
+              {
+                  "distinct_range": 36267.300853251356,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13433744"
+              },
+              {
+                  "distinct_range": 40628.65682510204,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13522709"
+              },
+              {
+                  "distinct_range": 51186.3350824051,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13634792"
+              },
+              {
+                  "distinct_range": 46724.96476941983,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13737106"
+              },
+              {
+                  "distinct_range": 52728.565356430205,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13852566"
+              },
+              {
+                  "distinct_range": 46914.94634892662,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "13955296"
+              },
+              {
+                  "distinct_range": 46596.6358659549,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14057329"
+              },
+              {
+                  "distinct_range": 52190.13198566456,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14171610"
+              },
+              {
+                  "distinct_range": 55903.44982934183,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14294022"
+              },
+              {
+                  "distinct_range": 63007.664855321855,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14431990"
+              },
+              {
+                  "distinct_range": 55852.300942551534,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14554290"
+              },
+              {
+                  "distinct_range": 53941.98135823201,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14672407"
+              },
+              {
+                  "distinct_range": 46811.73520236764,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14774911"
+              },
+              {
+                  "distinct_range": 51009.140724595876,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "14886606"
+              },
+              {
+                  "distinct_range": 63213.63046195062,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15025025"
+              },
+              {
+                  "distinct_range": 77074.06540914103,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15193794"
+              },
+              {
+                  "distinct_range": 70456.67818064716,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15348073"
+              },
+              {
+                  "distinct_range": 61889.69632976264,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15483593"
+              },
+              {
+                  "distinct_range": 73201.3639807333,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15643882"
+              },
+              {
+                  "distinct_range": 67573.61637433371,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15791848"
+              },
+              {
+                  "distinct_range": 64321.095198258256,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "15932692"
+              },
+              {
+                  "distinct_range": 73458.47847415235,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16093544"
+              },
+              {
+                  "distinct_range": 59875.252225905744,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16224653"
+              },
+              {
+                  "distinct_range": 71990.23141137748,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16382290"
+              },
+              {
+                  "distinct_range": 44221.86612211997,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16479123"
+              },
+              {
+                  "distinct_range": 68794.3393599627,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16629762"
+              },
+              {
+                  "distinct_range": 79512.77126146381,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "16803871"
+              },
+              {
+                  "distinct_range": 94309.87019800142,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "17010381"
+              },
+              {
+                  "distinct_range": 59579.31938090478,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "17140842"
+              },
+              {
+                  "distinct_range": 69496.2664938616,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "17293018"
+              },
+              {
+                  "distinct_range": 95178.94458694717,
+                  "num_eq": 619334,
+                  "num_range": 30347402,
+                  "upper_bound": "17501431"
+              },
+              {
+                  "distinct_range": 132249.1002882104,
+                  "num_eq": 619334,
+                  "num_range": 30966737,
+                  "upper_bound": "17791016"
+              },
+              {
+                  "distinct_range": 116803.04985052098,
+                  "num_eq": 619334,
+                  "num_range": 30966737,
+                  "upper_bound": "18046779"
+              },
+              {
+                  "distinct_range": 172661.7444039213,
+                  "num_eq": 619334,
+                  "num_range": 30966737,
+                  "upper_bound": "18424855"
+              },
+              {
+                  "distinct_range": 255216.96105642902,
+                  "num_eq": 619334,
+                  "num_range": 30966737,
+                  "upper_bound": "18983701"
+              }
+          ],
+          "histo_col_type": "INT8",
+          "name": "__auto__",
+          "null_count": 25263499,
+          "row_count": 6193218212
+      },
+      {
+          "avg_size": 0,
+          "columns": [
+              "f",
+              "c"
+          ],
+          "created_at": "2022-01-09 19:27:44.202499",
+          "distinct_count": 6118918533,
+          "histo_col_type": "",
+          "name": "__auto__",
+          "null_count": 0,
+          "row_count": 6193218212
+      }
+]'
+
+query TTTIIII
+SELECT statistics_name, column_names, created, row_count, distinct_count, null_count, avg_size
+FROM [SHOW STATISTICS FOR TABLE t1401 WITH FORECAST]
+ORDER BY created, column_names
+----
+__auto__      {a}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  5426151229  0           0
+__auto__      {b}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  5081612065  0           0
+__auto__      {c}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  5365341093  0           0
+__auto__      {d}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  1889961545  1955891971  0
+__auto__      {e}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  120198242   3447878972  0
+__auto__      {f}    2021-11-14 21:03:36.731171 +0000 +0000  5470854424  8033503     25263499    0
+__auto__      {f,c}  2021-11-14 21:03:36.731171 +0000 +0000  5470854424  5389115020  0           0
+__auto__      {a}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  5761422680  0           0
+__auto__      {b}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  5339885775  0           0
+__auto__      {c}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  5701907084  0           0
+__auto__      {d}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  2107756184  2052369078  0
+__auto__      {e}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  131613916   3654435068  0
+__auto__      {f}    2021-12-10 00:33:22.25132 +0000 +0000   5782480777  8286840     25263499    0
+__auto__      {f,c}  2021-12-10 00:33:22.25132 +0000 +0000   5782480777  5715039114  0           0
+__auto__      {a}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  6148389296  0           0
+__auto__      {b}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  5705793245  0           0
+__auto__      {c}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  6080666004  0           0
+__auto__      {d}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  2400885553  2176221321  0
+__auto__      {e}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  147208571   3929384749  0
+__auto__      {f}    2022-01-09 19:27:44.202499 +0000 +0000  6193218212  8668532     25263499    0
+__auto__      {f,c}  2022-01-09 19:27:44.202499 +0000 +0000  6193218212  6118918533  0           0
+__forecast__  {a}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  6512313587  0           0
+__forecast__  {b}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  6011960541  0           0
+__forecast__  {c}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  6442301187  0           0
+__forecast__  {c,f}  2022-02-06 18:39:47.938163 +0000 +0000  6550920018  6483244814  0           0
+__forecast__  {d}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  2653192118  2285703069  0
+__forecast__  {e}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  160520885   4167509088  0
+__forecast__  {f}    2022-02-06 18:39:47.938163 +0000 +0000  6550920018  8977521     25263499    0
+
+statement ok
+SET optimizer_use_forecasts = off
+
+# Without forecasts, we estimate 1 row with c newer than 2022-01-25.
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT c FROM t1401 WHERE c >= '2022-01-25T21:17:27.216095Z'
+----
+scan t1401@t1401_c_idx
+ ├── columns: c:3
+ ├── constraint: /3/1: [/'2022-01-25 21:17:27.216095+00:00' - ]
+ ├── stats: [rows=1.238644, distinct(3)=1, null(3)=0]
+ │   histogram(3)=
+ ├── cost: 15.3329623
+ └── distribution: test
+
+# Without forecasts, the bad plan uses t1401_c_idx.
+
+query T
+EXPLAIN SELECT
+  *
+FROM
+  t1401
+WHERE
+  (f = 4458256 AND (d IS NOT NULL))
+  AND c >= '2022-01-25T21:17:27.216095Z'
+ORDER BY
+  c DESC
+LIMIT
+  100
+----
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 100
+│
+└── • filter
+    │ estimated row count: 1
+    │ filter: (f = 4458256) AND (d IS NOT NULL)
+    │
+    └── • index join
+        │ estimated row count: 1
+        │ table: t1401@primary
+        │
+        └── • revscan
+              estimated row count: 1 (<0.01% of the table; stats collected <hidden> ago)
+              table: t1401@t1401_c_idx
+              spans: [/'2022-01-25 21:17:27.216095+00:00' - ]
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT
+  *
+FROM
+  t1401
+WHERE
+  (f = 4458256 AND (d IS NOT NULL))
+  AND c >= '2022-01-25T21:17:27.216095Z'
+ORDER BY
+  c DESC
+LIMIT
+  100
+----
+limit
+ ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ ├── internal-ordering: -3 opt(6)
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=1.238644]
+ ├── cost: 23.1483095
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5)
+ ├── ordering: -3 opt(6) [actual: -3]
+ ├── distribution: test
+ ├── prune: (1,2,5)
+ ├── interesting orderings: (-3,+1 opt(6))
+ ├── select
+ │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    ├── stats: [rows=1.238644, distinct(3)=1, null(3)=0, distinct(4)=1.23864, null(4)=0, distinct(6)=1, null(6)=0, distinct(3,6)=1, null(3,6)=0, distinct(3,4,6)=1.23864, null(3,4,6)=0]
+ │    │   histogram(3)=
+ │    │   histogram(4)=  0          0.00019147           1.2383              0.00019147
+ │    │                <--- '2020-02-26 19:33:14+00:00' -------- '2022-01-09 18:58:58.646811+00:00'
+ │    │   histogram(6)=  0  1.2386
+ │    │                <--- 4458256
+ │    ├── cost: 23.125923
+ │    ├── key: (1)
+ │    ├── fd: ()-->(6), (1)-->(2-5)
+ │    ├── ordering: -3 opt(6) [actual: -3]
+ │    ├── limit hint: 100.00
+ │    ├── distribution: test
+ │    ├── prune: (1,2,5)
+ │    ├── interesting orderings: (+1 opt(6)) (+2,+1 opt(6)) (-3,+1 opt(6)) (+3,+1 opt(6))
+ │    ├── index-join t1401
+ │    │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    │    ├── stats: [rows=1.238644]
+ │    │    ├── cost: 23.0735366
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-6)
+ │    │    ├── ordering: -3 opt(6) [actual: -3]
+ │    │    ├── distribution: test
+ │    │    ├── interesting orderings: (+3,+1)
+ │    │    └── scan t1401@t1401_c_idx,rev
+ │    │         ├── columns: a:1 c:3
+ │    │         ├── constraint: /3/1: [/'2022-01-25 21:17:27.216095+00:00' - ]
+ │    │         ├── stats: [rows=1.238644, distinct(3)=1, null(3)=0]
+ │    │         │   histogram(3)=
+ │    │         ├── cost: 15.3615596
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(3)
+ │    │         ├── ordering: -3
+ │    │         ├── distribution: test
+ │    │         └── interesting orderings: (+3,+1)
+ │    └── filters
+ │         ├── f:6 = 4458256 [outer=(6), constraints=(/6: [/4458256 - /4458256]; tight), fd=()-->(6)]
+ │         └── d:4 IS NOT NULL [outer=(4), constraints=(/4: (/NULL - ]; tight)]
+ └── 100
+
+statement ok
+RESET optimizer_use_forecasts
+
+# With forecasts, we estimate 179 million rows with c newer than 2022-01-25.
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT c FROM t1401 WHERE c >= '2022-01-25T21:17:27.216095Z'
+----
+scan t1401@t1401_c_idx
+ ├── columns: c:3
+ ├── constraint: /3/1: [/'2022-01-25 21:17:27.216095+00:00' - ]
+ ├── stats: [rows=1.794898e+08, distinct(3)=1.76231e+08, null(3)=0]
+ │   histogram(3)=  0                  0                   1.185e+07                  0                   22521                  0                   22533                  0                   22519                  0                   22525              5.4309e+05              3.2777e+07                  0                   22523                  0                   22533                  0                   22519                  0                   22516             5.4309e+05              3.2777e+07                  0                   22521                  0                   22539                  0                   22509                  0                   22523              5.4309e+05              3.2777e+07                  0                   22521                  0                  22536                  0                   22523              5.4309e+05              22507                  0                   3.2777e+07                  0                   22520                  0                   22525                  0                   22537                  0                   22523              5.4309e+05              3.2777e+07                  0                   22527                  0                   22516              5.4329e+05              9.6798e-05                   0
+ │                <--- '2022-01-25 21:17:27.216094+00:00' ----------- '2022-01-26 13:53:36.086677+00:00' ------- '2022-01-26 13:53:36.210566+00:00' ------- '2022-01-26 13:53:36.249608+00:00' ------- '2022-01-26 13:53:36.273256+00:00' ------- '2022-01-26 13:53:36.290149+00:00' ------------ '2022-01-28 16:52:54.882369+00:00' ------- '2022-01-28 16:52:55.040082+00:00' ------- '2022-01-28 16:52:55.081863+00:00' ------- '2022-01-28 16:52:55.095252+00:00' ------- '2022-01-28 16:52:55.10571+00:00' ------------ '2022-01-31 00:46:32.736103+00:00' ------- '2022-01-31 00:46:32.873121+00:00' ------- '2022-01-31 00:46:32.926866+00:00' ------- '2022-01-31 00:46:32.931511+00:00' ------- '2022-01-31 00:46:32.945369+00:00' ------------ '2022-02-02 08:59:13.005858+00:00' ------- '2022-02-02 08:59:13.15223+00:00' ------- '2022-02-02 08:59:13.207051+00:00' ------- '2022-02-02 08:59:13.221667+00:00' ------- '2022-02-02 08:59:13.226429+00:00' ------------ '2022-02-05 09:59:42.249075+00:00' ------- '2022-02-05 09:59:42.405033+00:00' ------- '2022-02-05 09:59:42.430149+00:00' ------- '2022-02-05 09:59:42.483822+00:00' ------- '2022-02-05 09:59:42.497593+00:00' ------------ '2022-02-06 19:22:44.256481+00:00' ------- '2022-02-06 19:22:44.423924+00:00' ------- '2022-02-06 19:22:44.437738+00:00' ------------ '294276-12-31 23:59:59.999999+00:00'
+ ├── cost: 190259204
+ └── distribution: test
+
+# With forecasts, the good plan uses t1401_f_c_idx1.
+
+query T
+EXPLAIN SELECT
+  *
+FROM
+  t1401
+WHERE
+  (f = 4458256 AND (d IS NOT NULL))
+  AND c >= '2022-01-25T21:17:27.216095Z'
+ORDER BY
+  c DESC
+LIMIT
+  100
+----
+distribution: local
+vectorized: true
+·
+• limit
+│ count: 100
+│
+└── • filter
+    │ estimated row count: 631
+    │ filter: d IS NOT NULL
+    │
+    └── • index join
+        │ estimated row count: 631
+        │ table: t1401@primary
+        │
+        └── • scan
+              estimated row count: 101 - 632 (<0.01% of the table; stats collected <hidden> ago; using stats forecast)
+              table: t1401@t1401_f_c_idx1 (partial index)
+              spans: [/4458256 - /4458256/'2022-01-25 21:17:27.216095+00:00']
+
+query T
+EXPLAIN (OPT, VERBOSE) SELECT
+  *
+FROM
+  t1401
+WHERE
+  (f = 4458256 AND (d IS NOT NULL))
+  AND c >= '2022-01-25T21:17:27.216095Z'
+ORDER BY
+  c DESC
+LIMIT
+  100
+----
+limit
+ ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ ├── internal-ordering: -3 opt(6)
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100]
+ ├── cost: 1371.51571
+ ├── key: (1)
+ ├── fd: ()-->(6), (1)-->(2-5)
+ ├── ordering: -3 opt(6) [actual: -3]
+ ├── distribution: test
+ ├── prune: (1,2,5)
+ ├── interesting orderings: (-3,+1 opt(6))
+ ├── select
+ │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    ├── stats: [rows=630.6055, distinct(3)=630.606, null(3)=0, distinct(4)=630.606, null(4)=0, distinct(6)=1, null(6)=0, distinct(3,4,6)=630.606, null(3,4,6)=0]
+ │    │   histogram(3)=  0                  0                   41.634                  0                   0.079122                  0                   0.079165                  0                   0.079118                  0                   0.079136                1.9081                115.16                  0                   0.079131                  0                   0.079165                  0                   0.079117                  0                   0.079106               1.9081                115.16                  0                   0.079124                  0                   0.079186                  0                   0.079081                  0                   0.07913                1.9081                115.16                  0                   0.079125                  0                  0.079177                  0                   0.079131                1.9081                0.079074                  0                   115.16                  0                   0.07912                  0                   0.079137                  0                   0.079181                  0                   0.079131                1.9081                115.16                  0                   0.079143                  0                   0.079107                1.9087                3.4008e-10                   0
+ │    │                <--- '2022-01-25 21:17:27.216094+00:00' -------- '2022-01-26 13:53:36.086677+00:00' ---------- '2022-01-26 13:53:36.210566+00:00' ---------- '2022-01-26 13:53:36.249608+00:00' ---------- '2022-01-26 13:53:36.273256+00:00' ---------- '2022-01-26 13:53:36.290149+00:00' -------- '2022-01-28 16:52:54.882369+00:00' ---------- '2022-01-28 16:52:55.040082+00:00' ---------- '2022-01-28 16:52:55.081863+00:00' ---------- '2022-01-28 16:52:55.095252+00:00' ---------- '2022-01-28 16:52:55.10571+00:00' -------- '2022-01-31 00:46:32.736103+00:00' ---------- '2022-01-31 00:46:32.873121+00:00' ---------- '2022-01-31 00:46:32.926866+00:00' ---------- '2022-01-31 00:46:32.931511+00:00' --------- '2022-01-31 00:46:32.945369+00:00' -------- '2022-02-02 08:59:13.005858+00:00' ---------- '2022-02-02 08:59:13.15223+00:00' ---------- '2022-02-02 08:59:13.207051+00:00' ---------- '2022-02-02 08:59:13.221667+00:00' ---------- '2022-02-02 08:59:13.226429+00:00' -------- '2022-02-05 09:59:42.249075+00:00' --------- '2022-02-05 09:59:42.405033+00:00' ---------- '2022-02-05 09:59:42.430149+00:00' ---------- '2022-02-05 09:59:42.483822+00:00' ---------- '2022-02-05 09:59:42.497593+00:00' -------- '2022-02-06 19:22:44.256481+00:00' ---------- '2022-02-06 19:22:44.423924+00:00' ---------- '2022-02-06 19:22:44.437738+00:00' ------------ '294276-12-31 23:59:59.999999+00:00'
+ │    │   histogram(4)=  0               0.096927               0.00055439                  0                   0.0013598                  0                   630.41                  0                   0.00136                  0                   0.00055438              0.096927
+ │    │                <--- '2020-02-26 21:52:44.379495+00:00' ------------ '2020-02-26 21:52:57.518799+00:00' ----------- '2020-02-26 21:56:25.489259+00:00' -------- '2022-02-06 19:19:19.915933+00:00' --------- '2022-02-06 19:22:47.917261+00:00' ------------ '2022-02-06 19:23:01.05628+00:00'
+ │    │   histogram(6)=  0  630.61
+ │    │                <--- 4458256
+ │    ├── cost: 1370.50571
+ │    ├── key: (1)
+ │    ├── fd: ()-->(6), (1)-->(2-5)
+ │    ├── ordering: -3 opt(6) [actual: -3]
+ │    ├── limit hint: 100.00
+ │    ├── distribution: test
+ │    ├── prune: (1,2,5)
+ │    ├── interesting orderings: (+1 opt(6)) (+2,+1 opt(6)) (-3,+1 opt(6)) (+3,+1 opt(6))
+ │    ├── index-join t1401
+ │    │    ├── columns: a:1 b:2 c:3 d:4 e:5 f:6
+ │    │    ├── stats: [rows=631.274]
+ │    │    ├── cost: 1364.16297
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(6), (1)-->(2-5)
+ │    │    ├── ordering: -3 opt(6) [actual: -3]
+ │    │    ├── limit hint: 100.11
+ │    │    ├── distribution: test
+ │    │    ├── interesting orderings: (-3,+1 opt(6))
+ │    │    └── scan t1401@t1401_f_c_idx1,partial
+ │    │         ├── columns: a:1 b:2 c:3 f:6
+ │    │         ├── constraint: /6/-3/1: [/4458256 - /4458256/'2022-01-25 21:17:27.216095+00:00']
+ │    │         ├── stats: [rows=631.274, distinct(3)=631.274, null(3)=0, distinct(6)=1, null(6)=0, distinct(3,6)=631.274, null(3,6)=0]
+ │    │         │   histogram(3)=  0                  0                   41.678                  0                   0.079206                  0                   0.079249                  0                   0.079202                  0                   0.07922                1.9101                115.28                  0                   0.079215                  0                   0.079249                  0                   0.079201                  0                   0.07919               1.9101                115.28                  0                   0.079207                  0                   0.07927                  0                   0.079165                  0                   0.079214                1.9101                115.28                  0                   0.079209                  0                  0.079261                  0                   0.079215                1.9101                0.079158                  0                   115.28                  0                   0.079203                  0                   0.079221                  0                   0.079265                  0                   0.079215                1.9101                115.28                  0                   0.079227                  0                   0.079191                1.9108                3.4044e-10                   0
+ │    │         │                <--- '2022-01-25 21:17:27.216094+00:00' -------- '2022-01-26 13:53:36.086677+00:00' ---------- '2022-01-26 13:53:36.210566+00:00' ---------- '2022-01-26 13:53:36.249608+00:00' ---------- '2022-01-26 13:53:36.273256+00:00' --------- '2022-01-26 13:53:36.290149+00:00' -------- '2022-01-28 16:52:54.882369+00:00' ---------- '2022-01-28 16:52:55.040082+00:00' ---------- '2022-01-28 16:52:55.081863+00:00' ---------- '2022-01-28 16:52:55.095252+00:00' --------- '2022-01-28 16:52:55.10571+00:00' -------- '2022-01-31 00:46:32.736103+00:00' ---------- '2022-01-31 00:46:32.873121+00:00' --------- '2022-01-31 00:46:32.926866+00:00' ---------- '2022-01-31 00:46:32.931511+00:00' ---------- '2022-01-31 00:46:32.945369+00:00' -------- '2022-02-02 08:59:13.005858+00:00' ---------- '2022-02-02 08:59:13.15223+00:00' ---------- '2022-02-02 08:59:13.207051+00:00' ---------- '2022-02-02 08:59:13.221667+00:00' ---------- '2022-02-02 08:59:13.226429+00:00' -------- '2022-02-05 09:59:42.249075+00:00' ---------- '2022-02-05 09:59:42.405033+00:00' ---------- '2022-02-05 09:59:42.430149+00:00' ---------- '2022-02-05 09:59:42.483822+00:00' ---------- '2022-02-05 09:59:42.497593+00:00' -------- '2022-02-06 19:22:44.256481+00:00' ---------- '2022-02-06 19:22:44.423924+00:00' ---------- '2022-02-06 19:22:44.437738+00:00' ------------ '294276-12-31 23:59:59.999999+00:00'
+ │    │         │   histogram(6)=  0  631.27
+ │    │         │                <--- 4458256
+ │    │         ├── cost: 130.142973
+ │    │         ├── key: (1)
+ │    │         ├── fd: ()-->(6), (1)-->(2,3)
+ │    │         ├── ordering: -3 opt(6) [actual: -3]
+ │    │         ├── limit hint: 100.11
+ │    │         ├── distribution: test
+ │    │         └── interesting orderings: (-3,+1 opt(6))
+ │    └── filters
+ │         └── d:4 IS NOT NULL [outer=(4), constraints=(/4: (/NULL - ]; tight)]
+ └── 100

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -214,6 +214,13 @@ func TestExecBuild_forecast(
 	runExecBuildLogicTest(t, "forecast")
 }
 
+func TestExecBuild_forecast1401(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "forecast1401")
+}
+
 func TestExecBuild_geospatial(
 	t *testing.T,
 ) {

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -44,10 +44,6 @@ const minObservationsForForecast = 3
 // predictive models in a forecast must have for us to use the forecast.
 const minGoodnessOfFit = 0.95
 
-// maxForecastDistance is the farthest into the future we can forecast from the
-// latest observed statistics.
-const maxForecastDistance = time.Hour * 24 * 7
-
 // ForecastTableStatistics produces zero or more statistics forecasts based on
 // the given observed statistics. The observed statistics must be ordered by
 // collection time descending, with the latest collected statistics first. The
@@ -76,14 +72,9 @@ func ForecastTableStatistics(ctx context.Context, observed []*TableStatistic) []
 	// To make forecasts deterministic, we must choose a time to forecast at based
 	// on only the observed statistics. We choose the time of the latest
 	// statistics + the average time between automatic stats collections, which
-	// should be roughly when the next automatic stats collection will occur. To
-	// avoid wildly futuristic predictions we cap this at maxForecastDistance.
+	// should be roughly when the next automatic stats collection will occur.
 	latest := observed[0].CreatedAt
-	horizon := latest.Add(maxForecastDistance)
 	at := latest.Add(avgRefreshTime(observed))
-	if at.After(horizon) {
-		at = horizon
-	}
 
 	// Group observed statistics by column set, and remove statistics with
 	// inverted histograms.


### PR DESCRIPTION
When generating statistics forecasts, we must pick a time at which to forecast. To make forecasts deterministic, this time must be based on only the existing collected statistics for the table (so it can't be the current time, for example). We calculate this time as:

  most recent collection time + average time between auto stats

Effectively making the forecast time the expected next auto stats collection time for the table.

Out of an (over)abundance of caution, I added an upper bound of 1 week to this time calculation so that we wouldn't forecast too far into the future. But now that we're testing with real stats we see that large tables tend to have less frequent auto stats collections. It's difficult to say what a reasonable upper bound would be for all tables; small tables that change frequently might need new stats after an hour, while large tables that change infrequently might need new stats after a few months.

Rather than try to guess an upper bound that would be reasonable for all tables, I think we should remove the time horizon altogether. I think we can trust the average time between auto stats calculation to limit the forecast to something reasonable for the table, regardless of the rate of change and the size of the table.

Fixes: #86395

Release note: None