### PR TITLE
cli: deprecate `debug unsafe-remove-dead-replicas`

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1104,8 +1104,10 @@ func runDebugSyncBench(cmd *cobra.Command, args []string) error {
 
 var debugUnsafeRemoveDeadReplicasCmd = &cobra.Command{
 	Use:   "unsafe-remove-dead-replicas --dead-store-ids=[store ID,...] [path]",
-	Short: "Unsafely attempt to recover a range that has lost quorum",
+	Short: "Unsafely attempt to recover a range that has lost quorum (deprecated)",
 	Long: `
+DEPRECATED: use 'debug recover' instead. unsafe-remove-dead-replicas will be
+removed in CockroachDB v23.1.
 
 This command is UNSAFE and should only be used with the supervision of
 a Cockroach Labs engineer. It is a last-resort option to recover data


### PR DESCRIPTION
This patch marks `unsafe-remove-dead-replicas` as deprecated, and refers users to the new `recover` commands. It will be removed in v23.1.

Resolves #86543.

Release note (cli change): The `debug unsafe-remove-dead-replicas` CLI command has been deprecated, and will be removed in v23.1. Users should use the new `debug recover` set of commands instead.