### PR TITLE
ui: update cluster-ui version to 22.2.0-prerelease-7

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "22.2.0-prerelease-5",
+  "version": "22.2.0-prerelease-7",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This commit updates cluster-ui version to match the `next` published version ([22.2.0-prerelease-7](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.2.0-prerelease-7)).

Note this commit changes the current cluster-ui version from 22.2.0-prerelease-5 to 22.2.0-prerelease-7, as [22.2.0-prerelease-6](https://www.npmjs.com/package/@cockroachlabs/cluster-ui/v/22.2.0-prerelease-6) was published, but not used in `cockroach` cluster-ui.

Release note: None
Release justification: non-production change