### PR TITLE
release-22.1: opt: fix error due to estimated row count must be non-zero

### DIFF
--- a/pkg/sql/opt/constraint/span_test.go
+++ b/pkg/sql/opt/constraint/span_test.go
@@ -864,6 +864,27 @@ func TestSpan_KeyCount(t *testing.T) {
 			span:     ParseSpan(&evalCtx, "(/US_WEST - /US_WEST/fix]"),
 			expected: "FAIL",
 		},
+		{ // 23
+			// Fails since the key count overflows.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/0 - /9223372036854775807]"),
+			expected: "FAIL",
+		},
+		{ // 24
+			// Succeeds since the key count is int64 max.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/1 - /9223372036854775807]"),
+			expected: "9223372036854775807",
+		},
+		{ // 25
+			// Fails since the key count overflows.
+			keyCtx:   kcAscAsc,
+			length:   1,
+			span:     ParseSpan(&evalCtx, "[/-9223372036854775808 - /9223372036854775807]"),
+			expected: "FAIL",
+		},
 	}
 
 	for i, tc := range testCases {

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3232,3 +3232,37 @@ select
  │                     <--- 0 ------- 100000000000
  └── filters
       └── x:1 = 10 [type=bool, outer=(1), constraints=(/1: [/10 - /10]; tight), fd=()-->(1)]
+
+# Regression test for #85499. Avoid overflow when calculating distinct count.
+exec-ddl
+CREATE TABLE t85499 (c0 INT);
+----
+
+norm
+SELECT t85499.rowid FROM t85499
+WHERE (t85499.rowid) BETWEEN (0) AND (
+  CASE  WHEN NULL THEN t85499.rowid
+  ELSE IF(NULL, 1, 9223372036854775807) END
+)
+UNION SELECT t85499.rowid FROM t85499;
+----
+union
+ ├── columns: rowid:9(int!null)
+ ├── left columns: t85499.rowid:2(int)
+ ├── right columns: t85499.rowid:6(int)
+ ├── stats: [rows=1111.111, distinct(9)=1111.11, null(9)=0, avgsize(9)=4]
+ ├── key: (9)
+ ├── select
+ │    ├── columns: t85499.rowid:2(int!null)
+ │    ├── stats: [rows=111.1111, distinct(2)=111.111, null(2)=0, avgsize(2)=4]
+ │    ├── key: (2)
+ │    ├── scan t85499
+ │    │    ├── columns: t85499.rowid:2(int!null)
+ │    │    ├── stats: [rows=1000, distinct(2)=1000, null(2)=0, avgsize(2)=4]
+ │    │    └── key: (2)
+ │    └── filters
+ │         └── (t85499.rowid:2 >= 0) AND (t85499.rowid:2 <= 9223372036854775807) [type=bool, outer=(2), constraints=(/2: [/0 - /9223372036854775807]; tight)]
+ └── scan t85499
+      ├── columns: t85499.rowid:6(int!null)
+      ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, avgsize(6)=4]
+      └── key: (6)

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5686,12 +5686,12 @@ func MaxDistinctCount(evalCtx *EvalContext, first, last Datum) (_ int64, ok bool
 		return 0, false
 	}
 
-	delta := end - start
-	if delta < 0 {
+	delta := (end - start) + 1
+	if delta <= 0 {
 		// Overflow or underflow.
 		return 0, false
 	}
-	return delta + 1, true
+	return delta, true
 }
 
 // ParseDatumPath parses a span key string like "/1/2/3".


### PR DESCRIPTION
Backport 1/1 commits from #88494.

/cc @cockroachdb/release

---

This commit fixes an error in the statistics code that was caused by integer overflow when calculating the distinct count.

Fixes #85499

Release note (bug fix): Fixed a rare internal error that could occur during planning when a predicate included values close to the maximum or minimum int64 value. The error, "estimated row count must be non-zero", has now been fixed.

----

Release justification: low risk bug fix for internal error