### PR TITLE
ui: reduce frequent Metrics page re-rendering

### DIFF
--- a/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
+++ b/pkg/ui/workspaces/db-console/src/test-utils/renderWithProviders.tsx
@@ -1,0 +1,51 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import React from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import type { PreloadedState } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+
+import { AdminUIState } from "src/redux/state";
+import { createMemoryHistory } from "history";
+import { apiReducersReducer } from "src/redux/apiReducers";
+import { hoverReducer } from "src/redux/hover";
+import { localSettingsReducer } from "src/redux/localsettings";
+import { metricsReducer } from "src/redux/metrics";
+import { queryManagerReducer } from "src/redux/queryManager/reducer";
+import { timeScaleReducer } from "src/redux/timeScale";
+import { uiDataReducer } from "src/redux/uiData";
+import { loginReducer } from "src/redux/login";
+import { connectRouter } from "connected-react-router";
+
+export function renderWithProviders(
+  element: React.ReactElement,
+  preloadedState?: PreloadedState<AdminUIState>,
+): React.ReactElement {
+  const history = createMemoryHistory({
+    initialEntries: ["/"],
+  });
+  const routerReducer = connectRouter(history);
+  const store = configureStore<AdminUIState>({
+    reducer: {
+      cachedData: apiReducersReducer,
+      hover: hoverReducer,
+      localSettings: localSettingsReducer,
+      metrics: metricsReducer,
+      queryManager: queryManagerReducer,
+      router: routerReducer,
+      timeScale: timeScaleReducer,
+      uiData: uiDataReducer,
+      login: loginReducer,
+    },
+    preloadedState,
+  });
+  return <Provider store={store}>{element}</Provider>;
+}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/clusterOverview/index.tsx
@@ -16,7 +16,7 @@ import { connect } from "react-redux";
 import { createSelector } from "reselect";
 
 import { AdminUIState } from "src/redux/state";
-import { nodesSummarySelector, NodesSummary } from "src/redux/nodes";
+import { nodeSumsSelector } from "src/redux/nodes";
 import { Bytes as formatBytes } from "src/util/format";
 import createChartComponent from "src/views/shared/util/d3-react";
 import capacityChart from "./capacity";
@@ -81,9 +81,9 @@ function renderCapacityUsage(props: CapacityUsageProps) {
 }
 
 const mapStateToCapacityUsageProps = createSelector(
-  nodesSummarySelector,
-  function (nodesSummary: NodesSummary) {
-    const { capacityUsed, capacityUsable } = nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { capacityUsed, capacityUsable } = nodeSums;
     return {
       usedCapacity: capacityUsed,
       usableCapacity: capacityUsable,
@@ -149,9 +149,9 @@ function renderNodeLiveness(props: NodeLivenessProps) {
 }
 
 const mapStateToNodeLivenessProps = createSelector(
-  nodesSummarySelector,
-  function (nodesSummary: NodesSummary) {
-    const { nodeCounts } = nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { nodeCounts } = nodeSums;
     return {
       liveNodes: nodeCounts.healthy,
       suspectNodes: nodeCounts.suspect,
@@ -220,10 +220,9 @@ function renderReplicationStatus(props: ReplicationStatusProps) {
 }
 
 const mapStateToReplicationStatusProps = createSelector(
-  nodesSummarySelector,
-  function (nodesSummary: NodesSummary) {
-    const { totalRanges, underReplicatedRanges, unavailableRanges } =
-      nodesSummary.nodeSums;
+  nodeSumsSelector,
+  nodeSums => {
+    const { totalRanges, underReplicatedRanges, unavailableRanges } = nodeSums;
     return {
       totalRanges: totalRanges,
       underReplicatedRanges: underReplicatedRanges,

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/dashboardUtils.ts
@@ -8,17 +8,11 @@
 // by the Apache License, Version 2.0, included in the file
 // licenses/APL.txt.
 
-import { NodesSummary } from "src/redux/nodes";
-
 /**
  * GraphDashboardProps are the properties accepted by the renderable component
  * of each graph dashboard.
  */
 export interface GraphDashboardProps {
-  /**
-   * Summary of nodes data.
-   */
-  nodesSummary: NodesSummary;
   /**
    * List of node IDs which should be used in graphs which display a series per
    * node.
@@ -40,21 +34,26 @@ export interface GraphDashboardProps {
    * all nodes" or "on node X".
    */
   tooltipSelection: string;
+
+  nodeDisplayNameByID: {
+    [key: string]: string;
+  };
+
+  storeIDsByNodeID: {
+    [key: string]: string[];
+  };
 }
 
-export function nodeDisplayName(nodesSummary: NodesSummary, nid: string) {
-  const ns = nodesSummary.nodeStatusByID[nid];
-  if (!ns) {
-    // This should only happen immediately after loading a page, and
-    // associated graphs should display no data.
-    return "unknown node";
-  }
-  return nodesSummary.nodeDisplayNameByID[ns.desc.node_id];
+export function nodeDisplayName(
+  nodeDisplayNameByID: { [nodeId: string]: string },
+  nid: string,
+): string {
+  return nodeDisplayNameByID[nid] || "unknown node";
 }
 
 export function storeIDsForNode(
-  nodesSummary: NodesSummary,
+  storeIDsByNodeID: { [key: string]: string[] },
   nid: string,
 ): string[] {
-  return nodesSummary.storeIDsByNodeID[nid] || [];
+  return storeIDsByNodeID[nid] || [];
 }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/distributed.tsx
@@ -18,7 +18,7 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources } = props;
+  const { nodeIDs, nodeSources, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph title="Batches" sources={nodeSources}>
@@ -93,7 +93,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.txn.durations-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -111,7 +111,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.txn.durations-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -129,7 +129,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.liveness.heartbeatlatency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -147,7 +147,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.liveness.heartbeatlatency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -24,8 +24,14 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 // TODO(vilterp): tooltips
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } =
-    props;
+  const {
+    nodeIDs,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+    nodeSources,
+    storeSources,
+    tooltipSelection,
+  } = props;
 
   return [
     <LineGraph title="CPU Percent" sources={nodeSources}>
@@ -33,7 +39,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.cpu.combined.percent-normalized"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -49,7 +55,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.rss"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -61,7 +67,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.read.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -74,7 +80,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.write.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -87,7 +93,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.read.count"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -100,7 +106,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.write.count"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -113,7 +119,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.disk.iopsinprogress"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -129,8 +135,8 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.store.capacity.available"
-            sources={storeIDsForNode(nodesSummary, nid)}
-            title={nodeDisplayName(nodesSummary, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
           />
         ))}
       </Axis>
@@ -141,7 +147,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.net.recv.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -154,7 +160,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.host.net.send.bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -9,7 +9,6 @@
 // licenses/APL.txt.
 
 import React from "react";
-import _ from "lodash";
 
 import { LineGraph } from "src/views/cluster/components/linegraph";
 import { Metric, Axis } from "src/views/shared/components/metricQuery";
@@ -22,7 +21,13 @@ import {
 } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, storeSources } = props;
+  const {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+  } = props;
 
   return [
     <LineGraph title="CPU Percent" sources={nodeSources}>
@@ -30,7 +35,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.cpu.combined.percent-normalized"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -46,7 +51,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.runnable.goroutines.per.cpu"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -64,14 +69,16 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.storage.l0-sublevels"
-              title={"L0 Sublevels " + nodeDisplayName(nodesSummary, nid)}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={
+                "L0 Sublevels " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />
             <Metric
               key={nid}
               name="cr.store.storage.l0-num-files"
-              title={"L0 Files " + nodeDisplayName(nodesSummary, nid)}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={"L0 Files " + nodeDisplayName(nodeDisplayNameByID, nid)}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
             />
           </>
         ))}
@@ -85,13 +92,13 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.granter.total_slots.kv"
-              title={"Total Slots " + nodeDisplayName(nodesSummary, nid)}
+              title={"Total Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
             />
             <Metric
               key={nid}
               name="cr.node.admission.granter.used_slots.kv"
-              title={"Used Slots " + nodeDisplayName(nodesSummary, nid)}
+              title={"Used Slots " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
             />
           </>
@@ -108,7 +115,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.admission.granter.io_tokens_exhausted_duration.kv"
-            title={"IO Exhausted " + nodeDisplayName(nodesSummary, nid)}
+            title={"IO Exhausted " + nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             nonNegativeRate
           />
@@ -123,7 +130,9 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.admitted.kv"
-              title={"KV request rate " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "KV request rate " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
@@ -131,7 +140,8 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.kv-stores"
               title={
-                "KV write request rate " + nodeDisplayName(nodesSummary, nid)
+                "KV write request rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -140,7 +150,8 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.sql-kv-response"
               title={
-                "SQL-KV response rate " + nodeDisplayName(nodesSummary, nid)
+                "SQL-KV response rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -149,7 +160,8 @@ export default function (props: GraphDashboardProps) {
               key={nid}
               name="cr.node.admission.admitted.sql-sql-response"
               title={
-                "SQL-SQL response rate " + nodeDisplayName(nodesSummary, nid)
+                "SQL-SQL response rate " +
+                nodeDisplayName(nodeDisplayNameByID, nid)
               }
               sources={[nid]}
               nonNegativeRate
@@ -166,28 +178,32 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv"
-              title={"KV " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.kv-stores"
-              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-kv-response"
-              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-KV response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_sum.sql-sql-response"
-              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-SQL response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               nonNegativeRate
             />
@@ -203,28 +219,32 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-p75"
-              title={"KV " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.kv-stores-p75"
-              title={"KV write " + nodeDisplayName(nodesSummary, nid)}
+              title={"KV write " + nodeDisplayName(nodeDisplayNameByID, nid)}
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-kv-response-p75"
-              title={"SQL-KV response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-KV response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               downsampleMax
             />
             <Metric
               key={nid}
               name="cr.node.admission.wait_durations.sql-sql-response-p75"
-              title={"SQL-SQL response " + nodeDisplayName(nodesSummary, nid)}
+              title={
+                "SQL-SQL response " + nodeDisplayName(nodeDisplayNameByID, nid)
+              }
               sources={[nid]}
               downsampleMax
             />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overview.tsx
@@ -23,8 +23,14 @@ import { CapacityGraphTooltip } from "src/views/cluster/containers/nodeGraphs/da
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } =
-    props;
+  const {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    tooltipSelection,
+    nodeDisplayNameByID,
+    storeIDsByNodeID,
+  } = props;
 
   return [
     <LineGraph
@@ -77,7 +83,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -118,8 +124,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -31,7 +31,8 @@ import { cockroach } from "src/js/protos";
 import TimeSeriesQueryAggregator = cockroach.ts.tspb.TimeSeriesQueryAggregator;
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, storeSources } = props;
+  const { nodeIDs, storeSources, nodeDisplayNameByID, storeIDsByNodeID } =
+    props;
 
   return [
     <LineGraph title="Ranges" sources={storeSources}>
@@ -61,8 +62,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -78,8 +79,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.replicas.leaseholders"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -94,8 +95,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rebalancing.queriespersecond"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -110,8 +111,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.totalbytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -185,15 +186,15 @@ export default function (props: GraphDashboardProps) {
             <Metric
               key={nid}
               name="cr.store.range.snapshots.rebalancing.rcvd-bytes"
-              title={nodeDisplayName(nodesSummary, nid) + "-rebalancing"}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={nodeDisplayName(nodeDisplayNameByID, nid) + "-rebalancing"}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
               nonNegativeRate
             />
             <Metric
               key={nid}
               name="cr.store.range.snapshots.recovery.rcvd-bytes"
-              title={nodeDisplayName(nodesSummary, nid) + "-recovery"}
-              sources={storeIDsForNode(nodesSummary, nid)}
+              title={nodeDisplayName(nodeDisplayNameByID, nid) + "-recovery"}
+              sources={storeIDsForNode(storeIDsByNodeID, nid)}
               nonNegativeRate
             />
           </>
@@ -210,8 +211,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.range.snapshots.recv-queue"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -226,8 +227,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             downsampler={TimeSeriesQueryAggregator.SUM}
           />
         ))}
@@ -243,8 +244,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.kv.replica_circuit_breaker.num_tripped_events"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -260,8 +261,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.admission.raft.paused_replicas"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -345,9 +346,10 @@ export default function (props: GraphDashboardProps) {
             key={nid}
             name="cr.store.queue.replicate.replacedecommissioningreplica.error"
             title={
-              nodeDisplayName(nodesSummary, nid) + " - Replaced Errors / Sec"
+              nodeDisplayName(nodeDisplayNameByID, nid) +
+              " - Replaced Errors / Sec"
             }
-            sources={storeIDsForNode(nodesSummary, nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -18,7 +18,7 @@ import { AxisUnits } from "@cockroachlabs/cluster-ui";
 import { GraphDashboardProps, nodeDisplayName } from "./dashboardUtils";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph
@@ -85,7 +85,7 @@ export default function (props: GraphDashboardProps) {
         {nodeIDs.map(nid => (
           <Metric
             name="cr.node.sys.runnable.goroutines.per.cpu"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}
@@ -150,7 +150,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.node.clock-offset.meannanos"
-            title={nodeDisplayName(nodesSummary, nid)}
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/sql.tsx
@@ -22,7 +22,7 @@ import {
 } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, tooltipSelection } = props;
+  const { nodeIDs, nodeSources, tooltipSelection, nodeDisplayNameByID } = props;
 
   return [
     <LineGraph
@@ -35,7 +35,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conns"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -152,7 +152,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.full.scan.count"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -169,7 +169,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.distsql.flows.active"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
           />
         ))}
@@ -185,7 +185,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conn.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -202,7 +202,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.conn.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -228,7 +228,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -254,7 +254,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.service.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -272,7 +272,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.exec.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -290,7 +290,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.exec.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -397,7 +397,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.txn.latency-p99"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -423,7 +423,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.txn.latency-p90"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />
@@ -441,7 +441,7 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={node}
             name="cr.node.sql.mem.root.current"
-            title={nodeDisplayName(nodesSummary, node)}
+            title={nodeDisplayName(nodeDisplayNameByID, node)}
             sources={[node]}
             downsampleMax
           />

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/storage.tsx
@@ -26,8 +26,17 @@ import {
 import { AxisUnits } from "@cockroachlabs/cluster-ui";
 
 export default function (props: GraphDashboardProps) {
-  const { nodeIDs, nodesSummary, nodeSources, storeSources, tooltipSelection } =
-    props;
+  const {
+    nodeIDs,
+    nodeSources,
+    storeSources,
+    tooltipSelection,
+    storeIDsByNodeID,
+    nodeDisplayNameByID,
+  } = props;
+
+  const getNodeNameById = (id: string) =>
+    nodeDisplayName(nodeDisplayNameByID, id);
 
   return [
     <LineGraph
@@ -64,8 +73,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.logcommit.latency-p99"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -82,8 +91,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.logcommit.latency-p50"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -101,8 +110,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.commandcommit.latency-p99"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -120,8 +129,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.raft.process.commandcommit.latency-p50"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -137,8 +146,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.read-amplification"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -154,8 +163,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.num-sstables"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
           />
         ))}
       </Axis>
@@ -183,8 +192,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.flushed-bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -201,8 +210,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.compacted-bytes-written"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}
@@ -219,8 +228,8 @@ export default function (props: GraphDashboardProps) {
           <Metric
             key={nid}
             name="cr.store.rocksdb.ingested-bytes"
-            title={nodeDisplayName(nodesSummary, nid)}
-            sources={storeIDsForNode(nodesSummary, nid)}
+            title={getNodeNameById(nid)}
+            sources={storeIDsForNode(storeIDsByNodeID, nid)}
             nonNegativeRate
           />
         ))}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/index.tsx
@@ -37,9 +37,12 @@ import {
   hoverOff,
 } from "src/redux/hover";
 import {
-  nodesSummarySelector,
-  NodesSummary,
   LivenessStatus,
+  nodeDisplayNameByIDSelector,
+  livenessStatusByNodeIDSelector,
+  nodeIDsSelector,
+  nodeIDsStringifiedSelector,
+  selectStoreIDsByNodeID,
 } from "src/redux/nodes";
 import Alerts from "src/views/shared/containers/alerts";
 import { MetricsDataProvider } from "src/views/shared/containers/metricDataProvider";
@@ -112,11 +115,18 @@ const dashboardDropdownOptions = _.map(dashboards, (dashboard, key) => {
 });
 
 type MapStateToProps = {
-  nodesSummary: NodesSummary;
   hoverState: HoverState;
   resolution10sStorageTTL: moment.Duration;
   resolution30mStorageTTL: moment.Duration;
   timeScale: TimeScale;
+  nodeDropdownOptions: ReturnType<
+    typeof nodeDropdownOptionsSelector.resultFunc
+  >;
+  nodeIds: string[];
+  storeIDsByNodeID: ReturnType<typeof selectStoreIDsByNodeID.resultFunc>;
+  nodeDisplayNameByID: ReturnType<
+    typeof nodeDisplayNameByIDSelector.resultFunc
+  >;
 };
 
 type MapDispatchToProps = {
@@ -145,36 +155,6 @@ export class NodeGraphs extends React.Component<
   NodeGraphsProps,
   NodeGraphsState
 > {
-  /**
-   * Selector to compute node dropdown options from the current node summary
-   * collection.
-   */
-  private nodeDropdownOptions = createSelector(
-    (summary: NodesSummary) => summary.nodeStatuses,
-    (summary: NodesSummary) => summary.nodeDisplayNameByID,
-    (summary: NodesSummary) => summary.livenessStatusByNodeID,
-    (
-      nodeStatuses,
-      nodeDisplayNameByID,
-      livenessStatusByNodeID,
-    ): DropdownOption[] => {
-      const base = [{ value: "", label: "Cluster" }];
-      return base.concat(
-        _.chain(nodeStatuses)
-          .filter(
-            ns =>
-              livenessStatusByNodeID[ns.desc.node_id] !==
-              LivenessStatus.NODE_STATUS_DECOMMISSIONED,
-          )
-          .map(ns => ({
-            value: ns.desc.node_id.toString(),
-            label: nodeDisplayNameByID[ns.desc.node_id],
-          }))
-          .value(),
-      );
-    },
-  );
-
   constructor(props: NodeGraphsProps) {
     super(props);
     this.state = {
@@ -257,7 +237,13 @@ export class NodeGraphs extends React.Component<
   };
 
   render() {
-    const { match, nodesSummary } = this.props;
+    const {
+      match,
+      nodeDropdownOptions,
+      storeIDsByNodeID,
+      nodeDisplayNameByID,
+      nodeIds,
+    } = this.props;
     const { showLowResolutionAlert, showDeletedDataAlert } = this.state;
     const selectedDashboard = getMatchParamByName(match, dashboardNameAttr);
     const dashboard = _.has(dashboards, selectedDashboard)
@@ -271,13 +257,13 @@ export class NodeGraphs extends React.Component<
     // node in the cluster using the nodeIDs collection. However, if a specific
     // node is already selected, these per-node graphs should only display data
     // only for the selected node.
-    const nodeIDs = nodeSources ? nodeSources : nodesSummary.nodeIDs;
+    const nodeIDs = nodeSources ? nodeSources : nodeIds;
 
     // If a single node is selected, we need to restrict the set of stores
     // queried for per-store metrics (only stores that belong to that node will
     // be queried).
     const storeSources = nodeSources
-      ? storeIDsForNode(nodesSummary, nodeSources[0])
+      ? storeIDsForNode(storeIDsByNodeID, nodeSources[0])
       : null;
 
     // tooltipSelection is a string used in tooltips to reference the currently
@@ -290,10 +276,11 @@ export class NodeGraphs extends React.Component<
 
     const dashboardProps: GraphDashboardProps = {
       nodeIDs,
-      nodesSummary,
       nodeSources,
       storeSources,
       tooltipSelection,
+      nodeDisplayNameByID,
+      storeIDsByNodeID,
     };
 
     const forwardParams = {
@@ -338,7 +325,7 @@ export class NodeGraphs extends React.Component<
           <PageConfigItem>
             <Dropdown
               title="Graph"
-              options={this.nodeDropdownOptions(this.props.nodesSummary)}
+              options={nodeDropdownOptions}
               selected={selectedNode}
               onChange={this.nodeChange}
             />
@@ -409,10 +396,7 @@ export class NodeGraphs extends React.Component<
             <div className="chart-group l-columns__left">{graphComponents}</div>
             <div className="l-columns__right">
               <Alerts />
-              <ClusterSummaryBar
-                nodesSummary={this.props.nodesSummary}
-                nodeSources={nodeSources}
-              />
+              <ClusterSummaryBar nodeSources={nodeSources} />
             </div>
           </div>
         </section>
@@ -421,12 +405,41 @@ export class NodeGraphs extends React.Component<
   }
 }
 
+/**
+ * Selector to compute node dropdown options from the current node summary
+ * collection.
+ */
+const nodeDropdownOptionsSelector = createSelector(
+  nodeIDsSelector,
+  nodeDisplayNameByIDSelector,
+  livenessStatusByNodeIDSelector,
+  (nodeIds, nodeDisplayNameByID, livenessStatusByNodeID): DropdownOption[] => {
+    const base = [{ value: "", label: "Cluster" }];
+    return base.concat(
+      _.chain(nodeIds)
+        .filter(
+          id =>
+            livenessStatusByNodeID[id] !==
+            LivenessStatus.NODE_STATUS_DECOMMISSIONED,
+        )
+        .map(id => ({
+          value: id.toString(),
+          label: nodeDisplayNameByID[id],
+        }))
+        .value(),
+    );
+  },
+);
+
 const mapStateToProps = (state: AdminUIState): MapStateToProps => ({
-  nodesSummary: nodesSummarySelector(state),
   hoverState: hoverStateSelector(state),
   resolution10sStorageTTL: selectResolution10sStorageTTL(state),
   resolution30mStorageTTL: selectResolution30mStorageTTL(state),
   timeScale: selectTimeScale(state),
+  nodeIds: nodeIDsStringifiedSelector(state),
+  storeIDsByNodeID: selectStoreIDsByNodeID(state),
+  nodeDropdownOptions: nodeDropdownOptionsSelector(state),
+  nodeDisplayNameByID: nodeDisplayNameByIDSelector(state),
 });
 
 const mapDispatchToProps: MapDispatchToProps = {

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/debug/index.tsx
@@ -25,7 +25,7 @@ import {
 import "./debug.styl";
 import { connect } from "react-redux";
 import { AdminUIState } from "src/redux/state";
-import { nodeIDsSelector } from "src/redux/nodes";
+import { nodeIDsStringifiedSelector } from "src/redux/nodes";
 import { refreshNodes, refreshUserSQLRoles } from "src/redux/apiReducers";
 import { selectHasViewActivityRedactedRole } from "src/redux/user";
 
@@ -142,7 +142,7 @@ function NodeIDSelector(props: {
 const NodeIDSelectorConnected = connect(
   (state: AdminUIState) => {
     return {
-      nodeIDs: nodeIDsSelector(state),
+      nodeIDs: nodeIDsStringifiedSelector(state),
     };
   },
   {


### PR DESCRIPTION
Before, many components on Metrics page relied on
`nodesSummarySelector` selector that in turn relies on `NodeStatus` that change constantly with every request (and we request it periodically every 10 seconds). `NodeStatus` include lots of unnecessary data for Metrics page (ie. node's and stores last metrics that aren't used on charts) but these changes forces react components to be re-rendered.

This patch refactors selectors that are used by metrics page in a way to provide only relevant subset of NodeStatus's info
to Graph components and reduce propagation of `props` passing from parent to child components. Instead, use selectors 
in child components if necessary.

Release note: None

Resolves #65030


Video that shows how often components were re-rendered **before** this fix - regardless of timewindow, it always
updates every 10 seconds:

https://user-images.githubusercontent.com/3106437/192295619-9b2da8bd-2fdb-4f5e-96db-688048fc54cf.mov

and here's after fix. Components re-render every 10 second for 10 minutes interval and it is not re-rendered 
for timewindows like 2 weeks or 1 month:

https://user-images.githubusercontent.com/3106437/192296089-13103781-6632-46a5-85aa-80ad8b20dd02.mov


