### PR TITLE
ui: insights overview rename 'execution id' to 'latest execution id'

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsTable.tsx
@@ -39,8 +39,8 @@ export function makeStatementInsightsColumns(): ColumnDescriptor<StatementInsigh
   const execType = InsightExecEnum.STATEMENT;
   return [
     {
-      name: "executionID",
-      title: insightsTableTitles.executionID(execType),
+      name: "latestExecutionID",
+      title: insightsTableTitles.latestExecutionID(execType),
       cell: (item: StatementInsightEvent) => (
         <Link to={`/insights/statement/${item.statementID}`}>
           {String(item.statementID)}
@@ -142,17 +142,17 @@ export function makeStatementInsightsColumns(): ColumnDescriptor<StatementInsigh
       showByDefault: false,
     },
     {
-      name: "transactionID",
-      title: insightsTableTitles.executionID(InsightExecEnum.TRANSACTION),
-      cell: (item: StatementInsightEvent) => item.transactionID,
-      sort: (item: StatementInsightEvent) => item.transactionID,
-      showByDefault: false,
-    },
-    {
       name: "transactionFingerprintID",
       title: insightsTableTitles.fingerprintID(InsightExecEnum.TRANSACTION),
       cell: (item: StatementInsightEvent) => item.transactionFingerprintID,
       sort: (item: StatementInsightEvent) => item.transactionFingerprintID,
+      showByDefault: false,
+    },
+    {
+      name: "transactionID",
+      title: insightsTableTitles.latestExecutionID(InsightExecEnum.TRANSACTION),
+      cell: (item: StatementInsightEvent) => item.transactionID,
+      sort: (item: StatementInsightEvent) => item.transactionID,
       showByDefault: false,
     },
   ];

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsTable.tsx
@@ -32,8 +32,8 @@ export function makeTransactionInsightsColumns(): ColumnDescriptor<TransactionIn
   const execType = InsightExecEnum.TRANSACTION;
   return [
     {
-      name: "executionID",
-      title: insightsTableTitles.executionID(execType),
+      name: "latestExecutionID",
+      title: insightsTableTitles.latestExecutionID(execType),
       cell: (item: TransactionInsightEvent) => (
         <Link to={`/insights/transaction/${item.transactionID}`}>
           {String(item.transactionID)}

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -17,6 +17,7 @@ import { contentionTime, readFromDisk, writtenToDisk } from "../../../util";
 
 export const insightsColumnLabels = {
   executionID: "Execution ID",
+  latestExecutionID: "Latest Execution ID",
   query: "Execution",
   insights: "Insights",
   startTime: "Start Time (UTC)",
@@ -42,8 +43,14 @@ export function getLabel(
 ): string {
   switch (execType) {
     case InsightExecEnum.TRANSACTION:
+      if (key === "latestExecutionID") {
+        return "Latest Transaction Execution ID";
+      }
       return "Transaction " + insightsColumnLabels[key];
     case InsightExecEnum.STATEMENT:
+      if (key === "latestExecutionID") {
+        return "Latest Statement Execution ID";
+      }
       return "Statement " + insightsColumnLabels[key];
     default:
       return insightsColumnLabels[key];
@@ -72,11 +79,18 @@ export const insightsTableTitles: InsightsTableTitleType = {
   },
   executionID: (execType: InsightExecEnum) => {
     return makeToolTip(
+      <p>The ID of the execution with the {execType} fingerprint.</p>,
+      "executionID",
+      execType,
+    );
+  },
+  latestExecutionID: (execType: InsightExecEnum) => {
+    return makeToolTip(
       <p>
         The execution ID of the latest execution with the {execType}{" "}
         fingerprint.
       </p>,
-      "executionID",
+      "latestExecutionID",
       execType,
     );
   },


### PR DESCRIPTION
The insights only shows the latest execution id per a fingerprint. Renaming the column will avoid confusion where user might expect multiple execution ids for the same fingerprint. 

After showing the new column name.
<img width="1131" alt="Screen Shot 2022-09-22 at 4 15 12 PM" src="https://user-images.githubusercontent.com/8868107/191842420-92877707-ed8d-4eee-af00-052fd1544516.png">
<img width="1457" alt="Screen Shot 2022-09-22 at 4 14 22 PM" src="https://user-images.githubusercontent.com/8868107/191842732-8c69099d-f18a-434f-b6c5-4ce231f364cc.png">

closes #88456

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: (ui change): Rename insights overview table column 'execution id' to 'latest execution id'. This will help avoid confusion since the ui only shows the latest id per fingerprint.