### PR TITLE
changefeedccl: use FmtExport in CSV feeds

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6359,28 +6359,28 @@ func TestChangefeedOnlyInitialScanCSV(t *testing.T) {
 		`initial scan only with csv`: {
 			changefeedStmt: `CREATE CHANGEFEED FOR foo WITH initial_scan_only, format = csv`,
 			expectedPayload: []string{
-				`1,'Alice'`,
-				`2,'Bob'`,
-				`3,'Carol'`,
+				`1,Alice`,
+				`2,Bob`,
+				`3,Carol`,
 			},
 		},
 		`initial backfill only with csv`: {
 			changefeedStmt: `CREATE CHANGEFEED FOR foo WITH initial_scan = 'only', format = csv`,
 			expectedPayload: []string{
-				`1,'Alice'`,
-				`2,'Bob'`,
-				`3,'Carol'`,
+				`1,Alice`,
+				`2,Bob`,
+				`3,Carol`,
 			},
 		},
 		`initial backfill only with csv multiple tables`: {
 			changefeedStmt: `CREATE CHANGEFEED FOR foo, bar WITH initial_scan = 'only', format = csv`,
 			expectedPayload: []string{
-				`1,'a'`,
-				`2,'b'`,
-				`3,'c'`,
-				`1,'Alice'`,
-				`2,'Bob'`,
-				`3,'Carol'`,
+				`1,a`,
+				`2,b`,
+				`3,c`,
+				`1,Alice`,
+				`2,Bob`,
+				`3,Carol`,
 			},
 		},
 	}
@@ -6458,9 +6458,9 @@ func TestChangefeedOnlyInitialScanCSVSinkless(t *testing.T) {
 				sqlDB.Exec(t, "INSERT INTO foo VALUES (4, 'Doug'), (5, 'Elaine'), (6, 'Fred')")
 
 				expectedMessages := []string{
-					`1,'Alice'`,
-					`2,'Bob'`,
-					`3,'Carol'`,
+					`1,Alice`,
+					`2,Bob`,
+					`3,Carol`,
 				}
 				var actualMessages []string
 

--- a/pkg/ccl/changefeedccl/encoder_csv.go
+++ b/pkg/ccl/changefeedccl/encoder_csv.go
@@ -32,7 +32,7 @@ func newCSVEncoder(opts changefeedbase.EncodingOptions) *csvEncoder {
 	newBuf := bytes.NewBuffer([]byte{})
 	newEncoder := &csvEncoder{
 		buf:       newBuf,
-		formatter: tree.NewFmtCtx(tree.FmtSimple),
+		formatter: tree.NewFmtCtx(tree.FmtExport),
 		writer:    csv.NewWriter(newBuf),
 	}
 	newEncoder.writer.SkipNewline = true


### PR DESCRIPTION
The tree.FmtExport formatting flag was specifically created for CSV exports that can be read by import. However we weren't using it in changefeeds, just the default format. This turns out to have noticeable impact on performance when emitting data containing non-ASCII characters, as these are escaped by default.

With tree.FmtExport set, we now see zero amortized allocs when writing arbitrary strings to CSV.

Before: BenchmarkCSVEncodeWideColumns-16         	    3134	    381179 ns/op	    9932 B/op	    2304 allocs/op
After: BenchmarkCSVEncodeWideColumns-16         	   37358	     31964 ns/op	      57 B/op	       0 allocs/op

Percentage improvement: 92% faster, 100% fewer allocs

Release note (enterprise change): Changefeeds with format=csv now use the same format as other CSV exports.