### PR TITLE
*: Use CPut when writing to `system.descriptor` table

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -48,6 +48,9 @@ type immutable struct {
 	// changed represents whether or not the descriptor was changed
 	// after RunPostDeserializationChanges.
 	changes catalog.PostDeserializationChanges
+
+	// This is the raw bytes (tag + data) of the database descriptor in storage.
+	rawBytesInStorage []byte
 }
 
 // Mutable wraps a database descriptor and provides methods
@@ -142,7 +145,9 @@ func (desc *immutable) ByteSize() int64 {
 
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
-	return newBuilder(desc.DatabaseDesc(), hlc.Timestamp{}, desc.isUncommittedVersion, desc.changes)
+	b := newBuilder(desc.DatabaseDesc(), hlc.Timestamp{}, desc.isUncommittedVersion, desc.changes)
+	b.SetRawBytesInStorage(desc.GetRawBytesInStorage())
+	return b
 }
 
 // NewBuilder implements the catalog.Descriptor interface.
@@ -150,7 +155,9 @@ func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 // It overrides the wrapper's implementation to deal with the fact that
 // mutable has overridden the definition of IsUncommittedVersion.
 func (desc *Mutable) NewBuilder() catalog.DescriptorBuilder {
-	return newBuilder(desc.DatabaseDesc(), hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b := newBuilder(desc.DatabaseDesc(), hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b.SetRawBytesInStorage(desc.GetRawBytesInStorage())
+	return b
 }
 
 // IsMultiRegion implements the DatabaseDescriptor interface.
@@ -519,6 +526,16 @@ func (desc *immutable) GetPrivilegeDescriptor(
 // SkipNamespace implements the descriptor interface.
 func (desc *immutable) SkipNamespace() bool {
 	return false
+}
+
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (desc *immutable) GetRawBytesInStorage() []byte {
+	return desc.rawBytesInStorage
+}
+
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (desc *Mutable) GetRawBytesInStorage() []byte {
+	return desc.rawBytesInStorage
 }
 
 // maybeRemoveDroppedSelfEntryFromSchemas removes an entry in the Schemas map corresponding to the

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -88,6 +88,9 @@ type DescriptorBuilder interface {
 	// upgrade migrations
 	RunRestoreChanges(descLookupFn func(id descpb.ID) Descriptor) error
 
+	// SetRawBytesInStorage sets `rawBytesInStorage` field by deep-copying `rawBytes`.
+	SetRawBytesInStorage(rawBytes []byte)
+
 	// BuildImmutable returns an immutable Descriptor.
 	BuildImmutable() Descriptor
 
@@ -225,6 +228,10 @@ type Descriptor interface {
 
 	// SkipNamespace is true when a descriptor should not have a namespace record.
 	SkipNamespace() bool
+
+	// GetRawBytesInStorage returns the raw bytes (tag + data) of the descriptor in storage.
+	// It is exclusively used in the CPut when persisting an updated descriptor to storage.
+	GetRawBytesInStorage() []byte
 }
 
 // HydratableDescriptor represent a Descriptor which needs user-define type

--- a/pkg/sql/catalog/descs/BUILD.bazel
+++ b/pkg/sql/catalog/descs/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -269,6 +269,20 @@ func (tc *Collection) WriteDescToBatch(
 			return err
 		}
 	}
+	// Retrieve the expected bytes of `desc` in storage.
+	// If this is the first time we write to `desc` in the transaction, its
+	// expected bytes will be retrieved when we read it into this desc.Collection,
+	// and carried over in it.
+	// If, however, this is not the first time we write to `desc` in the transaction,
+	// which means it has existed in `tc.uncommitted`, we will retrieve the expected
+	// bytes from there.
+	var expected []byte
+	if exist := tc.uncommitted.getUncommittedByID(desc.GetID()); exist != nil {
+		expected = exist.GetRawBytesInStorage()
+	} else {
+		expected = desc.GetRawBytesInStorage()
+	}
+
 	if err := tc.AddUncommittedDescriptor(ctx, desc); err != nil {
 		return err
 	}
@@ -277,7 +291,7 @@ func (tc *Collection) WriteDescToBatch(
 	if kvTrace {
 		log.VEventf(ctx, 2, "Put %s -> %s", descKey, proto)
 	}
-	b.Put(descKey, proto)
+	b.CPut(descKey, proto, expected)
 	return nil
 }
 

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -284,7 +284,7 @@ func TestAddUncommittedDescriptorAndMutableResolution(t *testing.T) {
 			immByNameAfter, err := descriptors.GetImmutableDatabaseByName(ctx, txn, "new_name", flags)
 			require.NoError(t, err)
 			require.Equal(t, db.GetVersion(), immByNameAfter.GetVersion())
-			require.Equal(t, mut.ImmutableCopy(), immByNameAfter)
+			require.Equal(t, mut.ImmutableCopy().DescriptorProto(), immByNameAfter.DescriptorProto())
 
 			_, immByIDAfter, err := descriptors.GetImmutableDatabaseByID(ctx, txn, db.GetID(), flags)
 			require.NoError(t, err)
@@ -733,7 +733,7 @@ func TestDescriptorCache(t *testing.T) {
 			}
 			found := cat.LookupDescriptorEntry(mut.ID)
 			require.NotEmpty(t, found)
-			require.Equal(t, mut.ImmutableCopy(), found)
+			require.Equal(t, mut.ImmutableCopy().DescriptorProto(), found.DescriptorProto())
 			return nil
 		}))
 	})
@@ -768,7 +768,7 @@ func TestDescriptorCache(t *testing.T) {
 				return err
 			}
 			require.Len(t, dbDescs, 4)
-			require.Equal(t, mut.ImmutableCopy(), dbDescs[0])
+			require.Equal(t, mut.ImmutableCopy().DescriptorProto(), dbDescs[0].DescriptorProto())
 			return nil
 		}))
 	})

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -46,6 +46,9 @@ type immutable struct {
 	isUncommittedVersion bool
 
 	changes catalog.PostDeserializationChanges
+
+	// This is the raw bytes (tag + data) of the function descriptor in storage.
+	rawBytesInStorage []byte
 }
 
 // Mutable represents a mutable function descriptor.
@@ -147,12 +150,16 @@ func (desc *immutable) GetDeclarativeSchemaChangerState() *scpb.DescriptorState 
 
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *Mutable) NewBuilder() catalog.DescriptorBuilder {
-	return newBuilder(&desc.FunctionDescriptor, hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b := newBuilder(&desc.FunctionDescriptor, hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b.SetRawBytesInStorage(desc.GetRawBytesInStorage())
+	return b
 }
 
 // NewBuilder implements the catalog.Descriptor interface.
 func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
-	return newBuilder(&desc.FunctionDescriptor, hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b := newBuilder(&desc.FunctionDescriptor, hlc.Timestamp{}, desc.IsUncommittedVersion(), desc.changes)
+	b.SetRawBytesInStorage(desc.GetRawBytesInStorage())
+	return b
 }
 
 // GetReferencedDescIDs implements the catalog.Descriptor interface.
@@ -361,6 +368,16 @@ func (desc *immutable) HasConcurrentSchemaChanges() bool {
 // SkipNamespace implements the catalog.Descriptor interface.
 func (desc *immutable) SkipNamespace() bool {
 	return true
+}
+
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (desc *immutable) GetRawBytesInStorage() []byte {
+	return desc.rawBytesInStorage
+}
+
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (desc *Mutable) GetRawBytesInStorage() []byte {
+	return desc.rawBytesInStorage
 }
 
 // IsUncommittedVersion implements the catalog.LeasableDescriptor interface.

--- a/pkg/sql/catalog/funcdesc/func_desc_builder.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_builder.go
@@ -74,13 +74,13 @@ type functionDescriptorBuilder struct {
 }
 
 // DescriptorType implements the catalog.DescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) DescriptorType() catalog.DescriptorType {
+func (fdb *functionDescriptorBuilder) DescriptorType() catalog.DescriptorType {
 	return catalog.Function
 }
 
 // RunPostDeserializationChanges implements the catalog.DescriptorBuilder
 // interface.
-func (fdb functionDescriptorBuilder) RunPostDeserializationChanges() (err error) {
+func (fdb *functionDescriptorBuilder) RunPostDeserializationChanges() (err error) {
 	defer func() {
 		err = errors.Wrapf(err, "function %q (%d)", fdb.original.Name, fdb.original.ID)
 	}()
@@ -101,29 +101,29 @@ func (fdb functionDescriptorBuilder) RunPostDeserializationChanges() (err error)
 }
 
 // RunRestoreChanges implements the catalog.DescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) RunRestoreChanges(
+func (fdb *functionDescriptorBuilder) RunRestoreChanges(
 	descLookupFn func(id descpb.ID) catalog.Descriptor,
 ) error {
 	return nil
 }
 
 // BuildImmutable implements the catalog.DescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildImmutable() catalog.Descriptor {
+func (fdb *functionDescriptorBuilder) BuildImmutable() catalog.Descriptor {
 	return fdb.BuildImmutableFunction()
 }
 
 // BuildExistingMutable implements the catalog.DescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildExistingMutable() catalog.MutableDescriptor {
+func (fdb *functionDescriptorBuilder) BuildExistingMutable() catalog.MutableDescriptor {
 	return fdb.BuildExistingMutableFunction()
 }
 
 // BuildCreatedMutable implements the catalog.DescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildCreatedMutable() catalog.MutableDescriptor {
+func (fdb *functionDescriptorBuilder) BuildCreatedMutable() catalog.MutableDescriptor {
 	return fdb.BuildCreatedMutableFunction()
 }
 
 // BuildImmutableFunction implements the FunctionDescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildImmutableFunction() catalog.FunctionDescriptor {
+func (fdb *functionDescriptorBuilder) BuildImmutableFunction() catalog.FunctionDescriptor {
 	desc := fdb.maybeModified
 	if desc == nil {
 		desc = fdb.original
@@ -136,7 +136,7 @@ func (fdb functionDescriptorBuilder) BuildImmutableFunction() catalog.FunctionDe
 }
 
 // BuildExistingMutableFunction implements the FunctionDescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildExistingMutableFunction() *Mutable {
+func (fdb *functionDescriptorBuilder) BuildExistingMutableFunction() *Mutable {
 	if fdb.maybeModified == nil {
 		fdb.maybeModified = protoutil.Clone(fdb.original).(*descpb.FunctionDescriptor)
 	}
@@ -151,7 +151,7 @@ func (fdb functionDescriptorBuilder) BuildExistingMutableFunction() *Mutable {
 }
 
 // BuildCreatedMutableFunction implements the FunctionDescriptorBuilder interface.
-func (fdb functionDescriptorBuilder) BuildCreatedMutableFunction() *Mutable {
+func (fdb *functionDescriptorBuilder) BuildCreatedMutableFunction() *Mutable {
 	desc := fdb.maybeModified
 	if desc == nil {
 		desc = fdb.original

--- a/pkg/sql/catalog/funcdesc/func_desc_builder.go
+++ b/pkg/sql/catalog/funcdesc/func_desc_builder.go
@@ -71,6 +71,8 @@ type functionDescriptorBuilder struct {
 	mvccTimestamp        hlc.Timestamp
 	isUncommittedVersion bool
 	changes              catalog.PostDeserializationChanges
+	// This is the raw bytes (tag + data) of the function descriptor in storage.
+	rawBytesInStorage []byte
 }
 
 // DescriptorType implements the catalog.DescriptorBuilder interface.
@@ -107,6 +109,11 @@ func (fdb *functionDescriptorBuilder) RunRestoreChanges(
 	return nil
 }
 
+// SetRawBytesInStorage implements the catalog.DescriptorBuilder interface.
+func (fdb *functionDescriptorBuilder) SetRawBytesInStorage(rawBytes []byte) {
+	fdb.rawBytesInStorage = append([]byte(nil), rawBytes...) // deep-copy
+}
+
 // BuildImmutable implements the catalog.DescriptorBuilder interface.
 func (fdb *functionDescriptorBuilder) BuildImmutable() catalog.Descriptor {
 	return fdb.BuildImmutableFunction()
@@ -132,6 +139,7 @@ func (fdb *functionDescriptorBuilder) BuildImmutableFunction() catalog.FunctionD
 		FunctionDescriptor:   *desc,
 		isUncommittedVersion: fdb.isUncommittedVersion,
 		changes:              fdb.changes,
+		rawBytesInStorage:    append([]byte(nil), fdb.rawBytesInStorage...), // deep-copy
 	}
 }
 
@@ -145,6 +153,7 @@ func (fdb *functionDescriptorBuilder) BuildExistingMutableFunction() *Mutable {
 			FunctionDescriptor:   *fdb.maybeModified,
 			isUncommittedVersion: fdb.isUncommittedVersion,
 			changes:              fdb.changes,
+			rawBytesInStorage:    append([]byte(nil), fdb.rawBytesInStorage...), // deep-copy
 		},
 		clusterVersion: &immutable{FunctionDescriptor: *fdb.original},
 	}
@@ -161,6 +170,7 @@ func (fdb *functionDescriptorBuilder) BuildCreatedMutableFunction() *Mutable {
 			FunctionDescriptor:   *desc,
 			isUncommittedVersion: fdb.isUncommittedVersion,
 			changes:              fdb.changes,
+			rawBytesInStorage:    append([]byte(nil), fdb.rawBytesInStorage...), // deep-copy
 		},
 	}
 }

--- a/pkg/sql/catalog/internal/catkv/catalog_query.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_query.go
@@ -149,6 +149,7 @@ func build(
 	if err := b.RunPostDeserializationChanges(); err != nil {
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "error during RunPostDeserializationChanges")
 	}
+	b.SetRawBytesInStorage(rowValue.TagAndDataBytes())
 	desc := b.BuildImmutable()
 	if id != desc.GetID() {
 		return nil, errors.AssertionFailedf("unexpected ID %d in descriptor", desc.GetID())

--- a/pkg/sql/catalog/schemadesc/public_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/public_schema_desc.go
@@ -51,6 +51,7 @@ func (p public) GetName() string        { return tree.PublicSchema }
 func (p public) GetPrivileges() *catpb.PrivilegeDescriptor {
 	return catpb.NewPublicSchemaPrivilegeDescriptor()
 }
+func (p public) GetRawBytesInStorage() []byte { return nil }
 
 // GetPrivilegeDescriptor implements the PrivilegeObject interface.
 func (p public) GetPrivilegeDescriptor(

--- a/pkg/sql/catalog/schemadesc/temporary_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/temporary_schema_desc.go
@@ -54,6 +54,7 @@ func (p temporary) GetParentID() descpb.ID { return p.parentID }
 func (p temporary) GetPrivileges() *catpb.PrivilegeDescriptor {
 	return catpb.NewTemporarySchemaPrivilegeDescriptor()
 }
+func (p temporary) GetRawBytesInStorage() []byte { return nil }
 
 // GetPrivilegeDescriptor implements the PrivilegeObject interface.
 func (p temporary) GetPrivilegeDescriptor(

--- a/pkg/sql/catalog/schemadesc/virtual_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/virtual_schema_desc.go
@@ -64,6 +64,7 @@ func (p virtual) GetParentID() descpb.ID { return descpb.InvalidID }
 func (p virtual) GetPrivileges() *catpb.PrivilegeDescriptor {
 	return catpb.NewVirtualSchemaPrivilegeDescriptor()
 }
+func (p virtual) GetRawBytesInStorage() []byte { return nil }
 
 // GetPrivilegeDescriptor implements the PrivilegeObject interface.
 func (p virtual) GetPrivilegeDescriptor(

--- a/pkg/sql/catalog/tabledesc/structured.go
+++ b/pkg/sql/catalog/tabledesc/structured.go
@@ -1011,6 +1011,11 @@ func (desc *Mutable) OriginalVersion() descpb.DescriptorVersion {
 	return desc.ClusterVersion().Version
 }
 
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (desc *Mutable) GetRawBytesInStorage() []byte {
+	return desc.rawBytesInStorage
+}
+
 // ClusterVersion returns the version of the table descriptor read from the
 // store, if any.
 //

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -222,6 +222,11 @@ func (v TableImplicitRecordType) ValidateTxnCommit(
 ) {
 }
 
+// GetRawBytesInStorage implements the catalog.Descriptor interface.
+func (v TableImplicitRecordType) GetRawBytesInStorage() []byte {
+	return nil
+}
+
 // TypeDesc implements the TypeDescriptor interface.
 func (v TableImplicitRecordType) TypeDesc() *descpb.TypeDescriptor {
 	v.panicNotSupported("TypeDesc")

--- a/pkg/sql/repair.go
+++ b/pkg/sql/repair.go
@@ -659,6 +659,7 @@ func unsafeReadDescriptor(
 	if err != nil || b == nil {
 		return nil, notice, err
 	}
+	b.SetRawBytesInStorage(descRow.Value.TagAndDataBytes())
 	return b.BuildExistingMutable(), notice, nil
 }
 


### PR DESCRIPTION
Each individual commit has a rather thorough message, so I encourage
reviewers to read them as well.

Commit 1: code pattern, non-functional changes
Commit 2: Added a `[]byte` field in descriptor builder
and immutable struct. We also modified existing functions
to carry over this field between descriptor and Mutable/immutable
descriptor, and vice versa.

Commit 3: Upgrade `WriteDescToBatch` to use `CPut` rather than
`Put` to prevent clobbering of the `system.descriptor` table.
We get the expected value for the `CPut` when first reading the
descriptor into collection from storage, as well as keep booking
the descriptor's latest change inside the `uncommitted` descriptor
set, in case more we write to the same descriptor more than once
in the same transaction.

I didn't add any tests in this PR since this changed function 
`WriteDescToBatch` is heavily invoked for many sql stmts,
so I think we should be pretty confident about its correctness
if it passes all existing tests (unit, logic, and roachtest).

Release note: None