### PR TITLE
server, sql: add plan gist to active queries

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -2139,6 +2139,7 @@ ActiveQuery represents a query in flight on some Session.
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
+| plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 
 
 
@@ -2281,6 +2282,7 @@ ActiveQuery represents a query in flight on some Session.
 | sql_summary | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | A summarized version of the sql query. | [reserved](#support-status) |
 | is_full_scan | [bool](#cockroach.server.serverpb.ListSessionsResponse-bool) |  | True if the query contains a full table or index scan. Note that this field is only valid if the query is in the EXECUTING phase. | [reserved](#support-status) |
 | elapsed_time | [google.protobuf.Duration](#cockroach.server.serverpb.ListSessionsResponse-google.protobuf.Duration) |  | Time elapsed since this query started execution. | [reserved](#support-status) |
+| plan_gist | [string](#cockroach.server.serverpb.ListSessionsResponse-string) |  | The compressed plan that can be converted back into the statement's logical plan. Empty if the statement is in the PREPARING state. | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -228,15 +228,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -912,6 +912,10 @@ message ActiveQuery {
   // Time elapsed since this query started execution.
   google.protobuf.Duration elapsed_time = 11
   [ (gogoproto.nullable) = false, (gogoproto.stdduration) = true ];
+
+  // The compressed plan that can be converted back into the statement's logical plan.
+  // Empty if the statement is in the PREPARING state.
+  string plan_gist = 12;
 }
 
 // Request object for ListSessions and ListLocalSessions.

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3194,6 +3194,7 @@ func (ex *connExecutor) serialize() serverpb.Session {
 			Phase:          (serverpb.ActiveQuery_Phase)(query.phase),
 			Progress:       float32(progress),
 			IsFullScan:     query.isFullScan,
+			PlanGist:       query.planGist,
 		})
 	}
 	lastActiveQuery := ""

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1129,6 +1129,7 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		if !ok {
 			return nil, errors.AssertionFailedf("query %d not in registry", stmt.QueryID)
 		}
+		queryMeta.planGist = planner.instrumentation.planGist.String()
 		queryMeta.phase = executing
 		// TODO(yuzefovich): introduce ternary PlanDistribution into queryMeta.
 		queryMeta.isDistributed = distributePlan.WillDistribute()

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1767,7 +1767,8 @@ CREATE TABLE crdb_internal.%s (
   application_name STRING,         -- the name of the application as per SET application_name
   distributed      BOOL,           -- whether the query is running distributed
   phase            STRING,         -- the current execution phase
-  full_scan        BOOL            -- whether the query contains a full table or index scan
+  full_scan        BOOL,           -- whether the query contains a full table or index scan
+  plan_gist        STRING          -- Compressed logical plan.
 )`
 
 func (p *planner) makeSessionsRequest(
@@ -1896,6 +1897,12 @@ func populateQueriesTable(
 			if err != nil {
 				return err
 			}
+
+			planGistDatum := tree.DNull
+			if len(query.PlanGist) > 0 {
+				planGistDatum = tree.NewDString(query.PlanGist)
+			}
+
 			if err := addRow(
 				tree.NewDString(query.ID),
 				txnID,
@@ -1909,6 +1916,7 @@ func populateQueriesTable(
 				isDistributedDatum,
 				tree.NewDString(phase),
 				isFullScanDatum,
+				planGistDatum,
 			); err != nil {
 				return err
 			}
@@ -1933,6 +1941,7 @@ func populateQueriesTable(
 				tree.DNull,                             // distributed
 				tree.DNull,                             // phase
 				tree.DNull,                             // full_scan
+				tree.DNull,                             // plan_gist
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1960,6 +1960,10 @@ type queryMeta struct {
 	hidden bool
 
 	progressAtomic uint64
+
+	// The compressed plan for this query. This can converted  back into the
+	// logical plan. This field will only be populated in the EXECUTING phase.
+	planGist string
 }
 
 // cancel cancels the query associated with this queryMeta, by closing the

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -347,15 +347,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
-query TTITTTTTTBTB colnames
+query TTITTTTTTBTBT colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id user_name  start  query  client_address  application_name  distributed  phase  full_scan
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist
 
 query TITTTTIIIT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -366,7 +366,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  CREATE TABLE crdb_internal.cluster_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -379,7 +380,8 @@ CREATE TABLE crdb_internal.cluster_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.cluster_sessions (
    node_id INT8 NOT NULL,
@@ -1058,7 +1060,8 @@ CREATE TABLE crdb_internal.node_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  CREATE TABLE crdb_internal.node_queries (
    query_id STRING NULL,
    txn_id UUID NULL,
@@ -1071,7 +1074,8 @@ CREATE TABLE crdb_internal.node_queries (
    application_name STRING NULL,
    distributed BOOL NULL,
    phase STRING NULL,
-   full_scan BOOL NULL
+   full_scan BOOL NULL,
+   plan_gist STRING NULL
 )  {}  {}
 CREATE TABLE crdb_internal.node_runtime_info (
    node_id INT8 NOT NULL,


### PR DESCRIPTION
Closes #76554

This commit surfaces an executing query's plan gist. This information is added to the ListSessions response and the `crdb_internal.{node,cluster}_queries` tables. This field is only populated when the query enters the EXECUTING phase.

Release note (sql change): new column `plan_gist`
added to `crdb_internal.{node,cluster}_queries`
representing the compressed logical plan.