### PR TITLE
release-21.2: colbuilder: avoid some allocations

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -199,7 +199,7 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 	case spec.Core.Aggregator != nil:
 		for _, agg := range spec.Core.Aggregator.Aggregations {
 			if agg.FilterColIdx != nil {
-				return errors.Newf("filtering aggregation not supported")
+				return errFilteringAggregation
 			}
 		}
 		return nil
@@ -212,13 +212,13 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 
 	case spec.Core.HashJoiner != nil:
 		if !spec.Core.HashJoiner.OnExpr.Empty() && spec.Core.HashJoiner.Type != descpb.InnerJoin {
-			return errors.Newf("can't plan vectorized non-inner hash joins with ON expressions")
+			return errNonInnerHashJoinWithOnExpr
 		}
 		return nil
 
 	case spec.Core.MergeJoiner != nil:
 		if !spec.Core.MergeJoiner.OnExpr.Empty() && spec.Core.MergeJoiner.Type != descpb.InnerJoin {
-			return errors.Errorf("can't plan non-inner merge join with ON expressions")
+			return errNonInnerMergeJoinWithOnExpr
 		}
 		return nil
 
@@ -228,11 +228,11 @@ func supportedNatively(spec *execinfrapb.ProcessorSpec) error {
 	case spec.Core.Windower != nil:
 		for _, wf := range spec.Core.Windower.WindowFns {
 			if wf.FilterColIdx != tree.NoColumnIdx {
-				return errors.Newf("window functions with FILTER clause are not supported")
+				return errWindowFunctionFilterClause
 			}
 			if wf.Func.AggregateFunc != nil {
 				if !colexecagg.IsAggOptimized(*wf.Func.AggregateFunc) {
-					return errors.Newf("default aggregate window functions not supported")
+					return errDefaultAggregateWindowFunction
 				}
 			}
 		}
@@ -266,6 +266,11 @@ var (
 	errWrappedCast                    = errors.New("mismatched types in NewColOperator and unsupported casts")
 	errLookupJoinUnsupported          = errors.New("lookup join reader is unsupported in vectorized")
 	errInterleavedIndexJoin           = errors.New("vectorized join reader is unsupported for interleaved indexes")
+	errFilteringAggregation           = errors.New("filtering aggregation not supported")
+	errNonInnerHashJoinWithOnExpr     = errors.New("can't plan vectorized non-inner hash joins with ON expressions")
+	errNonInnerMergeJoinWithOnExpr    = errors.New("can't plan vectorized non-inner merge joins with ON expressions")
+	errWindowFunctionFilterClause     = errors.New("window functions with FILTER clause are not supported")
+	errDefaultAggregateWindowFunction = errors.New("default aggregate window functions not supported")
 )
 
 func canWrap(mode sessiondatapb.VectorizeExecMode, spec *execinfrapb.ProcessorSpec) error {
@@ -1689,6 +1694,8 @@ var renderWrappingRenderCountThreshold = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
+var errFallbackToRenderWrapping = errors.New("falling back to wrapping a row-by-row processor due to many renders and low estimated row count")
+
 // planPostProcessSpec plans the post processing stage specified in post on top
 // of r.Op.
 func (r *postProcessResult) planPostProcessSpec(
@@ -1727,10 +1734,7 @@ func (r *postProcessResult) planPostProcessSpec(
 			for _, expr := range exprs {
 				tree.WalkExpr(&v, expr)
 				if v.renderCount >= renderCountThreshold {
-					return errors.Newf(
-						"falling back to wrapping a row-by-row processor for at least "+
-							"%d renders, estimated row count = %d", v.renderCount, estimatedRowCount,
-					)
+					return errFallbackToRenderWrapping
 				}
 			}
 		}
@@ -2372,6 +2376,8 @@ func planProjectionOperators(
 	}
 }
 
+var errMixedTypeUnsupported = errors.New("dates and timestamp(tz) not supported in mixed-type expressions in the vectorized engine")
+
 func checkSupportedProjectionExpr(left, right tree.TypedExpr) error {
 	leftTyp := left.ResolvedType()
 	rightTyp := right.ResolvedType()
@@ -2384,19 +2390,20 @@ func checkSupportedProjectionExpr(left, right tree.TypedExpr) error {
 	for _, t := range []*types.T{leftTyp, rightTyp} {
 		switch t.Family() {
 		case types.DateFamily, types.TimestampFamily, types.TimestampTZFamily:
-			return errors.New("dates and timestamp(tz) not supported in mixed-type expressions in the vectorized engine")
+			return errMixedTypeUnsupported
 		}
 	}
 	return nil
 }
+
+var errBinaryExprWithDatums = errors.New("datum-backed arguments on both sides and not datum-backed output of a binary expression is currently not supported")
 
 func checkSupportedBinaryExpr(left, right tree.TypedExpr, outputType *types.T) error {
 	leftDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(left.ResolvedType().Family()) == typeconv.DatumVecCanonicalTypeFamily
 	rightDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(right.ResolvedType().Family()) == typeconv.DatumVecCanonicalTypeFamily
 	outputDatumBacked := typeconv.TypeFamilyToCanonicalTypeFamily(outputType.Family()) == typeconv.DatumVecCanonicalTypeFamily
 	if (leftDatumBacked && rightDatumBacked) && !outputDatumBacked {
-		return errors.New("datum-backed arguments on both sides and not datum-backed " +
-			"output of a binary expression is currently not supported")
+		return errBinaryExprWithDatums
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #88530.

/cc @cockroachdb/release

---

This commit removes some of the allocations for errors that are returned when we need to fallback to wrapping row-by-row processors.

```
name                                     old time/op    new time/op    delta
RenderPlanning/rows=1/renders=1-24          386µs ± 2%     391µs ± 2%    ~     (p=0.143 n=10+10)
RenderPlanning/rows=1/renders=16-24         624µs ± 1%     604µs ± 1%  -3.24%  (p=0.000 n=10+10)
RenderPlanning/rows=1/renders=256-24       3.10ms ± 1%    3.06ms ± 1%  -1.22%  (p=0.000 n=10+10)
RenderPlanning/rows=1/renders=4096-24      61.1ms ± 1%    60.8ms ± 1%  -0.60%  (p=0.011 n=9+9)
RenderPlanning/rows=8/renders=1-24          437µs ± 1%     435µs ± 2%    ~     (p=0.549 n=10+9)
RenderPlanning/rows=8/renders=16-24         927µs ± 1%     903µs ± 1%  -2.59%  (p=0.000 n=10+10)
RenderPlanning/rows=8/renders=256-24       7.14ms ± 1%    7.11ms ± 1%  -0.48%  (p=0.043 n=9+10)
RenderPlanning/rows=8/renders=4096-24       127ms ± 2%     127ms ± 2%    ~     (p=0.436 n=10+10)
RenderPlanning/rows=64/renders=1-24         641µs ± 2%     636µs ± 1%    ~     (p=0.165 n=10+10)
RenderPlanning/rows=64/renders=16-24       3.01ms ± 1%    3.02ms ± 1%    ~     (p=0.143 n=10+10)
RenderPlanning/rows=64/renders=256-24      39.1ms ± 1%    39.1ms ± 1%    ~     (p=0.796 n=10+10)
RenderPlanning/rows=64/renders=4096-24      667ms ± 2%     667ms ± 2%    ~     (p=0.912 n=10+10)
RenderPlanning/rows=512/renders=1-24       1.94ms ± 2%    1.97ms ± 1%  +1.70%  (p=0.002 n=10+9)
RenderPlanning/rows=512/renders=16-24      19.7ms ± 1%    19.7ms ± 1%    ~     (p=0.631 n=10+10)
RenderPlanning/rows=512/renders=256-24      319ms ± 1%     318ms ± 1%    ~     (p=0.393 n=10+10)
RenderPlanning/rows=512/renders=4096-24     5.46s ± 1%     5.43s ± 1%  -0.58%  (p=0.035 n=10+9)
```

Informs: #88525.

Release note: None

Release justification: fix to a minor perf regression.