### PR TITLE
opt: add session setting to disable inequality lookup joins

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3342,6 +3342,10 @@ func (m *sessionDataMutator) SetEnforceHomeRegion(val bool) {
 	m.data.EnforceHomeRegion = val
 }
 
+func (m *sessionDataMutator) SetVariableInequalityLookupJoinEnabled(val bool) {
+	m.data.VariableInequalityLookupJoinEnabled = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4802,6 +4802,7 @@ transaction_rows_written_log                          0
 transaction_status                                    NoTxn
 troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
+variable_inequality_lookup_join_enabled               on
 xmloption                                             content
 
 # information_schema can be used with the anonymous database.

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1466,3 +1466,18 @@ NULL                                  294276-12-31 23:59:59.999999 +0000 +0000  
 0000-01-01 23:59:59.999999 +0000 UTC  1970-01-01 00:00:00 +0000 +0000           0000-01-02 00:00:00 +0000 UTC         2042-01-01 00:00:00 +0000 +0000
 0000-01-02 00:00:00 +0000 UTC         2042-01-01 00:00:00 +0000 +0000           NULL                                  294276-12-31 23:59:59.999999 +0000 +0000
 0000-01-02 00:00:00 +0000 UTC         2042-01-01 00:00:00 +0000 +0000           0000-01-02 00:00:00 +0000 UTC         2042-01-01 00:00:00 +0000 +0000
+
+statement ok
+SET variable_inequality_lookup_join_enabled=false
+
+statement error pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT a, b, c, d, e, f FROM abc INNER LOOKUP JOIN def ON f <= a ORDER BY a, b, c, d, e, f
+
+statement error pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT a, b, c, d, e, f FROM def INNER LOOKUP JOIN abc ON a >= f ORDER BY a, b, c, d, e, f
+
+statement error pq: could not produce a query plan conforming to the LOOKUP JOIN hint
+SELECT a, b, c, d, e, f FROM abc INNER LOOKUP JOIN def ON f < a AND f >= b ORDER BY a, b, c, d, e, f
+
+statement ok
+RESET variable_inequality_lookup_join_enabled

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4273,6 +4273,7 @@ transaction_status                                    NoTxn               NULL  
 troubleshooting_mode                                  off                 NULL      NULL        NULL        string
 unconstrained_non_covering_index_scan_enabled         off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                        on                  NULL      NULL        NULL        string
+variable_inequality_lookup_join_enabled               on                  NULL      NULL        NULL        string
 vectorize                                             on                  NULL      NULL        NULL        string
 xmloption                                             content             NULL      NULL        NULL        string
 
@@ -4406,6 +4407,7 @@ transaction_status                                    NoTxn               NULL  
 troubleshooting_mode                                  off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled         off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                        on                  NULL  user     NULL      on                  on
+variable_inequality_lookup_join_enabled               on                  NULL  user     NULL      on                  on
 vectorize                                             on                  NULL  user     NULL      on                  on
 xmloption                                             content             NULL  user     NULL      content             content
 
@@ -4538,6 +4540,7 @@ transaction_status                                    NULL    NULL     NULL     
 troubleshooting_mode                                  NULL    NULL     NULL     NULL        NULL
 unconstrained_non_covering_index_scan_enabled         NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                        NULL    NULL     NULL     NULL        NULL
+variable_inequality_lookup_join_enabled               NULL    NULL     NULL     NULL        NULL
 vectorize                                             NULL    NULL     NULL     NULL        NULL
 xmloption                                             NULL    NULL     NULL     NULL        NULL
 

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -146,6 +146,7 @@ transaction_status                                    NoTxn
 troubleshooting_mode                                  off
 unconstrained_non_covering_index_scan_enabled         off
 use_declarative_schema_changer                        on
+variable_inequality_lookup_join_enabled               on
 vectorize                                             on
 xmloption                                             content
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -2248,3 +2248,33 @@ SELECT y,w FROM family_index_join@family_index_join_y_idx WHERE y = 2
 ----
 Scan /Table/130/2/{2-3}
 Scan /Table/130/1/1/{0-1/2}, /Table/130/1/1/3/1
+
+statement ok
+SET variable_inequality_lookup_join_enabled=false
+
+query T
+EXPLAIN SELECT * FROM abc INNER LOOKUP JOIN def_e_decimal ON f = b AND e <= a::DECIMAL ORDER BY a, b, c, d, e, f
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ estimated row count: 33
+│ order: +a,+b,+c,+d,+e
+│ already ordered: +a
+│
+└── • lookup join
+    │ estimated row count: 33
+    │ table: def_e_decimal@def_e_decimal_pkey
+    │ equality: (b) = (f)
+    │ pred: column11 >= e
+    │
+    └── • render
+        │
+        └── • scan
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+              table: abc@abc_pkey
+              spans: FULL SCAN
+
+statement ok
+RESET variable_inequality_lookup_join_enabled

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -153,8 +153,12 @@ func (b *ConstraintBuilder) Build(
 	rightEqSet := rightEq.ToSet()
 
 	// Retrieve the inequality columns from onFilters.
-	rightCmp, inequalityFilterOrds :=
-		memo.ExtractJoinInequalityRightColumnsWithFilterOrds(b.leftCols, b.rightCols, onFilters)
+	var rightCmp opt.ColList
+	var inequalityFilterOrds []int
+	if b.evalCtx.SessionData().VariableInequalityLookupJoinEnabled {
+		rightCmp, inequalityFilterOrds =
+			memo.ExtractJoinInequalityRightColumnsWithFilterOrds(b.leftCols, b.rightCols, onFilters)
+	}
 
 	allFilters := append(onFilters, optionalFilters...)
 

--- a/pkg/sql/opt/lookupjoin/constraint_builder_test.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder_test.go
@@ -58,6 +58,7 @@ func TestLookupConstraints(t *testing.T) {
 	datadriven.Walk(t, tu.TestDataPath(t), func(t *testing.T, path string) {
 		semaCtx := tree.MakeSemaContext()
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+		evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
 
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			testCatalog := testcat.New()

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -157,6 +157,7 @@ type Memo struct {
 	testingOptimizerCostPerturbation       float64
 	testingOptimizerDisableRuleProbability float64
 	enforceHomeRegion                      bool
+	variableInequalityLookupJoinEnabled    bool
 
 	// curRank is the highest currently in-use scalar expression rank.
 	curRank opt.ScalarRank
@@ -209,6 +210,7 @@ func (m *Memo) Init(evalCtx *eval.Context) {
 		testingOptimizerCostPerturbation:       evalCtx.SessionData().TestingOptimizerCostPerturbation,
 		testingOptimizerDisableRuleProbability: evalCtx.SessionData().TestingOptimizerDisableRuleProbability,
 		enforceHomeRegion:                      evalCtx.SessionData().EnforceHomeRegion,
+		variableInequalityLookupJoinEnabled:    evalCtx.SessionData().VariableInequalityLookupJoinEnabled,
 	}
 	m.metadata.Init()
 	m.logPropsBuilder.init(evalCtx, m)
@@ -344,7 +346,8 @@ func (m *Memo) IsStale(
 		m.testingOptimizerRandomSeed != evalCtx.SessionData().TestingOptimizerRandomSeed ||
 		m.testingOptimizerCostPerturbation != evalCtx.SessionData().TestingOptimizerCostPerturbation ||
 		m.testingOptimizerDisableRuleProbability != evalCtx.SessionData().TestingOptimizerDisableRuleProbability ||
-		m.enforceHomeRegion != evalCtx.SessionData().EnforceHomeRegion {
+		m.enforceHomeRegion != evalCtx.SessionData().EnforceHomeRegion ||
+		m.variableInequalityLookupJoinEnabled != evalCtx.SessionData().VariableInequalityLookupJoinEnabled {
 		return true, nil
 	}
 

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -292,6 +292,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().EnforceHomeRegion = false
 	notStale()
 
+	// Stale inequality lookup joins enabled.
+	evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
+	stale()
+	evalCtx.SessionData().VariableInequalityLookupJoinEnabled = false
+	notStale()
+
 	// Stale testing_optimizer_random_seed.
 	evalCtx.SessionData().TestingOptimizerRandomSeed = 100
 	stale()

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -285,6 +285,7 @@ func New(catalog cat.Catalog, sql string) *OptTester {
 	ot.evalCtx.SessionData().ReorderJoinsLimit = opt.DefaultJoinOrderLimit
 	ot.evalCtx.SessionData().InsertFastPath = true
 	ot.evalCtx.SessionData().OptSplitScanLimit = tabledesc.MaxBucketAllowed
+	ot.evalCtx.SessionData().VariableInequalityLookupJoinEnabled = true
 
 	return ot
 }

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -320,7 +320,7 @@ func (c *CustomFuncs) GenerateLookupJoinsWithVirtualCols(
 // canGenerateLookupJoins makes a best-effort to filter out cases where no
 // joins can be constructed based on the join's filters and flags. It may miss
 // some cases that will be filtered out later.
-func canGenerateLookupJoins(
+func (c *CustomFuncs) canGenerateLookupJoins(
 	input memo.RelExpr, joinFlags memo.JoinFlags, leftCols, rightCols opt.ColSet, on memo.FiltersExpr,
 ) bool {
 	if joinFlags.Has(memo.DisallowLookupJoinIntoRight) {
@@ -334,8 +334,9 @@ func canGenerateLookupJoins(
 	// can be used for lookups. Since the current implementation does not
 	// deduplicate the resulting spans, only plan a lookup join with no equalities
 	// when the input has one row, or if a lookup join is forced.
-	if input.Relational().Cardinality.IsZeroOrOne() ||
-		joinFlags.Has(memo.AllowOnlyLookupJoinIntoRight) {
+	if c.e.evalCtx.SessionData().VariableInequalityLookupJoinEnabled &&
+		(input.Relational().Cardinality.IsZeroOrOne() ||
+			joinFlags.Has(memo.AllowOnlyLookupJoinIntoRight)) {
 		return memo.HasJoinCondition(leftCols, rightCols, on, true /* inequality */)
 	}
 	return false
@@ -361,7 +362,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	md := c.e.mem.Metadata()
 	inputProps := input.Relational()
 
-	if !canGenerateLookupJoins(input, joinPrivate.Flags, inputProps.OutputCols, rightCols, on) {
+	if !c.canGenerateLookupJoins(input, joinPrivate.Flags, inputProps.OutputCols, rightCols, on) {
 		return
 	}
 

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -3389,6 +3389,37 @@ inner-join (lookup abcd@abcd_a_b_idx)
  │    └── columns: m:1 n:2
  └── filters (true)
 
+# Don't use the inequality in the lookup condition when lookup joins with
+# variable inequalities are disabled.
+opt expect=GenerateLookupJoins set=variable_inequality_lookup_join_enabled=false
+SELECT a,b,n,m FROM small LEFT JOIN abcd ON a=m AND b>n
+----
+left-join (lookup abcd@abcd_a_b_idx)
+ ├── columns: a:6 b:7 n:2 m:1
+ ├── key columns: [1] = [6]
+ ├── scan small
+ │    └── columns: m:1 n:2
+ └── filters
+      └── b:7 > n:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+
+# Don't generate a lookup join when inequality lookup joins are disabled.
+opt expect-not=GenerateLookupJoins set=variable_inequality_lookup_join_enabled=false
+SELECT a,b,n,m FROM (SELECT * FROM small LIMIT 1) JOIN abcd ON a>=m
+----
+inner-join (cross)
+ ├── columns: a:6!null b:7 n:2 m:1!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── fd: ()-->(1,2)
+ ├── scan abcd@abcd_a_b_idx
+ │    └── columns: a:6 b:7
+ ├── scan small
+ │    ├── columns: m:1 n:2
+ │    ├── limit: 1
+ │    ├── key: ()
+ │    └── fd: ()-->(1,2)
+ └── filters
+      └── a:6 >= m:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ])]
+
 # --------------------------------------------------
 # GenerateLookupJoinsWithFilter
 # --------------------------------------------------

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -291,6 +291,10 @@ message LocalOnlySessionData {
   // OptimizerUseForecasts indicates whether we should use statistics forecasts
   // for cardinality estimation in the optimizer.
   bool optimizer_use_forecasts = 79;
+  // VariableInequalityLookupJoinEnabled indicates whether the optimizer should
+  // be allowed to consider lookup joins with inequality conditions, in
+  // addition to the other restrictions on when they are planned.
+  bool variable_inequality_lookup_join_enabled = 80;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2294,6 +2294,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`variable_inequality_lookup_join_enabled`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`variable_inequality_lookup_join_enabled`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("variable_inequality_lookup_join_enabled", s)
+			if err != nil {
+				return err
+			}
+			m.SetVariableInequalityLookupJoinEnabled(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().VariableInequalityLookupJoinEnabled), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 // We want test coverage for this on and off so make it metamorphic.


### PR DESCRIPTION
This commit adds a session setting (default on) that can be toggled to off in order to disable the lookup join behavior added in #85597. This will provide a quick route to mitigate any customer issues that might be caused by #85597.

Release note: None