### PR TITLE
release-22.2: sqlliveness: add timeouts to heartbeats

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -929,8 +929,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	// Make the tenant heartbeat like crazy.
 	ctx := context.Background()
-	//slinstance.DefaultTTL.Override(ctx, &st.SV, 20*time.Millisecond)
-	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 50*time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 10*time.Millisecond)
 
 	_, tenantDB := serverutils.StartTenant(t, hostServer, base.TestTenantArgs{
 		TenantID:                    tenantID,

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -930,7 +930,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 	// Make the tenant heartbeat like crazy.
 	ctx := context.Background()
 	//slinstance.DefaultTTL.Override(ctx, &st.SV, 20*time.Millisecond)
-	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 10*time.Millisecond)
 
 	_, tenantDB := serverutils.StartTenant(t, hostServer, base.TestTenantArgs{
 		TenantID:                    tenantID,
@@ -960,7 +960,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 
 	// Verify that heartbeats can go through and update the expiration time.
 	val := livenessValue()
-	time.Sleep(2 * time.Millisecond)
+	time.Sleep(20 * time.Millisecond)
 	testutils.SucceedsSoon(
 		t,
 		func() error {

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -322,7 +322,7 @@ func (ts *testState) request(
 	return ""
 }
 
-func (ts *testState) externalIngress(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) externalIngress(t *testing.T, _ *datadriven.TestData, args cmdArgs) string {
 	usage := multitenant.ExternalIOUsage{IngressBytes: args.bytes}
 	if err := ts.controller.OnExternalIOWait(context.Background(), usage); err != nil {
 		t.Errorf("OnExternalIOWait error: %s", err)
@@ -341,12 +341,12 @@ func (ts *testState) externalEgress(t *testing.T, d *datadriven.TestData, args c
 	return ""
 }
 
-func (ts *testState) enableRUAccounting(t *testing.T, _ *datadriven.TestData, _ cmdArgs) string {
+func (ts *testState) enableRUAccounting(_ *testing.T, _ *datadriven.TestData, _ cmdArgs) string {
 	tenantcostclient.ExternalIORUAccountingMode.Override(context.Background(), &ts.settings.SV, "on")
 	return ""
 }
 
-func (ts *testState) disableRUAccounting(t *testing.T, _ *datadriven.TestData, _ cmdArgs) string {
+func (ts *testState) disableRUAccounting(_ *testing.T, _ *datadriven.TestData, _ cmdArgs) string {
 	tenantcostclient.ExternalIORUAccountingMode.Override(context.Background(), &ts.settings.SV, "off")
 	return ""
 }
@@ -424,7 +424,7 @@ func (ts *testState) advance(t *testing.T, d *datadriven.TestData, args cmdArgs)
 
 // waitForEvent waits until the tenant controller reports the given event
 // type(s), at the current time.
-func (ts *testState) waitForEvent(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) waitForEvent(t *testing.T, d *datadriven.TestData, _ cmdArgs) string {
 	typs := make(map[string]tenantcostclient.TestEventType)
 	for ev, evStr := range eventTypeStr {
 		typs[evStr] = ev
@@ -444,7 +444,7 @@ func (ts *testState) waitForEvent(t *testing.T, d *datadriven.TestData, args cmd
 
 // unblockRequest resumes a token bucket request that was blocked by the
 // "blockRequest" configuration option.
-func (ts *testState) unblockRequest(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) unblockRequest(t *testing.T, _ *datadriven.TestData, _ cmdArgs) string {
 	ts.provider.unblockRequest(t)
 	return ""
 }
@@ -461,7 +461,7 @@ func (ts *testState) unblockRequest(t *testing.T, d *datadriven.TestData, args c
 //	----
 //	00:00:01.000
 //	00:00:02.000
-func (ts *testState) timers(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) timers(t *testing.T, d *datadriven.TestData, _ cmdArgs) string {
 	// If we are rewriting the test, just sleep a bit before returning the
 	// timers.
 	if d.Rewrite {
@@ -491,7 +491,7 @@ func timesToString(times []time.Time) string {
 }
 
 // configure the test provider.
-func (ts *testState) configure(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) configure(t *testing.T, d *datadriven.TestData, _ cmdArgs) string {
 	var cfg testProviderConfig
 	if err := yaml.UnmarshalStrict([]byte(d.Input), &cfg); err != nil {
 		d.Fatalf(t, "failed to parse request yaml: %v", err)
@@ -501,13 +501,13 @@ func (ts *testState) configure(t *testing.T, d *datadriven.TestData, args cmdArg
 }
 
 // tokenBucket dumps the current state of the tenant's token bucket.
-func (ts *testState) tokenBucket(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) tokenBucket(*testing.T, *datadriven.TestData, cmdArgs) string {
 	return tenantcostclient.TestingTokenBucketString(ts.controller)
 }
 
 // cpu adds CPU usage which will be observed by the controller on the next main
 // loop tick.
-func (ts *testState) cpu(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) cpu(t *testing.T, d *datadriven.TestData, _ cmdArgs) string {
 	duration, err := time.ParseDuration(d.Input)
 	if err != nil {
 		d.Fatalf(t, "error parsing cpu duration: %v", err)
@@ -518,7 +518,7 @@ func (ts *testState) cpu(t *testing.T, d *datadriven.TestData, args cmdArgs) str
 
 // pgwire adds PGWire egress usage which will be observed by the controller on the next
 // main loop tick.
-func (ts *testState) pgwireEgress(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) pgwireEgress(t *testing.T, d *datadriven.TestData, _ cmdArgs) string {
 	bytes, err := strconv.Atoi(d.Input)
 	if err != nil {
 		d.Fatalf(t, "error parsing pgwire bytes value: %v", err)
@@ -529,7 +529,7 @@ func (ts *testState) pgwireEgress(t *testing.T, d *datadriven.TestData, args cmd
 
 // usage prints out the latest consumption. Callers are responsible for
 // triggering calls to the token bucket provider and waiting for responses.
-func (ts *testState) usage(t *testing.T, d *datadriven.TestData, args cmdArgs) string {
+func (ts *testState) usage(*testing.T, *datadriven.TestData, cmdArgs) string {
 	c := ts.provider.consumption()
 	return fmt.Sprintf(""+
 		"RU:  %.2f\n"+
@@ -695,7 +695,7 @@ func (tp *testProvider) unblockRequest(t *testing.T) {
 
 // TokenBucket implements the kvtenant.TokenBucketProvider interface.
 func (tp *testProvider) TokenBucket(
-	ctx context.Context, in *roachpb.TokenBucketRequest,
+	_ context.Context, in *roachpb.TokenBucketRequest,
 ) (*roachpb.TokenBucketResponse, error) {
 	tp.mu.Lock()
 	defer tp.mu.Unlock()
@@ -930,7 +930,7 @@ func TestSQLLivenessExemption(t *testing.T) {
 	// Make the tenant heartbeat like crazy.
 	ctx := context.Background()
 	//slinstance.DefaultTTL.Override(ctx, &st.SV, 20*time.Millisecond)
-	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 10*time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &st.SV, 50*time.Millisecond)
 
 	_, tenantDB := serverutils.StartTenant(t, hostServer, base.TestTenantArgs{
 		TenantID:                    tenantID,
@@ -960,7 +960,6 @@ func TestSQLLivenessExemption(t *testing.T) {
 
 	// Verify that heartbeats can go through and update the expiration time.
 	val := livenessValue()
-	time.Sleep(20 * time.Millisecond)
 	testutils.SucceedsSoon(
 		t,
 		func() error {

--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slstorage",
+        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql/sqlliveness",
+        "//pkg/util/contextutil",
         "//pkg/util/grpcutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
@@ -18,6 +19,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -12,6 +12,7 @@ package slinstance_test
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slinstance"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -40,8 +42,8 @@ func TestSQLInstance(t *testing.T) {
 		clusterversion.TestingBinaryVersion,
 		clusterversion.TestingBinaryMinSupportedVersion,
 		true /* initializeVersion */)
-	slinstance.DefaultTTL.Override(ctx, &settings.SV, 2*time.Microsecond)
-	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, time.Microsecond)
+	slinstance.DefaultTTL.Override(ctx, &settings.SV, 20*time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)
 
 	fakeStorage := slstorage.NewFakeStorage()
 	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
@@ -90,4 +92,114 @@ func TestSQLInstance(t *testing.T) {
 	sqlInstance.ClearSessionForTest(ctx)
 	_, err = sqlInstance.Session(ctx)
 	require.Error(t, err)
+}
+
+// TestSQLInstanceDeadlines tests that we have proper deadlines set on the
+// create and extend session operations. This is done by blocking the fake
+// storage layer and ensuring that no sessions get created because the
+// timeouts are constantly triggered.
+func TestSQLInstanceDeadlines(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, stopper := context.Background(), stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	clock := hlc.NewClock(timeutil.NewManualTime(timeutil.Unix(0, 42)), time.Nanosecond /* maxOffset */)
+	settings := cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.TestingBinaryVersion,
+		clusterversion.TestingBinaryMinSupportedVersion,
+		true /* initializeVersion */)
+	slinstance.DefaultTTL.Override(ctx, &settings.SV, 20*time.Millisecond)
+	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)
+
+	fakeStorage := slstorage.NewFakeStorage()
+	// block the fake storage
+	fakeStorage.SetBlockCh()
+	cleanUpFunc := func() {
+		fakeStorage.CloseBlockCh()
+	}
+	defer cleanUpFunc()
+
+	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
+	sqlInstance.Start(ctx)
+
+	// verify that we do not create a session
+	require.Never(
+		t,
+		func() bool {
+			_, err := sqlInstance.Session(ctx)
+			return err == nil
+		},
+		100*time.Millisecond, 10*time.Millisecond,
+	)
+}
+
+// TestSQLInstanceDeadlinesExtend tests that we have proper deadlines set on the
+// create and extend session operations. This tests the case where the session is
+// successfully created first and then blocks indefinitely.
+func TestSQLInstanceDeadlinesExtend(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, stopper := context.Background(), stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	mt := timeutil.NewManualTime(timeutil.Unix(0, 42))
+	clock := hlc.NewClock(mt, time.Nanosecond /* maxOffset */)
+	settings := cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.TestingBinaryVersion,
+		clusterversion.TestingBinaryMinSupportedVersion,
+		true /* initializeVersion */)
+	slinstance.DefaultTTL.Override(ctx, &settings.SV, 20*time.Millisecond)
+	// Must be shorter than the storage sleep amount below
+	slinstance.DefaultHeartBeat.Override(ctx, &settings.SV, 10*time.Millisecond)
+
+	fakeStorage := slstorage.NewFakeStorage()
+	sqlInstance := slinstance.NewSQLInstance(stopper, clock, fakeStorage, settings, nil)
+	sqlInstance.Start(ctx)
+
+	// verify that eventually session is created successfully
+	testutils.SucceedsSoon(
+		t,
+		func() error {
+			_, err := sqlInstance.Session(ctx)
+			return err
+		},
+	)
+
+	// verify that session is also extended successfully a few times
+	require.Never(
+		t,
+		func() bool {
+			_, err := sqlInstance.Session(ctx)
+			return err != nil
+		},
+		100*time.Millisecond, 10*time.Millisecond,
+	)
+
+	// register a callback for verification that this session expired
+	var sessionExpired atomic.Bool
+	s, _ := sqlInstance.Session(ctx)
+	s.RegisterCallbackForSessionExpiry(func(ctx context.Context) {
+		sessionExpired.Store(true)
+	})
+
+	// block the fake storage
+	fakeStorage.SetBlockCh()
+	cleanUpFunc := func() {
+		fakeStorage.CloseBlockCh()
+	}
+	defer cleanUpFunc()
+	// advance manual clock so that session expires
+	mt.Advance(20 * time.Millisecond)
+
+	// expect session to expire
+	require.Eventually(
+		t,
+		func() bool {
+			return sessionExpired.Load()
+		},
+		testutils.DefaultSucceedsSoonDuration, 10*time.Millisecond,
+	)
 }

--- a/pkg/sql/sqlliveness/slinstance/slinstance_test.go
+++ b/pkg/sql/sqlliveness/slinstance/slinstance_test.go
@@ -192,7 +192,7 @@ func TestSQLInstanceDeadlinesExtend(t *testing.T) {
 	}
 	defer cleanUpFunc()
 	// advance manual clock so that session expires
-	mt.Advance(20 * time.Millisecond)
+	mt.Advance(slinstance.DefaultTTL.Get(&settings.SV))
 
 	// expect session to expire
 	require.Eventually(


### PR DESCRIPTION
Backport:
  * 2/2 commits from "sqlliveness: add timeouts to heartbeats" (#87533)
  * 1/1 commits from "sqlliveness: change heartbeat timeouts to be a fraction of TTL" (#88764)

Please see individual PRs for details.

Release justification: low-risk bugfix to existing functionality

/cc @cockroachdb/release
