### PR TITLE
github-post: assign owner when all slow tests share the same owner

### DIFF
--- a/pkg/cmd/github-post/main_test.go
+++ b/pkg/cmd/github-post/main_test.go
@@ -83,9 +83,11 @@ func TestListFailures(t *testing.T) {
 			fileName: "stress-unknown.json",
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/storage",
 			expIssues: []issue{{
-				testName: "(unknown)",
-				title:    "storage: package failed",
-				message:  "make: *** [bin/.submodules-initialized] Error 1",
+				testName:   "(unknown)",
+				title:      "storage: package failed",
+				message:    "make: *** [bin/.submodules-initialized] Error 1",
+				mention:    []string{"@cockroachdb/test-eng"},
+				hasProject: true,
 			}},
 			formatter: defaultFormatter,
 		},
@@ -143,14 +145,16 @@ TestAnchorKey - 1.01s
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv",
 			expIssues: []issue{
 				{
-					testName: "(unknown)",
-					title:    "kv: package timed out",
+					testName: "TestXXX/sub3",
+					title:    "kv: TestXXX/sub3 timed out",
 					message: `Slow failing tests:
 TestXXX/sub3 - 0.50s
 
 Slow passing tests:
 TestXXA - 1.00s
 `,
+					mention:    []string{"@cockroachdb/test-eng"},
+					hasProject: true,
 				},
 			},
 			formatter: defaultFormatter,
@@ -163,8 +167,8 @@ TestXXA - 1.00s
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv",
 			expIssues: []issue{
 				{
-					testName: "(unknown)",
-					title:    "kv: package timed out",
+					testName: "TestXXX/sub1",
+					title:    "kv: TestXXX/sub1 timed out",
 					message: `Slow failing tests:
 TestXXX/sub1 - 0.49s
 
@@ -172,6 +176,8 @@ Slow passing tests:
 TestXXB - 1.01s
 TestXXA - 1.00s
 `,
+					mention:    []string{"@cockroachdb/test-eng"},
+					hasProject: true,
 				},
 			},
 			formatter: defaultFormatter,
@@ -193,6 +199,8 @@ Slow passing tests:
 TestXXB - 1.01s
 TestXXA - 1.00s
 `,
+					mention:    []string{"@cockroachdb/test-eng"},
+					hasProject: true,
 				},
 			},
 			formatter: defaultFormatter,
@@ -204,9 +212,11 @@ TestXXA - 1.00s
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv",
 			expIssues: []issue{
 				{
-					testName: "TestXXX",
-					title:    "kv: TestXXX failed",
-					message:  `panic: induced panic`,
+					testName:   "TestXXX",
+					title:      "kv: TestXXX failed",
+					message:    `panic: induced panic`,
+					mention:    []string{"@cockroachdb/test-eng"},
+					hasProject: true,
 				},
 			},
 			formatter: defaultFormatter,
@@ -218,9 +228,11 @@ TestXXA - 1.00s
 			expPkg:   "github.com/cockroachdb/cockroach/pkg/kv",
 			expIssues: []issue{
 				{
-					testName: "(unknown)",
-					title:    "kv: package failed",
-					message:  `panic: induced panic`,
+					testName:   "(unknown)",
+					title:      "kv: package failed",
+					message:    `panic: induced panic`,
+					mention:    []string{"@cockroachdb/test-eng"},
+					hasProject: true,
 				},
 			},
 			formatter: defaultFormatter,

--- a/pkg/internal/codeowners/codeowners.go
+++ b/pkg/internal/codeowners/codeowners.go
@@ -35,6 +35,11 @@ type CodeOwners struct {
 	teams map[team.Alias]team.Team
 }
 
+// GetTeamForAlias returns the team matching the given Alias.
+func (co *CodeOwners) GetTeamForAlias(alias team.Alias) team.Team {
+	return co.teams[alias]
+}
+
 // LoadCodeOwners parses a CODEOWNERS file and returns the CodeOwners struct.
 func LoadCodeOwners(r io.Reader, teams map[team.Alias]team.Team) (*CodeOwners, error) {
 	s := bufio.NewScanner(r)


### PR DESCRIPTION
When a test report contains the line "panic: test timed out after", the corresponding test is assigned into 'timedOutCulprit'. However, if some other (slow) test took longer, then we'd like to shift the blame under the assumption that all tests in the same package _roughly_ take the same time. Thus, the longest test is likely to be an outlier; in conjunction with the other (slow) tests, it exceeded the max. running time. Of course, this assumption is not valid, generally. Yet, this is the current logic.

The existing logic is preserved _modulo_ improving the case when 'timedOutCulprit' is _not_ the slowest test but _all_ the slow tests belong to the same owner. Previously, this would result in an issue _without_ an owner, e.g., [1]. After this change, the (shared) owner is assigned.

Touches: https://github.com/cockroachdb/cockroach/issues/51653

[1] https://github.com/cockroachdb/cockroach/issues/87673

Release note: None
Release justification: CI improvement