### PR TITLE
ccl/changefeedccl: skip TestAvroArray

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -433,6 +434,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 
 func TestAvroArray(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 88816, "flaky test")
 	defer log.Scope(t).Close(t)
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {


### PR DESCRIPTION
Refs: #88816

Reason: flaky test

Generated by bin/skip-test.

Release justification: non-production code changes

Release note: None