### PR TITLE
sql/opt: fix negative annotation caching for RegionConfig

### DIFF
--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -61,6 +61,7 @@ go_test(
     embed = [":opt"],
     deps = [
         "//pkg/settings/cluster",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",
@@ -70,6 +71,7 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util",
+        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -667,6 +667,7 @@ func (tv *View) CollectTypes(ord int) (descpb.IDs, error) {
 // Table implements the cat.Table interface for testing purposes.
 type Table struct {
 	TabID      cat.StableID
+	DatabaseID descpb.ID
 	TabVersion int
 	TabName    tree.TableName
 	Columns    []cat.Column
@@ -869,7 +870,7 @@ func (tt *Table) HomeRegionColName() (colName string, ok bool) {
 
 // GetDatabaseID is part of the cat.Table interface.
 func (tt *Table) GetDatabaseID() descpb.ID {
-	return 0
+	return tt.DatabaseID
 }
 
 // FindOrdinal returns the ordinal of the column with the given name.


### PR DESCRIPTION
Fixes #88511

Release note (performance improvement): Fixed minor bug where negative caching of region configuration information could result in extra work when use a database that is not configured for multi-region.