### PR TITLE
release-22.1: sql: cluster setting for persisting gateway node ID

### DIFF
--- a/docs/generated/settings/settings-for-tenants.txt
+++ b/docs/generated/settings/settings-for-tenants.txt
@@ -150,6 +150,7 @@ sql.metrics.max_mem_stmt_fingerprints	integer	100000	the maximum number of state
 sql.metrics.max_mem_txn_fingerprints	integer	100000	the maximum number of transaction fingerprints stored in memory
 sql.metrics.statement_details.dump_to_logs	boolean	false	dump collected statement statistics to node logs when periodically cleared
 sql.metrics.statement_details.enabled	boolean	true	collect per-statement query statistics
+sql.metrics.statement_details.gateway_node.enabled	boolean	true	save the gateway node for each statement fingerprint. If false, the value will be stored as 0.
 sql.metrics.statement_details.plan_collection.enabled	boolean	false	periodically save a logical plan for each fingerprint
 sql.metrics.statement_details.plan_collection.period	duration	5m0s	the time until a new logical plan is collected
 sql.metrics.statement_details.threshold	duration	0s	minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.

--- a/docs/generated/settings/settings.html
+++ b/docs/generated/settings/settings.html
@@ -166,6 +166,7 @@
 <tr><td><code>sql.metrics.max_mem_txn_fingerprints</code></td><td>integer</td><td><code>100000</code></td><td>the maximum number of transaction fingerprints stored in memory</td></tr>
 <tr><td><code>sql.metrics.statement_details.dump_to_logs</code></td><td>boolean</td><td><code>false</code></td><td>dump collected statement statistics to node logs when periodically cleared</td></tr>
 <tr><td><code>sql.metrics.statement_details.enabled</code></td><td>boolean</td><td><code>true</code></td><td>collect per-statement query statistics</td></tr>
+<tr><td><code>sql.metrics.statement_details.gateway_node.enabled</code></td><td>boolean</td><td><code>true</code></td><td>save the gateway node for each statement fingerprint. If false, the value will be stored as 0.</td></tr>
 <tr><td><code>sql.metrics.statement_details.plan_collection.enabled</code></td><td>boolean</td><td><code>false</code></td><td>periodically save a logical plan for each fingerprint</td></tr>
 <tr><td><code>sql.metrics.statement_details.plan_collection.period</code></td><td>duration</td><td><code>5m0s</code></td><td>the time until a new logical plan is collected</td></tr>
 <tr><td><code>sql.metrics.statement_details.threshold</code></td><td>duration</td><td><code>0s</code></td><td>minimum execution time to cause statement statistics to be collected. If configured, no transaction stats are collected.</td></tr>

--- a/pkg/sql/sqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/cluster_settings.go
@@ -133,12 +133,12 @@ var MaxMemReportedSQLStatsTxnFingerprints = settings.RegisterIntSetting(
 // This results in 4 statement fingerprints and 1 txn fingerprint.
 // Let's suppose currently our statement fingerprint limit is 6.
 // If we are to execute the same statement again:
-// * BEGIN; <- this increments current statement fingerprint count to 5
-//             since we hold statement stats for explicit transaction in a
-//             temporary container before we can perform the upsert.
-// * SELECT 1; <- this increments the count to 6
-// * SELECT 1, 1; <- ERR: this causes the count to exceed our stmt fingerprint
-//                        limit before we can perform the upsert.
+//   - BEGIN; <- this increments current statement fingerprint count to 5
+//     since we hold statement stats for explicit transaction in a
+//     temporary container before we can perform the upsert.
+//   - SELECT 1; <- this increments the count to 6
+//   - SELECT 1, 1; <- ERR: this causes the count to exceed our stmt fingerprint
+//     limit before we can perform the upsert.
 //
 // The total amount of memory consumed will still be constrained by the
 // top-level memory monitor created for SQL Stats.
@@ -158,4 +158,14 @@ var MaxSQLStatReset = settings.RegisterDurationSetting(
 		"if not collected by telemetry reporter. It has a max value of 24H.",
 	time.Hour*2,
 	settings.NonNegativeDurationWithMaximum(time.Hour*24),
+).WithPublic()
+
+// GatewayNodeEnabled specifies whether we save the gateway node id for each fingerprint
+// during sql stats collection, otherwise the value will be set to 0.
+var GatewayNodeEnabled = settings.RegisterBoolSetting(
+	settings.TenantWritable,
+	"sql.metrics.statement_details.gateway_node.enabled",
+	"save the gateway node for each statement fingerprint. If false, the value will "+
+		"be stored as 0.",
+	true,
 ).WithPublic()

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -162,6 +162,20 @@ func (s *PersistedSQLStats) GetNextFlushAt() time.Time {
 	return s.atomic.nextFlushAt.Load().(time.Time)
 }
 
+// GetSQLInstanceID returns the SQLInstanceID.
+func (s *PersistedSQLStats) GetSQLInstanceID() base.SQLInstanceID {
+	return s.cfg.SQLIDContainer.SQLInstanceID()
+}
+
+// GetEnabledSQLInstanceID returns the SQLInstanceID when gateway node is enabled,
+// and zero otherwise.
+func (s *PersistedSQLStats) GetEnabledSQLInstanceID() base.SQLInstanceID {
+	if sqlstats.GatewayNodeEnabled.Get(&s.cfg.Settings.SV) {
+		return s.cfg.SQLIDContainer.SQLInstanceID()
+	}
+	return 0
+}
+
 // nextFlushInterval calculates the wait interval that is between:
 // [(1 - SQLStatsFlushJitter) * SQLStatsFlushInterval),
 //  (1 + SQLStatsFlushJitter) * SQLStatsFlushInterval)]


### PR DESCRIPTION
Backport 1/1 commits from #88583.

/cc @cockroachdb/release

---

When persisting statement statistics, one of the columns is the gateway node id, but because it needs to be a unique value, users who have a large amount of data are creating a lot of rows on the system.statement_statistics table.
To help decrease the amount of rows, the new cluster setting `sql.metrics.statement_details.gateway_node.enabled` define if the value on that column should be the gateway node ID or 0. We still display the node ID on the statistics column.

Fixes #88484

Release note (sql change): New cluster setting
`sql.metrics.statement_details.gateway_node.enabled` that controls if the gateway node ID should be persisted to the `system.statement_statistics` table as is or as a 0, to decrease cardinality on the table. The node id is still available on the statistics column.

---
Release justification: low risk, high benefit change
