### PR TITLE
geomfn: skip some testcases when running `TestVoronoiPolygons` on ARM64

### DIFF
--- a/pkg/geo/geomfn/voronoi_test.go
+++ b/pkg/geo/geomfn/voronoi_test.go
@@ -11,6 +11,7 @@
 package geomfn
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/geo"
@@ -31,6 +32,7 @@ func TestVoronoiPolygons(t *testing.T) {
 		args        args
 		expected    geo.Geometry
 		expectedErr error
+		skipOnArm64 bool
 	}{
 		{
 			name: "Computes Voronoi Polygons for a given MultiPoint",
@@ -75,7 +77,8 @@ func TestVoronoiPolygons(t *testing.T) {
 				tol:       0,
 				onlyEdges: true,
 			},
-			expected: geo.MustParseGeometry("MULTILINESTRING ((310.3571428571428 500, 353.515625 298.59375), (353.515625 298.59375, 306.875 231.9642857142857), (306.875 231.9642857142857, 110 175.7142857142857), (589.1666666666666 -10, 306.875 231.9642857142857), (353.515625 298.59375, 590 204))"),
+			expected:    geo.MustParseGeometry("MULTILINESTRING ((310.3571428571428 500, 353.515625 298.59375), (353.515625 298.59375, 306.875 231.9642857142857), (306.875 231.9642857142857, 110 175.7142857142857), (589.1666666666666 -10, 306.875 231.9642857142857), (353.515625 298.59375, 590 204))"),
+			skipOnArm64: true,
 		},
 		{
 			name: "Computes Voronoi Diagram for a given MultiPoint with an empty envelope",
@@ -89,6 +92,9 @@ func TestVoronoiPolygons(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
+		if runtime.GOARCH == "arm64" && tc.skipOnArm64 {
+			continue
+		}
 		t.Run(tc.name, func(t *testing.T) {
 			actual, err := VoronoiDiagram(tc.args.a, tc.args.env, tc.args.tol, tc.args.onlyEdges)
 			if tc.expectedErr != nil && tc.expectedErr.Error() != err.Error() {


### PR DESCRIPTION
This code change skips a testcase in `TestVoronoiPolygons` when running on ARM64 (Graviton2 / M1).

Release note: None