### PR TITLE
tree: improve error message for empty array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/srfs
+++ b/pkg/sql/logictest/testdata/logic_test/srfs
@@ -449,10 +449,10 @@ SELECT information_schema._pg_expandarray()
 query error pq: unknown signature: information_schema._pg_expandarray()
 SELECT * FROM information_schema._pg_expandarray()
 
-query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
 SELECT information_schema._pg_expandarray(ARRAY[])
 
-query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+query error pq: information_schema\._pg_expandarray\(\): cannot determine type of empty array\. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
 SELECT * FROM information_schema._pg_expandarray(ARRAY[])
 
 statement error could not determine polymorphic type
@@ -581,7 +581,7 @@ SELECT ('a').x
 query error pq: type string is not composite
 SELECT (('a')).x
 
-query error pq: unnest\(\): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY\[\]:::int\[\]
+query error pq: unnest\(\): cannot determine type of empty array. Consider casting to the desired type, for example ARRAY\[\]::int\[\]
 SELECT (unnest(ARRAY[])).*
 
 query error type int is not composite

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -317,7 +317,7 @@ error (42804): cannot subscript type tuple{char AS k, char AS v} because it is n
 build
 SELECT ARRAY[]
 ----
-error (42P18): cannot determine type of empty array. Consider annotating with the desired type, for example ARRAY[]:::int[]
+error (42P18): cannot determine type of empty array. Consider casting to the desired type, for example ARRAY[]::int[]
 
 build
 SELECT FOO.k FROM kv AS foo WHERE foo.k = 'a'

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1611,7 +1611,7 @@ func (expr *Tuple) TypeCheck(
 }
 
 var errAmbiguousArrayType = pgerror.Newf(pgcode.IndeterminateDatatype, "cannot determine type of empty array. "+
-	"Consider annotating with the desired type, for example ARRAY[]:::int[]")
+	"Consider casting to the desired type, for example ARRAY[]::int[]")
 
 // TypeCheck implements the Expr interface.
 func (expr *Array) TypeCheck(


### PR DESCRIPTION
The old message was here since ceb1af949e from 6 years ago. At that point, the type system was less mature, and we didn't advertise casting as much. However, that should be recommended here.

Release note: None