### PR TITLE
cluster-ui: add helper to determine empty sql results and export sql api wrapper

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/clusterLocksApi.ts
@@ -13,6 +13,7 @@ import {
   executeInternalSql,
   LONG_TIMEOUT,
   SqlExecutionRequest,
+  sqlResultsAreEmpty,
 } from "./sqlApi";
 
 export type ClusterLockState = {
@@ -73,10 +74,7 @@ WHERE
   };
 
   return executeInternalSql<ClusterLockColumns>(request).then(result => {
-    if (
-      result.execution.txn_results.length === 0 ||
-      !result.execution.txn_results[0].rows
-    ) {
+    if (sqlResultsAreEmpty(result)) {
       // No data.
       return [];
     }

--- a/pkg/ui/workspaces/cluster-ui/src/api/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/index.ts
@@ -18,3 +18,4 @@ export * from "./insightsApi";
 export * from "./indexActionsApi";
 export * from "./schemaInsightsApi";
 export * from "./schedulesApi";
+export * from "./sqlApi";

--- a/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/insightsApi.ts
@@ -15,6 +15,7 @@ import {
   LONG_TIMEOUT,
   SqlExecutionRequest,
   SqlExecutionResponse,
+  sqlResultsAreEmpty,
 } from "./sqlApi";
 import {
   BlockedContentionDetails,
@@ -199,10 +200,10 @@ export function getTransactionInsightEventState(): Promise<TransactionInsightEve
   return executeInternalSql<TransactionContentionResponseColumns>(
     txnContentionRequest,
   ).then(contentionResults => {
-    const res = contentionResults.execution.txn_results[0].rows;
-    if (!res || res.length < 1) {
+    if (sqlResultsAreEmpty(contentionResults)) {
       return;
     }
+    const res = contentionResults.execution.txn_results[0].rows;
     const txnFingerprintIDs = res.map(row => row.waiting_txn_fingerprint_id);
     const txnFingerprintRequest: SqlExecutionRequest = {
       statements: [
@@ -217,11 +218,11 @@ export function getTransactionInsightEventState(): Promise<TransactionInsightEve
     return executeInternalSql<TxnStmtFingerprintsResponseColumns>(
       txnFingerprintRequest,
     ).then(txnStmtFingerprintResults => {
-      const txnStmtRes =
-        txnStmtFingerprintResults.execution.txn_results[0].rows;
-      if (!txnStmtRes || txnStmtRes.length < 1) {
+      if (sqlResultsAreEmpty(txnStmtFingerprintResults)) {
         return;
       }
+      const txnStmtRes =
+        txnStmtFingerprintResults.execution.txn_results[0].rows;
       const stmtFingerprintIDs = txnStmtRes.map(row => row.query_ids);
       const fingerprintStmtsRequest: SqlExecutionRequest = {
         statements: [
@@ -419,10 +420,10 @@ export function getTransactionInsightEventDetailsState(
   return executeInternalSql<TxnContentionDetailsResponseColumns>(
     txnContentionDetailsRequest,
   ).then(contentionResults => {
-    const res = contentionResults.execution.txn_results[0].rows;
-    if (!res || res.length < 1) {
+    if (sqlResultsAreEmpty(contentionResults)) {
       return;
     }
+    const res = contentionResults.execution.txn_results[0].rows;
     const waitingTxnFingerprintId = res[0].waiting_txn_fingerprint_id;
     const waitingTxnFingerprintRequest: SqlExecutionRequest = {
       statements: [

--- a/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
@@ -10,7 +10,11 @@
 
 import Long from "long";
 import moment from "moment";
-import { executeInternalSql, SqlExecutionRequest } from "./sqlApi";
+import {
+  executeInternalSql,
+  SqlExecutionRequest,
+  sqlResultsAreEmpty,
+} from "./sqlApi";
 import { RequestError } from "../util";
 
 type ScheduleColumns = {
@@ -76,7 +80,7 @@ export function getSchedules(req: {
   };
   return executeInternalSql<ScheduleColumns>(request).then(result => {
     const txn_results = result.execution.txn_results;
-    if (txn_results.length === 0 || !txn_results[0].rows) {
+    if (sqlResultsAreEmpty(result)) {
       // No data.
       return [];
     }

--- a/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schemaInsightsApi.ts
@@ -13,6 +13,7 @@ import {
   SqlTxnResult,
   executeInternalSql,
   LONG_TIMEOUT,
+  sqlResultsAreEmpty,
 } from "./sqlApi";
 import {
   InsightRecommendation,
@@ -186,7 +187,7 @@ export function getSchemaInsights(): Promise<InsightRecommendation[]> {
   };
   return executeInternalSql<SchemaInsightResponse>(request).then(result => {
     const results: InsightRecommendation[] = [];
-    if (result.execution.txn_results.length === 0) {
+    if (sqlResultsAreEmpty(result)) {
       // No data.
       return results;
     }

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.spec.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.spec.ts
@@ -1,0 +1,86 @@
+// Copyright 2022 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+import { SqlExecutionResponse, sqlResultsAreEmpty } from "./sqlApi";
+
+describe("sqlApi", () => {
+  test("sqlResultsAreEmpty should return true when there are no rows in the response", () => {
+    const testCases: {
+      response: SqlExecutionResponse<unknown>;
+      expected: boolean;
+    }[] = [
+      {
+        response: {
+          num_statements: 1,
+          execution: {
+            retries: 0,
+            txn_results: [
+              {
+                statement: 1,
+                tag: "SELECT",
+                start: "start-date",
+                end: "end-date",
+                rows_affected: 0,
+                rows: [{ hello: "world" }],
+              },
+            ],
+          },
+        },
+        expected: false,
+      },
+      {
+        response: {
+          num_statements: 1,
+          execution: {
+            retries: 0,
+            txn_results: [
+              {
+                statement: 1,
+                tag: "SELECT",
+                start: "start-date",
+                end: "end-date",
+                rows_affected: 0,
+                rows: [],
+              },
+            ],
+          },
+        },
+        expected: true,
+      },
+      {
+        response: {
+          num_statements: 1,
+          execution: {
+            retries: 0,
+            txn_results: [
+              {
+                statement: 1,
+                tag: "SELECT",
+                start: "start-date",
+                end: "end-date",
+                rows_affected: 0,
+                columns: [],
+              },
+            ],
+          },
+        },
+        expected: true,
+      },
+      {
+        response: {},
+        expected: true,
+      },
+    ];
+
+    testCases.forEach(tc => {
+      expect(sqlResultsAreEmpty(tc.response)).toEqual(tc.expected);
+    });
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -103,6 +103,12 @@ export function executeInternalSql<RowType>(
   return executeSql(req);
 }
 
+/**
+ * sqlResultsAreEmpty returns true if the provided result
+ * does not contain any rows.
+ * @param result the sql execution result returned by the server
+ * @returns
+ */
 export function sqlResultsAreEmpty(
   result: SqlExecutionResponse<unknown>,
 ): boolean {

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -102,3 +102,14 @@ export function executeInternalSql<RowType>(
 
   return executeSql(req);
 }
+
+export function sqlResultsAreEmpty(
+  result: SqlExecutionResponse<unknown>,
+): boolean {
+  return (
+    !result.execution?.txn_results?.length ||
+    result.execution.txn_results.every(
+      txn => !txn.rows || txn.rows.length === 0,
+    )
+  );
+}


### PR DESCRIPTION
### Commit 1
This commit adds a helper function, `sqlResultsAreEmpty` to
the sql api that determines whether there are execution
results in the request response.

Release note: None

### Commit 2

Release note: None