### PR TITLE
sql: add SHOW CREATE INDEXES and SHOW CREATE SECONDARY INDEXES

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -283,10 +283,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBBIT colnames
+query ITITTBBBBITT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at  create_statement
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/ccl/logictestccl/testdata/logic_test/show_create
+++ b/pkg/ccl/logictestccl/testdata/logic_test/show_create
@@ -1,0 +1,56 @@
+statement ok
+CREATE TABLE residents (
+	id INT,
+	name STRING,
+	country STRING,
+	PRIMARY KEY (country, id)
+)
+
+query TT
+SHOW CREATE INDEXES FROM residents
+----
+residents_pkey  CREATE UNIQUE INDEX residents_pkey ON public.residents (country ASC, id ASC)
+
+query TT
+SHOW CREATE SECONDARY INDEXES FROM residents
+----
+
+statement ok
+ALTER TABLE residents PARTITION BY LIST (country) (
+	PARTITION north_america VALUES IN ('CA', 'US', 'MX'),
+	PARTITION DEFAULT VALUES IN (default)
+)
+
+query TT
+SHOW CREATE INDEXES FROM residents
+----
+residents_pkey  CREATE UNIQUE INDEX residents_pkey ON public.residents (country ASC, id ASC) PARTITION BY LIST (country) (
+                PARTITION north_america VALUES IN (('CA'), ('US'), ('MX')),
+                PARTITION "default" VALUES IN ((DEFAULT))
+)
+
+statement ok
+CREATE UNIQUE INDEX ON residents (id) PARTITION BY RANGE (id) (
+	PARTITION negative VALUES FROM (MINVALUE) TO (0),
+	PARTITION nonnegative VALUES FROM (0) TO (MAXVALUE)
+)
+
+query TT
+SHOW CREATE INDEXES FROM residents
+----
+residents_pkey    CREATE UNIQUE INDEX residents_pkey ON public.residents (country ASC, id ASC) PARTITION BY LIST (country) (
+                  PARTITION north_america VALUES IN (('CA'), ('US'), ('MX')),
+                  PARTITION "default" VALUES IN ((DEFAULT))
+)
+residents_id_key  CREATE UNIQUE INDEX residents_id_key ON public.residents (id ASC) PARTITION BY RANGE (id) (
+                  PARTITION negative VALUES FROM (MINVALUE) TO (0),
+                  PARTITION nonnegative VALUES FROM (0) TO (MAXVALUE)
+)
+
+query TT
+SHOW CREATE SECONDARY INDEXES FROM residents
+----
+residents_id_key  CREATE UNIQUE INDEX residents_id_key ON public.residents (id ASC) PARTITION BY RANGE (id) (
+                  PARTITION negative VALUES FROM (MINVALUE) TO (0),
+                  PARTITION nonnegative VALUES FROM (0) TO (MAXVALUE)
+)

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2171,6 +2171,13 @@ func TestTenantLogicCCL_schema_change_in_txn(
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
 
+func TestTenantLogicCCL_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}
+
 func TestTenantLogicCCL_tenant(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -93,3 +93,10 @@ func TestCCLLogic_schema_change_in_txn(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
+
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -93,3 +93,10 @@ func TestCCLLogic_schema_change_in_txn(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
+
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 4,
+    shard_count = 5,
     tags = ["cpu:2"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -100,3 +100,10 @@ func TestCCLLogic_schema_change_in_txn(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
+
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -93,3 +93,10 @@ func TestCCLLogic_schema_change_in_txn(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
+
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 3,
+    shard_count = 4,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -93,3 +93,10 @@ func TestCCLLogic_schema_change_in_txn(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
+
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}

--- a/pkg/ccl/logictestccl/tests/local/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//c-deps:libgeos",  # keep
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
-    shard_count = 15,
+    shard_count = 16,
     tags = ["cpu:1"],
     deps = [
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -171,6 +171,13 @@ func TestCCLLogic_schema_change_in_txn(
 	runCCLLogicTest(t, "schema_change_in_txn")
 }
 
+func TestCCLLogic_show_create(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "show_create")
+}
+
 func TestCCLLogic_tenant_usage(
 	t *testing.T,
 ) {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catformat"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
@@ -2902,16 +2903,18 @@ CREATE TABLE crdb_internal.table_indexes (
   is_sharded          BOOL NOT NULL,
   is_visible          BOOL NOT NULL,
   shard_bucket_count  INT,
-  created_at          TIMESTAMP
+  created_at          TIMESTAMP,
+  create_statement    STRING NOT NULL
 )
 `,
 	generator: func(ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, stopper *stop.Stopper) (virtualTableGenerator, cleanupFunc, error) {
 		primary := tree.NewDString("primary")
 		secondary := tree.NewDString("secondary")
-		row := make(tree.Datums, 7)
+		var row []tree.Datum
 		worker := func(ctx context.Context, pusher rowPusher) error {
+			alloc := &tree.DatumAlloc{}
 			return forEachTableDescAll(ctx, p, dbContext, hideVirtual,
-				func(db catalog.DatabaseDescriptor, _ string, table catalog.TableDescriptor) error {
+				func(db catalog.DatabaseDescriptor, scName string, table catalog.TableDescriptor) error {
 					tableID := tree.NewDInt(tree.DInt(table.GetID()))
 					tableName := tree.NewDString(table.GetName())
 					// We report the primary index of non-physical tables here. These
@@ -2937,6 +2940,35 @@ CREATE TABLE crdb_internal.table_indexes (
 						if idx.IsSharded() {
 							shardBucketCnt = tree.NewDInt(tree.DInt(idx.GetSharded().ShardBuckets))
 						}
+						namePrefix := tree.ObjectNamePrefix{SchemaName: tree.Name(scName), ExplicitSchema: true}
+						fullTableName := tree.MakeTableNameFromPrefix(namePrefix, tree.Name(table.GetName()))
+						var partitionBuf bytes.Buffer
+						if err := ShowCreatePartitioning(
+							alloc,
+							p.ExecCfg().Codec,
+							table,
+							idx,
+							idx.GetPartitioning(),
+							&partitionBuf,
+							0, /* indent */
+							0, /* colOffset */
+						); err != nil {
+							return err
+						}
+						createIndexStmt, err := catformat.IndexForDisplay(
+							ctx,
+							table,
+							&fullTableName,
+							idx,
+							partitionBuf.String(),
+							tree.FmtSimple,
+							p.SemaCtx(),
+							p.SessionData(),
+							catformat.IndexDisplayShowCreate,
+						)
+						if err != nil {
+							return err
+						}
 						row = append(row,
 							tableID,
 							tableName,
@@ -2949,6 +2981,7 @@ CREATE TABLE crdb_internal.table_indexes (
 							tree.MakeDBool(tree.DBool(!idx.IsNotVisible())),
 							shardBucketCnt,
 							createdAt,
+							tree.NewDString(createIndexStmt),
 						)
 						return pusher.pushRow(row...)
 					})

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -28,6 +28,8 @@ func (d *delegator) delegateShowCreate(n *tree.ShowCreate) (tree.Statement, erro
 		return d.delegateShowCreateTable(n)
 	case tree.ShowCreateModeDatabase:
 		return d.delegateShowCreateDatabase(n)
+	case tree.ShowCreateModeIndexes, tree.ShowCreateModeSecondaryIndexes:
+		return d.delegateShowCreateIndexes(n)
 	default:
 		return nil, errors.Newf("unknown show create mode: %d", n.Mode)
 	}
@@ -98,6 +100,30 @@ ORDER BY
     1, 2;`
 
 	return d.showTableDetails(n.Name, showCreateQuery)
+}
+
+func (d *delegator) delegateShowCreateIndexes(n *tree.ShowCreate) (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Indexes)
+
+	showCreateIndexesQuery := `
+SELECT
+	index_name,
+	create_statement
+FROM %[4]s.crdb_internal.table_indexes
+WHERE descriptor_id = %[3]s::regclass::int`
+
+	// Add additional conditions based on desired index types.
+	switch n.Mode {
+	// This case is intentionally empty since it should return all types of indexes.
+	case tree.ShowCreateModeIndexes:
+	case tree.ShowCreateModeSecondaryIndexes:
+		showCreateIndexesQuery += `
+	AND index_type != 'primary'`
+	default:
+		return nil, errors.Newf("unknown show create indexes mode: %d", n.Mode)
+	}
+
+	return d.showTableDetails(n.Name, showCreateIndexesQuery)
 }
 
 // delegateShowIndexes implements SHOW INDEX FROM, SHOW INDEXES FROM, SHOW KEYS

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -402,10 +402,10 @@ SELECT * FROM crdb_internal.table_columns WHERE descriptor_name = ''
 ----
 descriptor_id  descriptor_name  column_id  column_name  column_type  nullable  default_expr  hidden
 
-query ITITTBBBBIT colnames
+query ITITTBBBBITT colnames
 SELECT * FROM crdb_internal.table_indexes WHERE descriptor_name = ''
 ----
-descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at
+descriptor_id  descriptor_name  index_id  index_name  index_type  is_unique  is_inverted  is_sharded  is_visible  shard_bucket_count  created_at  create_statement
 
 query ITITTITTB colnames
 SELECT * FROM crdb_internal.index_columns WHERE descriptor_name = ''

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1676,7 +1676,8 @@ CREATE TABLE crdb_internal.table_indexes (
    is_sharded BOOL NOT NULL,
    is_visible BOOL NOT NULL,
    shard_bucket_count INT8 NULL,
-   created_at TIMESTAMP NULL
+   created_at TIMESTAMP NULL,
+   create_statement STRING NOT NULL
 )  CREATE TABLE crdb_internal.table_indexes (
    descriptor_id INT8 NULL,
    descriptor_name STRING NOT NULL,
@@ -1688,7 +1689,8 @@ CREATE TABLE crdb_internal.table_indexes (
    is_sharded BOOL NOT NULL,
    is_visible BOOL NOT NULL,
    shard_bucket_count INT8 NULL,
-   created_at TIMESTAMP NULL
+   created_at TIMESTAMP NULL,
+   create_statement STRING NOT NULL
 )  {}  {}
 CREATE TABLE crdb_internal.table_row_statistics (
    table_id INT8 NOT NULL,

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -140,3 +140,30 @@ CREATE TABLE public.t (
   CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
 );
 COMMENT ON COLUMN public.t.c IS 'first comment'
+
+statement ok
+CREATE TABLE t1 (
+  k INT PRIMARY KEY,
+  a INT UNIQUE,
+  b STRING,
+  INDEX (a, b)
+)
+
+query TT
+SHOW CREATE INDEXES FROM t1
+----
+t1_pkey     CREATE UNIQUE INDEX t1_pkey ON public.t1 (k ASC)
+t1_a_key    CREATE UNIQUE INDEX t1_a_key ON public.t1 (a ASC)
+t1_a_b_idx  CREATE INDEX t1_a_b_idx ON public.t1 (a ASC, b ASC)
+
+query TT
+SHOW CREATE SECONDARY INDEXES FROM t1
+----
+t1_a_key    CREATE UNIQUE INDEX t1_a_key ON public.t1 (a ASC)
+t1_a_b_idx  CREATE INDEX t1_a_b_idx ON public.t1 (a ASC, b ASC)
+
+statement error relation "nonexistent" does not exist
+SHOW CREATE INDEXES FROM nonexistent
+
+statement error relation "nonexistent" does not exist
+SHOW CREATE SECONDARY INDEXES FROM nonexistent

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -7310,6 +7310,7 @@ show_transfer_stmt:
 // %Category: DDL
 // %Text:
 // SHOW CREATE [ TABLE | SEQUENCE | VIEW | DATABASE ] <object_name>
+// SHOW CREATE [ SECONDARY ] INDEXES FROM <table_name>
 // SHOW CREATE ALL SCHEMAS
 // SHOW CREATE ALL TABLES
 // SHOW CREATE ALL TYPES
@@ -7339,6 +7340,16 @@ show_create_stmt:
     /* SKIP DOC */
     $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeDatabase, Name: $4.unresolvedObjectName()}
 	}
+| SHOW CREATE INDEXES FROM table_name
+  {
+    /* SKIP DOC */
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeIndexes, Name: $5.unresolvedObjectName()}
+  }
+| SHOW CREATE SECONDARY INDEXES FROM table_name
+  {
+    /* SKIP DOC */
+    $$.val = &tree.ShowCreate{Mode: tree.ShowCreateModeSecondaryIndexes, Name: $6.unresolvedObjectName()}
+  }
 | SHOW CREATE FUNCTION db_object_name
   {
     /* SKIP DOC */

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -1778,3 +1778,19 @@ SHOW CREATE FUNCTION db.sch.foo
 SHOW CREATE FUNCTION db.sch.foo -- fully parenthesized
 SHOW CREATE FUNCTION db.sch.foo -- literals removed
 SHOW CREATE FUNCTION _._._ -- identifiers removed
+
+parse
+SHOW CREATE INDEXES FROM t
+----
+SHOW CREATE INDEXES FROM t
+SHOW CREATE INDEXES FROM t -- fully parenthesized
+SHOW CREATE INDEXES FROM t -- literals removed
+SHOW CREATE INDEXES FROM _ -- identifiers removed
+
+parse
+SHOW CREATE SECONDARY INDEXES FROM t
+----
+SHOW CREATE SECONDARY INDEXES FROM t
+SHOW CREATE SECONDARY INDEXES FROM t -- fully parenthesized
+SHOW CREATE SECONDARY INDEXES FROM t -- literals removed
+SHOW CREATE SECONDARY INDEXES FROM _ -- identifiers removed

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -531,6 +531,10 @@ const (
 	ShowCreateModeSequence
 	// ShowCreateModeDatabase represents SHOW CREATE DATABASE
 	ShowCreateModeDatabase
+	// ShowCreateModeIndexes represents SHOW CREATE INDEXES FROM
+	ShowCreateModeIndexes
+	// ShowCreateModeSecondaryIndexes represents SHOW CREATE SECONDARY INDEXES FROM
+	ShowCreateModeSecondaryIndexes
 )
 
 // ShowCreate represents a SHOW CREATE statement.
@@ -546,6 +550,10 @@ func (node *ShowCreate) Format(ctx *FmtCtx) {
 	switch node.Mode {
 	case ShowCreateModeDatabase:
 		ctx.WriteString("DATABASE ")
+	case ShowCreateModeIndexes:
+		ctx.WriteString("INDEXES FROM ")
+	case ShowCreateModeSecondaryIndexes:
+		ctx.WriteString("SECONDARY INDEXES FROM ")
 	}
 	ctx.FormatNode(node.Name)
 }


### PR DESCRIPTION
This patch adds the SQL statements `SHOW CREATE INDEXES FROM <table_name>`
and `SHOW CREATE SECONDARY INDEXES FROM <table_name>`, which users can use to
generate easy-to-read `CREATE INDEX` statements for a table's (secondary)
indexes. As part of this work, a new `create_statement` column was added to
the `crdb_internal.table_indexes` virtual table, which is queried by the
delegate logic.

Builds on #79201.

Closes #74748.

Release note (sql change): `SHOW CREATE INDEXES FROM <table_name>` and
and `SHOW CREATE SECONDARY INDEXES FROM <table_name>` are new statements
that can be used to generate easy-to-read `CREATE INDEX` statements for
a table's (secondary) indexes.