### PR TITLE
contention: prevent nil type assertion in event store

### DIFF
--- a/pkg/sql/contention/event_store.go
+++ b/pkg/sql/contention/event_store.go
@@ -276,22 +276,26 @@ func (s *eventStore) ForEachEvent(
 			// getting the event. In this case we simply ignore it.
 			continue
 		}
-		if err := op(&event); err != nil {
+		if err := op(event); err != nil {
 			return err
 		}
 	}
-
 	return nil
 }
 
 func (s *eventStore) getEventByEventHash(
 	hash uint64,
-) (_ contentionpb.ExtendedContentionEvent, ok bool) {
+) (_ *contentionpb.ExtendedContentionEvent, ok bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-
-	event, ok := s.mu.store.Get(hash)
-	return event.(contentionpb.ExtendedContentionEvent), ok
+	var contentionEvent contentionpb.ExtendedContentionEvent
+	var event interface{}
+	if event, ok = s.mu.store.Get(hash); ok {
+		if contentionEvent, ok = event.(contentionpb.ExtendedContentionEvent); ok {
+			return &contentionEvent, ok
+		}
+	}
+	return nil, ok
 }
 
 // flushAndResolve is the main method called by the resolver goroutine each


### PR DESCRIPTION
This commit prevents a nil type assertion from causing the system to panic.

Fixes #88091.

Release note: None