### PR TITLE
sql, sqlstats: update sql stats compaction job async

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/mon",
+        "//pkg/util/retry",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -93,6 +93,9 @@ func New(cfg *Config, memSQLStats *sslocal.SQLStats) *PersistedSQLStats {
 		scanInterval: defaultScanInterval,
 		jitterFn:     p.jitterInterval,
 	}
+	if cfg.Knobs != nil {
+		p.jobMonitor.testingKnobs.updateCheckInterval = cfg.Knobs.JobMonitorUpdateCheckInterval
+	}
 
 	return p
 }

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -181,8 +181,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 	skip.UnderStressRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
-	helper, helperCleanup := newTestHelper(t, nil /* sqlStatsKnobs */)
-	helper.sqlDB.SucceedsSoonDuration = 2 * time.Minute
+	helper, helperCleanup := newTestHelper(t, &sqlstats.TestingKnobs{JobMonitorUpdateCheckInterval: time.Second})
 	defer helperCleanup()
 
 	schedID := getSQLStatsCompactionSchedule(t, helper).ScheduleID()
@@ -218,7 +217,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 			helper.sqlDB.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = $1", expr)
 
 			var err error
-			testutils.SucceedsWithin(t, func() error {
+			testutils.SucceedsSoon(t, func() error {
 				// Reload schedule from DB.
 				sj := getSQLStatsCompactionSchedule(t, helper)
 				err = persistedsqlstats.CheckScheduleAnomaly(sj)
@@ -227,7 +226,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 				}
 				require.Equal(t, expr, sj.ScheduleExpr())
 				return nil
-			}, time.Minute*2)
+			})
 
 			require.True(t, errors.Is(
 				errors.Unwrap(err), persistedsqlstats.ErrScheduleIntervalTooLong),

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -177,9 +178,11 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 func TestSQLStatsScheduleOperations(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderStressRace(t, "test is too slow to run under race")
 
 	ctx := context.Background()
 	helper, helperCleanup := newTestHelper(t, nil /* sqlStatsKnobs */)
+	helper.sqlDB.SucceedsSoonDuration = 2 * time.Minute
 	defer helperCleanup()
 
 	schedID := getSQLStatsCompactionSchedule(t, helper).ScheduleID()
@@ -215,7 +218,7 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 			helper.sqlDB.Exec(t, "SET CLUSTER SETTING sql.stats.cleanup.recurrence = $1", expr)
 
 			var err error
-			testutils.SucceedsSoon(t, func() error {
+			testutils.SucceedsWithin(t, func() error {
 				// Reload schedule from DB.
 				sj := getSQLStatsCompactionSchedule(t, helper)
 				err = persistedsqlstats.CheckScheduleAnomaly(sj)
@@ -224,7 +227,8 @@ func TestSQLStatsScheduleOperations(t *testing.T) {
 				}
 				require.Equal(t, expr, sj.ScheduleExpr())
 				return nil
-			})
+			}, time.Minute*2)
+
 			require.True(t, errors.Is(
 				errors.Unwrap(err), persistedsqlstats.ErrScheduleIntervalTooLong),
 				"expected ErrScheduleIntervalTooLong, but found %+v", err)

--- a/pkg/sql/sqlstats/test_utils.go
+++ b/pkg/sql/sqlstats/test_utils.go
@@ -33,6 +33,11 @@ type TestingKnobs struct {
 	// AOSTClause overrides the AS OF SYSTEM TIME clause in queries used in
 	// persistedsqlstats.
 	AOSTClause string
+
+	// JobMonitorUpdateCheckInterval if non-zero indicates the frequency at
+	// which the job monitor needs to check whether the schedule needs to be
+	// updated.
+	JobMonitorUpdateCheckInterval time.Duration
 }
 
 // ModuleTestingKnobs implements base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Closes #85582

Currently, during sql stats compaction job scheduling, the schedule is
retrieved by  querying from the `system.scheduled_jobs` table. The function
handling scheduling is called synchronously during node startup to ensure the
first schedule, and can thus block node startup if the query experiences
contention.

This commit changes the scheduling setup to be called ascynchronously using a
channel notification to ensure the stats collector does not block node startup.
The callback for changing the cluster setting  `SQLStatsCleanupRecurrence` is
also modified to match this behaviour, now issuing a channel notification to
update the schedule to the new value.

Release justification: bug fix, low risk update to existing functionality

Release note: None

Backport:
  * 1/1 commits from "sql, sqlstats: schedule  sql stats compaction job async" (#86404)
  * 1/1 commits from "persistedsqlstats: speed up a test" (#88496)

Please see individual PRs for details.

/cc @cockroachdb/release
