### PR TITLE
kvnemesis: allow non-transactional DeleteRange

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -270,9 +270,6 @@ func applyClientOp(ctx context.Context, db clientI, op *Operation, inTxn bool) {
 			o.Result.Keys[i] = deletedKey
 		}
 	case *DeleteRangeOperation:
-		if !inTxn {
-			panic(errors.AssertionFailedf(`non-transactional DelRange operations currently unsupported`))
-		}
 		res, ts, err := dbRunWithResultAndTimestamp(ctx, db, func(b *kv.Batch) {
 			b.DelRange(o.Key, o.EndKey, true /* returnKeys */)
 		})

--- a/pkg/kv/kvnemesis/applier_test.go
+++ b/pkg/kv/kvnemesis/applier_test.go
@@ -13,7 +13,6 @@ package kvnemesis
 import (
 	"context"
 	gosql "database/sql"
-	"fmt"
 	"regexp"
 	"strings"
 	"testing"
@@ -64,12 +63,6 @@ func TestApplier(t *testing.T) {
 		assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(actual))
 	}
 
-	checkPanics := func(t *testing.T, s Step, expectedPanic string) {
-		t.Helper()
-		_ /* trace */, err := a.Apply(ctx, &s)
-		require.EqualError(t, err, fmt.Sprintf("panic applying step %s: %v", s, expectedPanic))
-	}
-
 	// Basic operations
 	check(t, step(get(`a`)), `db0.Get(ctx, "a") // (nil, nil)`)
 	check(t, step(scan(`a`, `c`)), `db1.Scan(ctx, "a", "c", 0) // ([], nil)`)
@@ -118,8 +111,9 @@ db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 }) // context canceled
 		`)
 
-	checkPanics(t, step(delRange(`b`, `d`)), `non-transactional DelRange operations currently unsupported`)
-	checkPanics(t, step(batch(delRange(`b`, `d`))), `non-transactional batch DelRange operations currently unsupported`)
+	// TODO add proper test for this now that it works
+	// checkPanics(t, step(delRange(`b`, `d`)), `non-transactional DelRange operations currently unsupported`)
+	// checkPanics(t, step(batch(delRange(`b`, `d`))), `non-transactional batch DelRange operations currently unsupported`)
 
 	// Batch
 	check(t, step(batch(put(`b`, `2`), get(`a`), del(`b`), del(`c`), scan(`a`, `c`), reverseScanForUpdate(`a`, `e`))), `

--- a/pkg/kv/kvnemesis/generator.go
+++ b/pkg/kv/kvnemesis/generator.go
@@ -227,9 +227,8 @@ func newAllOperationsConfig() GeneratorConfig {
 // operations/make some operations more likely.
 func NewDefaultConfig() GeneratorConfig {
 	config := newAllOperationsConfig()
-	// TODO(sarkesian): Enable non-transactional DelRange once #69642 is fixed.
-	config.Ops.DB.DeleteRange = 0
-	config.Ops.Batch.Ops.DeleteRange = 0
+	config.Ops.DB.DeleteRange = 1
+	config.Ops.Batch.Ops.DeleteRange = 1
 	// TODO(sarkesian): Enable DeleteRange in comingled batches once #71236 is fixed.
 	config.Ops.ClosureTxn.CommitBatchOps.DeleteRange = 0
 	config.Ops.ClosureTxn.TxnBatchOps.Ops.DeleteRange = 0


### PR DESCRIPTION
This is possible now, thanks to #88722.

Closes #69642.

Release note: None
