### PR TITLE
kvnemesis: use execution timestamp from ambiguous errors

### DIFF
--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -62,6 +63,8 @@ func TestApplier(t *testing.T) {
 		// the context cancellation was noticed.
 		actual = regexp.MustCompile(` aborted .*: context canceled`).ReplaceAllString(actual, ` context canceled`)
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
+		v := roachpb.Value{}
+		v.VerifyHeader()
 	}
 
 	checkPanics := func(t *testing.T, s Step, expectedPanic string) {

--- a/pkg/kv/kvnemesis/deletion_tracker.go
+++ b/pkg/kv/kvnemesis/deletion_tracker.go
@@ -1,0 +1,72 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+//
+
+package kvnemesis
+
+import (
+	"math"
+	"time"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// DeletionTracker helps map tombstones to the operations that wrote them.
+// Before operations are sent to KV, they undergo Inject(). Inside of KV,
+// requests are intercepted using Extract() to determine the execution timestamp
+// for the deletion.
+//
+// This allows identifying tombstones in MVCC history with their creating
+// operation, in effect salvaging kvnemesis' approach of "unique writes".
+type DeletionTracker struct {
+	syncutil.Mutex
+	m map[DelSeq]hlc.Timestamp
+}
+
+// DelSeq is the type of sequence numbers used by DeletionTracker.
+type DelSeq uint32
+
+func (d *DeletionTracker) Extract(header roachpb.Header) (DelSeq, bool) {
+	n := int64(header.LockTimeout)
+	// Check whether high 32 bits match math.MaxInt64, which identifies a
+	// LockTimeout that is being slightly abused as a carrier for the sequence
+	// number.
+	if (n>>32)<<32 != (math.MaxInt64>>32)<<32 {
+		return 0, false
+	}
+	i := (n << 32) >> 32
+	seq := DelSeq(*(*uint32)(unsafe.Pointer(&i)))
+	// Take the lowest 32 bits and interpret them as a uint32.
+	if d.m == nil {
+		d.m = map[DelSeq]hlc.Timestamp{}
+	}
+	d.m[seq] = header.Timestamp
+	return seq, true
+}
+
+func (d *DeletionTracker) Inject(header *roachpb.Header, seq DelSeq) {
+	var n int64
+	// Use 32 uppermost bits off MaxInt64.
+	n += (math.MaxInt64 >> 32) << 32
+	// Interpret seq as an int32, and add it (thus
+	// making it the lower 32 bits)
+	n += int64(*(*int32)(unsafe.Pointer(&seq)))
+	header.LockTimeout = time.Duration(n)
+}
+
+func (d *DeletionTracker) Lookup(seq DelSeq) (hlc.Timestamp, bool) {
+	d.Lock()
+	defer d.Unlock()
+	ts, ok := d.m[seq]
+	return ts, ok
+}

--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -26,6 +26,7 @@ import (
 // the Applier operates in.
 type Env struct {
 	sqlDBs []*gosql.DB
+	dt     *DeletionTracker
 }
 
 func (e *Env) anyNode() *gosql.DB {

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -502,13 +502,13 @@ func randDelMissing(g *generator, rng *rand.Rand) Operation {
 	key := randKey(rng)
 	g.keys[key] = struct{}{}
 	g.nextDelSeq++
-	return delWithID(key, g.nextDelSeq)
+	return delWithSeq(key, g.nextDelSeq)
 }
 
 func randDelExisting(g *generator, rng *rand.Rand) Operation {
 	key := randMapKey(rng, g.keys)
 	g.nextDelSeq++
-	return delWithID(key, g.nextDelSeq)
+	return delWithSeq(key, g.nextDelSeq)
 }
 
 func randDelRange(g *generator, rng *rand.Rand) Operation {
@@ -732,10 +732,10 @@ func reverseScanForUpdate(key, endKey string) Operation {
 	return Operation{Scan: &ScanOperation{Key: []byte(key), EndKey: []byte(endKey), Reverse: true, ForUpdate: true}}
 }
 
-func delWithID(key string, id DelSeq) Operation {
+func delWithSeq(key string, seq DelSeq) Operation {
 	return Operation{Delete: &DeleteOperation{
 		Key: []byte(key),
-		Seq: id,
+		Seq: seq,
 	}}
 }
 

--- a/pkg/kv/kvnemesis/kvnemesis.go
+++ b/pkg/kv/kvnemesis/kvnemesis.go
@@ -94,7 +94,7 @@ func RunNemesis(
 	}
 	kvs := w.Finish()
 	defer kvs.Close()
-	failures := Validate(allSteps, kvs)
+	failures := Validate(allSteps, kvs, env.dt)
 
 	if len(failures) > 0 {
 		log.Infof(ctx, "reproduction steps:\n%s", printRepro(stepsByWorker))

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -60,6 +60,7 @@ message PutOperation {
 
 message DeleteOperation {
   bytes key = 1;
+  uint32 Seq = 3 [(gogoproto.casttype) = "DelSeq"];
   Result result = 2 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -36,8 +36,10 @@ func Delete(
 		ctx, readWriter, cArgs.Stats, args.Key, h.Timestamp, cArgs.Now, h.Txn,
 	)
 
+	knobs := cArgs.EvalCtx.EvalKnobs()
+
 	// If requested, replace point tombstones with range tombstones.
-	if cArgs.EvalCtx.EvalKnobs().UseRangeTombstonesForPointDeletes && err == nil && h.Txn == nil {
+	if knobs.UseRangeTombstonesForPointDeletes && err == nil && h.Txn == nil {
 		if err := storage.ReplacePointTombstonesWithRangeTombstones(
 			ctx, spanset.DisableReadWriterAssertions(readWriter),
 			cArgs.Stats, args.Key, args.EndKey); err != nil {


### PR DESCRIPTION
Now whenever data actually made it to KV (ambiguously or not) we know
the timestamp at which this has happened.

We can thus remove much of the special-casing around deletions. In
particular, we no longer need to consider half-materialized writes,
i.e. the case `Materialized=true && Timestamp.IsEmpty()`. In turn,
we get to remove the `Materialized` field altogether, as it now
always equals `Timestamp.IsSet()`. This then removes all special
casing around deletions. They are still keyed by key and timestamp
as opposed to by value (since they have no value) but other than
that they get treated the same.

Release note: None
