### PR TITLE
sql: enable `IdempotentTombstone` for schema GC

### DIFF
--- a/pkg/sql/gcjob/table_garbage_collection.go
+++ b/pkg/sql/gcjob/table_garbage_collection.go
@@ -254,6 +254,7 @@ func deleteAllSpanData(
 					EndKey: endKey.AsRawKey(),
 				},
 				UseRangeTombstone:       true,
+				IdempotentTombstone:     true,
 				UpdateRangeDeleteGCHint: true,
 			})
 			log.VEventf(ctx, 2, "delete range %s - %s", lastKey, endKey)

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -792,6 +792,7 @@ func (p *planner) ForceDeleteTableData(ctx context.Context, descID int64) error 
 		b.AddRawRequest(&roachpb.DeleteRangeRequest{
 			RequestHeader:           requestHeader,
 			UseRangeTombstone:       true,
+			IdempotentTombstone:     true,
 			UpdateRangeDeleteGCHint: true,
 		})
 	} else {


### PR DESCRIPTION
@ajwerner Looks like we forgot to enable this. Let's get it in before the backport freeze.

---

This will avoid writing MVCC range tombstones across ranges if they don't contain any live data. This is particularly useful to avoid writing additional tombstones on retries.

Release note: None