### PR TITLE
ui: fix ui on dbconsole table detail page with very long index name

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/databaseTablePage/databaseTablePage.module.scss
@@ -34,12 +34,13 @@
 
   p {
     @include text--body;
+    overflow-wrap: anywhere;
   }
 }
 
 .icon {
   &__container {
-    display: inline-flex;
+    display: inline;
     align-items: center;
   }
 
@@ -71,9 +72,11 @@
 
 .index-stats {
   &__summary-card {
-    width: fit-content;
-    padding: 0;
-    margin-left: 9px;
+    width: 75%;
+    padding-right: 9px;
+    padding-left: 9px;
+    margin-right: -9px;
+    margin-left: -9px;
   }
 
   &__header {
@@ -108,9 +111,10 @@
       &-indexes {
         font-family: $font-family--semi-bold;
         width: 30em;
+        overflow-wrap: anywhere;
       }
       &-last-used {
-        width: 30em;
+        width: 25em;
       }
     }
   }


### PR DESCRIPTION
Previously, when there was a very long index name, it would run off the edge of the summary card and cause the Index Stats table to scroll for a long time. This change wraps the index name text so the user can see the entirety of the name on the summary card and in the table. This change also fixed the width of the Index Stats table to be aligned with the other summary cards on the page.

<img width="1203" alt="cluster-ui" src="https://user-images.githubusercontent.com/54999459/192319099-71c7734d-3ed1-4ee0-b6ee-568bd46f0dba.png">

Partially Fixes #86559

Release justification: Category 2: Bug fixes and
low-risk updates to new functionality

Release note: None