### PR TITLE
kv: use RaftAppliedIndexTerm to generate SnapshotMetadata, don't scan log

### DIFF
--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -963,9 +963,7 @@ func (r *Replica) applySnapshot(
 		log.Fatalf(ctx, "snapshot RaftAppliedIndex %d doesn't match its metadata index %d",
 			state.RaftAppliedIndex, nonemptySnap.Metadata.Index)
 	}
-	// If we've migrated to populating RaftAppliedIndexTerm, check that the term
-	// from the two sources are equal.
-	if state.RaftAppliedIndexTerm != 0 && state.RaftAppliedIndexTerm != nonemptySnap.Metadata.Term {
+	if state.RaftAppliedIndexTerm != nonemptySnap.Metadata.Term {
 		log.Fatalf(ctx, "snapshot RaftAppliedIndexTerm %d doesn't match its metadata term %d",
 			state.RaftAppliedIndexTerm, nonemptySnap.Metadata.Term)
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -414,15 +414,10 @@ func (r *Replica) GetLeaseAppliedIndex() uint64 {
 // Snapshot method.
 func (r *replicaRaftStorage) Snapshot() (raftpb.Snapshot, error) {
 	r.mu.AssertHeld()
-	appliedIndex := r.mu.state.RaftAppliedIndex
-	term, err := r.Term(appliedIndex)
-	if err != nil {
-		return raftpb.Snapshot{}, err
-	}
 	return raftpb.Snapshot{
 		Metadata: raftpb.SnapshotMetadata{
-			Index: appliedIndex,
-			Term:  term,
+			Index: r.mu.state.RaftAppliedIndex,
+			Term:  r.mu.state.RaftAppliedIndexTerm,
 		},
 	}, nil
 }
@@ -605,17 +600,6 @@ func snapshot(
 		return OutgoingSnapshot{}, err
 	}
 
-	term, err := term(ctx, rsl, snap, rangeID, eCache, state.RaftAppliedIndex)
-	// If we've migrated to populating RaftAppliedIndexTerm, check that the term
-	// from the two sources are equal.
-	if state.RaftAppliedIndexTerm != 0 && term != state.RaftAppliedIndexTerm {
-		return OutgoingSnapshot{},
-			errors.AssertionFailedf("unequal terms %d != %d", term, state.RaftAppliedIndexTerm)
-	}
-	if err != nil {
-		return OutgoingSnapshot{}, errors.Wrapf(err, "failed to fetch term of %d", state.RaftAppliedIndex)
-	}
-
 	return OutgoingSnapshot{
 		RaftEntryCache: eCache,
 		WithSideloaded: withSideloaded,
@@ -626,7 +610,7 @@ func snapshot(
 			Data: snapUUID.GetBytes(),
 			Metadata: raftpb.SnapshotMetadata{
 				Index: state.RaftAppliedIndex,
-				Term:  term,
+				Term:  state.RaftAppliedIndexTerm,
 				// Synthesize our raftpb.ConfState from desc.
 				ConfState: desc.Replicas().ConfState(),
 			},


### PR DESCRIPTION
This commit replaces the call to `Term(raftAppliedIndex)` with direct use of the new `RaftAppliedIndexTerm` field (added in c3bc064) when generating a `SnapshotMetadata` in service of the `raft.Storage.Snapshot` interface. As of v22.2, this field has been fully migrated in.

First and foremost, this is a code simplification. However, it also helps with projects like #87050, where async Raft log writes make it possible for a Raft leader to apply an entry before it has been appended to the leader's own log. Such flexibility[^1] would help smooth out tail latency in any single replica's local log writes, even if that replica is the leader itself. This is an important characteristic of quorum systems that we fail to provide because of the tight coupling between the Raft leader's own log writes and the Raft leader's acknowledgment of committed proposals.

Release justification: None. Don't backport to release-22.2.

Release note: None.

[^1]: if safe, I haven't convinced myself that it is in all cases. It certainly is not for operations like non-loosely coupled log truncation.