### PR TITLE
release-21.2: kv: Use the cached stats for lease preference

### DIFF
--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1344,7 +1344,7 @@ func (r *Replica) checkLeaseRespectsPreferences(ctx context.Context) (bool, erro
 	if len(conf.LeasePreferences) == 0 {
 		return true, nil
 	}
-	storeDesc, err := r.store.Descriptor(ctx, false /* useCached */)
+	storeDesc, err := r.store.Descriptor(ctx, true /* useCached */)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #88821.

/cc @cockroachdb/release

---

Previously it would specify that the descriptor should use an uncached version of the descriptor. What this means in practice is that it recomputes the store level stats every time when it is making a lease preference decision. This was unnecessary as the check was only whether leases were in the right place.

Release note: None

Release justification: Small change with potentially big performance benefit for customers using lease preferences.