### PR TITLE
release-22.2: xform: make FoldDivOne an essential normalization

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -185,7 +185,6 @@ func runOneRoundQueryComparison(
 		// TODO(mgartner): Re-enable aggregate functions when we can guarantee
 		// they are deterministic.
 		sqlsmith.DisableAggregateFuncs(),
-		sqlsmith.DisableDivision(),
 		sqlsmith.SetComplexity(.3),
 		sqlsmith.SetScalarComplexity(.1),
 	)

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -584,3 +584,27 @@ SELECT attname, atttypmod FROM pg_attribute WHERE attrelid = 't71926'::regclass:
 no_typmod            -1
 precision            327684
 precision_and_width  327687
+
+# Regression test for #86790
+statement ok
+CREATE TABLE t86790 (x INT8 NOT NULL)
+
+statement ok
+INSERT INTO t86790 VALUES (-4429772553778622992)
+
+query R
+SELECT (x / 1)::DECIMAL FROM t86790
+----
+-4429772553778622992
+
+statement ok
+SET testing_optimizer_disable_rule_probability = 1
+
+# The results should be the same as the previous SELECT.
+query R
+SELECT (x / 1)::DECIMAL FROM t86790
+----
+-4429772553778622992
+
+statement ok
+RESET testing_optimizer_disable_rule_probability

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -974,6 +974,8 @@ func (o *Optimizer) disableRulesRandom(probability float64) {
 		int(opt.FoldNullBinaryLeft),
 		int(opt.FoldNullComparisonRight),
 		int(opt.FoldNullComparisonLeft),
+		// FoldDivOne is needed for consistent formatting, so tests won't fail.
+		int(opt.FoldDivOne),
 		// Without PruneAggCols, it's common to receive
 		// "optimizer factory constructor call stack exceeded max depth of 10000"
 		int(opt.PruneAggCols),


### PR DESCRIPTION
Backport 1/1 commits from #88485.

/cc @cockroachdb/release

---

Fixes #86790

This fixes sqlsmith errors caused by differences in the number of
displayed digits right of the decimal place for `expression / 1`
by making the folding of this expression essential.

Release note: None

Release justification: Low risk fix SQLSmith test flakes