### PR TITLE
release-22.2: backupccl: elide expensive ShowCreate call in SHOW BACKUP

### DIFF
--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/retry",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",

--- a/pkg/sql/catalog/descs/hydrate.go
+++ b/pkg/sql/catalog/descs/hydrate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 // hydrateDescriptors installs user defined type metadata in all types.T present
@@ -151,6 +152,9 @@ func makeImmutableTypeLookupFunc(
 // HydrateCatalog installs type metadata in the type.T objects present for all
 // objects referencing them in the catalog.
 func HydrateCatalog(ctx context.Context, c nstree.MutableCatalog) error {
+	ctx, sp := tracing.ChildSpan(ctx, "descs.HydrateCatalog")
+	defer sp.Finish()
+
 	fakeLookupFunc := func(_ context.Context, id descpb.ID) (catalog.Descriptor, error) {
 		return nil, catalog.WrapDescRefErr(id, catalog.ErrDescriptorNotFound)
 	}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -989,6 +990,9 @@ type tableLookupFn = *internalLookupCtx
 func newInternalLookupCtxFromDescriptorProtos(
 	ctx context.Context, rawDescs []descpb.Descriptor,
 ) (*internalLookupCtx, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "sql.newInternalLookupCtxFromDescriptorProtos")
+	defer sp.Finish()
+
 	var c nstree.MutableCatalog
 	for i := range rawDescs {
 		desc := descbuilder.NewBuilder(&rawDescs[i]).BuildImmutable()

--- a/pkg/sql/show_create.go
+++ b/pkg/sql/show_create.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 type shouldOmitFKClausesFromCreate int
@@ -72,6 +73,9 @@ func ShowCreateTable(
 	lCtx simpleSchemaResolver,
 	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "sql.ShowCreateTable")
+	defer sp.Finish()
+
 	a := &tree.DatumAlloc{}
 
 	f := p.ExtendedEvalContext().FmtCtx(tree.FmtSimple)
@@ -221,6 +225,9 @@ func (p *planner) ShowCreate(
 	desc catalog.TableDescriptor,
 	displayOptions ShowCreateDisplayOptions,
 ) (string, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "sql.ShowCreate")
+	defer sp.Finish()
+
 	var stmt string
 	var err error
 	tn := tree.MakeUnqualifiedTableName(tree.Name(desc.GetName()))


### PR DESCRIPTION
Backport 1/1 commits from #88293.

/cc @cockroachdb/release

---

In https://github.com/cockroachdb/cockroach/issues/88376 we see the call to `ShowCreate` taking ~all the time on a cluster with
2.5K empty tables. In all cases except `SHOW BACKUP SCHEMAS` we do not
need to construct the SQL representation of the table's schema. This
results in a marked improvement in the performance of `SHOW BACKUP`
as can be seen in https://github.com/cockroachdb/cockroach/issues/88376#issuecomment-1254164321.

Fixes: https://github.com/cockroachdb/cockroach/issues/88376

Release note (performance improvement): `SHOW BACKUP` on a backup containing
several table descriptors is now more performant

Release justification: low risk performance improvement required for the use of schedules in CockroachCloud
