### PR TITLE
release-22.1: opt: fix node-crashing panics with correlated With exprs

### DIFF
--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -211,7 +211,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 		// the right side of the join using the optimizer, with all outer columns
 		// in the right side replaced by the bindings that were defined by the most
 		// recently read left row.
-		p, err := a.planRightSideFn(newExecFactory(params.p), leftRow)
+		p, err := a.planRightSideFn(params.ctx, newExecFactory(params.p), leftRow)
 		if err != nil {
 			return false, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/apply_join
+++ b/pkg/sql/logictest/testdata/logic_test/apply_join
@@ -473,3 +473,29 @@ VALUES
         (VALUES (0:::OID), (3790322641:::OID)) AS tab_54747 (col_95055)
     )
   );
+
+subtest regression_87733
+
+statement ok
+CREATE TABLE t87733a (a INT);
+CREATE TABLE t87733b (b INT);
+INSERT INTO t87733a VALUES (1)
+
+# Regression test for #87733. Do not panic when planning the RHS of an
+# apply-join that refers to a With expression transitively through another With
+# expression.
+query T
+WITH
+  t1 AS (SELECT a FROM t87733a),
+  t2 AS MATERIALIZED (SELECT a, b FROM t1 JOIN t87733b ON true)
+SELECT NULL
+FROM t1
+LEFT JOIN LATERAL (
+  WITH t3 AS (SELECT * FROM t2 WHERE t2.a = t1.a)
+  SELECT array_agg(CASE WHEN v = '' THEN b END)
+  FROM (
+    SELECT '' AS v, b FROM t3 ORDER BY b DESC
+  )
+) ON true;
+----
+NULL

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -39,7 +39,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -974,7 +976,29 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (execPlan, error) {
 	//
 	// Note: we put o outside of the function so we allocate it only once.
 	var o xform.Optimizer
-	planRightSideFn := func(ef exec.Factory, leftRow tree.Datums) (exec.Plan, error) {
+	planRightSideFn := func(ctx context.Context, ef exec.Factory, leftRow tree.Datums) (_ exec.Plan, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				// This code allows us to propagate internal errors without having to add
+				// error checks everywhere throughout the code. This is only possible
+				// because the code does not update shared state and does not manipulate
+				// locks.
+				//
+				// This is the same panic-catching logic that exists in
+				// o.Optimize() below. It's required here because it's possible
+				// for factory functions to panic below, like
+				// CopyAndReplaceDefault.
+				if ok, e := errorutil.ShouldCatch(r); ok {
+					err = e
+					log.VEventf(ctx, 1, "%v", err)
+				} else {
+					// Other panic objects can't be considered "safe" and thus are
+					// propagated as crashes that terminate the session.
+					panic(r)
+				}
+			}
+		}()
+
 		o.Init(b.evalCtx, b.catalog)
 		f := o.Factory()
 

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -204,7 +204,7 @@ type RecursiveCTEIterationFn func(ef Factory, bufferRef Node) (Plan, error)
 // ApplyJoinPlanRightSideFn creates a plan for an iteration of ApplyJoin, given
 // a row produced from the left side. The plan is guaranteed to produce the
 // rightColumns passed to ConstructApplyJoin (in order).
-type ApplyJoinPlanRightSideFn func(ef Factory, leftRow tree.Datums) (Plan, error)
+type ApplyJoinPlanRightSideFn func(ctx context.Context, ef Factory, leftRow tree.Datums) (Plan, error)
 
 // Cascade describes a cascading query. The query uses a node created by
 // ConstructBuffer as an input; it should only be triggered if this buffer is

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -447,6 +447,12 @@ func (m *Memo) NextWithID() opt.WithID {
 	return m.curWithID
 }
 
+// MaxWithID returns the current maximum assigned identifier for a WITH
+// expression.
+func (m *Memo) MaxWithID() opt.WithID {
+	return m.curWithID
+}
+
 // Detach is used when we detach a memo that is to be reused later (either for
 // execbuilding or with AssignPlaceholders). New expressions should no longer be
 // constructed in this memo.


### PR DESCRIPTION
Backport 2/2 commits from #88396.

/cc @cockroachdb/release

---

#### opt: prevent apply-join panics from crashing nodes

Previously, it was possible for the execution of an apply-join to crash
a node due to an uncaught optimizer panic when calling the
`planRightSideFn` closure. This closure is invoked for every input row
to the apply-join. It replaces variables in the expression on the right
side of the join with constants using `Factory.CopyAndReplace`, which
can panic. This panic won't be caught by the panic-catching logic in
`Optimizer.Optimize` because the closure is invoked outside the context
of `Optimizer.Optimize` - it's occurring during execution instead.

This commit copies the panic-catching logic of `Optimizer.Optimize` to
the apply-join's `planRightSideFn` closure to ensure that any panics are
caught.

Release Note (bug fix): A bug has been fixed that could cause nodes to
crash in rare cases when executing apply-joins in query plans.

#### opt: fix transitive references to With exprs in RHS of apply-join

This commit fixes an error that could occur when the RHS of an
apply-join referenced a With expression transitive through another With
expression. The error occurred because the optimizer could not access
the relational properties of the transitively referenced With expression
because the With was not added to the metadata. The commit fixes the
issue by adding all With expressions to the metadata if any With
expressions are referenced.

Fixes #87733

Release note (bug fix): A bug has been fixed that caused errors in rare
cases when executing queries with correlated WITH expressions. This bug
was present since correlated WITH expressions were introduced in
v21.2.0.

----

Release justification: This fixes a rare bug that can crash nodes.

