### PR TITLE
release-22.2: Fix show_backup diagram.

### DIFF
--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1350,7 +1350,7 @@ var specs = []stmtSpec{
 			"'BACKUP' string_or_placeholder 'IN' string_or_placeholder": "'BACKUP' subdirectory 'IN' location",
 			"'BACKUP' 'SCHEMAS' string_or_placeholder":                  "'BACKUP' 'SCHEMAS' location",
 		},
-		unlink: []string{"subdirectory", "location"},
+		unlink: []string{"subdirectory", "location", "location_opt_list"},
 	},
 	{
 		name:    "show_jobs",


### PR DESCRIPTION
Backport 2/2 commits from #87292.

/cc @cockroachdb/release

---

DOC-5517

The show_backup diagram doesn't unlink `location_opt_list`, so links to it in the SQL grammar. The master branch build fails.

Release justification: diagram update. This is needed for doc builds.
