### PR TITLE
release-21.2: kvserver: don't transfer leases to draining nodes during scatters

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -271,6 +271,7 @@ go_test(
         "replicate_test.go",
         "reset_quorum_test.go",
         "scanner_test.go",
+        "scatter_test.go",
         "scheduler_test.go",
         "single_key_test.go",
         "split_delay_helper_test.go",

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1493,7 +1493,7 @@ func (a *Allocator) ShouldTransferLease(
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.filter(conf.Constraints)
 	sl = sl.filter(conf.VoterConstraints)
-	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseRepl, sl)
+	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=s%d):\n%s", leaseRepl.StoreID(), sl)
 
 	transferDec, _ := a.shouldTransferLeaseUsingStats(ctx, source, existing, stats, nil, sl.candidateLeases.mean)
 	var result bool

--- a/pkg/kv/kvserver/allocator.go
+++ b/pkg/kv/kvserver/allocator.go
@@ -1237,6 +1237,118 @@ func (a *Allocator) scorerOptions() scorerOptions {
 	}
 }
 
+// ValidLeaseTargets returns a set of candidate stores that are suitable to be
+// transferred a lease for the given range.
+//
+// - It excludes stores that are dead, or marked draining or suspect.
+// - If the range has lease_preferences, and there are any non-draining,
+// non-suspect nodes that match those preferences, it excludes stores that don't
+// match those preferences.
+// - It excludes replicas that may need snapshots. If replica calling this
+// method is not the Raft leader (meaning that it doesn't know whether follower
+// replicas need a snapshot or not), produces no results.
+func (a *Allocator) ValidLeaseTargets(
+	ctx context.Context,
+	conf roachpb.SpanConfig,
+	existing []roachpb.ReplicaDescriptor,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
+	// excludeLeaseRepl dictates whether the result set can include the source
+	// replica.
+	excludeLeaseRepl bool,
+) []roachpb.ReplicaDescriptor {
+	candidates := make([]roachpb.ReplicaDescriptor, 0, len(existing))
+	for i := range existing {
+		if existing[i].GetType() != roachpb.VOTER_FULL {
+			continue
+		}
+		// If we're not allowed to include the current replica, remove it from
+		// consideration here.
+		if existing[i].StoreID == leaseRepl.StoreID() && excludeLeaseRepl {
+			continue
+		}
+		candidates = append(candidates, existing[i])
+	}
+	candidates, _ = a.storePool.liveAndDeadReplicas(
+		candidates, false, /* includeSuspectAndDrainingStores */
+	)
+
+	// Only proceed with the lease transfer if we are also the raft leader (we
+	// already know we are the leaseholder at this point), and only consider
+	// replicas that are in `StateReplicate` as potential candidates.
+	//
+	// NB: The RaftStatus() only returns a non-empty and non-nil result on the
+	// Raft leader (since Raft followers do not track the progress of other
+	// replicas, only the leader does).
+	//
+	// NB: On every Raft tick, we try to ensure that leadership is collocated with
+	// leaseholdership (see
+	// Replica.maybeTransferRaftLeadershipToLeaseholderLocked()). This means that
+	// on a range that is not already borked (i.e. can accept writes), periods of
+	// leader/leaseholder misalignment should be ephemeral and rare. We choose to
+	// be pessimistic here and choose to bail on the lease transfer, as opposed to
+	// potentially transferring the lease to a replica that may be waiting for a
+	// snapshot (which will wedge the range until the replica applies that
+	// snapshot).
+	candidates = excludeReplicasInNeedOfSnapshots(ctx, leaseRepl.RaftStatus(), candidates)
+
+	// Determine which store(s) is preferred based on user-specified preferences.
+	// If any stores match, only consider those stores as candidates.
+	preferred := a.preferredLeaseholders(conf, candidates)
+	if len(preferred) > 0 {
+		candidates = preferred
+	}
+	return candidates
+}
+
+// leaseholderShouldMoveDueToPreferences returns true if the current leaseholder
+// is in violation of lease preferences _that can otherwise be satisfied_ by
+// some existing replica.
+//
+// INVARIANT: This method should only be called with an `allExistingReplicas`
+// slice that contains `leaseRepl`.
+func (a *Allocator) leaseholderShouldMoveDueToPreferences(
+	ctx context.Context,
+	conf roachpb.SpanConfig,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
+	allExistingReplicas []roachpb.ReplicaDescriptor,
+) bool {
+	// Defensive check to ensure that this is never called with a replica set that
+	// does not contain the leaseholder.
+	var leaseholderInExisting bool
+	for _, repl := range allExistingReplicas {
+		if repl.StoreID == leaseRepl.StoreID() {
+			leaseholderInExisting = true
+			break
+		}
+	}
+	if !leaseholderInExisting {
+		log.Errorf(ctx, "programming error: expected leaseholder store to be in the slice of existing replicas")
+	}
+
+	// Exclude suspect/draining/dead stores.
+	candidates, _ := a.storePool.liveAndDeadReplicas(
+		allExistingReplicas, false, /* includeSuspectAndDrainingStores */
+	)
+	// If there are any replicas that do match lease preferences, then we check if
+	// the existing leaseholder is one of them.
+	preferred := a.preferredLeaseholders(conf, candidates)
+	if len(preferred) == 0 {
+		return false
+	}
+	for _, repl := range preferred {
+		if repl.StoreID == leaseRepl.StoreID() {
+			return false
+		}
+	}
+	return true
+}
+
 // TransferLeaseTarget returns a suitable replica to transfer the range lease
 // to from the provided list. It excludes the current lease holder replica
 // unless asked to do otherwise by the checkTransferLeaseSource parameter.
@@ -1265,11 +1377,17 @@ func (a *Allocator) TransferLeaseTarget(
 	checkCandidateFullness bool,
 	alwaysAllowDecisionWithoutStats bool,
 ) roachpb.ReplicaDescriptor {
+	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+		// Explicitly exclude the current leaseholder from the result set if it is
+		// in violation of lease preferences that can be satisfied by some other
+		// replica.
+		checkTransferLeaseSource = false
+	}
+	excludeLeaseRepl := !checkTransferLeaseSource
+
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.filter(conf.Constraints)
 	sl = sl.filter(conf.VoterConstraints)
-	// The only thing we use the storeList for is for the lease mean across the
-	// eligible stores, make that explicit here.
 	candidateLeasesMean := sl.candidateLeases.mean
 
 	source, ok := a.storePool.getStoreDescriptor(leaseRepl.StoreID())
@@ -1277,66 +1395,7 @@ func (a *Allocator) TransferLeaseTarget(
 		return roachpb.ReplicaDescriptor{}
 	}
 
-	// Determine which store(s) is preferred based on user-specified preferences.
-	// If any stores match, only consider those stores as candidates. If only one
-	// store matches, it's where the lease should be (unless the preferred store
-	// is the current one and checkTransferLeaseSource is false).
-	var preferred []roachpb.ReplicaDescriptor
-	if checkTransferLeaseSource {
-		preferred = a.preferredLeaseholders(conf, existing)
-	} else {
-		// TODO(a-robinson): Should we just always remove the source store from
-		// existing when checkTransferLeaseSource is false? I'd do it now, but
-		// it's too big a change to make right before a major release.
-		var candidates []roachpb.ReplicaDescriptor
-		for _, repl := range existing {
-			if repl.StoreID != leaseRepl.StoreID() {
-				candidates = append(candidates, repl)
-			}
-		}
-		preferred = a.preferredLeaseholders(conf, candidates)
-	}
-	if len(preferred) == 1 {
-		if preferred[0].StoreID == leaseRepl.StoreID() {
-			return roachpb.ReplicaDescriptor{}
-		}
-		// Verify that the preferred replica is eligible to receive the lease.
-		preferred, _ = a.storePool.liveAndDeadReplicas(preferred, false /* includeSuspectAndDrainingStores */)
-		if len(preferred) == 1 {
-			return preferred[0]
-		}
-		return roachpb.ReplicaDescriptor{}
-	} else if len(preferred) > 1 {
-		// If the current leaseholder is not preferred, set checkTransferLeaseSource
-		// to false to motivate the below logic to transfer the lease.
-		existing = preferred
-		if !storeHasReplica(leaseRepl.StoreID(), roachpb.MakeReplicaSet(preferred).ReplicationTargets()) {
-			checkTransferLeaseSource = false
-		}
-	}
-
-	// Only consider live, non-draining, non-suspect replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectAndDrainingStores */)
-
-	// Only proceed with the lease transfer if we are also the raft leader (we
-	// already know we are the leaseholder at this point), and only consider
-	// replicas that are in `StateReplicate` as potential candidates.
-	//
-	// NB: The RaftStatus() only returns a non-empty and non-nil result on the
-	// Raft leader (since Raft followers do not track the progress of other
-	// replicas, only the leader does).
-	//
-	// NB: On every Raft tick, we try to ensure that leadership is collocated with
-	// leaseholdership (see
-	// Replica.maybeTransferRaftLeadershipToLeaseholderLocked()). This means that
-	// on a range that is not already borked (i.e. can accept writes), periods of
-	// leader/leaseholder misalignment should be ephemeral and rare. We choose to
-	// be pessimistic here and choose to bail on the lease transfer, as opposed to
-	// potentially transferring the lease to a replica that may be waiting for a
-	// snapshot (which will wedge the range until the replica applies that
-	// snapshot).
-	existing = excludeReplicasInNeedOfSnapshots(ctx, leaseRepl.RaftStatus(), existing)
-
+	existing = a.ValidLeaseTargets(ctx, conf, existing, leaseRepl, excludeLeaseRepl)
 	// Short-circuit if there are no valid targets out there.
 	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		log.VEventf(ctx, 2, "no lease transfer target found for r%d", leaseRepl.GetRangeID())
@@ -1411,41 +1470,30 @@ func (a *Allocator) ShouldTransferLease(
 	ctx context.Context,
 	conf roachpb.SpanConfig,
 	existing []roachpb.ReplicaDescriptor,
-	leaseStoreID roachpb.StoreID,
+	leaseRepl interface {
+		RaftStatus() *raft.Status
+		StoreID() roachpb.StoreID
+	},
 	stats *replicaStats,
 ) bool {
-	source, ok := a.storePool.getStoreDescriptor(leaseStoreID)
-	if !ok {
+	if a.leaseholderShouldMoveDueToPreferences(ctx, conf, leaseRepl, existing) {
+		return true
+	}
+	existing = a.ValidLeaseTargets(ctx, conf, existing, leaseRepl, false /* excludeLeaseRepl */)
+
+	// Short-circuit if there are no valid targets out there.
+	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == leaseRepl.StoreID()) {
 		return false
 	}
-
-	// Determine which store(s) is preferred based on user-specified preferences.
-	// If any stores match, only consider those stores as options. If only one
-	// store matches, it's where the lease should be.
-	preferred := a.preferredLeaseholders(conf, existing)
-	if len(preferred) == 1 {
-		return preferred[0].StoreID != leaseStoreID
-	} else if len(preferred) > 1 {
-		existing = preferred
-		// If the current leaseholder isn't one of the preferred stores, then we
-		// should try to transfer the lease.
-		if !storeHasReplica(leaseStoreID, roachpb.MakeReplicaSet(existing).ReplicationTargets()) {
-			return true
-		}
+	source, ok := a.storePool.getStoreDescriptor(leaseRepl.StoreID())
+	if !ok {
+		return false
 	}
 
 	sl, _, _ := a.storePool.getStoreList(storeFilterSuspect)
 	sl = sl.filter(conf.Constraints)
 	sl = sl.filter(conf.VoterConstraints)
-	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseStoreID, sl)
-
-	// Only consider live, non-draining, non-suspect replicas.
-	existing, _ = a.storePool.liveAndDeadReplicas(existing, false /* includeSuspectNodes */)
-
-	// Short-circuit if there are no valid targets out there.
-	if len(existing) == 0 || (len(existing) == 1 && existing[0].StoreID == source.StoreID) {
-		return false
-	}
+	log.VEventf(ctx, 3, "ShouldTransferLease (lease-holder=%d):\n%s", leaseRepl, sl)
 
 	transferDec, _ := a.shouldTransferLeaseUsingStats(ctx, source, existing, stats, nil, sl.candidateLeases.mean)
 	var result bool
@@ -1460,7 +1508,9 @@ func (a *Allocator) ShouldTransferLease(
 		log.Fatalf(ctx, "unexpected transfer decision %d", transferDec)
 	}
 
-	log.VEventf(ctx, 3, "ShouldTransferLease decision (lease-holder=%d): %t", leaseStoreID, result)
+	log.VEventf(
+		ctx, 3, "ShouldTransferLease decision (lease-holder=s%d): %t", leaseRepl.StoreID(), result,
+	)
 	return result
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3227,14 +3227,17 @@ func (r *Replica) adminScatter(
 	// probability 1/N of choosing each.
 	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc := r.Desc()
-		// Learner replicas aren't allowed to become the leaseholder or raft leader,
-		// so only consider the `VoterDescriptors` replicas.
-		voterReplicas := desc.Replicas().VoterDescriptors()
-		newLeaseholderIdx := rand.Intn(len(voterReplicas))
-		targetStoreID := voterReplicas[newLeaseholderIdx].StoreID
-		if targetStoreID != r.store.StoreID() {
-			if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
-				log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
+		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
+			ctx, r.SpanConfig(), desc.Replicas().VoterDescriptors(), r, false, /* excludeLeaseRepl */
+		)
+		if len(potentialLeaseTargets) > 0 {
+			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
+			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID
+			if targetStoreID != r.store.StoreID() {
+				log.VEventf(ctx, 2, "randomly transferring lease to s%d", targetStoreID)
+				if err := r.AdminTransferLease(ctx, targetStoreID); err != nil {
+					log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
+				}
 			}
 		}
 	}

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -277,7 +277,7 @@ func (rq *replicateQueue) shouldQueue(
 	status := repl.LeaseStatusAt(ctx, now)
 	if status.IsValid() &&
 		rq.canTransferLeaseFrom(ctx, repl) &&
-		rq.allocator.ShouldTransferLease(ctx, conf, voterReplicas, status.Lease.Replica.StoreID, repl.leaseholderStats) {
+		rq.allocator.ShouldTransferLease(ctx, conf, voterReplicas, repl, repl.leaseholderStats) {
 
 		log.VEventf(ctx, 2, "lease transfer needed, enqueuing")
 		return true, 0

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -824,6 +824,9 @@ func (rq *replicateQueue) maybeTransferLeaseAway(
 		conf,
 		transferLeaseOptions{
 			dryRun: dryRun,
+			// NB: This option means that the allocator is asked to not consider the
+			// current replica in its set of potential candidates.
+			checkTransferLeaseSource: false,
 		},
 	)
 	return transferred == transferOK, err

--- a/pkg/kv/kvserver/scatter_test.go
+++ b/pkg/kv/kvserver/scatter_test.go
@@ -1,0 +1,91 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package kvserver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func adminScatterArgs(key roachpb.Key, randomizeLeases bool) *roachpb.AdminScatterRequest {
+	return &roachpb.AdminScatterRequest{
+		RequestHeader: roachpb.RequestHeader{
+			Key:    key,
+			EndKey: key.Next(),
+		},
+		RandomizeLeases: randomizeLeases,
+	}
+}
+
+// TestAdminScatterWithDrainingNodes tests that when `AdminScatter` is called
+// with the `RandomizeLeases` option, it does not transfer leases to draining
+// nodes.
+func TestAdminScatterWithDrainingNodes(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// We set up a scratch range on 2 nodes, and then drain the second node.
+	const drainingServerIdx = 1
+	tc := testcluster.StartTestCluster(
+		t, 2, base.TestClusterArgs{
+			ReplicationMode: base.ReplicationManual,
+		},
+	)
+	defer tc.Stopper().Stop(ctx)
+	scratchKey := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, scratchKey, tc.Target(drainingServerIdx))
+
+	client, err := tc.GetAdminClient(ctx, t, drainingServerIdx)
+	require.NoError(t, err)
+	drain(ctx, t, client)
+
+	nonDrainingStore := tc.GetFirstStoreFromServer(t, 0)
+	drainingStore := tc.GetFirstStoreFromServer(t, drainingServerIdx)
+
+	// Wait until the non-draining node is aware of the draining node.
+	testutils.SucceedsSoon(t, tc.Servers[drainingServerIdx].HeartbeatNodeLiveness)
+	testutils.SucceedsSoon(t, func() error {
+		isDraining, err := nonDrainingStore.GetStoreConfig().StorePool.IsDraining(drainingStore.StoreID())
+		if err != nil {
+			return err
+		}
+		if !isDraining {
+			return errors.Newf("expected s%d to be in draining state", drainingStore.StoreID())
+		}
+		return nil
+	})
+
+	// Now, we repeatedly call `AdminScatter` with the `RandomizeLeases` option on
+	// this scratch range, and ensure that the lease is never transferred to the
+	// draining node.
+	const numIterations = 50
+	for i := 0; i < numIterations; i++ {
+		_, pErr := kv.SendWrapped(
+			ctx, nonDrainingStore.TestSender(), adminScatterArgs(scratchKey, true /* randomizeLeases */),
+		)
+		require.Nil(t, pErr)
+		leaseHolder, err := tc.FindRangeLeaseHolder(tc.LookupRangeOrFatal(t, scratchKey), nil /* hint */)
+		require.NoError(t, err)
+		require.NotEqual(t, drainingStore.StoreID(), leaseHolder.StoreID)
+	}
+}

--- a/pkg/kv/kvserver/store_pool.go
+++ b/pkg/kv/kvserver/store_pool.go
@@ -643,6 +643,16 @@ func (sp *StorePool) IsUnknown(storeID roachpb.StoreID) (bool, error) {
 	return status == storeStatusUnknown, nil
 }
 
+// IsDraining returns true if the given store's status is `storeStatusDraining`
+// or an error if the store is not found in the pool.
+func (sp *StorePool) IsDraining(storeID roachpb.StoreID) (bool, error) {
+	status, err := sp.storeStatus(storeID)
+	if err != nil {
+		return false, err
+	}
+	return status == storeStatusDraining, nil
+}
+
 // IsLive returns true if the node is considered alive by the store pool or an error
 // if the store is not found in the pool.
 func (sp *StorePool) IsLive(storeID roachpb.StoreID) (bool, error) {


### PR DESCRIPTION
Backport:
  * 3/4 commits from "kvserver: don't transfer leases to draining nodes during scatters" (#79295)
  * 1/1 commits from "kv: fix logging of leaseholder's StoreID in ShouldTransferLease" (#79581)

Please see individual PRs for details.

Release justification: bug fix.

/cc @cockroachdb/release
