### PR TITLE
kv: Use the cached stats for lease preference

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1500,7 +1500,7 @@ func (r *Replica) maybeExtendLeaseAsyncLocked(ctx context.Context, st kvserverpb
 // error or no preferences defined then it will return false and consider that
 // to be in-conformance.
 func (r *Replica) leaseViolatesPreferences(ctx context.Context) bool {
-	storeDesc, err := r.store.Descriptor(ctx, false /* useCached */)
+	storeDesc, err := r.store.Descriptor(ctx, true /* useCached */)
 	if err != nil {
 		log.Infof(ctx, "Unable to load the descriptor %v: cannot check if lease violates preference", err)
 		return false


### PR DESCRIPTION
Previously it would specify that the descriptor should use an uncached version of the descriptor. What this means in practice is that it recomputes the store level stats every time when it is making a lease preference decision. This was unnecessary as the check was only whether leases where in the right place.

Release note: None