### PR TITLE
sql: use SessionUser in event_log instead of CurrentUser

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -194,7 +194,7 @@ func (p *planner) getCommonSQLEventDetails(opt redactionOptions) eventpb.CommonS
 	commonSQLEventDetails := eventpb.CommonSQLEventDetails{
 		Statement:       redactableStmt,
 		Tag:             p.stmt.AST.StatementTag(),
-		User:            p.User().Normalized(),
+		User:            p.SessionData().SessionUser().Normalized(),
 		ApplicationName: p.SessionData().ApplicationName,
 	}
 	if pls := p.extendedEvalCtx.Context.Placeholders.Values; len(pls) > 0 {

--- a/pkg/sql/set_session_authorization.go
+++ b/pkg/sql/set_session_authorization.go
@@ -31,5 +31,8 @@ func (n *setSessionAuthorizationDefaultNode) startExec(params runParams) error {
 	// also changes the "session user," but since the session user cannot be
 	// modified in CockroachDB (at the time of writing), we just need to change
 	// the current user here.
+	// NOTE: If in the future we do allow the session user to be modified, we
+	// should still track the original logged-user, and use that for the audit
+	// logs written by event_log.
 	return params.p.setRole(params.ctx, false /* local */, params.p.SessionData().SessionUser())
 }


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/88753

The SessionUser is the user who originally logged in, and it is
immutable.

The CurrentUser is the user who is executing the command, and it
can be changed using the SET ROLE command.

Release note (bug fix): Audit logs and other structured logs will now
use the "session user" for the User field of the log entry, rather than
the "current user." The "session user" is the user who originally logged
in, and it is immutable. The "current user" can be modified by SET ROLE
commands, so it's not appropriate for this kind of logging.