### PR TITLE
sql: `has_function_privilege` and `regprocedure` casting to consider arg types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -707,10 +707,20 @@ bit_in
 query T
 SELECT to_regprocedure('bit_in')
 ----
+NULL
+
+query T
+SELECT to_regprocedure('bit_in(int)')
+----
 bit_in
 
 query T
 SELECT to_regprocedure('version')
+----
+NULL
+
+query T
+SELECT to_regprocedure('version()')
 ----
 version
 

--- a/pkg/sql/logictest/testdata/logic_test/pgoidtype
+++ b/pkg/sql/logictest/testdata/logic_test/pgoidtype
@@ -33,8 +33,17 @@ SELECT pg_typeof('1'::OID), pg_typeof('pg_constraint'::REGCLASS), pg_typeof('pub
 ----
 oid  regclass  regnamespace
 
+statement error pq: unknown function: upper\(string\)\(\): function undefined
+SELECT 'upper(string)'::REGPROC
+
+statement error invalid function signature: upper
+SELECT 'upper'::REGPROCEDURE
+
+statement error pq: function upper\(int\) does not exist: function undefined
+SELECT 'upper(int)'::REGPROCEDURE
+
 query TT
-SELECT pg_typeof('upper'::REGPROC), pg_typeof('upper'::REGPROCEDURE)
+SELECT pg_typeof('upper'::REGPROC), pg_typeof('upper(string)'::REGPROCEDURE)
 ----
 regproc  regprocedure
 
@@ -81,28 +90,31 @@ WHERE relname = 'pg_constraint'
 0  pg_constraint  0  pg_constraint  pg_constraint
 
 query OOOO
-SELECT 'upper'::REGPROC, 'upper'::REGPROCEDURE, 'pg_catalog.upper'::REGPROCEDURE, 'upper'::REGPROC::OID
+SELECT 'upper'::REGPROC, 'upper(string)'::REGPROCEDURE, 'pg_catalog.upper(string)'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
 upper  upper  upper  829
 
-query error invalid function name
+query error pq: invalid function signature: invalid.more.pg_catalog.upper: at or near ".": syntax error
 SELECT 'invalid.more.pg_catalog.upper'::REGPROCEDURE
 
 query OOO
-SELECT 'upper(int)'::REGPROC, 'upper(int)'::REGPROCEDURE, 'upper(int)'::REGPROC::OID
+SELECT 'upper'::REGPROC, 'upper(string)'::REGPROCEDURE, 'upper'::REGPROC::OID
 ----
 upper  upper  829
 
-query error unknown function: blah\(\)
-SELECT 'blah(ignored, ignored)'::REGPROC, 'blah(ignored, ignored)'::REGPROCEDURE
+query error pq: unknown function: blah\(ignored\)\(\): function undefined
+SELECT 'blah(ignored)'::REGPROC
 
-query error unknown function: blah\(\)
+query error pq: unknown function: blah\(\): function undefined
+SELECT 'blah(int, int)'::REGPROCEDURE
+
+query error pq: invalid name: expected separator .: blah \( ignored , ignored \)
 SELECT ' blah ( ignored , ignored ) '::REGPROC
 
-query error unknown function: blah\(\)
+query error pq: invalid name: expected separator .: blah \(\)
 SELECT 'blah ()'::REGPROC
 
-query error unknown function: blah\(\)
+query error pq: invalid name: expected separator .: blah\( \)
 SELECT 'blah( )'::REGPROC
 
 query error invalid name: expected separator \.: blah\(, \)
@@ -111,15 +123,15 @@ SELECT 'blah(, )'::REGPROC
 query error more than one function named 'sqrt'
 SELECT 'sqrt'::REGPROC
 
-query OOOO
-SELECT 'array_in'::REGPROC, 'array_in(a,b,c)'::REGPROC, 'pg_catalog.array_in'::REGPROC, 'pg_catalog.array_in( a ,b, c )'::REGPROC
+query OO
+SELECT 'array_in'::REGPROC, 'pg_catalog.array_in'::REGPROC
 ----
-array_in  array_in  array_in  array_in
+array_in  array_in
 
-query OOOO
-SELECT 'array_in'::REGPROCEDURE, 'array_in(a,b,c)'::REGPROCEDURE, 'pg_catalog.array_in'::REGPROCEDURE, 'pg_catalog.array_in( a ,b, c )'::REGPROCEDURE
+query OO
+SELECT 'array_in(int)'::REGPROCEDURE, 'pg_catalog.array_in(int)'::REGPROCEDURE
 ----
-array_in  array_in  array_in  array_in
+array_in  array_in
 
 query OO
 SELECT 'public'::REGNAMESPACE, 'public'::REGNAMESPACE::OID
@@ -156,7 +168,7 @@ query error pgcode 42883 unknown function: blah\(\)
 SELECT 'blah'::REGPROC
 
 query error pgcode 42883 unknown function: blah\(\)
-SELECT 'blah'::REGPROCEDURE
+SELECT 'blah()'::REGPROCEDURE
 
 query error pgcode 42704 namespace 'blah' does not exist
 SELECT 'blah'::REGNAMESPACE
@@ -472,7 +484,12 @@ SELECT 'pg_catalog."radians"'::regproc
 radians
 
 query T
-SELECT 'pg_catalog."radians"("float4")'::regproc
+SELECT 'pg_catalog."radians"'::regproc
+----
+radians
+
+query T
+SELECT 'pg_catalog."radians"("float4")'::regprocedure
 ----
 radians
 

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -505,14 +505,14 @@ SELECT has_function_privilege((SELECT oid FROM pg_proc LIMIT 1), 'EXECUTE')
 ----
 true
 
-query error pgcode 42883 unknown function: does_not_exist()
+query error pq: has_function_privilege\(\): invalid function signature: does_not_exist
 SELECT has_function_privilege('does_not_exist', 'EXECUTE')
 
 query error pgcode 42883 unknown function: does_not_exist()
 SELECT has_function_privilege('does_not_exist()', 'EXECUTE')
 
 query B
-SELECT has_function_privilege('version', '  EXECUTE      ')
+SELECT has_function_privilege('version()', '  EXECUTE      ')
 ----
 true
 
@@ -524,10 +524,15 @@ true
 query B
 SELECT has_function_privilege('cos(float)', 'EXECUTE WITH GRANT OPTION')
 ----
+false
+
+query B
+SELECT has_function_privilege('cos(float)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
 true
 
 query B
-SELECT has_function_privilege('version'::Name, 'EXECUTE')
+SELECT has_function_privilege('version()'::Name, 'EXECUTE')
 ----
 true
 

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -889,6 +889,85 @@ test           public         100140       test_priv_f1()      root     EXECUTE 
 test           public         100143       test_priv_f2(int8)  root     EXECUTE         true
 test           test_priv_sc1  100144       test_priv_f3()      root     EXECUTE         true
 
+# Make sure has_function_privilege works.
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user testuser
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE')
+----
+false
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+false
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+false
+
+user root
+
+statement ok
+GRANT EXECUTE ON FUNCTION test_priv_f1(), test_priv_f2(int), test_priv_sc1.test_priv_f3 TO testuser WITH GRANT OPTION;
+
+user testuser
+
+query B retry
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user root
+
+statement ok
+REVOKE GRANT OPTION FOR EXECUTE ON FUNCTION test_priv_f1(), test_priv_f2(int), test_priv_sc1.test_priv_f3 FROM testuser;
+
+user testuser
+
+query B retry
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE WITH GRANT OPTION')
+----
+false
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE')
+----
+true
+
+query B
+SELECT has_function_privilege('test_priv_f2(INT)', 'EXECUTE, EXECUTE WITH GRANT OPTION')
+----
+true
+
+user root
+
 statement ok
 SET search_path = public;
 

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -351,6 +351,12 @@ func (p *planner) ResolveDescriptorForPrivilegeSpecifier(
 			}
 		}
 		return table, nil
+	} else if specifier.FunctionOID != nil {
+		fnID, err := funcdesc.UserDefinedFunctionOIDToID(*specifier.FunctionOID)
+		if err != nil {
+			return nil, err
+		}
+		return p.Descriptors().GetImmutableFunctionByID(ctx, p.txn, fnID, tree.ObjectLookupFlagsWithRequired())
 	}
 	return nil, errors.AssertionFailedf("invalid HasPrivilegeSpecifier")
 }

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/lex",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgnotice",

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -161,6 +161,11 @@ type HasPrivilegeSpecifier struct {
 	// Only one of ColumnName, ColumnAttNum is filled.
 	ColumnName   *tree.Name
 	ColumnAttNum *uint32
+
+	// Function privilege
+	// This needs to be a user-defined function OID. Builtin function OIDs won't
+	// work since they're not descriptors based.
+	FunctionOID *oid.Oid
 }
 
 // TypeResolver is an interface for resolving types and type OIDs.


### PR DESCRIPTION
backport addresses #83237

Release note (sql change): Previously, `has_function_privlege` builtin function and `::regprocedure` casting only consider function names and argument types are ignored. An umbiguous error was returned if a function name matched more than one overloads. This commit utilizes argument types to narrow down an overload to avoid ambiguity. Also `::regproc` casting is modified to consider whole string as function name. This is to match postgres behavior.
Release justification: GA blocker.