### PR TITLE
sqlliveness: change heartbeat timeouts to be a fraction of TTL

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -929,8 +929,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	// Make the tenant heartbeat like crazy.
 	ctx := context.Background()
-	//slinstance.DefaultTTL.Override(ctx, &st.SV, 20*time.Millisecond)
-	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 50*time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 10*time.Millisecond)
 
 	_, tenantDB := serverutils.StartTenant(t, hostServer, base.TestTenantArgs{
 		TenantID:                    tenantID,

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -192,7 +192,7 @@ func TestSQLInstanceDeadlinesExtend(t *testing.T) {
 	}
 	defer cleanUpFunc()
 	// advance manual clock so that session expires
-	mt.Advance(20 * time.Millisecond)
+	mt.Advance(slinstance.DefaultTTL.Get(&settings.SV))
 
 	// expect session to expire
 	require.Eventually(


### PR DESCRIPTION
Previously, the heartbeat timeouts were being set as the length of the heartbeat. This can cause issues when there is longer latency in the system and caused flaky tests.

By making the heartbeat timout a fraction of the TTL, we are able to avoid timing out too early and also ensure that we can retry at least once before the seession expiry.

Ran test with `--stress` to verify it doesn't flake:
```
2559 runs so far, 0 failures, over 5m0s
```

Resolves: #88743

Release note: None