### PR TITLE
ci: add MacOS ARM CI config

### DIFF
--- a/build/teamcity/cockroach/ci/builds/build_macos_arm64.sh
+++ b/build/teamcity/cockroach/ci/builds/build_macos_arm64.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run Bazel build"
+run_bazel build/teamcity/cockroach/ci/builds/build_impl.sh crossmacosarm
+tc_end_block "Run Bazel build"


### PR DESCRIPTION
Previously, MacOS64 ARM64 platform was added, but CI wouldn't run it.

This PR adds a CI platform to build MacOS ARM64 binaries.

Release note: None