### PR TITLE
sql: Fix parse type length in type-prefixed bit-string literals

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -13502,6 +13502,13 @@ d_expr:
   {
     $$.val = tree.NewBytesStrVal($1)
   }
+| bit_with_length SCONST
+  {
+    d, err := tree.ParseDBitArray($2)
+    if err != nil { return setErr(sqllex, err) }
+    $$.val = &tree.CastExpr{Expr: d, Type: $1.colType(), SyntaxMode: tree.CastPrepend}
+
+  }
 | BITCONST
   {
     d, err := tree.ParseDBitArray($1)

--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -603,20 +603,20 @@ SELECT BOOL '_', '_'::BOOL -- literals removed
 SELECT BOOL 'foo', 'foo'::BOOL -- identifiers removed
 
 parse
-SELECT BIT '10', '10'::BIT
+SELECT BIT '10', '10'::BIT, BIT(2) '10'
 ----
-SELECT BIT '10', '10'::BIT
-SELECT (BIT ('10')), (('10')::BIT) -- fully parenthesized
-SELECT BIT '_', '_'::BIT -- literals removed
-SELECT BIT '10', '10'::BIT -- identifiers removed
+SELECT BIT '10', '10'::BIT, B'10'::BIT(2) -- normalized!
+SELECT (BIT ('10')), (('10')::BIT), ((B'10')::BIT(2)) -- fully parenthesized
+SELECT BIT '_', '_'::BIT, _::BIT(2) -- literals removed
+SELECT BIT '10', '10'::BIT, B'10'::BIT(2) -- identifiers removed
 
 parse
-SELECT VARBIT '1', '1'::VARBIT
+SELECT VARBIT '1', '1'::VARBIT, VARBIT(2) '01'
 ----
-SELECT VARBIT '1', '1'::VARBIT
-SELECT (VARBIT ('1')), (('1')::VARBIT) -- fully parenthesized
-SELECT VARBIT '_', '_'::VARBIT -- literals removed
-SELECT VARBIT '1', '1'::VARBIT -- identifiers removed
+SELECT VARBIT '1', '1'::VARBIT, B'01'::VARBIT(2) -- normalized!
+SELECT (VARBIT ('1')), (('1')::VARBIT), ((B'01')::VARBIT(2)) -- fully parenthesized
+SELECT VARBIT '_', '_'::VARBIT, _::VARBIT(2) -- literals removed
+SELECT VARBIT '1', '1'::VARBIT, B'01'::VARBIT(2) -- identifiers removed
 
 parse
 SELECT INT2 'foo', 'foo'::INT2


### PR DESCRIPTION
Fixes #79253

This commit fixes a bug where queries like the following could not be parsed:
    SELECT VARBIT(4) '1101';
    SELECT BIT(4) '1101';

I have added also a couple of tests testing said behavior and fix.
