### PR TITLE
server: fix panic when SendKVBatch is used with invalid req

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3072,6 +3072,9 @@ func (s *adminServer) SendKVBatch(
 	var br *roachpb.BatchResponse
 	defer func() { sp.finish(ctx, br) }()
 	br, pErr := s.server.db.NonTransactionalSender().Send(ctx, *ba)
+	if br == nil {
+		br = &roachpb.BatchResponse{}
+	}
 	br.Error = pErr
 	return br, nil
 }


### PR DESCRIPTION
This commit fixes a panic in admin.SendKVBatch when `debug send-kv-request` command is called with invalid request.

Release note: None

Fixes #88826