### PR TITLE
schemachanger/rel: fix race due to failure to clone constraint slots

### DIFF
--- a/pkg/sql/schemachanger/rel/BUILD.bazel
+++ b/pkg/sql/schemachanger/rel/BUILD.bazel
@@ -62,7 +62,10 @@ go_test(
         "//pkg/sql/schemachanger/rel/internal/cyclegraphtest",
         "//pkg/sql/schemachanger/rel/internal/entitynodetest",
         "//pkg/sql/schemachanger/rel/reltest",
+        "//pkg/util/leaktest",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/sql/schemachanger/rel/query_build.go
+++ b/pkg/sql/schemachanger/rel/query_build.go
@@ -303,7 +303,7 @@ func (p *queryBuilder) processValueExpr(rawValue expr) slotIdx {
 		if err != nil {
 			panic(err)
 		}
-		return p.fillSlot(slot{not: tv}, false /* isEntity */)
+		return p.fillSlot(slot{not: &tv}, false /* isEntity */)
 	case containsExpr:
 		return p.processValueExpr(v.v)
 	default:

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "rename_column_test.go",
         "repair_test.go",
         "rsg_test.go",
+        "schema_changes_in_parallel_test.go",
         "split_test.go",
         "system_table_test.go",
         "table_split_test.go",

--- a/pkg/sql/tests/schema_changes_in_parallel_test.go
+++ b/pkg/sql/tests/schema_changes_in_parallel_test.go
@@ -1,0 +1,77 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestSchemaChangesInParallel exists to try to shake out races in the
+// declarative schema changer infrastructure. At its time of writing, it
+// effectively reproduced a race in the rules engine's object pooling.
+func TestSchemaChangesInParallel(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			GCJob: &sql.GCJobTestingKnobs{
+				SkipWaitingForMVCCGC: true,
+			},
+			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
+		},
+	})
+	defer s.Stopper().Stop(ctx)
+
+	const N = 4
+	run := func(i int) func() (retErr error) {
+		return func() (retErr error) {
+			conn, err := sqlDB.Conn(ctx)
+			if err != nil {
+				return err
+			}
+			defer func() {
+				retErr = errors.CombineErrors(retErr, conn.Close())
+			}()
+			for _, stmt := range []string{
+				fmt.Sprintf("CREATE DATABASE db%d", i),
+				fmt.Sprintf("USE db%d", i),
+				"CREATE TABLE t (i INT PRIMARY KEY, k INT)",
+				"ALTER TABLE t ADD COLUMN j INT DEFAULT 42",
+				"ALTER TABLE t DROP COLUMN k",
+				"CREATE SEQUENCE s",
+				"ALTER TABLE t ADD COLUMN l INT DEFAULT nextval('s')",
+				fmt.Sprintf("DROP DATABASE db%d", i),
+			} {
+				if _, err := conn.ExecContext(ctx, stmt); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
+	}
+	var g errgroup.Group
+	for i := 0; i < N; i++ {
+		g.Go(run(i))
+	}
+	require.NoError(t, g.Wait())
+}


### PR DESCRIPTION
The fundamental race here is that while the slots themselves were being copied by value, the "any" clauses which are a slice were not. The second bug here is that the "inline" values were not being properly reset. That bug could lead to problems when the query was run again in the context of a different element set. We need to reset those inline values too.

Fixes #88628

Release note: None