### PR TITLE
sql: reduce job times for randomized syntax change tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -778,6 +779,8 @@ func testRandomSyntax(
 	s, rawDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 	db := &verifyFormatDB{db: rawDB}
+	err := db.exec(t, ctx, "SET CLUSTER SETTING schemachanger.job.max_retry_backoff='1s'")
+	require.NoError(t, err)
 
 	yBytes, err := os.ReadFile(testutils.TestDataPath(t, "rsg", "sql.y"))
 	if err != nil {


### PR DESCRIPTION
Fixes: #86366
Fixes #87569

Previously, the exponential back off time for randomized syntax change tests was 20 seconds, which was inappropriate for some randomized tests, since transaction retry errors could lead to schema changes taking a really long time. This could cause the test to fail with timeout errors, since we would incorrectly think that connections were hung. To address this, this patch
makes the exponential back off configurable for the purpose of testing.

Release note: None
Release justification: low risk change to improve test stability