### PR TITLE
roachtest: run clearrange test with range tombstones

### DIFF
--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -27,43 +27,62 @@ import (
 
 func registerClearRange(r registry.Registry) {
 	for _, checks := range []bool{true, false} {
-		checks := checks
-		r.Add(registry.TestSpec{
-			Name:  fmt.Sprintf(`clearrange/checks=%t`, checks),
-			Owner: registry.OwnerStorage,
-			// 5h for import, 90 for the test. The import should take closer
-			// to <3:30h but it varies.
-			Timeout: 5*time.Hour + 90*time.Minute,
-			Cluster: r.MakeClusterSpec(10, spec.CPU(16)),
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runClearRange(ctx, t, c, checks)
-			},
-		})
+		for _, rangeTombstones := range []bool{true, false} {
+			checks := checks
+			rangeTombstones := rangeTombstones
+			r.Add(registry.TestSpec{
+				Name:  fmt.Sprintf(`clearrange/checks=%t/rangeTs=%t`, checks, rangeTombstones),
+				Owner: registry.OwnerStorage,
+				// 5h for import, 90 for the test. The import should take closer
+				// to <3:30h but it varies.
+				Timeout: 5*time.Hour + 90*time.Minute,
+				Cluster: r.MakeClusterSpec(10, spec.CPU(16)),
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runClearRange(ctx, t, c, checks, rangeTombstones)
+				},
+			})
 
-		// Using a separate clearrange test on zfs instead of randomly
-		// using the same test, cause the Timeout might be different,
-		// and may need to be tweaked.
-		r.Add(registry.TestSpec{
-			Name:  fmt.Sprintf(`clearrange/zfs/checks=%t`, checks),
-			Skip:  "Consistently failing. See #68716 context.",
-			Owner: registry.OwnerStorage,
-			// 5h for import, 120 for the test. The import should take closer
-			// to <3:30h but it varies.
-			Timeout:           5*time.Hour + 120*time.Minute,
-			Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
-			EncryptionSupport: registry.EncryptionMetamorphic,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runClearRange(ctx, t, c, checks)
-			},
-		})
+			// Using a separate clearrange test on zfs instead of randomly
+			// using the same test, cause the Timeout might be different,
+			// and may need to be tweaked.
+			r.Add(registry.TestSpec{
+				Name:  fmt.Sprintf(`clearrange/zfs/checks=%t/rangeTs=%t`, checks, rangeTombstones),
+				Skip:  "Consistently failing. See #68716 context.",
+				Owner: registry.OwnerStorage,
+				// 5h for import, 120 for the test. The import should take closer
+				// to <3:30h but it varies.
+				Timeout:           5*time.Hour + 120*time.Minute,
+				Cluster:           r.MakeClusterSpec(10, spec.CPU(16), spec.SetFileSystem(spec.Zfs)),
+				EncryptionSupport: registry.EncryptionMetamorphic,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runClearRange(ctx, t, c, checks, rangeTombstones)
+				},
+			})
+		}
 	}
 }
 
-func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressiveChecks bool) {
+func runClearRange(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	aggressiveChecks bool,
+	useRangeTombstones bool,
+) {
 	c.Put(ctx, t.Cockroach(), "./cockroach")
 
 	t.Status("restoring fixture")
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+
+	{
+		conn := c.Conn(ctx, t.L(), 1)
+		if _, err := conn.ExecContext(ctx,
+			`SET CLUSTER SETTING storage.mvcc.range_tombstones.enabled = $1`,
+			useRangeTombstones); err != nil {
+			t.Fatal(err)
+		}
+		conn.Close()
+	}
 
 	// NB: on a 10 node cluster, this should take well below 3h.
 	tBegin := timeutil.Now()


### PR DESCRIPTION
Previously clear range tests were run with default server settings. Range tombstones are disabled by default so new functionality in schema change commands is not execised. This commit adds test variant that enables range tombstones.

Release note: None

Fixes #86752