### PR TITLE
sql: don't log on descriptor lookup when tracing enabled

### DIFF
--- a/pkg/sql/catalog/internal/catkv/catalog_reader.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_reader.go
@@ -195,7 +195,7 @@ func (cr catalogReader) GetDescriptorEntries(
 		return nstree.Catalog{}, nil
 	}
 	if log.ExpensiveLogEnabled(ctx, 2) {
-		log.Infof(ctx, "looking up descriptors by id: %v", ids)
+		log.VEventf(ctx, 2, "looking up descriptors by id: %v", ids)
 	}
 	var needsQuery bool
 	for _, id := range ids {


### PR DESCRIPTION
Fixes #88564.

Likely fallout from 6c45224.