### PR TITLE
testserver: add ShareMostTestingKnobsWithTenant option

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -157,6 +157,12 @@ type TestServerArgs struct {
 	// or if some of the functionality being tested is not accessible from
 	// within tenants.
 	DisableDefaultTestTenant bool
+
+	// ShareMostTestingKnobsWithTenant should be set by tests that want their
+	// testing knobs shared with the any DefaultTestTenant that the server starts.
+	// See (*testserver).TestingKnobsForTenant for details on which knobs aren't
+	// shared.
+	ShareMostTestingKnobsWithTenant bool
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test


### PR DESCRIPTION
The new ShareMostTestingKnobs copies nearly all of the testing knobs specified for a TestServer to any tenant started for that server.

The goal here is to make it easier to write tests that depend on testing hooks that work under probabilistic tenant testing.

Release justification: non-production code change

Release note: None