### PR TITLE
sqlliveness: fix error handling for sqlliveness sessions

### DIFF
--- a/pkg/cli/mt_start_sql.go
+++ b/pkg/cli/mt_start_sql.go
@@ -169,14 +169,12 @@ func runStartSQL(cmd *cobra.Command, args []string) error {
 	// TODO(tbg): make the other goodies in `./cockroach start` reusable, such as
 	// logging to files, periodic memory output, heap and goroutine dumps.
 	// Then use them here.
-
-	errChan := make(chan error, 1)
 	var serverStatusMu serverStatus
 	serverStatusMu.started = true
 
 	return waitForShutdown(
 		func() serverShutdownInterface { return sqlServer },
 		stopper,
-		errChan, signalCh,
+		sqlServer.SqllivenessErrChan, signalCh,
 		&serverStatusMu)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1625,7 +1625,8 @@ func (s *Server) PreStart(ctx context.Context) error {
 	// executes a SQL query, this must be done after the SQL layer is ready.
 	s.node.recordJoinEvent(ctx)
 
-	if err := s.sqlServer.preStart(
+	// TODO(aadityas): figure out what to do with errChan here
+	if _, err := s.sqlServer.preStart(
 		workersCtx,
 		s.stopper,
 		s.cfg.TestingKnobs,

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -895,7 +895,7 @@ func (ts *TestServer) StartTenant(
 			tenantKnobs.ClusterSettingsUpdater = st.MakeUpdater()
 		}
 	}
-	sqlServer, authServer, drainServer, addr, httpAddr, err := startTenantInternal(
+	sqlServer, authServer, drainServer, addr, httpAddr, _, err := startTenantInternal(
 		ctx,
 		stopper,
 		ts.Cfg.ClusterName,

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1814,9 +1814,6 @@ type fakeSession struct{ exp hlc.Timestamp }
 func (f fakeSession) ID() sqlliveness.SessionID { return "foo" }
 func (f fakeSession) Expiration() hlc.Timestamp { return f.exp }
 func (f fakeSession) Start() hlc.Timestamp      { panic("unimplemented") }
-func (f fakeSession) RegisterCallbackForSessionExpiry(func(ctx context.Context)) {
-	panic("unimplemented")
-}
 
 var _ sqlliveness.Session = (*fakeSession)(nil)
 

--- a/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
+++ b/pkg/sql/sqlinstance/instanceprovider/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
+++ b/pkg/sql/sqlinstance/instanceprovider/test_helpers.go
@@ -51,5 +51,5 @@ func (p *provider) InitAndWaitForTest(ctx context.Context) {
 
 // ShutdownSQLInstanceForTest explicitly calls shutdownSQLInstance for testing purposes.
 func (p *provider) ShutdownSQLInstanceForTest(ctx context.Context) {
-	p.shutdownSQLInstance(ctx)
+	p.Shutdown(ctx)
 }

--- a/pkg/sql/sqlinstance/sqlinstance.go
+++ b/pkg/sql/sqlinstance/sqlinstance.go
@@ -52,6 +52,8 @@ type Provider interface {
 	// Start starts the instanceprovider and initializes the current SQL instance.
 	// This will block until the underlying instance data reader has been started.
 	Start(context.Context) error
+	// Shutdown shuts down the current SQL instance and releases the instance ID.
+	Shutdown(ctx context.Context)
 }
 
 // fakeSQLProvider implements the sqlinstance.Provider interface as a
@@ -76,6 +78,9 @@ func (p *fakeSQLProvider) Instance(
 ) (_ base.SQLInstanceID, _ sqlliveness.SessionID, err error) {
 	return base.SQLInstanceID(0), "", NotASQLInstanceError
 }
+
+// Shutdown implements the sqlinstance.Provider interface.
+func (p *fakeSQLProvider) Shutdown(ctx context.Context) {}
 
 // GetInstance implements the AddressResolver interface.
 func (p *fakeSQLProvider) GetInstance(context.Context, base.SQLInstanceID) (InstanceInfo, error) {

--- a/pkg/sql/sqlliveness/slinstance/BUILD.bazel
+++ b/pkg/sql/sqlliveness/slinstance/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/stop",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sqlliveness/slinstance/helpers_test.go
+++ b/pkg/sql/sqlliveness/slinstance/helpers_test.go
@@ -15,5 +15,5 @@ import "context"
 // ClearSessionForTest is used in test to
 // immediately delete the current session.
 func (l *Instance) ClearSessionForTest(ctx context.Context) {
-	l.clearSession(ctx)
+	l.clearSession()
 }

--- a/pkg/sql/sqlliveness/slprovider/slprovider.go
+++ b/pkg/sql/sqlliveness/slprovider/slprovider.go
@@ -36,20 +36,23 @@ func New(
 	codec keys.SQLCodec,
 	settings *cluster.Settings,
 	testingKnobs *sqlliveness.TestingKnobs,
+	isTenant bool,
 ) sqlliveness.Provider {
 	storage := slstorage.NewStorage(ambientCtx, stopper, clock, db, codec, settings)
-	instance := slinstance.NewSQLInstance(stopper, clock, storage, settings, testingKnobs)
+	instance := slinstance.NewSQLInstance(stopper, clock, storage, settings, testingKnobs, isTenant)
 	return &provider{
 		Storage:  storage,
 		Instance: instance,
 	}
 }
 
-func (p *provider) Start(ctx context.Context) {
+// Start implements the sqlliveness.Provider interface
+func (p *provider) Start(ctx context.Context) <-chan error {
 	p.Storage.Start(ctx)
-	p.Instance.Start(ctx)
+	return p.Instance.Start(ctx)
 }
 
+// Metrics implements the sqlliveness.Provider interface
 func (p *provider) Metrics() metric.Struct {
 	return p.Storage.Metrics()
 }

--- a/pkg/sql/sqlliveness/sqlliveness.go
+++ b/pkg/sql/sqlliveness/sqlliveness.go
@@ -34,7 +34,7 @@ type SessionID string
 // Provider is a wrapper around the sqllivness subsystem for external
 // consumption.
 type Provider interface {
-	Start(ctx context.Context)
+	Start(ctx context.Context) <-chan error
 	Metrics() metric.Struct
 	Liveness
 
@@ -88,9 +88,6 @@ type Session interface {
 	// this time will be assured that any resources claimed under this session
 	// are known to be valid.
 	Expiration() hlc.Timestamp
-
-	// RegisterCallbackForSessionExpiry registers a callback to be executed when the session expires.
-	RegisterCallbackForSessionExpiry(func(ctx context.Context))
 }
 
 // Reader abstracts over the state of session records.

--- a/pkg/sql/sqlliveness/sqllivenesstestutils/alwaysalivesession.go
+++ b/pkg/sql/sqlliveness/sqllivenesstestutils/alwaysalivesession.go
@@ -11,8 +11,6 @@
 package sqllivenesstestutils
 
 import (
-	"context"
-
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 )
@@ -35,6 +33,3 @@ func (f alwaysAliveSession) Expiration() hlc.Timestamp { return hlc.MaxTimestamp
 
 // Start implements the sqlliveness.Session interface.
 func (f alwaysAliveSession) Start() hlc.Timestamp { return hlc.MinTimestamp }
-
-// RegisterCallbackForSessionExpiry implements the sqlliveness.Session interface.
-func (f alwaysAliveSession) RegisterCallbackForSessionExpiry(func(context.Context)) {}


### PR DESCRIPTION
In a previous patch, timeouts and retries were added to the sqlliveness heartbeat loop. This introduced cases where the session could potentially go between valid, invalid, and valid state again.

This patch introduces a tenant flag for the sqlliveness instance. When enabled, the heartbeat loop is terminated if there are any errors in the session create or extend calls.

This patch also introduces an error channel which is used to propagate sqlliveness errors to the server and cli level for better visibility on the reason for process termination.

Resolves #85540

Release note: None