### PR TITLE
scripts/bench: update benchstat install instructions

### DIFF
--- a/scripts/bench
+++ b/scripts/bench
@@ -3,9 +3,9 @@ set -euo pipefail
 
 if ! which benchstat > /dev/null; then
   cat 1>&2 <<EOF
-Requires github.com/cockroachdb/benchstat
+Requires golang.org/x/perf/cmd/benchstat
 Run:
-  go get github.com/cockroachdb/benchstat
+  go install golang.org/x/perf/cmd/benchstat@latest
 EOF
   exit 1
 fi


### PR DESCRIPTION
As far as I can tell, we're not relying on the JSON output in github.com/cockroachdb/benchstat so change the instructions here to install the original benchstat instead of the fork.

Release note: None