### PR TITLE
cloud: direct S3 logs to CRDB logger

### DIFF
--- a/pkg/cloud/amazon/BUILD.bazel
+++ b/pkg/cloud/amazon/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "@com_github_aws_aws_sdk_go//service/s3",
         "@com_github_aws_aws_sdk_go//service/s3/s3manager",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_gogo_protobuf//types",
     ],
 )

--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -104,6 +105,11 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 		Credentials: credentials.NewStaticCredentials(kmsURIParams.accessKey,
 			kmsURIParams.secret, kmsURIParams.tempToken),
 	}
+	awsConfig.Logger = newLogAdapter(ctx)
+	if log.V(2) {
+		awsConfig.LogLevel = awsVerboseLogging
+	}
+
 	if kmsURIParams.endpoint != "" {
 		if env.KMSConfig().DisableHTTP {
 			return nil, errors.New(


### PR DESCRIPTION
By default, verbose logging from the s3_storage module would be sent to STDOUT. This has proven confusing in some production situations.

This change installs sets the required configuration to direct S3 logs to the DEV channel.

A side-effect of this is that we will need to be sure to ask for unredacted logs if we want to see any meaningful content.

Release note (ops change): Logs produced by setting an increased vmodule setting for s3_storage are now directed to the DEV channel rather than STDOUT.