### PR TITLE
diagrams: Remove linking of subdirectory in show backup diagram

### DIFF
--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1303,7 +1303,7 @@ var specs = []stmtSpec{
 			"'BACKUP' string_or_placeholder 'IN' string_or_placeholder": "'BACKUP' subdirectory 'IN' location",
 			"'BACKUP' 'SCHEMAS' string_or_placeholder":                  "'BACKUP' 'SCHEMAS' location",
 		},
-		unlink: []string{"location"},
+		unlink: []string{"location", "subdirectory"},
 	},
 	{
 		name:    "show_jobs",


### PR DESCRIPTION
This removes any link to subdirectory, which has been removed in the product

Release note: None

Release justification: SQL grammar diagram update