### PR TITLE
sql: use tree.Name for storing portal, stmt name

### DIFF
--- a/pkg/clusterversion/key_string.go
+++ b/pkg/clusterversion/key_string.go
@@ -45,11 +45,12 @@ func _() {
 	_ = x[UpdateInvalidColumnIDsInSequenceBackReferences-33]
 	_ = x[TTLDistSQL-34]
 	_ = x[PrioritizeSnapshots-35]
+	_ = x[EnableLeaseUpgrade-36]
 }
 
-const _Key_name = "invalidVersionKeyV22_1Start22_2LocalTimestampsPebbleFormatSplitUserKeysMarkedCompactedEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTableAlterSystemStatementStatisticsAddIndexRecommendationsRoleIDSequenceAddSystemUserIDColumnSystemUsersIDColumnIsBackfilledSetSystemUsersUserIDColumnNotNullSQLSchemaTelemetryScheduledJobsSchemaChangeSupportsCreateFunctionDeleteRequestReturnKeyPebbleFormatPrePebblev1MarkedRoleOptionsTableHasIDColumnRoleOptionsIDColumnIsBackfilledSetRoleOptionsUserIDColumnNotNullUseDelRangeInGCJobWaitedForDelRangeInGCJobRangefeedUseOneStreamPerNodeNoNonMVCCAddSSTableGCHintInReplicaStateUpdateInvalidColumnIDsInSequenceBackReferencesTTLDistSQLPrioritizeSnapshots"
+const _Key_name = "invalidVersionKeyV22_1Start22_2LocalTimestampsPebbleFormatSplitUserKeysMarkedCompactedEnsurePebbleFormatVersionRangeKeysEnablePebbleFormatVersionRangeKeysTrigramInvertedIndexesRemoveGrantPrivilegeMVCCRangeTombstonesUpgradeSequenceToBeReferencedByIDSampledStmtDiagReqsAddSSTableTombstonesSystemPrivilegesTableEnablePredicateProjectionChangefeedAlterSystemSQLInstancesAddLocalitySystemExternalConnectionsTableAlterSystemStatementStatisticsAddIndexRecommendationsRoleIDSequenceAddSystemUserIDColumnSystemUsersIDColumnIsBackfilledSetSystemUsersUserIDColumnNotNullSQLSchemaTelemetryScheduledJobsSchemaChangeSupportsCreateFunctionDeleteRequestReturnKeyPebbleFormatPrePebblev1MarkedRoleOptionsTableHasIDColumnRoleOptionsIDColumnIsBackfilledSetRoleOptionsUserIDColumnNotNullUseDelRangeInGCJobWaitedForDelRangeInGCJobRangefeedUseOneStreamPerNodeNoNonMVCCAddSSTableGCHintInReplicaStateUpdateInvalidColumnIDsInSequenceBackReferencesTTLDistSQLPrioritizeSnapshotsEnableLeaseUpgrade"
 
-var _Key_index = [...]uint16{0, 17, 22, 31, 46, 86, 120, 154, 176, 196, 215, 248, 267, 287, 308, 343, 377, 407, 460, 474, 495, 526, 559, 590, 624, 646, 675, 702, 733, 766, 784, 808, 836, 855, 875, 921, 931, 950}
+var _Key_index = [...]uint16{0, 17, 22, 31, 46, 86, 120, 154, 176, 196, 215, 248, 267, 287, 308, 343, 377, 407, 460, 474, 495, 526, 559, 590, 624, 646, 675, 702, 733, 766, 784, 808, 836, 855, 875, 921, 931, 950, 968}
 
 func (i Key) String() string {
 	i -= -1

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -160,7 +160,7 @@ var _ Command = ExecStmt{}
 
 // ExecPortal is the Command for executing a portal.
 type ExecPortal struct {
-	Name string
+	Name tree.Name
 	// limit is a feature of pgwire that we don't really support. We accept it and
 	// don't complain as long as the statement produces fewer results than this.
 	Limit int
@@ -184,7 +184,7 @@ var _ Command = ExecPortal{}
 // PrepareStmt is the command for creating a prepared statement.
 type PrepareStmt struct {
 	// Name of the prepared statement (optional).
-	Name string
+	Name tree.Name
 
 	// Information returned from parsing: AST, SQL, NumPlaceholders.
 	// Note that AST can be nil, in which case executing it should produce an
@@ -233,8 +233,8 @@ var _ Command = DescribeStmt{}
 
 // BindStmt is the Command for creating a portal from a prepared statement.
 type BindStmt struct {
-	PreparedStatementName string
-	PortalName            string
+	PreparedStatementName tree.Name
+	PortalName            tree.Name
 	// OutFormats contains the requested formats for the output columns.
 	// It either contains a bunch of format codes, in which case the number will
 	// need to match the number of output columns of the portal, or contains a single
@@ -273,7 +273,7 @@ var _ Command = BindStmt{}
 
 // DeletePreparedStmt is the Command for freeing a prepared statement.
 type DeletePreparedStmt struct {
-	Name string
+	Name tree.Name
 	Type pgwirebase.PrepareType
 }
 
@@ -620,7 +620,7 @@ type ClientComm interface {
 		conv sessiondatapb.DataConversionConfig,
 		location *time.Location,
 		limit int,
-		portalName string,
+		portalName tree.Name,
 		implicitTxn bool,
 	) CommandResult
 	// CreatePrepareResult creates a result for a PrepareStmt command.

--- a/pkg/sql/deallocate.go
+++ b/pkg/sql/deallocate.go
@@ -24,7 +24,7 @@ func (p *planner) Deallocate(ctx context.Context, s *tree.Deallocate) (planNode,
 	if s.Name == "" {
 		p.preparedStatements.DeleteAll(ctx)
 	} else {
-		if found := p.preparedStatements.Delete(ctx, string(s.Name)); !found {
+		if found := p.preparedStatements.Delete(ctx, s.Name); !found {
 			return nil, pgerror.Newf(pgcode.InvalidSQLStatementName,
 				"prepared statement %q does not exist", s.Name)
 		}

--- a/pkg/sql/execute.go
+++ b/pkg/sql/execute.go
@@ -26,7 +26,7 @@ import (
 // the referenced prepared statement and correctly updated placeholder info.
 // See https://www.postgresql.org/docs/current/static/sql-execute.html for details.
 func (p *planner) fillInPlaceholders(
-	ctx context.Context, ps *PreparedStatement, name string, params tree.Exprs,
+	ctx context.Context, ps *PreparedStatement, name tree.Name, params tree.Exprs,
 ) (*tree.PlaceholderInfo, error) {
 	if len(ps.Types) != len(params) {
 		return nil, pgerror.Newf(pgcode.Syntax,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -574,6 +574,6 @@ func (ps *DummyPreparedStatementState) MigratablePreparedStatements() []sessiond
 }
 
 // HasPortal is part of the tree.PreparedStatementState interface.
-func (ps *DummyPreparedStatementState) HasPortal(_ string) bool {
+func (ps *DummyPreparedStatementState) HasPortal(_ tree.Name) bool {
 	return false
 }

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1137,7 +1137,7 @@ func (icc *internalClientComm) CreateStatementResult(
 	_ sessiondatapb.DataConversionConfig,
 	_ *time.Location,
 	_ int,
-	_ string,
+	_ tree.Name,
 	_ bool,
 ) CommandResult {
 	return icc.createRes(pos, nil /* onClose */)

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4730,13 +4730,13 @@ statement ok
 PREPARE test_insert_statement (integer, timestamptz) AS INSERT INTO types VALUES ($2, $1)
 
 statement ok
-PREPARE test_select_statement AS SELECT * FROM types
+PREPARE "test select statement" AS SELECT * FROM types
 
 query TTTB
 select name, statement, parameter_types, from_sql from pg_prepared_statements ORDER BY 1, 2
 ----
+test select statement  PREPARE "test select statement" AS SELECT * FROM types                                 {}                                     true
 test_insert_statement  PREPARE test_insert_statement (int, timestamptz) AS INSERT INTO types VALUES ($2, $1)  {bigint,"'timestamp with time zone'"}  true
-test_select_statement  PREPARE test_select_statement AS SELECT * FROM types                                   {}                                     true
 
 subtest pg_catalog.pg_prepare_statement,with_possible_mismatch_num_types
 

--- a/pkg/sql/logictest/testdata/logic_test/prepare
+++ b/pkg/sql/logictest/testdata/logic_test/prepare
@@ -1482,3 +1482,28 @@ query ITT
 EXECUTE args_deduce_type_1(1,10,100);
 ----
 1  10  100
+
+# Test to check prepare statement with special characters works as expected
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (x int, y int);
+
+statement ok
+INSERT INTO t VALUES(10, 20);
+INSERT INTO t VALUES(30, 40);
+
+statement error pq: at or near "data": syntax error
+PREPARE read data(int) AS SELECT * FROM t WHERE t.x = $1;
+
+statement ok
+PREPARE "read data"(int) AS SELECT * FROM t WHERE t.x = $1;
+
+query error pq: at or near "data": syntax error
+EXECUTE read data(10)
+
+query II
+EXECUTE "read data"(10);
+----
+10 20

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -2271,8 +2271,8 @@ https://www.postgresql.org/docs/9.6/view-pg-prepared-statements.html`,
 				return err
 			}
 			if err := addRow(
-				tree.NewDString(name),
-				tree.NewDString(fmt.Sprintf("PREPARE %s%s AS %s", name, argumentsStr, stmt.SQL)),
+				tree.NewDString(string(name)),
+				tree.NewDString(fmt.Sprintf("PREPARE %s%s AS %s", name.String(), argumentsStr, stmt.SQL)),
 				ts,
 				paramTypes,
 				fromSQL,

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -352,7 +352,7 @@ func (c *conn) newCommandResult(
 	conv sessiondatapb.DataConversionConfig,
 	location *time.Location,
 	limit int,
-	portalName string,
+	portalName tree.Name,
 	implicitTxn bool,
 ) sql.CommandResult {
 	r := c.allocCommandResult()
@@ -410,7 +410,7 @@ func (c *conn) newMiscResult(pos sql.CmdPos, typ completionMsgType) *commandResu
 // per statement instead of once per portal.
 type limitedCommandResult struct {
 	*commandResult
-	portalName  string
+	portalName  tree.Name
 	implicitTxn bool
 
 	seenTuples int
@@ -537,8 +537,8 @@ func (r *limitedCommandResult) isCommit() (bool, error) {
 		}
 	}
 
-	commitStmtName := ""
-	commitPortalName := ""
+	commitStmtName := tree.Name("")
+	commitPortalName := tree.Name("")
 	// Case 2a: Check if cmd is a prepared COMMIT statement.
 	if prepareStmt, ok := cmd.(sql.PrepareStmt); ok {
 		if _, isCommit := prepareStmt.AST.(*tree.CommitTransaction); isCommit {

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -992,7 +992,7 @@ func (c *conn) handleParse(
 	return c.stmtBuf.Push(
 		ctx,
 		sql.PrepareStmt{
-			Name:         name,
+			Name:         tree.Name(name),
 			Statement:    stmt,
 			TypeHints:    sqlTypeHints,
 			RawTypeHints: inTypeHints,
@@ -1036,7 +1036,7 @@ func (c *conn) handleClose(ctx context.Context, buf *pgwirebase.ReadBuffer) erro
 	return c.stmtBuf.Push(
 		ctx,
 		sql.DeletePreparedStmt{
-			Name: name,
+			Name: tree.Name(name),
 			Type: typ,
 		})
 }
@@ -1163,8 +1163,8 @@ func (c *conn) handleBind(ctx context.Context, buf *pgwirebase.ReadBuffer) error
 	return c.stmtBuf.Push(
 		ctx,
 		sql.BindStmt{
-			PreparedStatementName: statementName,
-			PortalName:            portalName,
+			PreparedStatementName: tree.Name(statementName),
+			PortalName:            tree.Name(portalName),
 			Args:                  qargs,
 			ArgFormatCodes:        qArgFormatCodes,
 			OutFormats:            columnFormatCodes,
@@ -1186,7 +1186,7 @@ func (c *conn) handleExecute(
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
 	}
 	return c.stmtBuf.Push(ctx, sql.ExecPortal{
-		Name:           portalName,
+		Name:           tree.Name(portalName),
 		TimeReceived:   timeReceived,
 		Limit:          int(limit),
 		FollowedBySync: followedBySync,
@@ -1692,7 +1692,7 @@ func (c *conn) CreateStatementResult(
 	conv sessiondatapb.DataConversionConfig,
 	location *time.Location,
 	limit int,
-	portalName string,
+	portalName tree.Name,
 	implicitTxn bool,
 ) sql.CommandResult {
 	return c.newCommandResult(descOpt, pos, stmt, formatCodes, conv, location, limit, portalName, implicitTxn)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -88,15 +88,14 @@ func (p *planner) prepareUsingOptimizer(ctx context.Context) (planFlags, error) 
 		// This statement is going to execute a prepared statement. To prepare it,
 		// we need to set the expected output columns to the output columns of the
 		// prepared statement that the user is trying to execute.
-		name := string(t.Name)
-		prepared, ok := p.preparedStatements.Get(name)
+		prepared, ok := p.preparedStatements.Get(t.Name)
 		if !ok {
 			// We're trying to prepare an EXECUTE of a statement that doesn't exist.
 			// Let's just give up at this point.
 			// Postgres doesn't fail here, instead it produces an EXECUTE that returns
 			// no columns. This seems like dubious behavior at best.
 			return opc.flags, pgerror.Newf(pgcode.UndefinedPreparedStatement,
-				"no such prepared statement %s", name)
+				"no such prepared statement %s", t.Name)
 		}
 		stmt.Prepared.Columns = prepared.Columns
 		return opc.flags, nil

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -857,7 +857,7 @@ type statementPreparer interface {
 	// hints, and returns it.
 	addPreparedStmt(
 		ctx context.Context,
-		name string,
+		name tree.Name,
 		stmt Statement,
 		placeholderHints tree.PlaceholderTypes,
 		rawTypeHints []oid.Oid,

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -105,15 +105,15 @@ func (p *PreparedStatement) incRef(ctx context.Context) {
 type preparedStatementsAccessor interface {
 	// List returns all prepared statements as a map keyed by name.
 	// The map itself is a copy of the prepared statements.
-	List() map[string]*PreparedStatement
+	List() map[tree.Name]*PreparedStatement
 	// Get returns the prepared statement with the given name. The returned bool
 	// is false if a statement with the given name doesn't exist.
-	Get(name string) (*PreparedStatement, bool)
+	Get(name tree.Name) (*PreparedStatement, bool)
 	// Delete removes the PreparedStatement with the provided name from the
 	// collection. If a portal exists for that statement, it is also removed.
 	// The method returns true if statement with that name was found and removed,
 	// false otherwise.
-	Delete(ctx context.Context, name string) bool
+	Delete(ctx context.Context, name tree.Name) bool
 	// DeleteAll removes all prepared statements and portals from the collection.
 	DeleteAll(ctx context.Context)
 }
@@ -138,7 +138,7 @@ type PreparedPortal struct {
 // accountForCopy() doesn't need to be called on the prepared statement.
 func (ex *connExecutor) makePreparedPortal(
 	ctx context.Context,
-	name string,
+	name tree.Name,
 	stmt *PreparedStatement,
 	qargs tree.QueryArguments,
 	outFormats []pgwirebase.FormatCode,
@@ -148,7 +148,7 @@ func (ex *connExecutor) makePreparedPortal(
 		Qargs:      qargs,
 		OutFormats: outFormats,
 	}
-	return portal, portal.accountForCopy(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, name)
+	return portal, portal.accountForCopy(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc, string(name))
 }
 
 // accountForCopy updates the state to account for the copy of the

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -426,7 +426,7 @@ type PreparedStatementState interface {
 	// MigratablePreparedStatements returns a mapping of all prepared statements.
 	MigratablePreparedStatements() []sessiondatapb.MigratableSession_PreparedStatement
 	// HasPortal returns true if there exists a given named portal in the session.
-	HasPortal(s string) bool
+	HasPortal(s tree.Name) bool
 }
 
 // ClientNoticeSender is a limited interface to send notices to the

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -189,7 +189,7 @@ func (p *planner) DeserializeSessionState(state *tree.DBytes) (*tree.DBool, erro
 
 		_, err = evalCtx.statementPreparer.addPreparedStmt(
 			evalCtx.Ctx(),
-			prepStmt.Name,
+			tree.Name(prepStmt.Name),
 			stmt,
 			placeholderTypes,
 			prepStmt.PlaceholderTypeHints,

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -53,7 +53,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists", s.Name)
 			}
 
-			if p.extendedEvalCtx.PreparedStatementState.HasPortal(string(s.Name)) {
+			if p.extendedEvalCtx.PreparedStatementState.HasPortal(s.Name) {
 				return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor %q already exists as portal", s.Name)
 			}
 


### PR DESCRIPTION
This PR updates the sql code to store portal and prepared statement names 
using the tree.Name datatype instead of a raw string. This allows the names
to be escaped correctly when the names contain special identifiers.

Additionally, it also aligns the display format of the names within the
pg_prepared_statements table to be in line with postgresql.
For example, if "read data" was the name of a prepared statement,
it would be displayed with the double quotes when the
pg_prepared_statements table was queried unlike postgresql
which does not display the name enclosed within double quotes.
With this change, the name is no longer enclosed within double quotes
while querying from the pg_catalog table.

This is a follow up to the PR: https://github.com/cockroachdb/cockroach/pull/85859

Release note (bug fix): Prepared statement names with special characters
are displayed within the pg_prepared_statements without double quotes
providing parity with postgresql output.