### PR TITLE
release-22.2: roachtest: use highmem instances for some tests

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -44,6 +44,7 @@ type ClusterSpec struct {
 	NodeCount    int
 	// CPUs is the number of CPUs per node.
 	CPUs                 int
+	HighMem              bool
 	SSDs                 int
 	RAID0                bool
 	VolumeSize           int
@@ -82,6 +83,9 @@ func ClustersCompatible(s1, s2 ClusterSpec) bool {
 // String implements fmt.Stringer.
 func (s ClusterSpec) String() string {
 	str := fmt.Sprintf("n%dcpu%d", s.NodeCount, s.CPUs)
+	if s.HighMem {
+		str += "m"
+	}
 	if s.Geo {
 		str += "-Geo"
 	}
@@ -191,11 +195,11 @@ func (s *ClusterSpec) RoachprodOpts(
 			// based on the cloud and CPU count.
 			switch s.Cloud {
 			case AWS:
-				machineType = AWSMachineType(s.CPUs)
+				machineType = AWSMachineType(s.CPUs, s.HighMem)
 			case GCE:
-				machineType = GCEMachineType(s.CPUs)
+				machineType = GCEMachineType(s.CPUs, s.HighMem)
 			case Azure:
-				machineType = AzureMachineType(s.CPUs)
+				machineType = AzureMachineType(s.CPUs, s.HighMem)
 			}
 		}
 

--- a/pkg/cmd/roachtest/spec/machine_type.go
+++ b/pkg/cmd/roachtest/spec/machine_type.go
@@ -37,11 +37,11 @@ func AWSMachineType(cpus int) string {
 
 // GCEMachineType selects a machine type given the desired number of CPUs.
 func GCEMachineType(cpus int) string {
-	// TODO(peter): This is awkward: below 16 cpus, use n1-standard so that the
-	// machines have a decent amount of RAM. We could use customer machine
+	// TODO(peter): This is awkward: at or below 16 cpus, use n1-standard so that
+	// the machines have a decent amount of RAM. We could use custom machine
 	// configurations, but the rules for the amount of RAM per CPU need to be
 	// determined (you can't request any arbitrary amount of RAM).
-	if cpus < 16 {
+	if cpus <= 16 {
 		return fmt.Sprintf("n1-standard-%d", cpus)
 	}
 	return fmt.Sprintf("n1-highcpu-%d", cpus)

--- a/pkg/cmd/roachtest/spec/option.go
+++ b/pkg/cmd/roachtest/spec/option.go
@@ -28,6 +28,17 @@ func CPU(n int) Option {
 	return nodeCPUOption(n)
 }
 
+type nodeHighMemOption bool
+
+func (o nodeHighMemOption) apply(spec *ClusterSpec) {
+	spec.HighMem = bool(o)
+}
+
+// HighMem requests nodes with additional memory per CPU.
+func HighMem(enabled bool) Option {
+	return nodeHighMemOption(enabled)
+}
+
 type volumeSizeOption int
 
 func (o volumeSizeOption) apply(spec *ClusterSpec) {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -407,6 +407,8 @@ func registerRestore(r registry.Registry) {
 			clusterOpts = append(clusterOpts, spec.VolumeSize(largeVolumeSize))
 			testName += fmt.Sprintf("/pd-volume=%dGB", largeVolumeSize)
 		}
+		// Has been seen to OOM: https://github.com/cockroachdb/cockroach/issues/71805
+		clusterOpts = append(clusterOpts, spec.HighMem(true))
 
 		r.Add(registry.TestSpec{
 			Name:              testName,

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -751,6 +751,7 @@ func registerTPCC(r registry.Registry) {
 	registerTPCCBenchSpec(r, tpccBenchSpec{
 		Nodes:        9,
 		CPUs:         4,
+		HighMem:      true, // can OOM otherwise: https://github.com/cockroachdb/cockroach/issues/73376
 		Distribution: multiRegion,
 		LoadConfig:   multiLoadgen,
 
@@ -835,6 +836,7 @@ type tpccBenchSpec struct {
 	Owner                    registry.Owner // defaults to Test-Eng
 	Nodes                    int
 	CPUs                     int
+	HighMem                  bool
 	Chaos                    bool
 	AdmissionControlDisabled bool
 	Distribution             tpccBenchDistribution
@@ -901,7 +903,7 @@ func registerTPCCBenchSpec(r registry.Registry, b tpccBenchSpec) {
 		nameParts = append(nameParts, "no-admission")
 	}
 
-	opts := []spec.Option{spec.CPU(b.CPUs)}
+	opts := []spec.Option{spec.CPU(b.CPUs), spec.HighMem(b.HighMem)}
 	switch b.Distribution {
 	case singleZone:
 		// No specifier.


### PR DESCRIPTION
Backport:
  * 1/1 commits from "roachtest: use n1-standard for 16-core GCE machines" (#88346)
  * 2/2 commits from "roachtest: use highmem instances for some tests " (#88444)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: deflakes tests.