### PR TITLE
release: use cockroach-sql in cockroach-sql archive

### DIFF
--- a/pkg/cmd/publish-provisional-artifacts/main.go
+++ b/pkg/cmd/publish-provisional-artifacts/main.go
@@ -269,7 +269,7 @@ func putRelease(svc s3I, o opts) {
 		Platform:      o.Platform,
 		VersionStr:    o.VersionStr,
 		ArchivePrefix: "cockroach-sql",
-		Files:         []release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.AbsolutePath, "cockroach-sql")},
+		Files:         []release.ArchiveFile{release.MakeCRDBBinaryArchiveFile(o.CockroachSQLAbsolutePath, "cockroach-sql")},
 	})
 }
 


### PR DESCRIPTION
Previously, the cockroach-sql release archive was packaging the `cockroach` binary instead of the `cockroach-sql` binary.

This change fixes the path used for archiving.

Fixes #88833

Release note: None