### PR TITLE
storage: validate `MVCCClearTimeRange` timestamps

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -60,6 +60,7 @@ func TestCmdRevertRange(t *testing.T) {
 	defer eng.Close()
 
 	baseTime := hlc.Timestamp{WallTime: 1000}
+	tsReq := hlc.Timestamp{WallTime: 10000}
 
 	// Lay down some keys to be the starting point to which we'll revert later.
 	var stats enginepb.MVCCStats
@@ -106,7 +107,7 @@ func TestCmdRevertRange(t *testing.T) {
 		StartKey: roachpb.RKey(startKey),
 		EndKey:   roachpb.RKey(endKey),
 	}
-	cArgs := batcheval.CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC, MaxSpanRequestKeys: 2}}
+	cArgs := batcheval.CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsReq, MaxSpanRequestKeys: 2}}
 	evalCtx := &batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */), Stats: stats}
 	cArgs.EvalCtx = evalCtx.EvalContext()
 	afterStats, err := storage.ComputeStats(eng, keys.LocalMax, keys.MaxKey, 0)
@@ -185,7 +186,6 @@ func TestCmdRevertRange(t *testing.T) {
 	tsD := tsC.Add(100, 0)
 	sumD := hashRange(t, eng, startKey, endKey)
 
-	cArgs.Header.Timestamp = tsD
 	// Re-set EvalCtx to pick up revised stats.
 	cArgs.EvalCtx = (&batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond), Stats: stats}).EvalContext( /* maxOffset */ )
 	for _, tc := range []struct {

--- a/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_revert_range_test.go
@@ -44,19 +44,6 @@ func hashRange(t *testing.T, reader storage.Reader, start, end roachpb.Key) []by
 	return h.Sum(nil)
 }
 
-// createTestPebbleEngine returns a new in-memory Pebble storage engine.
-func createTestPebbleEngine(ctx context.Context) (storage.Engine, error) {
-	return storage.Open(ctx, storage.InMemory(),
-		storage.MaxSize(1<<20), storage.ForTesting)
-}
-
-var engineImpls = []struct {
-	name   string
-	create func(context.Context) (storage.Engine, error)
-}{
-	{"pebble", createTestPebbleEngine},
-}
-
 func TestCmdRevertRange(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -69,196 +56,189 @@ func TestCmdRevertRange(t *testing.T) {
 
 	// Run this test on both RocksDB and Pebble. Regression test for:
 	// https://github.com/cockroachdb/cockroach/pull/42386
-	for _, engineImpl := range engineImpls {
-		t.Run(engineImpl.name, func(t *testing.T) {
-			eng, err := engineImpl.create(ctx)
-			if err != nil {
-				t.Fatal(err)
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
+	baseTime := hlc.Timestamp{WallTime: 1000}
+
+	// Lay down some keys to be the starting point to which we'll revert later.
+	var stats enginepb.MVCCStats
+	for i := 0; i < keyCount; i++ {
+		key := roachpb.Key(fmt.Sprintf("%04d", i))
+		var value roachpb.Value
+		value.SetString(fmt.Sprintf("%d", i))
+		if err := storage.MVCCPut(ctx, eng, &stats, key, baseTime.Add(int64(i%10), 0), hlc.ClockTimestamp{}, value, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tsA := baseTime.Add(100, 0)
+	sumA := hashRange(t, eng, startKey, endKey)
+
+	// Lay down some more keys that we'll revert later, with some of them
+	// shadowing existing keys and some as new keys.
+	for i := 5; i < keyCount+5; i++ {
+		key := roachpb.Key(fmt.Sprintf("%04d", i))
+		var value roachpb.Value
+		value.SetString(fmt.Sprintf("%d-rev-a", i))
+		if err := storage.MVCCPut(ctx, eng, &stats, key, tsA.Add(int64(i%5), 1), hlc.ClockTimestamp{}, value, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sumB := hashRange(t, eng, startKey, endKey)
+	tsB := tsA.Add(10, 0)
+
+	// Lay down more keys, this time shadowing some of our earlier shadows too.
+	for i := 7; i < keyCount+7; i++ {
+		key := roachpb.Key(fmt.Sprintf("%04d", i))
+		var value roachpb.Value
+		value.SetString(fmt.Sprintf("%d-rev-b", i))
+		if err := storage.MVCCPut(ctx, eng, &stats, key, tsB.Add(1, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sumC := hashRange(t, eng, startKey, endKey)
+	tsC := tsB.Add(10, 0)
+
+	desc := roachpb.RangeDescriptor{RangeID: 99,
+		StartKey: roachpb.RKey(startKey),
+		EndKey:   roachpb.RKey(endKey),
+	}
+	cArgs := batcheval.CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC, MaxSpanRequestKeys: 2}}
+	evalCtx := &batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */), Stats: stats}
+	cArgs.EvalCtx = evalCtx.EvalContext()
+	afterStats, err := storage.ComputeStats(eng, keys.LocalMax, keys.MaxKey, 0)
+	require.NoError(t, err)
+	for _, tc := range []struct {
+		name     string
+		ts       hlc.Timestamp
+		expected []byte
+		resumes  int
+	}{
+		{"revert revert to time A", tsA, sumA, 4},
+		{"revert revert to time B", tsB, sumB, 4},
+		{"revert revert to time C (nothing)", tsC, sumC, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			batch := &wrappedBatch{Batch: eng.NewBatch()}
+			defer batch.Close()
+
+			req := roachpb.RevertRangeRequest{
+				RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+				TargetTime:    tc.ts,
 			}
-			defer eng.Close()
-
-			baseTime := hlc.Timestamp{WallTime: 1000}
-
-			// Lay down some keys to be the starting point to which we'll revert later.
-			var stats enginepb.MVCCStats
-			for i := 0; i < keyCount; i++ {
-				key := roachpb.Key(fmt.Sprintf("%04d", i))
-				var value roachpb.Value
-				value.SetString(fmt.Sprintf("%d", i))
-				if err := storage.MVCCPut(ctx, eng, &stats, key, baseTime.Add(int64(i%10), 0), hlc.ClockTimestamp{}, value, nil); err != nil {
+			cArgs.Stats = &enginepb.MVCCStats{}
+			cArgs.Args = &req
+			var resumes int
+			for {
+				var reply roachpb.RevertRangeResponse
+				result, err := batcheval.RevertRange(ctx, batch, cArgs, &reply)
+				if err != nil {
 					t.Fatal(err)
 				}
-			}
-
-			tsA := baseTime.Add(100, 0)
-			sumA := hashRange(t, eng, startKey, endKey)
-
-			// Lay down some more keys that we'll revert later, with some of them
-			// shadowing existing keys and some as new keys.
-			for i := 5; i < keyCount+5; i++ {
-				key := roachpb.Key(fmt.Sprintf("%04d", i))
-				var value roachpb.Value
-				value.SetString(fmt.Sprintf("%d-rev-a", i))
-				if err := storage.MVCCPut(ctx, eng, &stats, key, tsA.Add(int64(i%5), 1), hlc.ClockTimestamp{}, value, nil); err != nil {
-					t.Fatal(err)
+				require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+				require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
+					[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
+				if reply.ResumeSpan == nil {
+					break
 				}
+				resumes++
+				req.RequestHeader.Key = reply.ResumeSpan.Key
 			}
-
-			sumB := hashRange(t, eng, startKey, endKey)
-			tsB := tsA.Add(10, 0)
-
-			// Lay down more keys, this time shadowing some of our earlier shadows too.
-			for i := 7; i < keyCount+7; i++ {
-				key := roachpb.Key(fmt.Sprintf("%04d", i))
-				var value roachpb.Value
-				value.SetString(fmt.Sprintf("%d-rev-b", i))
-				if err := storage.MVCCPut(ctx, eng, &stats, key, tsB.Add(1, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
-					t.Fatal(err)
-				}
+			if resumes != tc.resumes {
+				// NB: since ClearTimeRange buffers keys until it hits one that is not
+				// going to be cleared, and thus may exceed the max batch size by up to
+				// the buffer size (64) when it flushes after breaking out of the loop,
+				// expected resumes isn't *quite* a simple num_cleared_keys/batch_size.
+				t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
 			}
-
-			sumC := hashRange(t, eng, startKey, endKey)
-			tsC := tsB.Add(10, 0)
-
-			desc := roachpb.RangeDescriptor{RangeID: 99,
-				StartKey: roachpb.RKey(startKey),
-				EndKey:   roachpb.RKey(endKey),
+			if reverted := hashRange(t, batch, startKey, endKey); !bytes.Equal(reverted, tc.expected) {
+				t.Error("expected reverted keys to match checksum")
 			}
-			cArgs := batcheval.CommandArgs{Header: roachpb.Header{RangeID: desc.RangeID, Timestamp: tsC, MaxSpanRequestKeys: 2}}
-			evalCtx := &batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond /* maxOffset */), Stats: stats}
-			cArgs.EvalCtx = evalCtx.EvalContext()
-			afterStats, err := storage.ComputeStats(eng, keys.LocalMax, keys.MaxKey, 0)
+			evalStats := afterStats
+			evalStats.Add(*cArgs.Stats)
+			realStats, err := storage.ComputeStats(batch, keys.LocalMax, keys.MaxKey, evalStats.LastUpdateNanos)
 			require.NoError(t, err)
-			for _, tc := range []struct {
-				name     string
-				ts       hlc.Timestamp
-				expected []byte
-				resumes  int
-			}{
-				{"revert revert to time A", tsA, sumA, 4},
-				{"revert revert to time B", tsB, sumB, 4},
-				{"revert revert to time C (nothing)", tsC, sumC, 0},
-			} {
-				t.Run(tc.name, func(t *testing.T) {
-					batch := &wrappedBatch{Batch: eng.NewBatch()}
-					defer batch.Close()
+			require.Equal(t, realStats, evalStats)
+		})
+	}
 
-					req := roachpb.RevertRangeRequest{
-						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
-						TargetTime:    tc.ts,
-					}
-					cArgs.Stats = &enginepb.MVCCStats{}
-					cArgs.Args = &req
-					var resumes int
-					for {
-						var reply roachpb.RevertRangeResponse
-						result, err := batcheval.RevertRange(ctx, batch, cArgs, &reply)
-						if err != nil {
-							t.Fatal(err)
-						}
-						require.NotNil(t, result.Replicated.MVCCHistoryMutation)
-						require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
-							[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
-						if reply.ResumeSpan == nil {
-							break
-						}
-						resumes++
-						req.RequestHeader.Key = reply.ResumeSpan.Key
-					}
-					if resumes != tc.resumes {
-						// NB: since ClearTimeRange buffers keys until it hits one that is not
-						// going to be cleared, and thus may exceed the max batch size by up to
-						// the buffer size (64) when it flushes after breaking out of the loop,
-						// expected resumes isn't *quite* a simple num_cleared_keys/batch_size.
-						t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
-					}
-					if reverted := hashRange(t, batch, startKey, endKey); !bytes.Equal(reverted, tc.expected) {
-						t.Error("expected reverted keys to match checksum")
-					}
-					evalStats := afterStats
-					evalStats.Add(*cArgs.Stats)
-					realStats, err := storage.ComputeStats(batch, keys.LocalMax, keys.MaxKey, evalStats.LastUpdateNanos)
-					require.NoError(t, err)
-					require.Equal(t, realStats, evalStats)
-				})
+	txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, tsC, 1, 1)
+	if err := storage.MVCCPut(
+		ctx, eng, &stats, []byte("0012"), tsC, hlc.ClockTimestamp{}, roachpb.MakeValueFromBytes([]byte("i")), &txn,
+	); err != nil {
+		t.Fatal(err)
+	}
+	sumCIntent := hashRange(t, eng, startKey, endKey)
+
+	// Lay down more revisions (skipping even keys to avoid our intent on 0012).
+	for i := 7; i < keyCount+7; i += 2 {
+		key := roachpb.Key(fmt.Sprintf("%04d", i))
+		var value roachpb.Value
+		value.SetString(fmt.Sprintf("%d-rev-b", i))
+		if err := storage.MVCCPut(ctx, eng, &stats, key, tsC.Add(10, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
+			t.Fatalf("writing key %s: %+v", key, err)
+		}
+	}
+	tsD := tsC.Add(100, 0)
+	sumD := hashRange(t, eng, startKey, endKey)
+
+	cArgs.Header.Timestamp = tsD
+	// Re-set EvalCtx to pick up revised stats.
+	cArgs.EvalCtx = (&batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond), Stats: stats}).EvalContext( /* maxOffset */ )
+	for _, tc := range []struct {
+		name        string
+		ts          hlc.Timestamp
+		expectErr   bool
+		expectedSum []byte
+		resumes     int
+	}{
+		{"hit intent", tsB, true, nil, 2},
+		{"hit intent exactly", tsC, false, sumCIntent, 2},
+		{"clear above intent", tsC.Add(0, 1), false, sumCIntent, 2},
+		{"clear nothing above intent", tsD, false, sumD, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			batch := &wrappedBatch{Batch: eng.NewBatch()}
+			defer batch.Close()
+			cArgs.Stats = &enginepb.MVCCStats{}
+			req := roachpb.RevertRangeRequest{
+				RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
+				TargetTime:    tc.ts,
 			}
-
-			txn := roachpb.MakeTransaction("test", nil, roachpb.NormalUserPriority, tsC, 1, 1)
-			if err := storage.MVCCPut(
-				ctx, eng, &stats, []byte("0012"), tsC, hlc.ClockTimestamp{}, roachpb.MakeValueFromBytes([]byte("i")), &txn,
-			); err != nil {
-				t.Fatal(err)
-			}
-			sumCIntent := hashRange(t, eng, startKey, endKey)
-
-			// Lay down more revisions (skipping even keys to avoid our intent on 0012).
-			for i := 7; i < keyCount+7; i += 2 {
-				key := roachpb.Key(fmt.Sprintf("%04d", i))
-				var value roachpb.Value
-				value.SetString(fmt.Sprintf("%d-rev-b", i))
-				if err := storage.MVCCPut(ctx, eng, &stats, key, tsC.Add(10, int32(i%5)), hlc.ClockTimestamp{}, value, nil); err != nil {
-					t.Fatalf("writing key %s: %+v", key, err)
+			cArgs.Args = &req
+			var resumes int
+			var err error
+			for {
+				var reply roachpb.RevertRangeResponse
+				var result result.Result
+				result, err = batcheval.RevertRange(ctx, batch, cArgs, &reply)
+				if err != nil || reply.ResumeSpan == nil {
+					break
 				}
+				require.NotNil(t, result.Replicated.MVCCHistoryMutation)
+				require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
+					[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
+				req.RequestHeader.Key = reply.ResumeSpan.Key
+				resumes++
 			}
-			tsD := tsC.Add(100, 0)
-			sumD := hashRange(t, eng, startKey, endKey)
+			if resumes != tc.resumes {
+				t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
+			}
 
-			cArgs.Header.Timestamp = tsD
-			// Re-set EvalCtx to pick up revised stats.
-			cArgs.EvalCtx = (&batcheval.MockEvalCtx{Desc: &desc, Clock: hlc.NewClockWithSystemTimeSource(time.Nanosecond), Stats: stats}).EvalContext( /* maxOffset */ )
-			for _, tc := range []struct {
-				name        string
-				ts          hlc.Timestamp
-				expectErr   bool
-				expectedSum []byte
-				resumes     int
-			}{
-				{"hit intent", tsB, true, nil, 2},
-				{"hit intent exactly", tsC, false, sumCIntent, 2},
-				{"clear above intent", tsC.Add(0, 1), false, sumCIntent, 2},
-				{"clear nothing above intent", tsD, false, sumD, 0},
-			} {
-				t.Run(tc.name, func(t *testing.T) {
-					batch := &wrappedBatch{Batch: eng.NewBatch()}
-					defer batch.Close()
-					cArgs.Stats = &enginepb.MVCCStats{}
-					req := roachpb.RevertRangeRequest{
-						RequestHeader: roachpb.RequestHeader{Key: startKey, EndKey: endKey},
-						TargetTime:    tc.ts,
-					}
-					cArgs.Args = &req
-					var resumes int
-					var err error
-					for {
-						var reply roachpb.RevertRangeResponse
-						var result result.Result
-						result, err = batcheval.RevertRange(ctx, batch, cArgs, &reply)
-						if err != nil || reply.ResumeSpan == nil {
-							break
-						}
-						require.NotNil(t, result.Replicated.MVCCHistoryMutation)
-						require.Equal(t, result.Replicated.MVCCHistoryMutation.Spans,
-							[]roachpb.Span{{Key: req.RequestHeader.Key, EndKey: req.RequestHeader.EndKey}})
-						req.RequestHeader.Key = reply.ResumeSpan.Key
-						resumes++
-					}
-					if resumes != tc.resumes {
-						t.Fatalf("expected %d resumes, got %d", tc.resumes, resumes)
-					}
-
-					if tc.expectErr {
-						if !testutils.IsError(err, "intents") {
-							t.Fatalf("expected write intent error; got: %T %+v", err, err)
-						}
-					} else {
-						if err != nil {
-							t.Fatal(err)
-						}
-						if reverted := hashRange(t, batch, startKey, endKey); !bytes.Equal(reverted, tc.expectedSum) {
-							t.Error("expected reverted keys to match checksum")
-						}
-					}
-				})
+			if tc.expectErr {
+				if !testutils.IsError(err, "intents") {
+					t.Fatalf("expected write intent error; got: %T %+v", err, err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if reverted := hashRange(t, batch, startKey, endKey); !bytes.Equal(reverted, tc.expectedSum) {
+					t.Error("expected reverted keys to match checksum")
+				}
 			}
 		})
 	}

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2422,6 +2422,17 @@ func MVCCClearTimeRange(
 		rightPeekBound = keys.MaxKey
 	}
 
+	// endTime must be set. Otherwise, MVCCIncrementalIterator defaults to
+	// MaxTimestamp, unlike the code below which uses it literally.
+	if endTime.IsEmpty() {
+		return nil, errors.New("end time is required")
+	}
+
+	// endTime must also be above startTime.
+	if endTime.LessEq(startTime) {
+		return nil, errors.Errorf("end time %s must be above start time %s", endTime, startTime)
+	}
+
 	// Since we're setting up multiple iterators, we require consistent iterators.
 	if !rw.ConsistentIterators() {
 		return nil, errors.AssertionFailedf("requires consistent iterators")

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -1969,7 +1969,7 @@ func TestMVCCClearTimeRange(t *testing.T) {
 	t.Run("clear > ts5 (nothing)", func(t *testing.T) {
 		b := eng.NewBatch()
 		defer b.Close()
-		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts5, ts5, nil, nil, 64, 10, kb)
+		_, err := MVCCClearTimeRange(ctx, b, nil, localMax, keyMax, ts5, ts5.Next(), nil, nil, 64, 10, kb)
 		require.NoError(t, err)
 		assertKVs(t, b, ts4, ts4Content)
 		assertKVs(t, b, ts5, ts4Content)

--- a/pkg/storage/testdata/mvcc_histories/clear_time_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_time_range
@@ -12,6 +12,38 @@
 #  1  o---------------------------------------o
 #     a   b   c   d   e   f   g   h   i   j   k   l   m   n
 
+# A clear without a time span should error, as should a clear with a target time
+# at or above the end time.
+run stats error
+clear_time_range k=a end=z
+----
+>> clear_time_range k=a end=z
+stats: no change
+>> at end:
+<no data>
+stats: 
+error: (*withstack.withStack:) end time is required
+
+run stats error
+clear_time_range k=a end=z ts=5 targetTs=5
+----
+>> clear_time_range k=a end=z ts=5 targetTs=5
+stats: no change
+>> at end:
+<no data>
+stats: 
+error: (*withstack.withStack:) end time 5.000000000,0 must be above start time 5.000000000,0
+
+run stats error
+clear_time_range k=a end=z ts=5 targetTs=6
+----
+>> clear_time_range k=a end=z ts=5 targetTs=6
+stats: no change
+>> at end:
+<no data>
+stats: 
+error: (*withstack.withStack:) end time 5.000000000,0 must be above start time 6.000000000,0
+
 # Clear the entire span.
 run ok
 del_range_ts k=a end=k ts=1


### PR DESCRIPTION
This patch adds validation of `MVCCClearTimeRange` start/end timestamps. Otherwise, due to interactions with `MVCCIncrementalIterator`, passing e.g. an empty `endTime` could result in unexpected behaviour such as all MVCC range keys being cleared in the keyspan, but none of the point keys.

This shouldn't affect any KV callers: all `RevertRange` callers let the server assign the request timestamp, and this must be non-zero and strictly higher than the given `TargetTime` due to HLC monotonicity.

Release note: None