### PR TITLE
sql: fix panic due to missing schema

### DIFF
--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -1145,7 +1145,9 @@ func makeAllRelationsVirtualTableWithDescriptorIDIndex(
 					h := makeOidHasher()
 					scResolver := oneAtATimeSchemaResolver{p: p, ctx: ctx}
 					sc, err := p.Descriptors().GetImmutableSchemaByID(
-						ctx, p.txn, table.GetParentSchemaID(), tree.SchemaLookupFlags{})
+						ctx, p.txn, table.GetParentSchemaID(), tree.SchemaLookupFlags{
+							Required: true,
+						})
 					if err != nil {
 						return false, err
 					}


### PR DESCRIPTION
A schema might not exist because it has been dropped. We need to mark the lookup as required.

Fixes #87895

Release note (bug fix): Fixed a bug in pg_catalog tables which could result in an internal error if a schema is concurrently dropped.